### PR TITLE
Sprint 6I: chat thread selection and continuity review UI

### DIFF
--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -2,7 +2,38 @@
 
 ## sprint objective
 
-Implement Sprint 6H by exposing narrow user-scoped continuity APIs over the shipped continuity store:
+Implement Sprint 6I by extending `/chat` with visible thread selection, compact thread creation, and bounded continuity review using only the shipped continuity APIs, while preserving the existing assistant-response and governed-request seams.
+
+## exact `/chat` files and components updated
+
+- `apps/web/app/chat/page.tsx`
+- `apps/web/app/chat/page.test.tsx`
+- `apps/web/app/globals.css`
+- `apps/web/components/mode-toggle.tsx`
+- `apps/web/components/request-composer.tsx`
+- `apps/web/components/request-composer.test.tsx`
+- `apps/web/components/response-composer.tsx`
+- `apps/web/components/response-composer.test.tsx`
+- `apps/web/components/thread-list.tsx`
+- `apps/web/components/thread-list.test.tsx`
+- `apps/web/components/thread-create.tsx`
+- `apps/web/components/thread-create.test.tsx`
+- `apps/web/components/thread-summary.tsx`
+- `apps/web/components/thread-summary.test.tsx`
+- `apps/web/components/thread-event-list.tsx`
+- `apps/web/components/thread-event-list.test.tsx`
+- `apps/web/lib/api.ts`
+- `apps/web/lib/api.test.ts`
+- `apps/web/lib/fixtures.ts`
+- `BUILD_REPORT.md`
+
+## continuity data mode
+
+- live API-backed when the web API base URL and user ID are configured
+- fixture-backed for thread selection, thread summary, continuity review, and history when API configuration is absent
+- explicit unavailable state for thread creation when API configuration is absent
+
+## shipped backend continuity endpoints consumed
 
 - `POST /v0/threads`
 - `GET /v0/threads`
@@ -10,208 +41,61 @@ Implement Sprint 6H by exposing narrow user-scoped continuity APIs over the ship
 - `GET /v0/threads/{thread_id}/sessions`
 - `GET /v0/threads/{thread_id}/events`
 
-The work stays inside backend continuity scope and does not widen response generation, task orchestration, Gmail, or UI behavior.
+## additional existing seams preserved
 
-## completed work
+- `POST /v0/responses`
+- `POST /v0/approvals/requests`
 
-- added continuity response contracts and ordering metadata in `apps/api/src/alicebot_api/contracts.py`
-- introduced `ThreadCreateInput`
-- introduced `ThreadRecord`
-- introduced `ThreadCreateResponse`
-- introduced `ThreadListSummary`
-- introduced `ThreadListResponse`
-- introduced `ThreadDetailResponse`
-- introduced `ThreadSessionRecord`
-- introduced `ThreadSessionListSummary`
-- introduced `ThreadSessionListResponse`
-- introduced `ThreadEventRecord`
-- introduced `ThreadEventListSummary`
-- introduced `ThreadEventListResponse`
-- introduced continuity ordering constants:
-  - `THREAD_LIST_ORDER`
-  - `THREAD_SESSION_LIST_ORDER`
-  - `THREAD_EVENT_LIST_ORDER`
-- added deterministic thread listing support in `apps/api/src/alicebot_api/store.py` with `list_threads()`
-- implemented the five scoped continuity endpoints in `apps/api/src/alicebot_api/main.py`
-- kept continuity reads user-scoped by reusing the existing RLS-backed `ContinuityStore`
-- added unit coverage for create/list/detail/session/event response shape, ordering, and invisible-thread handling
-- added Postgres-backed integration coverage for create/list/detail/session/event behavior and cross-user isolation
-- added a migration guard asserting the shipped thread created-time index remains present for deterministic continuity review queries
+## completed UI work
 
-## exact ordering rules
+- replaced the raw manual thread-ID-first assistant flow with a selected-thread-driven `/chat` surface
+- added a bounded right-rail continuity stack:
+  - visible thread list
+  - compact thread-create card
+  - selected-thread identity summary
+  - bounded recent continuity review for sessions and events
+- updated assistant mode to submit against the selected thread instead of a typed UUID field
+- updated governed mode to reuse the selected thread explicitly while keeping tool/action/scope controls unchanged
+- preserved thread continuity across mode switches by carrying the selected thread in the route query
+- added fixture continuity data so fallback states remain explicit and readable when the live API is not configured
+- tightened spacing, containment, overflow handling, and responsive stacking for long IDs, pills, and continuity cards
 
-- thread list order: `created_at DESC`, then `id DESC`
-- thread session list order: `started_at ASC`, then `created_at ASC`, then `id ASC`
-- thread event list order: `sequence_no ASC`
+## exact commands run
 
-## incomplete work
+- `cd apps/web && npm run lint`
+- `cd apps/web && npm test`
+- `cd apps/web && npm run build`
 
-- no in-scope code deliverables remain incomplete
-- intentionally not added:
-  - thread rename
-  - thread archive
-  - session mutation APIs
-  - event mutation or deletion behavior
-  - thread search, pagination, or filtering
-  - `/chat` UI thread selection or thread creation UX
+## verification results
 
-## files changed
+- `npm run lint`: PASS
+- `npm test`: PASS (`40` tests)
+- `npm run build`: PASS
 
-- `ARCHITECTURE.md`
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/store.py`
-- `apps/api/src/alicebot_api/main.py`
-- `tests/unit/test_20260310_0001_foundation_continuity.py`
-- `tests/unit/test_events.py`
-- `tests/integration/test_continuity_api.py`
-- `BUILD_REPORT.md`
+## concise desktop visual verification notes
 
-## tests run
+- `/chat` now reads with a clearer hierarchy: composer/history on the left, continuity selection/review on the right
+- selected thread identity is repeated in a controlled way at the page header, composer, and summary card so context stays explicit without relying on a raw UUID input
+- long thread IDs and metadata pills wrap inside their containers instead of leaking outside cards
+- continuity review remains bounded and readable rather than becoming a transcript-style event dump
 
-- `./.venv/bin/python -m pytest tests/unit/test_events.py tests/unit/test_20260310_0001_foundation_continuity.py tests/integration/test_continuity_api.py`
-  - result: partial pass, then blocked by sandbox-local Postgres access for integration setup
-- `./.venv/bin/python -m pytest tests/unit/test_main.py -q`
-  - result: PASS (`41` passed)
-- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py`
-  - result: PASS (`2` passed)
-- `./.venv/bin/python -m pytest tests/unit`
-  - result: PASS (`454` passed)
-- `./.venv/bin/python -m pytest tests/integration`
-  - result: PASS (`145` passed)
+## concise mobile visual verification notes
 
-## example thread create response
+- the wide layout collapses to one column at the existing responsive breakpoints
+- thread review subpanels collapse from two columns to one column on small screens
+- composer actions and secondary buttons expand to full width on mobile to avoid cramped wrapping
+- selected-thread banners and summary toplines stack cleanly instead of forcing horizontal overflow
 
-```json
-{
-  "thread": {
-    "id": "30000000-0000-4000-8000-000000000003",
-    "title": "Gamma thread",
-    "created_at": "2026-03-17T10:00:00+00:00",
-    "updated_at": "2026-03-17T10:00:00+00:00"
-  }
-}
-```
+## blockers or issues
 
-## example thread list response
-
-```json
-{
-  "items": [
-    {
-      "id": "30000000-0000-4000-8000-000000000003",
-      "title": "Gamma thread",
-      "created_at": "2026-03-17T10:00:00+00:00",
-      "updated_at": "2026-03-17T10:00:00+00:00"
-    },
-    {
-      "id": "00000000-0000-4000-8000-000000000002",
-      "title": "Beta thread",
-      "created_at": "2026-03-17T09:00:00+00:00",
-      "updated_at": "2026-03-17T09:00:00+00:00"
-    },
-    {
-      "id": "00000000-0000-4000-8000-000000000001",
-      "title": "Alpha thread",
-      "created_at": "2026-03-17T09:00:00+00:00",
-      "updated_at": "2026-03-17T09:00:00+00:00"
-    }
-  ],
-  "summary": {
-    "total_count": 3,
-    "order": ["created_at_desc", "id_desc"]
-  }
-}
-```
-
-## example thread detail response
-
-```json
-{
-  "thread": {
-    "id": "00000000-0000-4000-8000-000000000002",
-    "title": "Beta thread",
-    "created_at": "2026-03-17T09:00:00+00:00",
-    "updated_at": "2026-03-17T09:00:00+00:00"
-  }
-}
-```
-
-## example thread-session list response
-
-```json
-{
-  "items": [
-    {
-      "id": "10000000-0000-4000-8000-000000000001",
-      "thread_id": "00000000-0000-4000-8000-000000000002",
-      "status": "completed",
-      "started_at": "2026-03-17T09:00:00+00:00",
-      "ended_at": "2026-03-17T09:05:00+00:00",
-      "created_at": "2026-03-17T09:00:00+00:00"
-    },
-    {
-      "id": "10000000-0000-4000-8000-000000000002",
-      "thread_id": "00000000-0000-4000-8000-000000000002",
-      "status": "active",
-      "started_at": "2026-03-17T10:00:00+00:00",
-      "ended_at": null,
-      "created_at": "2026-03-17T10:00:00+00:00"
-    }
-  ],
-  "summary": {
-    "thread_id": "00000000-0000-4000-8000-000000000002",
-    "total_count": 2,
-    "order": ["started_at_asc", "created_at_asc", "id_asc"]
-  }
-}
-```
-
-## example thread-event list response
-
-```json
-{
-  "items": [
-    {
-      "id": "20000000-0000-4000-8000-000000000002",
-      "thread_id": "00000000-0000-4000-8000-000000000002",
-      "session_id": "10000000-0000-4000-8000-000000000002",
-      "sequence_no": 1,
-      "kind": "message.user",
-      "payload": {"text": "Hello"},
-      "created_at": "2026-03-17T10:00:00+00:00"
-    },
-    {
-      "id": "20000000-0000-4000-8000-000000000001",
-      "thread_id": "00000000-0000-4000-8000-000000000002",
-      "session_id": "10000000-0000-4000-8000-000000000002",
-      "sequence_no": 2,
-      "kind": "message.assistant",
-      "payload": {"text": "Hello back"},
-      "created_at": "2026-03-17T10:01:00+00:00"
-    }
-  ],
-  "summary": {
-    "thread_id": "00000000-0000-4000-8000-000000000002",
-    "total_count": 2,
-    "order": ["sequence_no_asc"]
-  }
-}
-```
-
-## blockers/issues
-
-- no remaining code blockers inside sprint scope
-- local sandbox execution initially blocked localhost Postgres access for integration setup; rerunning the Postgres-backed suite with unrestricted execution resolved verification
-- `ARCHITECTURE.md` was updated after review so the documented runtime/API inventory matches the shipped `/v0/threads*` continuity surface
-
-## recommended next step
-
-Use these continuity endpoints in a follow-up `/chat` sprint so the operator can create a thread, browse visible threads, and load thread history without typing raw thread ids manually.
+- no remaining blockers inside sprint scope
+- no screenshot automation or browser capture was run during this pass; visual notes are based on the implemented layout, CSS breakpoints, and successful web build/test verification
 
 ## intentionally deferred after this sprint
 
-- all UI work for thread selection, thread creation, and session history presentation
-- any new session write endpoint
-- any event rewrite, delete, or archive behavior
-- any broader chat orchestration changes
-- any Gmail, Calendar, auth, approval, task, execution, or runner scope expansion
+- thread rename, archive, search, filter, and pagination
+- full transcript tooling or unbounded event review
+- thread-event mutation UI
+- new backend continuity endpoints
+- unrelated route redesigns
+- Gmail, Calendar, auth, runner, connector, task-orchestration, or broader workflow scope expansion

--- a/apps/web/app/chat/page.test.tsx
+++ b/apps/web/app/chat/page.test.tsx
@@ -4,9 +4,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ChatPage from "./page";
 
-const { getApiConfigMock, hasLiveApiConfigMock } = vi.hoisted(() => ({
+const {
+  getApiConfigMock,
+  getThreadDetailMock,
+  getThreadEventsMock,
+  getThreadSessionsMock,
+  hasLiveApiConfigMock,
+  listThreadsMock,
+} = vi.hoisted(() => ({
   getApiConfigMock: vi.fn(),
+  getThreadDetailMock: vi.fn(),
+  getThreadEventsMock: vi.fn(),
+  getThreadSessionsMock: vi.fn(),
   hasLiveApiConfigMock: vi.fn(),
+  listThreadsMock: vi.fn(),
 }));
 
 vi.mock("next/link", () => ({
@@ -27,19 +38,34 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
 vi.mock("../../lib/api", async () => {
   const actual = await vi.importActual("../../lib/api");
   return {
     ...actual,
     getApiConfig: getApiConfigMock,
+    getThreadDetail: getThreadDetailMock,
+    getThreadEvents: getThreadEventsMock,
+    getThreadSessions: getThreadSessionsMock,
     hasLiveApiConfig: hasLiveApiConfigMock,
+    listThreads: listThreadsMock,
   };
 });
 
 describe("ChatPage", () => {
   beforeEach(() => {
     getApiConfigMock.mockReset();
+    getThreadDetailMock.mockReset();
+    getThreadEventsMock.mockReset();
+    getThreadSessionsMock.mockReset();
     hasLiveApiConfigMock.mockReset();
+    listThreadsMock.mockReset();
   });
 
   afterEach(() => {
@@ -54,10 +80,38 @@ describe("ChatPage", () => {
       defaultToolId: "tool-1",
     });
     hasLiveApiConfigMock.mockReturnValue(true);
+    listThreadsMock.mockResolvedValue({
+      items: [
+        {
+          id: "thread-1",
+          title: "Gamma thread",
+          created_at: "2026-03-17T10:00:00Z",
+          updated_at: "2026-03-17T10:00:00Z",
+        },
+      ],
+      summary: { total_count: 1, order: ["created_at_desc", "id_desc"] },
+    });
+    getThreadDetailMock.mockResolvedValue({
+      thread: {
+        id: "thread-1",
+        title: "Gamma thread",
+        created_at: "2026-03-17T10:00:00Z",
+        updated_at: "2026-03-17T10:00:00Z",
+      },
+    });
+    getThreadSessionsMock.mockResolvedValue({
+      items: [],
+      summary: { thread_id: "thread-1", total_count: 0, order: [] },
+    });
+    getThreadEventsMock.mockResolvedValue({
+      items: [],
+      summary: { thread_id: "thread-1", total_count: 0, order: [] },
+    });
 
     render(await ChatPage({ searchParams: Promise.resolve({}) }));
 
-    expect(screen.getByText("Live submission enabled")).toBeInTheDocument();
+    expect(screen.getByText("Live continuity enabled")).toBeInTheDocument();
+    expect(screen.getByText("Selected: Gamma thread")).toBeInTheDocument();
     expect(screen.getByText("No assistant replies yet")).toBeInTheDocument();
     expect(screen.queryByText("Fixture response preview")).not.toBeInTheDocument();
     expect(screen.queryByText(/What do I need to know about the last Vitamin D request/i)).not.toBeInTheDocument();
@@ -71,6 +125,33 @@ describe("ChatPage", () => {
       defaultToolId: "tool-1",
     });
     hasLiveApiConfigMock.mockReturnValue(true);
+    listThreadsMock.mockResolvedValue({
+      items: [
+        {
+          id: "thread-1",
+          title: "Gamma thread",
+          created_at: "2026-03-17T10:00:00Z",
+          updated_at: "2026-03-17T10:00:00Z",
+        },
+      ],
+      summary: { total_count: 1, order: ["created_at_desc", "id_desc"] },
+    });
+    getThreadDetailMock.mockResolvedValue({
+      thread: {
+        id: "thread-1",
+        title: "Gamma thread",
+        created_at: "2026-03-17T10:00:00Z",
+        updated_at: "2026-03-17T10:00:00Z",
+      },
+    });
+    getThreadSessionsMock.mockResolvedValue({
+      items: [],
+      summary: { thread_id: "thread-1", total_count: 0, order: [] },
+    });
+    getThreadEventsMock.mockResolvedValue({
+      items: [],
+      summary: { thread_id: "thread-1", total_count: 0, order: [] },
+    });
 
     render(
       await ChatPage({
@@ -80,9 +161,44 @@ describe("ChatPage", () => {
       }),
     );
 
-    expect(screen.getByText("Live submission enabled")).toBeInTheDocument();
+    expect(screen.getByText("Live continuity enabled")).toBeInTheDocument();
     expect(screen.getByText("No governed requests yet")).toBeInTheDocument();
     expect(screen.queryByText("Fixture preview")).not.toBeInTheDocument();
     expect(screen.queryByText(/place_order \/ supplements/i)).not.toBeInTheDocument();
+  });
+
+  it("shows an unavailable continuity status when live continuity reads fail", async () => {
+    getApiConfigMock.mockReturnValue({
+      apiBaseUrl: "https://api.example.com",
+      userId: "user-1",
+      defaultThreadId: "thread-1",
+      defaultToolId: "tool-1",
+    });
+    hasLiveApiConfigMock.mockReturnValue(true);
+    listThreadsMock.mockResolvedValue({
+      items: [
+        {
+          id: "thread-1",
+          title: "Gamma thread",
+          created_at: "2026-03-17T10:00:00Z",
+          updated_at: "2026-03-17T10:00:00Z",
+        },
+      ],
+      summary: { total_count: 1, order: ["created_at_desc", "id_desc"] },
+    });
+    getThreadDetailMock.mockRejectedValue(new Error("detail failed"));
+    getThreadSessionsMock.mockResolvedValue({
+      items: [],
+      summary: { thread_id: "thread-1", total_count: 0, order: [] },
+    });
+    getThreadEventsMock.mockResolvedValue({
+      items: [],
+      summary: { thread_id: "thread-1", total_count: 0, order: [] },
+    });
+
+    render(await ChatPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText("Continuity unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Summary unavailable")).toBeInTheDocument();
   });
 });

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -2,12 +2,43 @@ import { ModeToggle, type ChatMode } from "../../components/mode-toggle";
 import { PageHeader } from "../../components/page-header";
 import { RequestComposer } from "../../components/request-composer";
 import { ResponseComposer } from "../../components/response-composer";
-import { SectionCard } from "../../components/section-card";
-import { getApiConfig, hasLiveApiConfig } from "../../lib/api";
-import { requestHistoryFixtures, responseHistoryFixtures } from "../../lib/fixtures";
+import { ThreadCreate } from "../../components/thread-create";
+import { ThreadEventList } from "../../components/thread-event-list";
+import { ThreadList } from "../../components/thread-list";
+import { ThreadSummary } from "../../components/thread-summary";
+import type { ThreadEventItem, ThreadItem, ThreadSessionItem } from "../../lib/api";
+import {
+  getApiConfig,
+  getThreadDetail,
+  getThreadEvents,
+  getThreadSessions,
+  hasLiveApiConfig,
+  listThreads,
+} from "../../lib/api";
+import {
+  getFixtureThread,
+  getFixtureThreadEvents,
+  getFixtureThreadSessions,
+  requestHistoryFixtures,
+  responseHistoryFixtures,
+  threadFixtures,
+} from "../../lib/fixtures";
 
 type ChatPageProps = {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+type ContinuitySource = "live" | "fixture" | "unavailable";
+
+type ContinuityViewModel = {
+  threadListSource: ContinuitySource;
+  continuitySource: ContinuitySource;
+  unavailableReason?: string;
+  threads: ThreadItem[];
+  selectedThreadId: string;
+  selectedThread: ThreadItem | null;
+  sessions: ThreadSessionItem[];
+  events: ThreadEventItem[];
 };
 
 function normalizeMode(value: string | string[] | undefined): ChatMode {
@@ -18,11 +49,135 @@ function normalizeMode(value: string | string[] | undefined): ChatMode {
   return value === "request" ? "request" : "assistant";
 }
 
+function normalizeThreadId(value: string | string[] | undefined) {
+  if (Array.isArray(value)) {
+    return normalizeThreadId(value[0]);
+  }
+
+  return value?.trim() ?? "";
+}
+
+function resolveSelectedThreadId(
+  requestedThreadId: string,
+  defaultThreadId: string,
+  threads: ThreadItem[],
+) {
+  const availableIds = new Set(threads.map((thread) => thread.id));
+
+  if (requestedThreadId && availableIds.has(requestedThreadId)) {
+    return requestedThreadId;
+  }
+
+  if (defaultThreadId && availableIds.has(defaultThreadId)) {
+    return defaultThreadId;
+  }
+
+  return threads[0]?.id ?? "";
+}
+
+async function loadFixtureContinuity(
+  requestedThreadId: string,
+  defaultThreadId: string,
+): Promise<ContinuityViewModel> {
+  const selectedThreadId = resolveSelectedThreadId(requestedThreadId, defaultThreadId, threadFixtures);
+
+  return {
+    threadListSource: "fixture",
+    continuitySource: "fixture",
+    threads: threadFixtures,
+    selectedThreadId,
+    selectedThread: selectedThreadId ? getFixtureThread(selectedThreadId) : null,
+    sessions: selectedThreadId ? getFixtureThreadSessions(selectedThreadId) : [],
+    events: selectedThreadId ? getFixtureThreadEvents(selectedThreadId) : [],
+  };
+}
+
+async function loadLiveContinuity(
+  apiBaseUrl: string,
+  userId: string,
+  requestedThreadId: string,
+  defaultThreadId: string,
+): Promise<ContinuityViewModel> {
+  try {
+    const threadResponse = await listThreads(apiBaseUrl, userId);
+    const threads = threadResponse.items;
+    const selectedThreadId = resolveSelectedThreadId(requestedThreadId, defaultThreadId, threads);
+
+    if (!selectedThreadId) {
+      return {
+        threadListSource: "live",
+        continuitySource: "live",
+        threads,
+        selectedThreadId: "",
+        selectedThread: null,
+        sessions: [],
+        events: [],
+      };
+    }
+
+    const [threadResult, sessionsResult, eventsResult] = await Promise.allSettled([
+      getThreadDetail(apiBaseUrl, selectedThreadId, userId),
+      getThreadSessions(apiBaseUrl, selectedThreadId, userId),
+      getThreadEvents(apiBaseUrl, selectedThreadId, userId),
+    ]);
+
+    const unavailableReason =
+      threadResult.status === "rejected"
+        ? threadResult.reason instanceof Error
+          ? threadResult.reason.message
+          : "Thread detail failed to load."
+        : sessionsResult.status === "rejected"
+          ? sessionsResult.reason instanceof Error
+            ? sessionsResult.reason.message
+            : "Thread sessions failed to load."
+          : eventsResult.status === "rejected"
+            ? eventsResult.reason instanceof Error
+              ? eventsResult.reason.message
+              : "Thread events failed to load."
+            : undefined;
+
+    return {
+      threadListSource: "live",
+      continuitySource: unavailableReason ? "unavailable" : "live",
+      unavailableReason,
+      threads,
+      selectedThreadId,
+      selectedThread:
+        threadResult.status === "fulfilled"
+          ? threadResult.value.thread
+          : threads.find((thread) => thread.id === selectedThreadId) ?? null,
+      sessions: sessionsResult.status === "fulfilled" ? sessionsResult.value.items : [],
+      events: eventsResult.status === "fulfilled" ? eventsResult.value.items : [],
+    };
+  } catch (error) {
+    return {
+      threadListSource: "unavailable",
+      continuitySource: "unavailable",
+      unavailableReason: error instanceof Error ? error.message : "Thread continuity failed to load.",
+      threads: [],
+      selectedThreadId: "",
+      selectedThread: null,
+      sessions: [],
+      events: [],
+    };
+  }
+}
+
 export default async function ChatPage({ searchParams }: ChatPageProps) {
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
   const mode = normalizeMode(resolvedSearchParams?.mode);
+  const requestedThreadId = normalizeThreadId(resolvedSearchParams?.thread);
   const apiConfig = getApiConfig();
   const liveModeReady = hasLiveApiConfig(apiConfig);
+  const continuity = liveModeReady
+    ? await loadLiveContinuity(
+        apiConfig.apiBaseUrl,
+        apiConfig.userId,
+        requestedThreadId,
+        apiConfig.defaultThreadId,
+      )
+    : await loadFixtureContinuity(requestedThreadId, apiConfig.defaultThreadId);
+
   const initialResponseEntries = liveModeReady ? [] : responseHistoryFixtures;
   const initialRequestEntries = liveModeReady ? [] : requestHistoryFixtures;
 
@@ -31,16 +186,26 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
       <PageHeader
         eyebrow="Operator conversation surface"
         title="Chat with the assistant or route a governed request"
-        description="Normal conversation and approval-gated actions now share one calm shell, but the two behaviors stay visibly separate so consequential work never hides inside a chat transcript."
+        description="Normal conversation and approval-gated actions now share one calm shell. Thread identity stays explicit, bounded, and visible so continuity never depends on a raw UUID field."
         meta={
           <div className="header-meta">
-            <span className="subtle-chip">{liveModeReady ? "Live submission enabled" : "Fixture preview mode"}</span>
-            <span className="subtle-chip">Responses and approvals stay explicit</span>
+            <span className="subtle-chip">
+              {continuity.continuitySource === "unavailable"
+                ? "Continuity unavailable"
+                : liveModeReady
+                  ? "Live continuity enabled"
+                  : "Fixture continuity preview"}
+            </span>
+            <span className="subtle-chip">
+              {continuity.selectedThread
+                ? `Selected: ${continuity.selectedThread.title}`
+                : "Select or create a thread"}
+            </span>
           </div>
         }
       />
 
-      <ModeToggle currentMode={mode} />
+      <ModeToggle currentMode={mode} selectedThreadId={continuity.selectedThreadId} />
 
       <div className="content-grid content-grid--wide">
         {mode === "assistant" ? (
@@ -48,92 +213,50 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
             initialEntries={initialResponseEntries}
             apiBaseUrl={apiConfig.apiBaseUrl}
             userId={apiConfig.userId}
-            defaultThreadId={apiConfig.defaultThreadId}
+            selectedThreadId={continuity.selectedThreadId}
+            selectedThreadTitle={continuity.selectedThread?.title}
           />
         ) : (
-          <RequestComposer initialEntries={initialRequestEntries} {...apiConfig} />
+          <RequestComposer
+            initialEntries={initialRequestEntries}
+            apiBaseUrl={apiConfig.apiBaseUrl}
+            userId={apiConfig.userId}
+            selectedThreadId={continuity.selectedThreadId}
+            selectedThreadTitle={continuity.selectedThread?.title}
+            defaultToolId={apiConfig.defaultToolId}
+          />
         )}
 
         <div className="stack">
-          {mode === "assistant" ? (
-            <>
-              <SectionCard
-                eyebrow="Assistant mode"
-                title="Normal conversation first"
-                description="This mode stays for analysis, summaries, and question answering without implying approval-gated execution."
-              >
-                <ul className="bullet-list">
-                  <li>Questions are submitted directly to `POST /v0/responses` with only the shipped user, thread, and message fields.</li>
-                  <li>The operator still provides thread identity explicitly instead of relying on hidden routing or auto-selected context.</li>
-                  <li>Each reply keeps compile and response trace summaries attached so explainability remains one click away.</li>
-                </ul>
-              </SectionCard>
+          <ThreadList
+            threads={continuity.threads}
+            selectedThreadId={continuity.selectedThreadId}
+            currentMode={mode}
+            source={continuity.threadListSource}
+            unavailableReason={continuity.unavailableReason}
+          />
 
-              <SectionCard
-                eyebrow="Mode boundary"
-                title="What stays out of assistant mode"
-                description="Consequential work remains visibly separated from normal conversation to preserve trust and reviewability."
-              >
-                <dl className="key-value-grid">
-                  <div>
-                    <dt>Assistant mode</dt>
-                    <dd>Answer questions, summarize state, and explain prior work without submitting an approval request.</dd>
-                  </div>
-                  <div>
-                    <dt>Governed mode</dt>
-                    <dd>Submit action-oriented payloads that can create approval and task records through the shipped request seam.</dd>
-                  </div>
-                  <div>
-                    <dt>Fallback</dt>
-                    <dd>Fixture previews stay explicit when live API configuration is absent instead of failing silently.</dd>
-                  </div>
-                  <div>
-                    <dt>Trace review</dt>
-                    <dd>Compile and response trace IDs remain linked from each reply so the operator can inspect why the answer was produced.</dd>
-                  </div>
-                </dl>
-              </SectionCard>
-            </>
-          ) : (
-            <>
-              <SectionCard
-                eyebrow="Governed mode"
-                title="Consequential actions remain reviewable"
-                description="The request surface keeps operational intent explicit and bounded instead of blurring it into casual conversation."
-              >
-                <ul className="bullet-list">
-                  <li>Requests are submitted directly to `POST /v0/approvals/requests` using shipped payload fields only.</li>
-                  <li>The operator supplies thread and tool identifiers explicitly instead of relying on hidden web-side routing.</li>
-                  <li>Every resulting summary keeps decision, approval linkage, task status, and trace references visible.</li>
-                </ul>
-              </SectionCard>
+          <ThreadCreate
+            apiBaseUrl={liveModeReady ? apiConfig.apiBaseUrl : undefined}
+            userId={liveModeReady ? apiConfig.userId : undefined}
+            currentMode={mode}
+          />
 
-              <SectionCard
-                eyebrow="Request schema"
-                title="Submission fields"
-                description="The governed path stays narrow on purpose so approvals and downstream task state remain deterministic."
-              >
-                <dl className="key-value-grid">
-                  <div>
-                    <dt>Required</dt>
-                    <dd>Thread ID, tool ID, action, scope</dd>
-                  </div>
-                  <div>
-                    <dt>Optional</dt>
-                    <dd>Domain hint, risk hint</dd>
-                  </div>
-                  <div>
-                    <dt>Attributes</dt>
-                    <dd>JSON object sent unchanged to the backend</dd>
-                  </div>
-                  <div>
-                    <dt>Fallback</dt>
-                    <dd>Fixture preview instead of broken live submission</dd>
-                  </div>
-                </dl>
-              </SectionCard>
-            </>
-          )}
+          <ThreadSummary
+            thread={continuity.selectedThread}
+            sessions={continuity.sessions}
+            events={continuity.events}
+            source={continuity.continuitySource}
+            unavailableReason={continuity.unavailableReason}
+          />
+
+          <ThreadEventList
+            threadTitle={continuity.selectedThread?.title}
+            sessions={continuity.sessions}
+            events={continuity.events}
+            source={continuity.continuitySource}
+            unavailableReason={continuity.unavailableReason}
+          />
         </div>
       </div>
     </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -279,12 +279,16 @@ code,
   gap: 24px;
 }
 
+.page-stack {
+  gap: 28px;
+}
+
 .page-header {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
   justify-content: space-between;
-  gap: 18px 24px;
+  gap: 20px 28px;
 }
 
 .page-header__copy {
@@ -347,8 +351,8 @@ code,
 
 .section-card {
   display: grid;
-  gap: 18px;
-  padding: 26px;
+  gap: 20px;
+  padding: 28px;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.5), rgba(255, 252, 248, 0.72)),
     var(--surface);
@@ -365,7 +369,7 @@ code,
 
 .section-card__header {
   display: grid;
-  gap: 10px;
+  gap: 12px;
 }
 
 .section-card__title {
@@ -566,8 +570,9 @@ code,
   border-radius: 14px;
   border: 1px solid transparent;
   font-weight: 600;
-  line-height: 1;
+  line-height: 1.2;
   text-align: center;
+  overflow-wrap: anywhere;
   transition:
     transform 140ms ease,
     background-color 140ms ease,
@@ -607,7 +612,7 @@ code,
 .composer-card {
   display: grid;
   gap: 22px;
-  padding: 26px;
+  padding: 28px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
@@ -647,10 +652,8 @@ code,
 }
 
 .governance-banner {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   gap: 10px;
-  align-items: center;
   padding: 14px 16px;
   background: rgba(39, 75, 99, 0.06);
   border: 1px solid rgba(39, 75, 99, 0.12);
@@ -675,8 +678,8 @@ code,
 
 .mode-toggle__item {
   display: grid;
-  gap: 8px;
-  padding: 18px 20px;
+  gap: 10px;
+  padding: 20px 22px;
   border-radius: 22px;
   border: 1px solid rgba(42, 52, 66, 0.08);
   background: rgba(255, 252, 248, 0.66);
@@ -714,7 +717,7 @@ code,
 
 .chat-workspace {
   display: grid;
-  gap: 24px;
+  gap: 22px;
   grid-template-columns: minmax(0, 1.04fr) minmax(340px, 0.92fr);
   align-items: stretch;
 }
@@ -747,11 +750,23 @@ code,
   border-radius: 18px;
   color: var(--text);
   resize: vertical;
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    background-color 140ms ease;
 }
 
 .form-field textarea {
   min-height: 168px;
   line-height: 1.6;
+}
+
+.form-field textarea:focus-visible,
+.form-field input:focus-visible {
+  outline: none;
+  border-color: rgba(39, 75, 99, 0.26);
+  box-shadow: 0 0 0 4px rgba(39, 75, 99, 0.08);
+  background: rgba(255, 255, 255, 0.9);
 }
 
 .field-hint {
@@ -800,6 +815,25 @@ code,
 .history-entry {
   display: grid;
   gap: 14px;
+}
+
+.selected-thread-panel,
+.thread-summary__topline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(42, 52, 66, 0.08);
+}
+
+.selected-thread-panel__copy {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
 }
 
 .history-entry__topline,
@@ -896,6 +930,10 @@ code,
   background: var(--accent-soft);
 }
 
+.list-row[aria-current="page"] {
+  box-shadow: inset 0 0 0 1px rgba(39, 75, 99, 0.08);
+}
+
 .list-row__title {
   margin: 0;
   font-size: 0.98rem;
@@ -943,6 +981,12 @@ code,
 .detail-grid {
   display: grid;
   gap: 20px;
+}
+
+.thread-review-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .detail-group {
@@ -1040,6 +1084,13 @@ code,
 }
 
 .detail-summary__label {
+  overflow-wrap: anywhere;
+}
+
+.thread-summary__id {
+  margin: 0;
+  color: var(--text-soft);
+  line-height: 1.65;
   overflow-wrap: anywhere;
 }
 
@@ -1212,6 +1263,8 @@ code,
   .shell-topbar__row,
   .page-header,
   .composer-actions,
+  .selected-thread-panel,
+  .thread-summary__topline,
   .list-panel__header,
   .history-entry__topline,
   .list-row__topline,
@@ -1232,6 +1285,10 @@ code,
   }
 
   .key-value-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .thread-review-grid {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/components/mode-toggle.tsx
+++ b/apps/web/components/mode-toggle.tsx
@@ -4,6 +4,7 @@ export type ChatMode = "assistant" | "request";
 
 type ModeToggleProps = {
   currentMode: ChatMode;
+  selectedThreadId?: string;
 };
 
 const MODE_ITEMS: Array<{
@@ -23,12 +24,23 @@ const MODE_ITEMS: Array<{
   },
 ];
 
-export function ModeToggle({ currentMode }: ModeToggleProps) {
+export function ModeToggle({ currentMode, selectedThreadId }: ModeToggleProps) {
   return (
     <nav className="mode-toggle" aria-label="Chat mode">
       {MODE_ITEMS.map((item) => {
         const isActive = item.mode === currentMode;
-        const href = item.mode === "assistant" ? "/chat" : `/chat?mode=${item.mode}`;
+        const params = new URLSearchParams();
+
+        if (item.mode === "request") {
+          params.set("mode", item.mode);
+        }
+
+        if (selectedThreadId) {
+          params.set("thread", selectedThreadId);
+        }
+
+        const query = params.toString();
+        const href = query ? `/chat?${query}` : "/chat";
 
         return (
           <Link

--- a/apps/web/components/request-composer.test.tsx
+++ b/apps/web/components/request-composer.test.tsx
@@ -1,0 +1,171 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RequestComposer } from "./request-composer";
+
+const { submitApprovalRequestMock } = vi.hoisted(() => ({
+  submitApprovalRequestMock: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual("../lib/api");
+  return {
+    ...actual,
+    submitApprovalRequest: submitApprovalRequestMock,
+  };
+});
+
+describe("RequestComposer", () => {
+  beforeEach(() => {
+    submitApprovalRequestMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("submits governed requests against the selected thread", async () => {
+    submitApprovalRequestMock.mockResolvedValue({
+      request: {
+        thread_id: "thread-1",
+        tool_id: "tool-1",
+        action: "place_order",
+        scope: "supplements",
+        domain_hint: "ecommerce",
+        risk_hint: "purchase",
+        attributes: {
+          merchant: "Thorne",
+          item: "Magnesium Bisglycinate",
+          quantity: "1",
+        },
+      },
+      decision: "approval_required",
+      tool: {
+        id: "tool-1",
+        tool_key: "merchant_proxy",
+        name: "Merchant Proxy",
+        description: "Proxy",
+        version: "0.1.0",
+        metadata_version: "tool_metadata_v0",
+        active: true,
+        tags: [],
+        action_hints: [],
+        scope_hints: [],
+        domain_hints: [],
+        risk_hints: [],
+        metadata: {},
+        created_at: "2026-03-17T00:00:00Z",
+      },
+      reasons: [],
+      task: {
+        id: "task-1",
+        thread_id: "thread-1",
+        tool_id: "tool-1",
+        status: "pending_approval",
+        request: {
+          thread_id: "thread-1",
+          tool_id: "tool-1",
+          action: "place_order",
+          scope: "supplements",
+          domain_hint: "ecommerce",
+          risk_hint: "purchase",
+          attributes: {
+            merchant: "Thorne",
+            item: "Magnesium Bisglycinate",
+            quantity: "1",
+          },
+        },
+        tool: {
+          id: "tool-1",
+          tool_key: "merchant_proxy",
+          name: "Merchant Proxy",
+          description: "Proxy",
+          version: "0.1.0",
+          metadata_version: "tool_metadata_v0",
+          active: true,
+          tags: [],
+          action_hints: [],
+          scope_hints: [],
+          domain_hints: [],
+          risk_hints: [],
+          metadata: {},
+          created_at: "2026-03-17T00:00:00Z",
+        },
+        latest_approval_id: "approval-1",
+        latest_execution_id: null,
+        created_at: "2026-03-17T00:00:00Z",
+        updated_at: "2026-03-17T00:00:00Z",
+      },
+      approval: null,
+      routing_trace: {
+        trace_id: "route-trace-1",
+        trace_event_count: 3,
+      },
+      trace: {
+        trace_id: "request-trace-1",
+        trace_event_count: 6,
+      },
+    });
+
+    render(
+      <RequestComposer
+        initialEntries={[]}
+        apiBaseUrl="https://api.example.com"
+        userId="user-1"
+        selectedThreadId="thread-1"
+        selectedThreadTitle="Gamma thread"
+        defaultToolId="tool-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit governed request" }));
+
+    await waitFor(() => {
+      expect(submitApprovalRequestMock).toHaveBeenCalledWith("https://api.example.com", {
+        user_id: "user-1",
+        thread_id: "thread-1",
+        tool_id: "tool-1",
+        action: "place_order",
+        scope: "supplements",
+        domain_hint: "ecommerce",
+        risk_hint: "purchase",
+        attributes: {
+          merchant: "Thorne",
+          item: "Magnesium Bisglycinate",
+          quantity: "1",
+        },
+      });
+    });
+
+    expect(screen.getByText(/Governed request submitted successfully/i)).toBeInTheDocument();
+  });
+
+  it("disables governed submission when no thread is selected", () => {
+    render(
+      <RequestComposer
+        initialEntries={[]}
+        defaultToolId="tool-1"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Submit governed request" })).toBeDisabled();
+    expect(screen.getByText(/Select or create a thread from the right rail/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/request-composer.tsx
+++ b/apps/web/components/request-composer.tsx
@@ -14,7 +14,8 @@ type RequestComposerProps = {
   initialEntries: RequestHistoryEntry[];
   apiBaseUrl?: string;
   userId?: string;
-  defaultThreadId?: string;
+  selectedThreadId?: string;
+  selectedThreadTitle?: string;
   defaultToolId?: string;
 };
 
@@ -31,10 +32,10 @@ export function RequestComposer({
   initialEntries,
   apiBaseUrl,
   userId,
-  defaultThreadId,
+  selectedThreadId,
+  selectedThreadTitle,
   defaultToolId,
 }: RequestComposerProps) {
-  const [threadId, setThreadId] = useState(defaultThreadId ?? "");
   const [toolId, setToolId] = useState(defaultToolId ?? "");
   const [action, setAction] = useState("place_order");
   const [scope, setScope] = useState("supplements");
@@ -57,18 +58,21 @@ export function RequestComposer({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const liveModeReady = Boolean(apiBaseUrl && userId);
+  const activeThreadId = selectedThreadId?.trim() ?? "";
+  const visibleEntries = activeThreadId
+    ? entries.filter((entry) => entry.threadId === activeThreadId)
+    : [];
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    const nextThreadId = threadId.trim();
     const nextToolId = toolId.trim();
     const nextAction = action.trim();
     const nextScope = scope.trim();
 
-    if (!nextThreadId || !nextToolId || !nextAction || !nextScope) {
+    if (!activeThreadId || !nextToolId || !nextAction || !nextScope) {
       setStatusTone("danger");
-      setStatusText("Thread ID, tool ID, action, and scope are all required.");
+      setStatusText("Select a thread, then provide tool ID, action, and scope.");
       return;
     }
 
@@ -87,7 +91,7 @@ export function RequestComposer({
 
     const payload: ApprovalRequestPayload = {
       user_id: userId ?? "fixture-user",
-      thread_id: nextThreadId,
+      thread_id: activeThreadId,
       tool_id: nextToolId,
       action: nextAction,
       scope: nextScope,
@@ -166,17 +170,20 @@ export function RequestComposer({
           <span>Requests stay explicitly governed and the resulting approval, task, and trace links remain attached.</span>
         </div>
 
-        <div className="form-field-group form-field-group--two-up">
-          <div className="form-field">
-            <label htmlFor="thread-id">Thread ID</label>
-            <input
-              id="thread-id"
-              name="thread-id"
-              value={threadId}
-              onChange={(event) => setThreadId(event.target.value)}
-              placeholder="Thread UUID"
-            />
+        <div className="selected-thread-panel">
+          <div className="selected-thread-panel__copy">
+            <span className="history-entry__label">Linked thread</span>
+            <h2 className="composer-title">{selectedThreadTitle ?? "Choose a visible thread"}</h2>
+            <p className="field-hint">
+              {activeThreadId
+                ? "Governed requests stay explicitly linked to the selected continuity record."
+                : "Select or create a thread from the right rail before submitting a governed request."}
+            </p>
           </div>
+          {activeThreadId ? <span className="meta-pill mono">{activeThreadId}</span> : null}
+        </div>
+
+        <div className="form-field-group form-field-group--two-up">
           <div className="form-field">
             <label htmlFor="tool-id">Tool ID</label>
             <input
@@ -281,7 +288,7 @@ export function RequestComposer({
             type="submit"
             className="button"
             disabled={
-              isSubmitting || !threadId.trim() || !toolId.trim() || !action.trim() || !scope.trim()
+              isSubmitting || !activeThreadId || !toolId.trim() || !action.trim() || !scope.trim()
             }
           >
             {isSubmitting ? "Submitting..." : "Submit governed request"}
@@ -298,14 +305,19 @@ export function RequestComposer({
           </div>
         </div>
 
-        {entries.length === 0 ? (
+        {!activeThreadId ? (
+          <EmptyState
+            title="Select a thread first"
+            description="Governed request summaries appear here after one visible thread is selected and used."
+          />
+        ) : visibleEntries.length === 0 ? (
           <EmptyState
             title="No governed requests yet"
-            description="Submitted requests will appear here with approval and task linkage once the operator starts using the form."
+            description="Submitted requests for the selected thread appear here with approval and task linkage."
           />
         ) : (
           <div className="history-list">
-            {entries.map((entry) => (
+            {visibleEntries.map((entry) => (
               <article key={entry.id} className="history-entry">
                 <div className="history-entry__topline">
                   <div className="detail-stack">

--- a/apps/web/components/response-composer.test.tsx
+++ b/apps/web/components/response-composer.test.tsx
@@ -63,7 +63,8 @@ describe("ResponseComposer", () => {
         initialEntries={[]}
         apiBaseUrl="https://api.example.com"
         userId="user-1"
-        defaultThreadId="thread-1"
+        selectedThreadId="thread-1"
+        selectedThreadTitle="Gamma thread"
       />,
     );
 
@@ -89,7 +90,13 @@ describe("ResponseComposer", () => {
   });
 
   it("adds an explicit fixture preview when live API configuration is absent", async () => {
-    render(<ResponseComposer initialEntries={[]} defaultThreadId="thread-1" />);
+    render(
+      <ResponseComposer
+        initialEntries={[]}
+        selectedThreadId="thread-1"
+        selectedThreadTitle="Gamma thread"
+      />,
+    );
 
     fireEvent.change(screen.getByLabelText("Ask the assistant"), {
       target: { value: "Summarize the latest thread state." },
@@ -99,5 +106,12 @@ describe("ResponseComposer", () => {
     expect(submitAssistantResponseMock).not.toHaveBeenCalled();
     expect(await screen.findByText(/Fixture mode generated a preview response only/i)).toBeInTheDocument();
     expect(screen.getByText(/Fixture response preview added/i)).toBeInTheDocument();
+  });
+
+  it("requires a selected thread before enabling assistant submission", () => {
+    render(<ResponseComposer initialEntries={[]} />);
+
+    expect(screen.getByRole("button", { name: "Ask assistant" })).toBeDisabled();
+    expect(screen.getByText(/Select or create a thread from the right rail/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/components/response-composer.tsx
+++ b/apps/web/components/response-composer.tsx
@@ -13,39 +13,47 @@ type ResponseComposerProps = {
   initialEntries: ResponseHistoryEntry[];
   apiBaseUrl?: string;
   userId?: string;
-  defaultThreadId?: string;
+  selectedThreadId?: string;
+  selectedThreadTitle?: string;
 };
 
 export function ResponseComposer({
   initialEntries,
   apiBaseUrl,
   userId,
-  defaultThreadId,
+  selectedThreadId,
+  selectedThreadTitle,
 }: ResponseComposerProps) {
-  const [threadId, setThreadId] = useState(defaultThreadId ?? "");
   const [message, setMessage] = useState("");
   const [entries, setEntries] = useState(initialEntries);
-  const [statusText, setStatusText] = useState("Ready to ask the assistant inside the current thread.");
+  const [statusText, setStatusText] = useState(
+    selectedThreadId
+      ? "Ready to ask the assistant inside the selected thread."
+      : "Select a thread before sending an assistant message.",
+  );
   const [statusTone, setStatusTone] = useState<"info" | "success" | "danger">("info");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const liveModeReady = Boolean(apiBaseUrl && userId);
+  const activeThreadId = selectedThreadId?.trim() ?? "";
+  const visibleEntries = activeThreadId
+    ? entries.filter((entry) => entry.threadId === activeThreadId)
+    : [];
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    const nextThreadId = threadId.trim();
     const nextMessage = message.trim();
 
-    if (!nextThreadId || !nextMessage) {
+    if (!activeThreadId || !nextMessage) {
       setStatusTone("danger");
-      setStatusText("Thread ID and a message are both required.");
+      setStatusText("Select a thread and enter a message before submitting.");
       return;
     }
 
     const payload: AssistantResponsePayload = {
       user_id: userId ?? "fixture-user",
-      thread_id: nextThreadId,
+      thread_id: activeThreadId,
       message: nextMessage,
     };
 
@@ -59,7 +67,7 @@ export function ResponseComposer({
 
     if (!liveModeReady) {
       const entry = buildFixtureResponseEntry({
-        threadId: nextThreadId,
+        threadId: activeThreadId,
         message: nextMessage,
       });
       setEntries((current) => [entry, ...current]);
@@ -78,7 +86,7 @@ export function ResponseComposer({
         id: response.trace.response_trace_id,
         submittedAt: new Date().toISOString(),
         source: "live",
-        threadId: nextThreadId,
+        threadId: activeThreadId,
         message: nextMessage,
         assistantText: response.assistant.text,
         assistantEventId: response.assistant.event_id,
@@ -115,22 +123,23 @@ export function ResponseComposer({
           <div className="governance-banner governance-banner--assistant">
             <strong>{liveModeReady ? "Live assistant mode" : "Fixture assistant mode"}</strong>
             <span>
-              Normal questions go through `POST /v0/responses` while thread identity and trace linkage stay explicit.
+              Normal questions go through `POST /v0/responses` while the selected thread and linked traces stay explicit.
             </span>
           </div>
 
-          <div className="form-field">
-            <label htmlFor="assistant-thread-id">Thread ID</label>
-            <p className="field-hint">
-              Keep the thread explicit so assistant replies stay attached to the intended conversation context.
-            </p>
-            <input
-              id="assistant-thread-id"
-              name="assistant-thread-id"
-              value={threadId}
-              onChange={(event) => setThreadId(event.target.value)}
-              placeholder="Thread UUID"
-            />
+          <div className="selected-thread-panel">
+            <div className="selected-thread-panel__copy">
+              <span className="history-entry__label">Selected thread</span>
+              <h2 className="composer-title">
+                {selectedThreadTitle ?? "Choose a visible thread"}
+              </h2>
+              <p className="field-hint">
+                {activeThreadId
+                  ? "New assistant replies will stay attached to the selected continuity record."
+                  : "Select or create a thread from the right rail before starting assistant conversation."}
+              </p>
+            </div>
+            {activeThreadId ? <span className="meta-pill mono">{activeThreadId}</span> : null}
           </div>
         </div>
 
@@ -173,7 +182,7 @@ export function ResponseComposer({
             <button
               type="submit"
               className="button"
-              disabled={isSubmitting || !threadId.trim() || !message.trim()}
+              disabled={isSubmitting || !activeThreadId || !message.trim()}
             >
               {isSubmitting ? "Asking..." : "Ask assistant"}
             </button>
@@ -181,7 +190,7 @@ export function ResponseComposer({
         </form>
       </section>
 
-      <ResponseHistory entries={entries} />
+      <ResponseHistory entries={visibleEntries} />
     </div>
   );
 }

--- a/apps/web/components/thread-create.test.tsx
+++ b/apps/web/components/thread-create.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createThreadMock, refreshMock, pushMock } = vi.hoisted(() => ({
+  createThreadMock: vi.fn(),
+  pushMock: vi.fn(),
+  refreshMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual("../lib/api");
+  return {
+    ...actual,
+    createThread: createThreadMock,
+  };
+});
+
+import { ThreadCreate } from "./thread-create";
+
+describe("ThreadCreate", () => {
+  beforeEach(() => {
+    createThreadMock.mockReset();
+    pushMock.mockReset();
+    refreshMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("creates a live thread and routes the operator to the new selection", async () => {
+    createThreadMock.mockResolvedValue({
+      thread: {
+        id: "thread-2",
+        title: "Delta thread",
+        created_at: "2026-03-17T11:00:00Z",
+        updated_at: "2026-03-17T11:00:00Z",
+      },
+    });
+
+    render(
+      <ThreadCreate
+        apiBaseUrl="https://api.example.com"
+        userId="user-1"
+        currentMode="assistant"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Thread title"), {
+      target: { value: "Delta thread" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create thread" }));
+
+    await waitFor(() => {
+      expect(createThreadMock).toHaveBeenCalledWith("https://api.example.com", {
+        user_id: "user-1",
+        title: "Delta thread",
+      });
+    });
+
+    expect(pushMock).toHaveBeenCalledWith("/chat?thread=thread-2");
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  it("shows an explicit unavailable state when live API configuration is absent", () => {
+    render(<ThreadCreate currentMode="assistant" />);
+
+    expect(screen.getByRole("button", { name: "Create thread" })).toBeDisabled();
+    expect(
+      screen.getByText(/Thread creation becomes available when the live web API base URL and user ID are configured/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/thread-create.tsx
+++ b/apps/web/components/thread-create.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { createThread } from "../lib/api";
+import type { ChatMode } from "./mode-toggle";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type ThreadCreateProps = {
+  apiBaseUrl?: string;
+  userId?: string;
+  currentMode: ChatMode;
+};
+
+function buildThreadHref(mode: ChatMode, threadId: string) {
+  const params = new URLSearchParams();
+
+  if (mode === "request") {
+    params.set("mode", mode);
+  }
+  params.set("thread", threadId);
+
+  return `/chat?${params.toString()}`;
+}
+
+export function ThreadCreate({ apiBaseUrl, userId, currentMode }: ThreadCreateProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [statusText, setStatusText] = useState(
+    apiBaseUrl && userId
+      ? "Create a new visible thread when the current conversation needs a fresh continuity boundary."
+      : "Thread creation becomes available when the live web API base URL and user ID are configured.",
+  );
+  const [statusTone, setStatusTone] = useState<"info" | "success" | "danger">("info");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const liveModeReady = Boolean(apiBaseUrl && userId);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const nextTitle = title.trim();
+
+    if (!liveModeReady) {
+      setStatusTone("danger");
+      setStatusText(
+        "Thread creation is unavailable in fixture preview because the continuity create endpoint only persists through the live API.",
+      );
+      return;
+    }
+
+    if (!nextTitle) {
+      setStatusTone("danger");
+      setStatusText("A short thread title is required.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusTone("info");
+    setStatusText("Creating a new continuity thread through the shipped thread-create endpoint...");
+
+    try {
+      const response = await createThread(apiBaseUrl!, {
+        user_id: userId!,
+        title: nextTitle,
+      });
+
+      setStatusTone("success");
+      setStatusText("Thread created. Loading the new continuity record now.");
+      setTitle("");
+      router.push(buildThreadHref(currentMode, response.thread.id));
+      router.refresh();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "Request failed";
+      setStatusTone("danger");
+      setStatusText(`Unable to create thread: ${detail}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <SectionCard
+      eyebrow="Create thread"
+      title="Start a new continuity record"
+      description="Keep thread identity explicit instead of recycling one conversation container for unrelated work."
+    >
+      <form className="detail-stack" onSubmit={handleSubmit}>
+        <div className="form-field">
+          <label htmlFor="thread-title">Thread title</label>
+          <input
+            id="thread-title"
+            name="thread-title"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Magnesium reorder review"
+            disabled={!liveModeReady || isSubmitting}
+          />
+        </div>
+
+        <div className="composer-actions">
+          <div className="composer-status" aria-live="polite">
+            <StatusBadge
+              status={
+                isSubmitting
+                  ? "submitting"
+                  : statusTone === "success"
+                    ? "success"
+                    : statusTone === "danger"
+                      ? "error"
+                      : "info"
+              }
+              label={
+                isSubmitting
+                  ? "Creating"
+                  : statusTone === "success"
+                    ? "Ready"
+                    : statusTone === "danger"
+                      ? "Attention"
+                      : "Prepared"
+              }
+            />
+            <span>{statusText}</span>
+          </div>
+          <button
+            type="submit"
+            className="button"
+            disabled={isSubmitting || !liveModeReady || !title.trim()}
+          >
+            {isSubmitting ? "Creating..." : "Create thread"}
+          </button>
+        </div>
+      </form>
+    </SectionCard>
+  );
+}

--- a/apps/web/components/thread-event-list.test.tsx
+++ b/apps/web/components/thread-event-list.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ThreadEventList } from "./thread-event-list";
+
+describe("ThreadEventList", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders bounded recent sessions and event summaries for the selected thread", () => {
+    render(
+      <ThreadEventList
+        threadTitle="Gamma thread"
+        source="fixture"
+        sessions={[
+          {
+            id: "session-1",
+            thread_id: "thread-1",
+            status: "active",
+            started_at: "2026-03-17T10:00:00Z",
+            ended_at: null,
+            created_at: "2026-03-17T10:00:00Z",
+          },
+        ]}
+        events={[
+          {
+            id: "event-1",
+            thread_id: "thread-1",
+            session_id: "session-1",
+            sequence_no: 1,
+            kind: "message.user",
+            payload: { text: "Hello" },
+            created_at: "2026-03-17T10:00:00Z",
+          },
+          {
+            id: "event-2",
+            thread_id: "thread-1",
+            session_id: "session-1",
+            sequence_no: 2,
+            kind: "approval.request",
+            payload: { action: "place_order", scope: "supplements", status: "pending" },
+            created_at: "2026-03-17T10:05:00Z",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Recent continuity state")).toBeInTheDocument();
+    expect(screen.getByText(/place_order in supplements is pending/i)).toBeInTheDocument();
+    expect(screen.getByText("Sequence 2")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the selected thread has no continuity yet", () => {
+    render(
+      <ThreadEventList
+        threadTitle="Gamma thread"
+        source="fixture"
+        sessions={[]}
+        events={[]}
+      />,
+    );
+
+    expect(screen.getByText("No continuity captured yet")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/thread-event-list.tsx
+++ b/apps/web/components/thread-event-list.tsx
@@ -1,0 +1,181 @@
+import type { ThreadEventItem, ThreadSessionItem } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type ThreadEventListProps = {
+  threadTitle?: string;
+  sessions: ThreadSessionItem[];
+  events: ThreadEventItem[];
+  source: "live" | "fixture" | "unavailable";
+  unavailableReason?: string;
+};
+
+const SESSION_LIMIT = 3;
+const EVENT_LIMIT = 6;
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function summarizePayload(payload: unknown) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return "Structured continuity payload available.";
+  }
+
+  const record = payload as Record<string, unknown>;
+
+  if (typeof record.text === "string" && record.text.trim()) {
+    return record.text;
+  }
+
+  if (typeof record.summary === "string" && record.summary.trim()) {
+    return record.summary;
+  }
+
+  const action = typeof record.action === "string" ? record.action : null;
+  const scope = typeof record.scope === "string" ? record.scope : null;
+  const status = typeof record.status === "string" ? record.status : null;
+
+  if (action && scope && status) {
+    return `${action} in ${scope} is ${status.replace(/_/g, " ")}.`;
+  }
+
+  if (action && scope) {
+    return `${action} in ${scope}.`;
+  }
+
+  if (status) {
+    return `Continuity status is ${status.replace(/_/g, " ")}.`;
+  }
+
+  return "Structured continuity payload available.";
+}
+
+function formatKind(kind: string) {
+  return kind.replace(/[._]/g, " ");
+}
+
+export function ThreadEventList({
+  threadTitle,
+  sessions,
+  events,
+  source,
+  unavailableReason,
+}: ThreadEventListProps) {
+  if (source === "unavailable") {
+    return (
+      <SectionCard
+        eyebrow="Continuity review"
+        title="Recent continuity state unavailable"
+        description="The continuity review panel could not load the selected thread sessions and events."
+      >
+        <EmptyState
+          title="Review unavailable"
+          description={unavailableReason ?? "Try again once the continuity API is reachable."}
+        />
+      </SectionCard>
+    );
+  }
+
+  if (!threadTitle) {
+    return (
+      <SectionCard
+        eyebrow="Continuity review"
+        title="No continuity state selected"
+        description="Pick a visible thread before reviewing its recent sessions and continuity events."
+      >
+        <EmptyState
+          title="Select a thread"
+          description="Recent sessions and continuity events appear here after one thread is selected."
+        />
+      </SectionCard>
+    );
+  }
+
+  if (sessions.length === 0 && events.length === 0) {
+    return (
+      <SectionCard
+        eyebrow="Continuity review"
+        title="Recent continuity state"
+        description="This thread exists, but no sessions or continuity events have been recorded yet."
+      >
+        <EmptyState
+          title="No continuity captured yet"
+          description="Start the thread in assistant or governed mode and the latest sessions and continuity events will appear here."
+        />
+      </SectionCard>
+    );
+  }
+
+  const visibleSessions = sessions.slice(-SESSION_LIMIT).reverse();
+  const visibleEvents = events.slice(-EVENT_LIMIT).reverse();
+
+  return (
+    <SectionCard
+      eyebrow="Continuity review"
+      title="Recent continuity state"
+      description="The latest sessions and events stay bounded so the operator can review continuity without turning this page into a raw transcript."
+    >
+      <div className="thread-review-grid">
+        <div className="detail-group">
+          <div className="detail-summary">
+            <span className="detail-summary__label">Recent sessions</span>
+            <span className="subtle-chip">{sessions.length} total</span>
+          </div>
+
+          <div className="timeline-list">
+            {visibleSessions.map((session) => (
+              <article key={session.id} className="timeline-item">
+                <div className="timeline-item__topline">
+                  <div className="detail-stack">
+                    <h3 className="list-row__title">{formatDate(session.started_at ?? session.created_at)}</h3>
+                    <p>{session.ended_at ? "Session closed cleanly." : "Current live session remains open."}</p>
+                  </div>
+                  <StatusBadge status={session.status} />
+                </div>
+
+                <div className="attribute-list">
+                  <span className="meta-pill mono">{session.id}</span>
+                  <span className="meta-pill">Started {formatDate(session.started_at ?? session.created_at)}</span>
+                  {session.ended_at ? <span className="meta-pill">Ended {formatDate(session.ended_at)}</span> : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <div className="detail-group">
+          <div className="detail-summary">
+            <span className="detail-summary__label">Latest events</span>
+            <span className="subtle-chip">{events.length} total</span>
+          </div>
+
+          <div className="timeline-list">
+            {visibleEvents.map((event) => (
+              <article key={event.id} className="timeline-item">
+                <div className="timeline-item__topline">
+                  <div className="detail-stack">
+                    <span className="history-entry__label">{formatKind(event.kind)}</span>
+                    <h3 className="list-row__title">{summarizePayload(event.payload)}</h3>
+                  </div>
+                  <span className="subtle-chip">{formatDate(event.created_at)}</span>
+                </div>
+
+                <div className="attribute-list">
+                  <span className="meta-pill">Sequence {event.sequence_no}</span>
+                  {event.session_id ? <span className="meta-pill mono">{event.session_id}</span> : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/components/thread-list.test.tsx
+++ b/apps/web/components/thread-list.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ThreadList } from "./thread-list";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    "aria-current": ariaCurrent,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    "aria-current"?: string;
+  }) => (
+    <a href={href} className={className} aria-current={ariaCurrent}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("ThreadList", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders thread links that preserve the current mode and selected thread", () => {
+    render(
+      <ThreadList
+        threads={[
+          {
+            id: "thread-1",
+            title: "Gamma thread",
+            created_at: "2026-03-17T10:00:00Z",
+            updated_at: "2026-03-17T10:00:00Z",
+          },
+          {
+            id: "thread-2",
+            title: "Delta thread",
+            created_at: "2026-03-17T11:00:00Z",
+            updated_at: "2026-03-17T11:00:00Z",
+          },
+        ]}
+        selectedThreadId="thread-2"
+        currentMode="request"
+        source="live"
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /Gamma thread/i })).toHaveAttribute(
+      "href",
+      "/chat?mode=request&thread=thread-1",
+    );
+    expect(screen.getByRole("link", { name: /Delta thread/i })).toHaveAttribute(
+      "href",
+      "/chat?mode=request&thread=thread-2",
+    );
+    expect(screen.getByRole("link", { name: /Delta thread/i })).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/apps/web/components/thread-list.tsx
+++ b/apps/web/components/thread-list.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+
+import type { ThreadItem } from "../lib/api";
+import type { ChatMode } from "./mode-toggle";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+
+type ThreadListProps = {
+  threads: ThreadItem[];
+  selectedThreadId?: string;
+  currentMode: ChatMode;
+  source: "live" | "fixture" | "unavailable";
+  unavailableReason?: string;
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function buildThreadHref(mode: ChatMode, threadId: string) {
+  const params = new URLSearchParams();
+
+  if (mode === "request") {
+    params.set("mode", mode);
+  }
+  params.set("thread", threadId);
+
+  return `/chat?${params.toString()}`;
+}
+
+export function ThreadList({
+  threads,
+  selectedThreadId,
+  currentMode,
+  source,
+  unavailableReason,
+}: ThreadListProps) {
+  const description =
+    source === "live"
+      ? "Visible threads stay explicit and bounded so the operator can anchor work to one continuity record at a time."
+      : source === "fixture"
+        ? "Fixture preview keeps the selection surface readable when live continuity configuration is absent."
+        : "Thread review is temporarily unavailable even though the chat shell is still reachable.";
+
+  return (
+    <SectionCard
+      eyebrow="Visible threads"
+      title="Select a thread"
+      description={description}
+    >
+      {source === "unavailable" ? (
+        <EmptyState
+          title="Thread continuity unavailable"
+          description={unavailableReason ?? "The thread list could not be loaded from the continuity API."}
+        />
+      ) : threads.length === 0 ? (
+        <EmptyState
+          title="No threads yet"
+          description="Create a thread first so assistant replies and governed requests stay attached to a visible continuity record."
+        />
+      ) : (
+        <div className="history-list history-list--scrollable">
+          {threads.map((thread) => {
+            const isSelected = thread.id === selectedThreadId;
+
+            return (
+              <Link
+                key={thread.id}
+                href={buildThreadHref(currentMode, thread.id)}
+                className={["list-row", isSelected ? "is-selected" : ""].filter(Boolean).join(" ")}
+                aria-current={isSelected ? "page" : undefined}
+              >
+                <div className="list-row__topline">
+                  <div className="detail-stack">
+                    <span className="list-row__eyebrow">{isSelected ? "Selected thread" : "Thread"}</span>
+                    <h3 className="list-row__title">{thread.title}</h3>
+                  </div>
+                  <span className="subtle-chip">{formatDate(thread.updated_at)}</span>
+                </div>
+
+                <div className="list-row__meta">
+                  <span className="meta-pill">Updated {formatDate(thread.updated_at)}</span>
+                  <span className="meta-pill mono">{thread.id}</span>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/apps/web/components/thread-summary.test.tsx
+++ b/apps/web/components/thread-summary.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ThreadSummary } from "./thread-summary";
+
+describe("ThreadSummary", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders selected thread metadata and continuity counts", () => {
+    render(
+      <ThreadSummary
+        thread={{
+          id: "thread-1",
+          title: "Gamma thread",
+          created_at: "2026-03-17T10:00:00Z",
+          updated_at: "2026-03-17T10:05:00Z",
+        }}
+        sessions={[
+          {
+            id: "session-1",
+            thread_id: "thread-1",
+            status: "active",
+            started_at: "2026-03-17T10:00:00Z",
+            ended_at: null,
+            created_at: "2026-03-17T10:00:00Z",
+          },
+        ]}
+        events={[
+          {
+            id: "event-1",
+            thread_id: "thread-1",
+            session_id: "session-1",
+            sequence_no: 1,
+            kind: "message.user",
+            payload: { text: "Hello" },
+            created_at: "2026-03-17T10:01:00Z",
+          },
+        ]}
+        source="live"
+      />,
+    );
+
+    expect(screen.getByText("Gamma thread")).toBeInTheDocument();
+    expect(screen.getByText("Live continuity API")).toBeInTheDocument();
+    expect(screen.getByText("thread-1")).toBeInTheDocument();
+    expect(screen.getByText("Sessions")).toBeInTheDocument();
+    expect(screen.getByText("Events")).toBeInTheDocument();
+    expect(screen.getByText("active")).toBeInTheDocument();
+  });
+
+  it("shows the explicit no-thread state when nothing is selected", () => {
+    render(
+      <ThreadSummary
+        thread={null}
+        sessions={[]}
+        events={[]}
+        source="fixture"
+      />,
+    );
+
+    expect(screen.getByText("No thread selected")).toBeInTheDocument();
+    expect(screen.getByText("Select a thread")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/thread-summary.tsx
+++ b/apps/web/components/thread-summary.tsx
@@ -1,0 +1,116 @@
+import type { ThreadEventItem, ThreadItem, ThreadSessionItem } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type ThreadSummaryProps = {
+  thread: ThreadItem | null;
+  sessions: ThreadSessionItem[];
+  events: ThreadEventItem[];
+  source: "live" | "fixture" | "unavailable";
+  unavailableReason?: string;
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function formatStatus(status: string | undefined) {
+  if (!status) {
+    return "No sessions yet";
+  }
+
+  return status.replace(/_/g, " ");
+}
+
+export function ThreadSummary({
+  thread,
+  sessions,
+  events,
+  source,
+  unavailableReason,
+}: ThreadSummaryProps) {
+  if (source === "unavailable") {
+    return (
+      <SectionCard
+        eyebrow="Selected thread"
+        title="Continuity summary unavailable"
+        description="The thread summary could not be loaded from the continuity API."
+      >
+        <EmptyState
+          title="Summary unavailable"
+          description={unavailableReason ?? "Thread metadata and continuity counts are temporarily unavailable."}
+        />
+      </SectionCard>
+    );
+  }
+
+  if (!thread) {
+    return (
+      <SectionCard
+        eyebrow="Selected thread"
+        title="No thread selected"
+        description="Choose a visible thread first so the chat surface stays anchored to a single continuity record."
+      >
+        <EmptyState
+          title="Select a thread"
+          description="The assistant and governed request forms stay disabled until one visible thread is selected."
+        />
+      </SectionCard>
+    );
+  }
+
+  const latestSession = sessions[sessions.length - 1];
+
+  return (
+    <SectionCard
+      eyebrow="Selected thread"
+      title={thread.title}
+      description={
+        source === "live"
+          ? "Thread identity, lifecycle timing, and bounded continuity counts stay visible before any new message or governed action."
+          : "Fixture preview keeps the current thread identity and continuity footprint explicit."
+      }
+    >
+      <div className="thread-summary__topline">
+        <StatusBadge
+          status={latestSession?.status ?? "info"}
+          label={formatStatus(latestSession?.status)}
+        />
+        <div className="attribute-list">
+          <span className="meta-pill">Created {formatDate(thread.created_at)}</span>
+          <span className="meta-pill">Updated {formatDate(thread.updated_at)}</span>
+        </div>
+      </div>
+
+      <dl className="key-value-grid key-value-grid--compact">
+        <div>
+          <dt>Sessions</dt>
+          <dd>{sessions.length}</dd>
+        </div>
+        <div>
+          <dt>Events</dt>
+          <dd>{events.length}</dd>
+        </div>
+        <div>
+          <dt>Latest session</dt>
+          <dd>{latestSession?.started_at ? formatDate(latestSession.started_at) : "Not started yet"}</dd>
+        </div>
+        <div>
+          <dt>Review mode</dt>
+          <dd>{source === "live" ? "Live continuity API" : "Fixture preview"}</dd>
+        </div>
+      </dl>
+
+      <div className="detail-group">
+        <span className="history-entry__label">Thread ID</span>
+        <p className="thread-summary__id mono">{thread.id}</p>
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -3,10 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ApiError,
   combinePageModes,
+  createThread,
+  getThreadDetail,
+  getThreadEvents,
+  getThreadSessions,
   executeApproval,
   getToolExecution,
   getTraceDetail,
   getTraceEvents,
+  listThreads,
   listTraces,
   pageModeLabel,
   resolveApproval,
@@ -180,6 +185,121 @@ describe("api helpers", () => {
       user_id: "user-1",
       thread_id: "thread-1",
       message: "What do I usually take in coffee?",
+    });
+  });
+
+  it("uses the shipped continuity endpoints for thread create and review", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            thread: {
+              id: "thread-1",
+              title: "Gamma thread",
+              created_at: "2026-03-17T10:00:00Z",
+              updated_at: "2026-03-17T10:00:00Z",
+            },
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "thread-1",
+                title: "Gamma thread",
+                created_at: "2026-03-17T10:00:00Z",
+                updated_at: "2026-03-17T10:00:00Z",
+              },
+            ],
+            summary: {
+              total_count: 1,
+              order: ["created_at_desc", "id_desc"],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            thread: {
+              id: "thread-1",
+              title: "Gamma thread",
+              created_at: "2026-03-17T10:00:00Z",
+              updated_at: "2026-03-17T10:00:00Z",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "session-1",
+                thread_id: "thread-1",
+                status: "active",
+                started_at: "2026-03-17T10:00:00Z",
+                ended_at: null,
+                created_at: "2026-03-17T10:00:00Z",
+              },
+            ],
+            summary: {
+              thread_id: "thread-1",
+              total_count: 1,
+              order: ["started_at_asc", "created_at_asc", "id_asc"],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "event-1",
+                thread_id: "thread-1",
+                session_id: "session-1",
+                sequence_no: 1,
+                kind: "message.user",
+                payload: { text: "Hello" },
+                created_at: "2026-03-17T10:00:00Z",
+              },
+            ],
+            summary: {
+              thread_id: "thread-1",
+              total_count: 1,
+              order: ["sequence_no_asc"],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    await createThread("https://api.example.com", {
+      user_id: "user-1",
+      title: "Gamma thread",
+    });
+    await listThreads("https://api.example.com", "user-1");
+    await getThreadDetail("https://api.example.com", "thread-1", "user-1");
+    await getThreadSessions("https://api.example.com", "thread-1", "user-1");
+    await getThreadEvents("https://api.example.com", "thread-1", "user-1");
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "https://api.example.com/v0/threads",
+      "https://api.example.com/v0/threads?user_id=user-1",
+      "https://api.example.com/v0/threads/thread-1?user_id=user-1",
+      "https://api.example.com/v0/threads/thread-1/sessions?user_id=user-1",
+      "https://api.example.com/v0/threads/thread-1/events?user_id=user-1",
+    ]);
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      user_id: "user-1",
+      title: "Gamma thread",
     });
   });
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -8,6 +8,54 @@ export type ApiConfig = {
   defaultToolId: string;
 };
 
+export type ThreadItem = {
+  id: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ThreadSessionItem = {
+  id: string;
+  thread_id: string;
+  status: string;
+  started_at: string | null;
+  ended_at: string | null;
+  created_at: string;
+};
+
+export type ThreadEventItem = {
+  id: string;
+  thread_id: string;
+  session_id: string | null;
+  sequence_no: number;
+  kind: string;
+  payload: unknown;
+  created_at: string;
+};
+
+export type ThreadCreatePayload = {
+  user_id: string;
+  title: string;
+};
+
+export type ThreadListSummary = {
+  total_count: number;
+  order: string[];
+};
+
+export type ThreadSessionListSummary = {
+  thread_id: string;
+  total_count: number;
+  order: string[];
+};
+
+export type ThreadEventListSummary = {
+  thread_id: string;
+  total_count: number;
+  order: string[];
+};
+
 export type ToolRoutingReason = {
   code: string;
   source: string;
@@ -428,6 +476,49 @@ export function submitAssistantResponse(
     method: "POST",
     body: JSON.stringify(payload),
   });
+}
+
+export function createThread(apiBaseUrl: string, payload: ThreadCreatePayload) {
+  return requestJson<{ thread: ThreadItem }>(apiBaseUrl, "/v0/threads", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function listThreads(apiBaseUrl: string, userId: string) {
+  return requestJson<{ items: ThreadItem[]; summary: ThreadListSummary }>(
+    apiBaseUrl,
+    "/v0/threads",
+    undefined,
+    { user_id: userId },
+  );
+}
+
+export function getThreadDetail(apiBaseUrl: string, threadId: string, userId: string) {
+  return requestJson<{ thread: ThreadItem }>(
+    apiBaseUrl,
+    `/v0/threads/${threadId}`,
+    undefined,
+    { user_id: userId },
+  );
+}
+
+export function getThreadSessions(apiBaseUrl: string, threadId: string, userId: string) {
+  return requestJson<{ items: ThreadSessionItem[]; summary: ThreadSessionListSummary }>(
+    apiBaseUrl,
+    `/v0/threads/${threadId}/sessions`,
+    undefined,
+    { user_id: userId },
+  );
+}
+
+export function getThreadEvents(apiBaseUrl: string, threadId: string, userId: string) {
+  return requestJson<{ items: ThreadEventItem[]; summary: ThreadEventListSummary }>(
+    apiBaseUrl,
+    `/v0/threads/${threadId}/events`,
+    undefined,
+    { user_id: userId },
+  );
 }
 
 export function listApprovals(apiBaseUrl: string, userId: string) {

--- a/apps/web/lib/fixtures.ts
+++ b/apps/web/lib/fixtures.ts
@@ -3,6 +3,9 @@ import type {
   ApprovalRequestPayload,
   RequestHistoryEntry,
   ResponseHistoryEntry,
+  ThreadEventItem,
+  ThreadItem,
+  ThreadSessionItem,
   TaskItem,
   TaskStepItem,
   TaskStepListSummary,
@@ -30,6 +33,160 @@ const PURCHASE_TOOL: ToolRecord = {
 
 const THREAD_MAGNESIUM = "11111111-1111-4111-8111-111111111111";
 const THREAD_VITAMIN_D = "11111111-1111-4111-8111-111111111112";
+const THREAD_CLEANUP = "11111111-1111-4111-8111-111111111113";
+
+export const threadFixtures: ThreadItem[] = [
+  {
+    id: THREAD_MAGNESIUM,
+    title: "Magnesium continuity review",
+    created_at: "2026-03-17T06:40:00Z",
+    updated_at: "2026-03-17T08:45:00Z",
+  },
+  {
+    id: THREAD_VITAMIN_D,
+    title: "Vitamin D reorder follow-up",
+    created_at: "2026-03-16T13:58:00Z",
+    updated_at: "2026-03-16T14:32:00Z",
+  },
+  {
+    id: THREAD_CLEANUP,
+    title: "Quarterly routine cleanup",
+    created_at: "2026-03-15T09:20:00Z",
+    updated_at: "2026-03-15T09:20:00Z",
+  },
+];
+
+export const threadSessionFixtures: Record<string, ThreadSessionItem[]> = {
+  [THREAD_MAGNESIUM]: [
+    {
+      id: "session-magnesium-1",
+      thread_id: THREAD_MAGNESIUM,
+      status: "completed",
+      started_at: "2026-03-17T06:40:00Z",
+      ended_at: "2026-03-17T06:52:00Z",
+      created_at: "2026-03-17T06:40:00Z",
+    },
+    {
+      id: "session-magnesium-2",
+      thread_id: THREAD_MAGNESIUM,
+      status: "active",
+      started_at: "2026-03-17T08:40:00Z",
+      ended_at: null,
+      created_at: "2026-03-17T08:40:00Z",
+    },
+  ],
+  [THREAD_VITAMIN_D]: [
+    {
+      id: "session-vitamin-d-1",
+      thread_id: THREAD_VITAMIN_D,
+      status: "completed",
+      started_at: "2026-03-16T14:00:00Z",
+      ended_at: "2026-03-16T14:32:00Z",
+      created_at: "2026-03-16T14:00:00Z",
+    },
+  ],
+  [THREAD_CLEANUP]: [],
+};
+
+export const threadEventFixtures: Record<string, ThreadEventItem[]> = {
+  [THREAD_MAGNESIUM]: [
+    {
+      id: "event-magnesium-1",
+      thread_id: THREAD_MAGNESIUM,
+      session_id: "session-magnesium-1",
+      sequence_no: 1,
+      kind: "message.user",
+      payload: {
+        text: "Review my magnesium reorder context before I place another order.",
+      },
+      created_at: "2026-03-17T06:41:00Z",
+    },
+    {
+      id: "event-magnesium-2",
+      thread_id: THREAD_MAGNESIUM,
+      session_id: "session-magnesium-1",
+      sequence_no: 2,
+      kind: "approval.request",
+      payload: {
+        action: "place_order",
+        scope: "supplements",
+        status: "pending",
+      },
+      created_at: "2026-03-17T06:50:00Z",
+    },
+    {
+      id: "event-magnesium-3",
+      thread_id: THREAD_MAGNESIUM,
+      session_id: "session-magnesium-2",
+      sequence_no: 3,
+      kind: "message.user",
+      payload: {
+        text: "Summarize what is still waiting for approval.",
+      },
+      created_at: "2026-03-17T08:43:00Z",
+    },
+    {
+      id: "event-magnesium-4",
+      thread_id: THREAD_MAGNESIUM,
+      session_id: "session-magnesium-2",
+      sequence_no: 4,
+      kind: "message.assistant",
+      payload: {
+        text: "The latest magnesium purchase request is still waiting on approval and keeps the merchant and package details explicit.",
+      },
+      created_at: "2026-03-17T08:45:00Z",
+    },
+  ],
+  [THREAD_VITAMIN_D]: [
+    {
+      id: "event-vitamin-d-1",
+      thread_id: THREAD_VITAMIN_D,
+      session_id: "session-vitamin-d-1",
+      sequence_no: 1,
+      kind: "message.user",
+      payload: {
+        text: "What happened with my last Vitamin D reorder?",
+      },
+      created_at: "2026-03-16T14:05:00Z",
+    },
+    {
+      id: "event-vitamin-d-2",
+      thread_id: THREAD_VITAMIN_D,
+      session_id: "session-vitamin-d-1",
+      sequence_no: 2,
+      kind: "approval.resolution",
+      payload: {
+        status: "approved",
+        summary: "The operator approved the reorder before execution.",
+      },
+      created_at: "2026-03-16T14:22:00Z",
+    },
+    {
+      id: "event-vitamin-d-3",
+      thread_id: THREAD_VITAMIN_D,
+      session_id: "session-vitamin-d-1",
+      sequence_no: 3,
+      kind: "tool.execution",
+      payload: {
+        status: "completed",
+        summary: "Merchant proxy completed the approved supplement reorder.",
+      },
+      created_at: "2026-03-16T14:24:00Z",
+    },
+    {
+      id: "event-vitamin-d-4",
+      thread_id: THREAD_VITAMIN_D,
+      session_id: "session-vitamin-d-1",
+      sequence_no: 4,
+      kind: "message.assistant",
+      payload: {
+        text: "The prior Vitamin D request was approved and executed. Open the task or trace review if you need the full record.",
+      },
+      created_at: "2026-03-16T14:32:00Z",
+    },
+  ],
+  [THREAD_CLEANUP]: [],
+};
 
 export const traceFixtures: TraceItem[] = [
   {
@@ -701,6 +858,18 @@ export function getFixtureExecutionByApprovalId(approvalId: string) {
   return executionFixtures.find((item) => item.approval_id === approvalId) ?? null;
 }
 
+export function getFixtureThread(threadId: string) {
+  return threadFixtures.find((item) => item.id === threadId) ?? null;
+}
+
+export function getFixtureThreadSessions(threadId: string) {
+  return threadSessionFixtures[threadId] ?? [];
+}
+
+export function getFixtureThreadEvents(threadId: string) {
+  return threadEventFixtures[threadId] ?? [];
+}
+
 export function getFixtureTaskSteps(taskId: string) {
   return taskStepFixtures[taskId] ?? [];
 }
@@ -779,5 +948,17 @@ export function buildFixtureResponseEntry(
       responseTraceId: `fixture-response-trace-${nonce}`,
       responseTraceEventCount: 2,
     },
+  };
+}
+
+export function buildFixtureThread(title: string): ThreadItem {
+  const nonce = Date.now().toString(36);
+  const timestamp = new Date().toISOString();
+
+  return {
+    id: `fixture-thread-${nonce}`,
+    title,
+    created_at: timestamp,
+    updated_at: timestamp,
   };
 }


### PR DESCRIPTION
## Summary
- extend /chat with thread selection, compact thread creation, and bounded continuity review using the shipped continuity APIs
- keep assistant-response and governed-request modes explicit while anchoring both to selected-thread state instead of manual raw thread-id entry
- keep the sprint inside the shipped continuity and chat seams with no backend or broader workflow expansion

## Verification
- npm run lint in apps/web: PASS
- npm test in apps/web: PASS
- npm run build in apps/web: PASS

## Notes
- the sprint stayed a UI sprint over the shipped continuity and chat seams
- no backend, Gmail, Calendar, auth, runner, or broader workflow-scope expansion entered the sprint