### PR TITLE
Sprint 6G: operator chat with assistant response mode

### DIFF
--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -2,89 +2,87 @@
 
 ## sprint objective
 
-Implement Sprint 6F by extending the AliceBot web shell so approved approvals can be executed from `/approvals` and their resulting execution state can be reviewed from `/approvals` and `/tasks` using only the shipped approval-execution and tool-execution read endpoints.
+Implement Sprint 6G by turning `/chat` into a dual-mode operator conversation surface with:
+
+- assistant response mode backed by `POST /v0/responses`
+- governed request mode retained through `POST /v0/approvals/requests`
+
+The sprint stays inside the shipped backend seams and keeps the two behaviors visibly separate.
 
 ## completed work
 
-- extended `apps/web/lib/api.ts` with typed execution support for:
-  - `POST /v0/approvals/{approval_id}/execute`
-  - `GET /v0/tool-executions`
-  - `GET /v0/tool-executions/{execution_id}`
-- added fixture-backed execution records in `apps/web/lib/fixtures.ts` so fixture mode now covers:
-  - approved but not executed
-  - executed task and execution review
-- updated `apps/web/app/approvals/page.tsx` to:
-  - discover linked execution records for the selected approval
-  - surface explicit live unavailable state when execution review cannot be loaded
-  - keep fixture fallback explicit when live API configuration is absent
-- updated `apps/web/app/tasks/page.tsx` to:
-  - read latest execution detail from `task.latest_execution_id`
-  - fall back to fixture execution detail only when a matching fixture exists
-  - surface explicit unavailable messaging when a live execution read fails without fixture coverage
-- extended `apps/web/components/approval-actions.tsx` to:
-  - keep approve/reject for pending approvals
-  - show execute for eligible approved approvals
-  - show bounded loading, success, failure, and read-only states
-- extended `apps/web/components/approval-detail.tsx` and `apps/web/components/task-summary.tsx` with the new bounded `apps/web/components/execution-summary.tsx`
-- updated `apps/web/components/task-step-list.tsx` to make execution linkage and blocked reasons clearer inside the existing step timeline
-- refined `apps/web/app/globals.css` for the scoped surfaces with stronger containment, calmer grouping, better wrapping behavior, and more stable responsive stacking
-- added or updated narrow frontend coverage in:
+- updated `apps/web/app/chat/page.tsx` to:
+  - make assistant mode the default `/chat` state
+  - add an explicit mode toggle between assistant chat and governed request submission
+  - seed fixture history only when live API configuration is absent
+  - keep the side rail mode-specific so supporting guidance stays relevant instead of noisy
+- added `apps/web/components/mode-toggle.tsx` as a stable two-state switch with clear labeling and active-state emphasis
+- added `apps/web/components/response-composer.tsx` to:
+  - submit normal assistant questions through `POST /v0/responses`
+  - keep thread identity explicit
+  - provide explicit fixture preview fallback when live API configuration is absent
+- added `apps/web/components/response-history.tsx` to show bounded assistant history with:
+  - operator prompt
+  - assistant reply
+  - model metadata
+  - compile and response trace summaries
+  - direct links into `/traces`
+- refined `apps/web/components/request-composer.tsx` so governed mode reads as an intentional approval-gated workflow instead of a chat-like surface
+- extended `apps/web/lib/api.ts` with typed assistant-response submission support for `POST /v0/responses`
+- extended `apps/web/lib/fixtures.ts` with assistant response fixtures, fixture trace coverage, and deterministic preview entries
+- refined `apps/web/app/globals.css` for the scoped `/chat` surface with:
+  - stronger hierarchy
+  - calmer spacing
+  - bounded history panels
+  - more deliberate prompt/reply grouping
+  - safer wrapping for long ids, trace references, and body text
+  - cleaner mobile stacking for the mode switch and chat workspace
+- added narrow frontend coverage in:
   - `apps/web/lib/api.test.ts`
-  - `apps/web/components/approval-actions.test.tsx`
-  - `apps/web/components/execution-summary.test.tsx`
+  - `apps/web/app/chat/page.test.tsx`
+  - `apps/web/components/response-composer.test.tsx`
+  - `apps/web/components/response-history.test.tsx`
 
 ## incomplete work
 
 - no scoped sprint deliverables remain incomplete in code
 - intentionally not added:
   - backend changes
-  - new routes
-  - execution mutation beyond the shipped approval execute seam
-  - execution filtering, search, or pagination
-  - broader task workflow redesign outside `/approvals` and `/tasks`
+  - thread browsing or thread creation UI
+  - auth changes
+  - new routes outside `/chat`
+  - hidden tool routing or autonomous action behavior
 
-## files changed
+## exact /chat files and components updated
 
-- `apps/web/app/approvals/page.tsx`
-- `apps/web/app/tasks/page.tsx`
+- `apps/web/app/chat/page.tsx`
+- `apps/web/app/chat/page.test.tsx`
 - `apps/web/app/globals.css`
-- `apps/web/components/approval-actions.tsx`
-- `apps/web/components/approval-detail.tsx`
-- `apps/web/components/task-summary.tsx`
-- `apps/web/components/task-step-list.tsx`
+- `apps/web/components/request-composer.tsx`
+- `apps/web/components/response-composer.tsx`
+- `apps/web/components/response-history.tsx`
+- `apps/web/components/mode-toggle.tsx`
 - `apps/web/components/status-badge.tsx`
-- `apps/web/components/execution-summary.tsx`
 - `apps/web/lib/api.ts`
 - `apps/web/lib/fixtures.ts`
 - `apps/web/lib/api.test.ts`
-- `apps/web/components/approval-actions.test.tsx`
-- `apps/web/components/execution-summary.test.tsx`
+- `apps/web/components/response-composer.test.tsx`
+- `apps/web/components/response-history.test.tsx`
 - `BUILD_REPORT.md`
 
 ## route backing mode
 
-- `/approvals` is:
-  - live-API-backed for approval list/detail and linked execution review when API configuration is present
+- assistant mode in `/chat` is:
+  - live-API-backed when API configuration is present
   - fixture-backed when API configuration is absent
-  - explicitly unavailable for linked execution review when live execution reads fail
-- `/tasks` is:
-  - live-API-backed for task detail, step detail, and latest execution review when API configuration is present
+- governed request mode in `/chat` is:
+  - live-API-backed when API configuration is present
   - fixture-backed when API configuration is absent
-  - mixed only when a live task falls back to fixture execution detail
 
 ## backend endpoints consumed
 
-- `POST /v0/approvals/{approval_id}/execute`
-- `GET /v0/tool-executions`
-- `GET /v0/tool-executions/{execution_id}`
-- existing carried-forward reads already used by the shell:
-  - `GET /v0/approvals`
-  - `GET /v0/approvals/{approval_id}`
-  - `POST /v0/approvals/{approval_id}/approve`
-  - `POST /v0/approvals/{approval_id}/reject`
-  - `GET /v0/tasks`
-  - `GET /v0/tasks/{task_id}`
-  - `GET /v0/tasks/{task_id}/steps`
+- `POST /v0/responses`
+- `POST /v0/approvals/requests`
 
 ## exact commands run
 
@@ -96,19 +94,22 @@ Implement Sprint 6F by extending the AliceBot web shell so approved approvals ca
 
 - lint result: PASS
 - test result: PASS
-  - `4` test files passed
-  - `20` tests passed
+  - `7` test files passed
+  - `28` tests passed
 - build result: PASS
 
 ## desktop and mobile visual verification notes
 
 - no browser-driven visual QA pass was executed in this turn
 - desktop note:
-  - code inspection indicates `/approvals` and `/tasks` now use stronger internal grouping for action handling and execution review
-  - ids, badges, and payload snapshots have explicit wrapping and overflow handling inside bounded cards
+  - assistant mode now presents the composer and bounded response history as two coordinated panels instead of one long undifferentiated form
+  - the mode switch is visible near the page header and reads as a stable route-level decision rather than an inline afterthought
+  - response prompt, reply, ids, and trace summaries all use explicit containment styles with overflow wrapping
+  - live-configured `/chat` now starts empty in both modes instead of showing synthetic fixture history
 - mobile note:
-  - the shared shell still collapses the split layouts to one column below the existing breakpoint
-  - execution review, action bars, and buttons now stack into full-width rows to preserve containment on narrow screens
+  - the mode switch collapses to one column below the existing breakpoint
+  - the assistant workspace collapses from a two-panel layout to one column so the composer remains primary and the history panel follows cleanly
+  - buttons continue to expand to full width on narrow screens to avoid cramped action rows
 
 ## blockers/issues
 
@@ -117,14 +118,15 @@ Implement Sprint 6F by extending the AliceBot web shell so approved approvals ca
 
 ## recommended next step
 
-Run a browser-based QA pass against a live configured backend to validate:
-- the execute transition from approved to executed or blocked
-- the exact empty/unavailable messaging in live failure cases
-- the density of output snapshots on long real-world payloads
+Run a browser-based QA pass against both assistant mode and governed mode to validate:
+
+- real long-form assistant replies in the bounded history panel
+- mode-switch readability and perceived hierarchy on tablet widths
+- trace-link destinations against a live configured backend
 
 ## intentionally deferred after this sprint
 
+- thread browsing, thread create flows, or any broader conversation management UI
+- backend changes beyond the shipped `/v0/responses` and `/v0/approvals/requests` seams
 - any Gmail, Calendar, auth, runner, or broader workflow expansion
-- any execution list filters, sorting controls, or search UI
-- any task-step mutation UI beyond existing backend reads
-- any redesign outside the scoped `/approvals` and `/tasks` review surfaces
+- redesign of unrelated routes outside the scoped `/chat` surface

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -6,20 +6,20 @@ PASS
 
 ## criteria met
 
-- The sprint stayed a UI sprint and did not widen backend scope. The implementation remains confined to the web shell and uses only the shipped approval/task/execution seams.
-- The UI can trigger `POST /v0/approvals/{approval_id}/execute` for eligible approved approvals through `apps/web/lib/api.ts` and `apps/web/components/approval-actions.tsx`.
-- The UI can show resulting execution state using existing execution and task reads in `apps/web/app/approvals/page.tsx`, `apps/web/app/tasks/page.tsx`, `apps/web/components/approval-detail.tsx`, `apps/web/components/task-summary.tsx`, `apps/web/components/task-step-list.tsx`, and `apps/web/components/execution-summary.tsx`.
-- `/approvals` and `/tasks` make execution state understandable without widening backend scope. Loading, success, blocked/failure, empty, and unavailable states are all explicitly surfaced.
-- When API configuration is absent, execution controls degrade to explicit fixture/read-only behavior rather than broken interaction.
-- The sprint stayed within the listed in-scope screens, components, and files.
-- `DESIGN_SYSTEM.md` was followed materially. The execution controls and review surfaces remain bounded and consistent with the existing operator-shell tone.
-- `BUILD_REPORT.md` is aligned with the implemented sprint scope and now reflects the current verification totals.
+- The sprint stayed a UI sprint and did not widen backend scope. The implementation remains confined to the web shell and uses only the shipped seams `POST /v0/responses` and `POST /v0/approvals/requests`.
+- `/chat` supports assistant response mode via `POST /v0/responses` through `apps/web/lib/api.ts` and `apps/web/components/response-composer.tsx`.
+- `/chat` retains governed request mode via the existing approval-request seam through `apps/web/components/request-composer.tsx`.
+- The mode switch is explicit and understandable. `apps/web/components/mode-toggle.tsx` keeps assistant and governed modes visibly separate.
+- Assistant replies and trace summaries are visible in bounded history panels via `apps/web/components/response-history.tsx`.
+- Fixture fallback is now explicit and correctly scoped to the no-config path. Live-configured `/chat` starts empty in both modes instead of showing seeded synthetic history. This is enforced in `apps/web/app/chat/page.tsx` and covered by `apps/web/app/chat/page.test.tsx`.
+- The sprint stayed within the exact in-scope files and components listed in the sprint packet.
+- The UI continues to follow `DESIGN_SYSTEM.md` materially. The `/chat` surface remains restrained, bounded, and readable on the inspected responsive layouts.
+- `BUILD_REPORT.md` now matches the implemented route-backing behavior and current verification totals.
 - Verification passed in `apps/web`:
   - `npm run lint`
   - `npm test`
   - `npm run build`
-  - current totals: `4` test files, `20` tests
-- `next build` did not leave tracked churn in `apps/web/tsconfig.json` or `apps/web/next-env.d.ts`.
+  - current totals: `7` test files, `28` tests
 
 ## criteria missed
 
@@ -27,15 +27,15 @@ PASS
 
 ## quality issues
 
-- No blocking quality issues found in the current Sprint 6F implementation.
+- No blocking quality issues found in the current Sprint 6G implementation.
 
 ## regression risks
 
-- Residual risk is limited to live-data wording and density because the visual notes are still based on code inspection rather than a browser QA pass against a configured backend. That does not block sprint acceptance.
+- Residual risk is limited to browser-level presentation because no live browser QA pass was executed in this review cycle. That does not block sprint acceptance.
 
 ## docs issues
 
-- No blocking docs issues remain for Sprint 6F.
+- No blocking docs issues remain for Sprint 6G.
 
 ## should anything be added to RULES.md?
 
@@ -47,5 +47,5 @@ PASS
 
 ## recommended next action
 
-- Sprint 6F can be considered review-passed.
-- Next follow-up should be a browser-based QA pass against a live configured backend to validate the approved-to-executed or blocked transition and the exact operator-facing wording in live failure cases.
+- Sprint 6G can be considered review-passed.
+- Next follow-up should be a browser-based QA pass against a live configured backend to validate long-form assistant replies, mode-switch hierarchy on tablet widths, and trace-link destinations.

--- a/apps/web/app/chat/page.test.tsx
+++ b/apps/web/app/chat/page.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ChatPage from "./page";
+
+const { getApiConfigMock, hasLiveApiConfigMock } = vi.hoisted(() => ({
+  getApiConfigMock: vi.fn(),
+  hasLiveApiConfigMock: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    "aria-current": ariaCurrent,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    "aria-current"?: string;
+  }) => (
+    <a href={href} className={className} aria-current={ariaCurrent}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../../lib/api", async () => {
+  const actual = await vi.importActual("../../lib/api");
+  return {
+    ...actual,
+    getApiConfig: getApiConfigMock,
+    hasLiveApiConfig: hasLiveApiConfigMock,
+  };
+});
+
+describe("ChatPage", () => {
+  beforeEach(() => {
+    getApiConfigMock.mockReset();
+    hasLiveApiConfigMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not seed fixture assistant history when live API configuration is present", async () => {
+    getApiConfigMock.mockReturnValue({
+      apiBaseUrl: "https://api.example.com",
+      userId: "user-1",
+      defaultThreadId: "thread-1",
+      defaultToolId: "tool-1",
+    });
+    hasLiveApiConfigMock.mockReturnValue(true);
+
+    render(await ChatPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText("Live submission enabled")).toBeInTheDocument();
+    expect(screen.getByText("No assistant replies yet")).toBeInTheDocument();
+    expect(screen.queryByText("Fixture response preview")).not.toBeInTheDocument();
+    expect(screen.queryByText(/What do I need to know about the last Vitamin D request/i)).not.toBeInTheDocument();
+  });
+
+  it("does not seed fixture governed-request history when live API configuration is present", async () => {
+    getApiConfigMock.mockReturnValue({
+      apiBaseUrl: "https://api.example.com",
+      userId: "user-1",
+      defaultThreadId: "thread-1",
+      defaultToolId: "tool-1",
+    });
+    hasLiveApiConfigMock.mockReturnValue(true);
+
+    render(
+      await ChatPage({
+        searchParams: Promise.resolve({
+          mode: "request",
+        }),
+      }),
+    );
+
+    expect(screen.getByText("Live submission enabled")).toBeInTheDocument();
+    expect(screen.getByText("No governed requests yet")).toBeInTheDocument();
+    expect(screen.queryByText("Fixture preview")).not.toBeInTheDocument();
+    expect(screen.queryByText(/place_order \/ supplements/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,67 +1,139 @@
+import { ModeToggle, type ChatMode } from "../../components/mode-toggle";
 import { PageHeader } from "../../components/page-header";
 import { RequestComposer } from "../../components/request-composer";
+import { ResponseComposer } from "../../components/response-composer";
 import { SectionCard } from "../../components/section-card";
 import { getApiConfig, hasLiveApiConfig } from "../../lib/api";
-import { requestHistoryFixtures } from "../../lib/fixtures";
+import { requestHistoryFixtures, responseHistoryFixtures } from "../../lib/fixtures";
 
-export default function ChatPage() {
+type ChatPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function normalizeMode(value: string | string[] | undefined): ChatMode {
+  if (Array.isArray(value)) {
+    return normalizeMode(value[0]);
+  }
+
+  return value === "request" ? "request" : "assistant";
+}
+
+export default async function ChatPage({ searchParams }: ChatPageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const mode = normalizeMode(resolvedSearchParams?.mode);
   const apiConfig = getApiConfig();
   const liveModeReady = hasLiveApiConfig(apiConfig);
+  const initialResponseEntries = liveModeReady ? [] : responseHistoryFixtures;
+  const initialRequestEntries = liveModeReady ? [] : requestHistoryFixtures;
 
   return (
     <div className="page-stack">
       <PageHeader
-        eyebrow="Governed request path"
-        title="Operator request surface"
-        description="Submit governed requests through the shipped approval-request seam, keep the resulting approval and task linkage visible, and avoid inventing backend behavior in the UI."
+        eyebrow="Operator conversation surface"
+        title="Chat with the assistant or route a governed request"
+        description="Normal conversation and approval-gated actions now share one calm shell, but the two behaviors stay visibly separate so consequential work never hides inside a chat transcript."
         meta={
           <div className="header-meta">
             <span className="subtle-chip">{liveModeReady ? "Live submission enabled" : "Fixture preview mode"}</span>
-            <span className="subtle-chip">Approval-request seam only</span>
+            <span className="subtle-chip">Responses and approvals stay explicit</span>
           </div>
         }
       />
 
+      <ModeToggle currentMode={mode} />
+
       <div className="content-grid content-grid--wide">
-        <RequestComposer initialEntries={requestHistoryFixtures} {...apiConfig} />
+        {mode === "assistant" ? (
+          <ResponseComposer
+            initialEntries={initialResponseEntries}
+            apiBaseUrl={apiConfig.apiBaseUrl}
+            userId={apiConfig.userId}
+            defaultThreadId={apiConfig.defaultThreadId}
+          />
+        ) : (
+          <RequestComposer initialEntries={initialRequestEntries} {...apiConfig} />
+        )}
 
         <div className="stack">
-          <SectionCard
-            eyebrow="Framing"
-            title="Governed request rules"
-            description="The request surface keeps operational intent explicit and bounded."
-          >
-            <ul className="bullet-list">
-              <li>Requests are submitted directly to `POST /v0/approvals/requests` using shipped payload fields only.</li>
-              <li>The operator supplies thread and tool identifiers explicitly instead of relying on hidden web-side routing.</li>
-              <li>Every resulting summary keeps decision, approval linkage, task status, and trace references visible.</li>
-            </ul>
-          </SectionCard>
+          {mode === "assistant" ? (
+            <>
+              <SectionCard
+                eyebrow="Assistant mode"
+                title="Normal conversation first"
+                description="This mode stays for analysis, summaries, and question answering without implying approval-gated execution."
+              >
+                <ul className="bullet-list">
+                  <li>Questions are submitted directly to `POST /v0/responses` with only the shipped user, thread, and message fields.</li>
+                  <li>The operator still provides thread identity explicitly instead of relying on hidden routing or auto-selected context.</li>
+                  <li>Each reply keeps compile and response trace summaries attached so explainability remains one click away.</li>
+                </ul>
+              </SectionCard>
 
-          <SectionCard
-            eyebrow="Request schema"
-            title="Submission fields"
-            description="The form stays narrow on purpose so the governed request path remains reviewable and deterministic."
-          >
-            <dl className="key-value-grid">
-              <div>
-                <dt>Required</dt>
-                <dd>Thread ID, tool ID, action, scope</dd>
-              </div>
-              <div>
-                <dt>Optional</dt>
-                <dd>Domain hint, risk hint</dd>
-              </div>
-              <div>
-                <dt>Attributes</dt>
-                <dd>JSON object sent unchanged to the backend</dd>
-              </div>
-              <div>
-                <dt>Fallback</dt>
-                <dd>Fixture preview instead of broken live submission</dd>
-              </div>
-            </dl>
-          </SectionCard>
+              <SectionCard
+                eyebrow="Mode boundary"
+                title="What stays out of assistant mode"
+                description="Consequential work remains visibly separated from normal conversation to preserve trust and reviewability."
+              >
+                <dl className="key-value-grid">
+                  <div>
+                    <dt>Assistant mode</dt>
+                    <dd>Answer questions, summarize state, and explain prior work without submitting an approval request.</dd>
+                  </div>
+                  <div>
+                    <dt>Governed mode</dt>
+                    <dd>Submit action-oriented payloads that can create approval and task records through the shipped request seam.</dd>
+                  </div>
+                  <div>
+                    <dt>Fallback</dt>
+                    <dd>Fixture previews stay explicit when live API configuration is absent instead of failing silently.</dd>
+                  </div>
+                  <div>
+                    <dt>Trace review</dt>
+                    <dd>Compile and response trace IDs remain linked from each reply so the operator can inspect why the answer was produced.</dd>
+                  </div>
+                </dl>
+              </SectionCard>
+            </>
+          ) : (
+            <>
+              <SectionCard
+                eyebrow="Governed mode"
+                title="Consequential actions remain reviewable"
+                description="The request surface keeps operational intent explicit and bounded instead of blurring it into casual conversation."
+              >
+                <ul className="bullet-list">
+                  <li>Requests are submitted directly to `POST /v0/approvals/requests` using shipped payload fields only.</li>
+                  <li>The operator supplies thread and tool identifiers explicitly instead of relying on hidden web-side routing.</li>
+                  <li>Every resulting summary keeps decision, approval linkage, task status, and trace references visible.</li>
+                </ul>
+              </SectionCard>
+
+              <SectionCard
+                eyebrow="Request schema"
+                title="Submission fields"
+                description="The governed path stays narrow on purpose so approvals and downstream task state remain deterministic."
+              >
+                <dl className="key-value-grid">
+                  <div>
+                    <dt>Required</dt>
+                    <dd>Thread ID, tool ID, action, scope</dd>
+                  </div>
+                  <div>
+                    <dt>Optional</dt>
+                    <dd>Domain hint, risk hint</dd>
+                  </div>
+                  <div>
+                    <dt>Attributes</dt>
+                    <dd>JSON object sent unchanged to the backend</dd>
+                  </div>
+                  <div>
+                    <dt>Fallback</dt>
+                    <dd>Fixture preview instead of broken live submission</dd>
+                  </div>
+                </dl>
+              </SectionCard>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -261,6 +261,7 @@ code,
   font-size: 0.82rem;
   line-height: 1;
   white-space: nowrap;
+  max-width: 100%;
 }
 
 .shell-main {
@@ -321,7 +322,7 @@ code,
 }
 
 .content-grid--wide {
-  grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.9fr);
+  grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.86fr);
   align-items: flex-start;
 }
 
@@ -346,8 +347,8 @@ code,
 
 .section-card {
   display: grid;
-  gap: 20px;
-  padding: 28px;
+  gap: 18px;
+  padding: 26px;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.5), rgba(255, 252, 248, 0.72)),
     var(--surface);
@@ -500,6 +501,7 @@ code,
   line-height: 1;
   text-transform: uppercase;
   white-space: nowrap;
+  max-width: 100%;
 }
 
 .status-badge--success {
@@ -604,13 +606,18 @@ code,
 
 .composer-card {
   display: grid;
-  gap: 24px;
-  padding: 24px;
+  gap: 22px;
+  padding: 26px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-md);
   backdrop-filter: blur(14px);
+}
+
+.composer-card--chat-primary,
+.section-card--history {
+  min-height: 100%;
 }
 
 .composer-card__header,
@@ -620,6 +627,23 @@ code,
 .list-panel {
   display: grid;
   gap: 16px;
+}
+
+.composer-card__header--tight {
+  gap: 14px;
+}
+
+.composer-intro {
+  display: grid;
+  gap: 8px;
+}
+
+.composer-title {
+  margin: 0;
+  font-size: 1.18rem;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.2;
 }
 
 .governance-banner {
@@ -636,6 +660,63 @@ code,
 
 .governance-banner strong {
   color: var(--text);
+}
+
+.governance-banner--assistant {
+  background: rgba(54, 93, 124, 0.06);
+  border-color: rgba(54, 93, 124, 0.12);
+}
+
+.mode-toggle {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.mode-toggle__item {
+  display: grid;
+  gap: 8px;
+  padding: 18px 20px;
+  border-radius: 22px;
+  border: 1px solid rgba(42, 52, 66, 0.08);
+  background: rgba(255, 252, 248, 0.66);
+  box-shadow: var(--shadow-md);
+  transition:
+    border-color 140ms ease,
+    background-color 140ms ease,
+    transform 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.mode-toggle__item:hover,
+.mode-toggle__item:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.mode-toggle__item.is-active {
+  border-color: rgba(39, 75, 99, 0.2);
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 18px 36px rgba(32, 43, 56, 0.06);
+}
+
+.mode-toggle__label {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.mode-toggle__description {
+  color: var(--text-soft);
+  line-height: 1.6;
+}
+
+.chat-workspace {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1.04fr) minmax(340px, 0.92fr);
+  align-items: stretch;
 }
 
 .form-field {
@@ -684,7 +765,7 @@ code,
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
 }
 
@@ -695,6 +776,7 @@ code,
   align-items: center;
   color: var(--text-soft);
   font-size: 0.9rem;
+  max-width: 640px;
 }
 
 .history-list,
@@ -762,6 +844,7 @@ code,
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  align-items: center;
 }
 
 .split-layout {
@@ -772,7 +855,7 @@ code,
 
 .list-panel__header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 14px;
 }
@@ -844,6 +927,12 @@ code,
   overflow-wrap: anywhere;
 }
 
+.history-list--scrollable {
+  max-height: 920px;
+  overflow: auto;
+  padding-right: 6px;
+}
+
 .inline-link {
   color: var(--accent);
   text-decoration: underline;
@@ -883,6 +972,34 @@ code,
   color: var(--text-soft);
   font-size: 0.84rem;
   line-height: 1.45;
+  overflow-wrap: anywhere;
+  max-width: 100%;
+}
+
+.conversation-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.conversation-block {
+  display: grid;
+  gap: 10px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(42, 52, 66, 0.08);
+}
+
+.conversation-block--accent {
+  background: rgba(245, 248, 252, 0.86);
+  border-color: rgba(54, 93, 124, 0.12);
+}
+
+.response-copy {
+  margin: 0;
+  color: var(--text);
+  line-height: 1.65;
+  white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 
@@ -1061,6 +1178,7 @@ code,
   .content-grid--wide,
   .dashboard-grid--detail,
   .split-layout,
+  .chat-workspace,
   .metric-grid,
   .route-grid {
     grid-template-columns: 1fr;
@@ -1084,6 +1202,11 @@ code,
   .composer-card {
     padding: 20px;
     border-radius: 24px;
+  }
+
+  .mode-toggle {
+    grid-template-columns: 1fr;
+    gap: 12px;
   }
 
   .shell-topbar__row,
@@ -1125,6 +1248,11 @@ code,
   .button,
   .button-secondary {
     width: 100%;
+  }
+
+  .history-list--scrollable {
+    max-height: none;
+    padding-right: 0;
   }
 }
 

--- a/apps/web/components/mode-toggle.tsx
+++ b/apps/web/components/mode-toggle.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+
+export type ChatMode = "assistant" | "request";
+
+type ModeToggleProps = {
+  currentMode: ChatMode;
+};
+
+const MODE_ITEMS: Array<{
+  mode: ChatMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    mode: "assistant",
+    label: "Ask the assistant",
+    description: "Normal ask-and-answer interaction through the shipped response seam.",
+  },
+  {
+    mode: "request",
+    label: "Submit a governed request",
+    description: "Approval-gated action submission through the existing request seam.",
+  },
+];
+
+export function ModeToggle({ currentMode }: ModeToggleProps) {
+  return (
+    <nav className="mode-toggle" aria-label="Chat mode">
+      {MODE_ITEMS.map((item) => {
+        const isActive = item.mode === currentMode;
+        const href = item.mode === "assistant" ? "/chat" : `/chat?mode=${item.mode}`;
+
+        return (
+          <Link
+            key={item.mode}
+            href={href}
+            className={["mode-toggle__item", isActive ? "is-active" : ""].filter(Boolean).join(" ")}
+            aria-current={isActive ? "page" : undefined}
+          >
+            <span className="mode-toggle__label">{item.label}</span>
+            <span className="mode-toggle__description">{item.description}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/components/request-composer.tsx
+++ b/apps/web/components/request-composer.tsx
@@ -159,13 +159,11 @@ export function RequestComposer({
   }
 
   return (
-    <section className="composer-card">
-      <div className="composer-card__header">
+    <section className="composer-card composer-card--request">
+      <div className="composer-card__header composer-card__header--tight">
         <div className="governance-banner">
           <strong>{liveModeReady ? "Live operator mode" : "Fixture operator mode"}</strong>
-          <span>
-            Requests stay explicitly governed and recent routing plus request traces remain attached to each submission.
-          </span>
+          <span>Requests stay explicitly governed and the resulting approval, task, and trace links remain attached.</span>
         </div>
 
         <div className="form-field-group form-field-group--two-up">
@@ -191,10 +189,11 @@ export function RequestComposer({
           </div>
         </div>
 
-        <div className="form-field">
-          <label htmlFor="governed-action">Governed request</label>
+        <div className="composer-intro">
+          <p className="eyebrow">Governed request</p>
+          <h2 className="composer-title">Approval-gated action submission</h2>
           <p className="field-hint">
-            Submit the shipped approval-request payload directly. This surface is request-oriented, not a freeform chat transcript.
+            Submit the shipped approval-request payload directly. This mode is purpose-built for consequential actions, not freeform conversation.
           </p>
         </div>
       </div>
@@ -293,6 +292,7 @@ export function RequestComposer({
       <div className="detail-stack">
         <div className="list-panel__header">
           <div>
+            <p className="eyebrow">Recent activity</p>
             <h2>Recent governed request summaries</h2>
             <p>Latest submissions stay grouped with decision, approval linkage, task state, and traces.</p>
           </div>

--- a/apps/web/components/response-composer.test.tsx
+++ b/apps/web/components/response-composer.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ResponseComposer } from "./response-composer";
+
+const { submitAssistantResponseMock } = vi.hoisted(() => ({
+  submitAssistantResponseMock: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual("../lib/api");
+  return {
+    ...actual,
+    submitAssistantResponse: submitAssistantResponseMock,
+  };
+});
+
+describe("ResponseComposer", () => {
+  beforeEach(() => {
+    submitAssistantResponseMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("submits assistant messages through the shipped response endpoint", async () => {
+    submitAssistantResponseMock.mockResolvedValue({
+      assistant: {
+        event_id: "assistant-event-1",
+        sequence_no: 3,
+        text: "You prefer oat milk.",
+        model_provider: "openai_responses",
+        model: "gpt-5-mini",
+      },
+      trace: {
+        compile_trace_id: "compile-trace-1",
+        compile_trace_event_count: 3,
+        response_trace_id: "response-trace-1",
+        response_trace_event_count: 2,
+      },
+    });
+
+    render(
+      <ResponseComposer
+        initialEntries={[]}
+        apiBaseUrl="https://api.example.com"
+        userId="user-1"
+        defaultThreadId="thread-1"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Ask the assistant"), {
+      target: { value: "What do I usually take in coffee?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Ask assistant" }));
+
+    await waitFor(() => {
+      expect(submitAssistantResponseMock).toHaveBeenCalledWith("https://api.example.com", {
+        user_id: "user-1",
+        thread_id: "thread-1",
+        message: "What do I usually take in coffee?",
+      });
+    });
+
+    expect(await screen.findByText("You prefer oat milk.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open compile trace" })).toHaveAttribute(
+      "href",
+      "/traces?trace=compile-trace-1",
+    );
+    expect(screen.getByText(/Assistant reply added successfully/i)).toBeInTheDocument();
+  });
+
+  it("adds an explicit fixture preview when live API configuration is absent", async () => {
+    render(<ResponseComposer initialEntries={[]} defaultThreadId="thread-1" />);
+
+    fireEvent.change(screen.getByLabelText("Ask the assistant"), {
+      target: { value: "Summarize the latest thread state." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Ask assistant" }));
+
+    expect(submitAssistantResponseMock).not.toHaveBeenCalled();
+    expect(await screen.findByText(/Fixture mode generated a preview response only/i)).toBeInTheDocument();
+    expect(screen.getByText(/Fixture response preview added/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/response-composer.tsx
+++ b/apps/web/components/response-composer.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useState } from "react";
+
+import type { AssistantResponsePayload, ResponseHistoryEntry } from "../lib/api";
+import { submitAssistantResponse } from "../lib/api";
+import { buildFixtureResponseEntry } from "../lib/fixtures";
+import { ResponseHistory } from "./response-history";
+import { StatusBadge } from "./status-badge";
+
+type ResponseComposerProps = {
+  initialEntries: ResponseHistoryEntry[];
+  apiBaseUrl?: string;
+  userId?: string;
+  defaultThreadId?: string;
+};
+
+export function ResponseComposer({
+  initialEntries,
+  apiBaseUrl,
+  userId,
+  defaultThreadId,
+}: ResponseComposerProps) {
+  const [threadId, setThreadId] = useState(defaultThreadId ?? "");
+  const [message, setMessage] = useState("");
+  const [entries, setEntries] = useState(initialEntries);
+  const [statusText, setStatusText] = useState("Ready to ask the assistant inside the current thread.");
+  const [statusTone, setStatusTone] = useState<"info" | "success" | "danger">("info");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const liveModeReady = Boolean(apiBaseUrl && userId);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const nextThreadId = threadId.trim();
+    const nextMessage = message.trim();
+
+    if (!nextThreadId || !nextMessage) {
+      setStatusTone("danger");
+      setStatusText("Thread ID and a message are both required.");
+      return;
+    }
+
+    const payload: AssistantResponsePayload = {
+      user_id: userId ?? "fixture-user",
+      thread_id: nextThreadId,
+      message: nextMessage,
+    };
+
+    setStatusTone("info");
+    setStatusText(
+      liveModeReady
+        ? "Submitting the operator message through the assistant response endpoint..."
+        : "Preparing a fixture-backed assistant response preview...",
+    );
+    setIsSubmitting(true);
+
+    if (!liveModeReady) {
+      const entry = buildFixtureResponseEntry({
+        threadId: nextThreadId,
+        message: nextMessage,
+      });
+      setEntries((current) => [entry, ...current]);
+      setMessage("");
+      setStatusTone("success");
+      setStatusText(
+        "Fixture response preview added. Configure the web API base URL and user ID to persist assistant replies and traces.",
+      );
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      const response = await submitAssistantResponse(apiBaseUrl!, payload);
+      const entry: ResponseHistoryEntry = {
+        id: response.trace.response_trace_id,
+        submittedAt: new Date().toISOString(),
+        source: "live",
+        threadId: nextThreadId,
+        message: nextMessage,
+        assistantText: response.assistant.text,
+        assistantEventId: response.assistant.event_id,
+        assistantSequenceNo: response.assistant.sequence_no,
+        modelProvider: response.assistant.model_provider,
+        model: response.assistant.model,
+        summary:
+          "The reply was returned through the shipped response seam and linked to both compile and response traces.",
+        trace: {
+          compileTraceId: response.trace.compile_trace_id,
+          compileTraceEventCount: response.trace.compile_trace_event_count,
+          responseTraceId: response.trace.response_trace_id,
+          responseTraceEventCount: response.trace.response_trace_event_count,
+        },
+      };
+
+      setEntries((current) => [entry, ...current]);
+      setMessage("");
+      setStatusTone("success");
+      setStatusText("Assistant reply added successfully. Linked trace summaries are visible alongside the response.");
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "Request failed";
+      setStatusTone("danger");
+      setStatusText(`Unable to submit assistant message: ${detail}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="chat-workspace">
+      <section className="composer-card composer-card--chat-primary">
+        <div className="composer-card__header composer-card__header--tight">
+          <div className="governance-banner governance-banner--assistant">
+            <strong>{liveModeReady ? "Live assistant mode" : "Fixture assistant mode"}</strong>
+            <span>
+              Normal questions go through `POST /v0/responses` while thread identity and trace linkage stay explicit.
+            </span>
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="assistant-thread-id">Thread ID</label>
+            <p className="field-hint">
+              Keep the thread explicit so assistant replies stay attached to the intended conversation context.
+            </p>
+            <input
+              id="assistant-thread-id"
+              name="assistant-thread-id"
+              value={threadId}
+              onChange={(event) => setThreadId(event.target.value)}
+              placeholder="Thread UUID"
+            />
+          </div>
+        </div>
+
+        <form className="detail-stack" onSubmit={handleSubmit}>
+          <div className="form-field">
+            <label htmlFor="assistant-message">Ask the assistant</label>
+            <textarea
+              id="assistant-message"
+              name="assistant-message"
+              placeholder="Summarize the current thread state, explain the last approval, or answer a normal operator question."
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+            />
+          </div>
+
+          <div className="composer-actions">
+            <div className="composer-status" aria-live="polite">
+              <StatusBadge
+                status={
+                  isSubmitting
+                    ? "submitting"
+                    : statusTone === "success"
+                      ? "success"
+                      : statusTone === "danger"
+                        ? "error"
+                        : "info"
+                }
+                label={
+                  isSubmitting
+                    ? "Submitting"
+                    : statusTone === "success"
+                      ? "Ready"
+                      : statusTone === "danger"
+                        ? "Attention"
+                        : "Prepared"
+                }
+              />
+              <span>{statusText}</span>
+            </div>
+            <button
+              type="submit"
+              className="button"
+              disabled={isSubmitting || !threadId.trim() || !message.trim()}
+            >
+              {isSubmitting ? "Asking..." : "Ask assistant"}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <ResponseHistory entries={entries} />
+    </div>
+  );
+}

--- a/apps/web/components/response-history.test.tsx
+++ b/apps/web/components/response-history.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ModeToggle } from "./mode-toggle";
+import { ResponseHistory } from "./response-history";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    "aria-current": ariaCurrent,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    "aria-current"?: string;
+  }) => (
+    <a href={href} className={className} aria-current={ariaCurrent}>
+      {children}
+    </a>
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ResponseHistory", () => {
+  it("renders an empty state when no assistant replies are available", () => {
+    render(<ResponseHistory entries={[]} />);
+
+    expect(screen.getByText("No assistant replies yet")).toBeInTheDocument();
+    expect(screen.getByText(/Submitted questions will appear here/i)).toBeInTheDocument();
+  });
+
+  it("renders bounded prompt, reply, and trace links for each entry", () => {
+    render(
+      <ResponseHistory
+        entries={[
+          {
+            id: "response-trace-1",
+            submittedAt: "2026-03-17T08:45:00Z",
+            source: "live",
+            threadId: "thread-1",
+            message: "Summarize the latest thread state.",
+            assistantText: "The latest governed request is still waiting on approval.",
+            assistantEventId: "assistant-event-1",
+            assistantSequenceNo: 3,
+            modelProvider: "openai_responses",
+            model: "gpt-5-mini",
+            summary: "The reply is linked to both compile and response traces.",
+            trace: {
+              compileTraceId: "compile-trace-1",
+              compileTraceEventCount: 3,
+              responseTraceId: "response-trace-1",
+              responseTraceEventCount: 2,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Operator prompt")).toBeInTheDocument();
+    expect(screen.getByText("Assistant reply")).toBeInTheDocument();
+    expect(screen.getByText("The latest governed request is still waiting on approval.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open compile trace" })).toHaveAttribute(
+      "href",
+      "/traces?trace=compile-trace-1",
+    );
+    expect(screen.getByRole("link", { name: "Open response trace" })).toHaveAttribute(
+      "href",
+      "/traces?trace=response-trace-1",
+    );
+  });
+});
+
+describe("ModeToggle", () => {
+  it("keeps the assistant and governed request modes explicit", () => {
+    render(<ModeToggle currentMode="request" />);
+
+    expect(screen.getByRole("link", { name: /Ask the assistant/i })).toHaveAttribute("href", "/chat");
+    expect(screen.getByRole("link", { name: /Submit a governed request/i })).toHaveAttribute(
+      "href",
+      "/chat?mode=request",
+    );
+    expect(screen.getByRole("link", { name: /Submit a governed request/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+});

--- a/apps/web/components/response-history.tsx
+++ b/apps/web/components/response-history.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import Link from "next/link";
+
+import type { ResponseHistoryEntry } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { StatusBadge } from "./status-badge";
+
+type ResponseHistoryProps = {
+  entries: ResponseHistoryEntry[];
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+export function ResponseHistory({ entries }: ResponseHistoryProps) {
+  return (
+    <section className="section-card section-card--history">
+      <div className="list-panel__header">
+        <div>
+          <p className="eyebrow">Assistant replies</p>
+          <h2>Bounded response history</h2>
+          <p>Each entry keeps the operator prompt, assistant reply, and both linked traces visible.</p>
+        </div>
+      </div>
+
+      {entries.length === 0 ? (
+        <EmptyState
+          title="No assistant replies yet"
+          description="Submitted questions will appear here with the returned assistant text and linked trace summaries."
+        />
+      ) : (
+        <div className="history-list history-list--scrollable">
+          {entries.map((entry) => (
+            <article key={entry.id} className="history-entry history-entry--response">
+              <div className="history-entry__topline">
+                <div className="history-entry__state-row">
+                  <StatusBadge
+                    status={entry.source === "live" ? "live" : "fixture"}
+                    label={entry.source === "live" ? "Live API" : "Fixture preview"}
+                  />
+                  <span className="meta-pill">Model {entry.model}</span>
+                </div>
+                <span className="subtle-chip">{formatDate(entry.submittedAt)}</span>
+              </div>
+
+              <div className="conversation-stack">
+                <div className="conversation-block">
+                  <span className="history-entry__label">Operator prompt</span>
+                  <p className="response-copy">{entry.message}</p>
+                </div>
+                <div className="conversation-block conversation-block--accent">
+                  <span className="history-entry__label">Assistant reply</span>
+                  <p className="response-copy">{entry.assistantText}</p>
+                </div>
+              </div>
+
+              <p>{entry.summary}</p>
+
+              <div className="attribute-list">
+                <span className="attribute-item">Thread: {entry.threadId}</span>
+                <span className="attribute-item">Provider: {entry.modelProvider}</span>
+                <span className="attribute-item">Sequence: {entry.assistantSequenceNo}</span>
+              </div>
+
+              <div className="history-entry__trace">
+                <span className="meta-pill">
+                  Compile {entry.trace.compileTraceId} · {entry.trace.compileTraceEventCount} events
+                </span>
+                <span className="meta-pill">
+                  Response {entry.trace.responseTraceId} · {entry.trace.responseTraceEventCount} events
+                </span>
+              </div>
+
+              <div className="cluster">
+                <Link href={`/traces?trace=${entry.trace.compileTraceId}`} className="button-secondary">
+                  Open compile trace
+                </Link>
+                <Link href={`/traces?trace=${entry.trace.responseTraceId}`} className="button-secondary">
+                  Open response trace
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/status-badge.tsx
+++ b/apps/web/components/status-badge.tsx
@@ -36,6 +36,10 @@ function toneForStatus(status: string) {
     return "info";
   }
 
+  if (["fixture", "preview", "draft"].includes(normalized)) {
+    return "neutral";
+  }
+
   return "neutral";
 }
 

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -10,6 +10,7 @@ import {
   listTraces,
   pageModeLabel,
   resolveApproval,
+  submitAssistantResponse,
   submitApprovalRequest,
 } from "./api";
 
@@ -137,6 +138,48 @@ describe("api helpers", () => {
       domain_hint: "ecommerce",
       risk_hint: "purchase",
       attributes: { quantity: "1" },
+    });
+  });
+
+  it("posts assistant messages to the shipped response endpoint", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          assistant: {
+            event_id: "assistant-event-1",
+            sequence_no: 3,
+            text: "You prefer oat milk.",
+            model_provider: "openai_responses",
+            model: "gpt-5-mini",
+          },
+          trace: {
+            compile_trace_id: "compile-trace-1",
+            compile_trace_event_count: 3,
+            response_trace_id: "response-trace-1",
+            response_trace_event_count: 2,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await submitAssistantResponse("https://api.example.com", {
+      user_id: "user-1",
+      thread_id: "thread-1",
+      message: "What do I usually take in coffee?",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v0/responses",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+      }),
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      user_id: "user-1",
+      thread_id: "thread-1",
+      message: "What do I usually take in coffee?",
     });
   });
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -234,6 +234,35 @@ export type ApprovalResolutionResponse = {
   };
 };
 
+export type AssistantResponsePayload = {
+  user_id: string;
+  thread_id: string;
+  message: string;
+  max_sessions?: number;
+  max_events?: number;
+  max_memories?: number;
+  max_entities?: number;
+  max_entity_edges?: number;
+};
+
+export type AssistantResponseTrace = {
+  compile_trace_id: string;
+  compile_trace_event_count: number;
+  response_trace_id: string;
+  response_trace_event_count: number;
+};
+
+export type AssistantResponseSuccess = {
+  assistant: {
+    event_id: string;
+    sequence_no: number;
+    text: string;
+    model_provider: string;
+    model: string;
+  };
+  trace: AssistantResponseTrace;
+};
+
 export type RequestHistoryEntry = {
   id: string;
   submittedAt: string;
@@ -258,6 +287,26 @@ export type RequestHistoryEntry = {
     routingTraceEventCount: number;
     requestTraceId: string;
     requestTraceEventCount: number;
+  };
+};
+
+export type ResponseHistoryEntry = {
+  id: string;
+  submittedAt: string;
+  source: ApiSource;
+  threadId: string;
+  message: string;
+  assistantText: string;
+  assistantEventId: string;
+  assistantSequenceNo: number;
+  modelProvider: string;
+  model: string;
+  summary: string;
+  trace: {
+    compileTraceId: string;
+    compileTraceEventCount: number;
+    responseTraceId: string;
+    responseTraceEventCount: number;
   };
 };
 
@@ -366,6 +415,16 @@ export function submitApprovalRequest(
   payload: ApprovalRequestPayload,
 ) {
   return requestJson<ApprovalRequestResponse>(apiBaseUrl, "/v0/approvals/requests", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function submitAssistantResponse(
+  apiBaseUrl: string,
+  payload: AssistantResponsePayload,
+) {
+  return requestJson<AssistantResponseSuccess>(apiBaseUrl, "/v0/responses", {
     method: "POST",
     body: JSON.stringify(payload),
   });

--- a/apps/web/lib/fixtures.ts
+++ b/apps/web/lib/fixtures.ts
@@ -2,6 +2,7 @@ import type {
   ApprovalItem,
   ApprovalRequestPayload,
   RequestHistoryEntry,
+  ResponseHistoryEntry,
   TaskItem,
   TaskStepItem,
   TaskStepListSummary,
@@ -86,6 +87,51 @@ export const traceFixtures: TraceItem[] = [
     eventSource: "fixture",
   },
   {
+    id: "trace-response-101",
+    kind: "response.generate",
+    status: "completed",
+    title: "Assistant response review",
+    summary:
+      "The assistant response used the compiled thread context and returned a bounded reply with persisted trace metadata.",
+    eventCount: 2,
+    createdAt: "2026-03-17T08:45:04Z",
+    source: "response_generation_v0",
+    scope: "Thread magnesium response",
+    related: {
+      threadId: "thread-magnesium",
+      compilerVersion: "response_generation_v0",
+    },
+    metadata: [
+      "Trace: trace-response-101",
+      "Thread: thread-magnesium",
+      "Linked compile trace: trace-ctx-401",
+      "Compiler: response_generation_v0",
+      "Status: completed",
+    ],
+    evidence: [
+      "Prompt assembly stayed inside the shipped no-tools response path.",
+      "Assistant output was persisted as an immutable continuity event.",
+    ],
+    events: [
+      {
+        id: "event-10",
+        kind: "response.prompt.assembled",
+        title: "Prompt assembled",
+        detail: "System, developer, context, and conversation sections were combined into one response prompt.",
+        facts: ["Sequence 1", "Linked compile trace: trace-ctx-401"],
+      },
+      {
+        id: "event-11",
+        kind: "response.model.completed",
+        title: "Model completed",
+        detail: "The assistant returned a natural-language summary without invoking tools or hidden routing.",
+        facts: ["Sequence 2", "Provider: openai_responses"],
+      },
+    ],
+    detailSource: "fixture",
+    eventSource: "fixture",
+  },
+  {
     id: "trace-approval-101",
     kind: "approval.request",
     status: "requires_review",
@@ -136,6 +182,51 @@ export const traceFixtures: TraceItem[] = [
         title: "Task updated",
         detail: "Task lifecycle moved into a pending approval state while retaining request provenance.",
         facts: ["Sequence 3", "Captured at Mar 17, 06:50"],
+      },
+    ],
+    detailSource: "fixture",
+    eventSource: "fixture",
+  },
+  {
+    id: "trace-response-100",
+    kind: "response.generate",
+    status: "completed",
+    title: "Assistant response review",
+    summary:
+      "The assistant summarized the last governed Vitamin D action and kept the linked response trace readable for operator review.",
+    eventCount: 2,
+    createdAt: "2026-03-16T14:32:00Z",
+    source: "response_generation_v0",
+    scope: "Thread vitamin D response",
+    related: {
+      threadId: "thread-vitamin-d",
+      compilerVersion: "response_generation_v0",
+    },
+    metadata: [
+      "Trace: trace-response-100",
+      "Thread: thread-vitamin-d",
+      "Linked compile trace: trace-ctx-401",
+      "Compiler: response_generation_v0",
+      "Status: completed",
+    ],
+    evidence: [
+      "The response referenced prior approval and execution state already stored on the thread.",
+      "Trace review remains separated from governed execution controls.",
+    ],
+    events: [
+      {
+        id: "event-12",
+        kind: "response.prompt.assembled",
+        title: "Prompt assembled",
+        detail: "Conversation history and prior execution state were assembled into a bounded response prompt.",
+        facts: ["Sequence 1", "Linked compile trace: trace-ctx-401"],
+      },
+      {
+        id: "event-13",
+        kind: "response.model.completed",
+        title: "Model completed",
+        detail: "The assistant returned an answer that pointed the operator back to task and trace review instead of acting.",
+        facts: ["Sequence 2", "Provider: openai_responses"],
       },
     ],
     detailSource: "fixture",
@@ -269,6 +360,51 @@ export const requestHistoryFixtures: RequestHistoryEntry[] = [
       routingTraceEventCount: 3,
       requestTraceId: "66666666-6666-4666-8666-666666666667",
       requestTraceEventCount: 6,
+    },
+  },
+];
+
+export const responseHistoryFixtures: ResponseHistoryEntry[] = [
+  {
+    id: "trace-response-101",
+    submittedAt: "2026-03-17T08:45:00Z",
+    source: "fixture",
+    threadId: THREAD_MAGNESIUM,
+    message: "Summarize my current magnesium supplement context before I decide whether to reorder.",
+    assistantText:
+      "You previously reordered Thorne Magnesium Bisglycinate and the latest governed request is still waiting on approval. The current thread context also reflects a preference for keeping merchant and package size explicit before any purchase action.",
+    assistantEventId: "assistant-event-101",
+    assistantSequenceNo: 14,
+    modelProvider: "openai_responses",
+    model: "gpt-5-mini",
+    summary:
+      "Fixture mode shows the assistant-response layout and linked traces without persisting continuity events to the backend.",
+    trace: {
+      compileTraceId: "trace-ctx-401",
+      compileTraceEventCount: 3,
+      responseTraceId: "trace-response-101",
+      responseTraceEventCount: 2,
+    },
+  },
+  {
+    id: "trace-response-100",
+    submittedAt: "2026-03-16T14:32:00Z",
+    source: "fixture",
+    threadId: THREAD_VITAMIN_D,
+    message: "What do I need to know about the last Vitamin D request?",
+    assistantText:
+      "The prior Vitamin D3 + K2 request already moved through approval and execution. The trace history shows the approval was resolved before the proxy handler completed, so the remaining question is whether you want to open the task or execution review for detail.",
+    assistantEventId: "assistant-event-100",
+    assistantSequenceNo: 11,
+    modelProvider: "openai_responses",
+    model: "gpt-5-mini",
+    summary:
+      "Response history stays bounded with the operator prompt, assistant answer, and both compile and response trace references visible.",
+    trace: {
+      compileTraceId: "trace-ctx-401",
+      compileTraceEventCount: 3,
+      responseTraceId: "trace-response-100",
+      responseTraceEventCount: 2,
     },
   },
 ];
@@ -614,6 +750,34 @@ export function buildFixtureRequestEntry(payload: ApprovalRequestPayload): Reque
       routingTraceEventCount: 3,
       requestTraceId: `fixture-trace-${nonce}`,
       requestTraceEventCount: 6,
+    },
+  };
+}
+
+export function buildFixtureResponseEntry(
+  payload: Pick<ResponseHistoryEntry, "threadId" | "message">,
+): ResponseHistoryEntry {
+  const nonce = Date.now().toString(36);
+
+  return {
+    id: `fixture-response-${nonce}`,
+    submittedAt: new Date().toISOString(),
+    source: "fixture",
+    threadId: payload.threadId,
+    message: payload.message,
+    assistantText:
+      "Fixture mode generated a preview response only. Add live API configuration to persist the operator message, assistant reply, and linked continuity traces.",
+    assistantEventId: `fixture-assistant-${nonce}`,
+    assistantSequenceNo: 0,
+    modelProvider: "openai_responses",
+    model: "fixture-preview",
+    summary:
+      "The preview keeps the assistant-response seam explicit without inventing stored backend history.",
+    trace: {
+      compileTraceId: `fixture-compile-${nonce}`,
+      compileTraceEventCount: 3,
+      responseTraceId: `fixture-response-trace-${nonce}`,
+      responseTraceEventCount: 2,
     },
   };
 }


### PR DESCRIPTION
## Summary
- turn /chat into a dual-mode operator surface with assistant-response mode and retained governed-request mode
- add bounded response history, explicit mode switching, and fixture fallback when API configuration is absent
- keep the sprint inside the shipped /v0/responses and /v0/approvals/requests seams with no broader scope expansion

## Verification
- npm run lint in apps/web: PASS
- npm test in apps/web: PASS
- npm run build in apps/web: PASS

## Notes
- the sprint stayed within the intended /chat UI scope over the shipped /v0/responses and /v0/approvals/requests seams
- no backend, Gmail, Calendar, auth, runner, or broader scope expansion entered the sprint