### PR TITLE
Sprint 6J: project truth sync and context compaction

### DIFF
--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -2,51 +2,39 @@
 
 ## Canonical Truth
 
-- The working repo state is current through Sprint 5T, including narrow PDF/DOCX/RFC822 artifact ingestion, read-only Gmail account persistence and single-message ingestion, external-secret-backed Gmail credential storage on the primary path, refresh-token renewal through that seam, rotated refresh-token persistence through that seam, and the narrow `legacy_db_v0` transition path for older credential rows.
-- Use [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md) for implemented technical boundaries, [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md) for forward planning, and [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md) for durable operating rules.
-- Historical build and review reports remain the source of sprint-by-sprint detail; the active handoff should stay compact and current.
+- The working repo state is current through Sprint 6I.
+- Use [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md) for implemented boundaries, [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md) for forward planning, and [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md) for durable operating rules.
+- The live sprint reports are [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md) and [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md) at repo root; older accepted sprint history belongs in [docs/archive/sprints](/Users/samirusani/Desktop/Codex/AliceBot/docs/archive/sprints), not in this handoff.
 
-## Implemented Repo Slice
+## Implemented Surfaces
 
-- `apps/api` is the only shipped product surface. It implements continuity, tracing, deterministic context compilation, governed memory admission and review, embeddings, semantic retrieval, entities, policy and tool governance, approval persistence and resolution, approved-only `proxy.echo` execution, execution budgets, task/task-step lifecycle reads and mutations, explicit manual continuation lineage, explicit task-step linkage for approval and execution synchronization, deterministic rooted local task-workspace provisioning, explicit task-artifact registration, narrow local text/PDF/DOCX/RFC822 artifact ingestion into durable chunk rows, artifact-chunk embeddings, direct lexical and semantic artifact retrieval, compile-path semantic artifact retrieval, deterministic hybrid lexical-plus-semantic artifact merge inside the compile response, and a narrow read-only Gmail seam with external-secret-backed primary credentials plus single-message ingestion into the existing RFC822 artifact path.
-- The live schema includes continuity, trace, memory, embedding, entity, governance, `tasks`, `task_steps`, `task_workspaces`, `task_artifacts`, `task_artifact_chunks`, and `task_artifact_chunk_embeddings` tables with row-level security on user-owned data.
-- The live schema also includes `gmail_accounts` and `gmail_account_credentials` for the shipped Gmail seam; account metadata reads stay secret-free while `gmail_account_credentials` now stores locator metadata on the primary path and keeps the narrow `legacy_db_v0` transition state explicit for older rows.
-- `apps/web` and `workers` remain starter scaffolds only.
+- `apps/api` is the core shipped product surface. It implements continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact chunk retrieval and embeddings, traces, and the narrow read-only Gmail seam with selected-message ingestion.
+- `apps/web` is also a shipped surface now. The operator shell includes `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`, with live reads when API config is present and explicit fixture fallback when it is not.
+- `/chat` now ships assistant-response mode, governed-request mode, visible thread selection, compact thread creation, and bounded continuity review over thread sessions and events.
+- `workers` remains scaffold-only.
 
 ## Current Boundaries
 
-- Task workspaces are implemented only as deterministic rooted local directories plus durable `task_workspaces` records.
-- Task artifacts are implemented only as explicit rooted local-file registrations under those workspaces plus narrow deterministic ingestion for `text/plain`, `text/markdown`, `application/pdf`, DOCX text from `word/document.xml`, and `message/rfc822`.
-- Artifact retrieval operates only over persisted chunk rows and persisted chunk embeddings for one visible task or one visible artifact at a time; compile does not read raw files directly.
-- Compile can now include artifact chunks from lexical retrieval, semantic retrieval, or a deterministic hybrid merge of both into one artifact section with explicit per-chunk source provenance.
-- The shipped multi-step task path is still explicit and narrow: later steps are appended manually with lineage, while approval and execution synchronization use explicit linked `task_step_id` references.
-- The shipped Gmail path is still explicit and narrow: one read-only account seam, one selected-message ingestion path, secret-free account reads, one explicit secret-manager seam for primary credential reads and writes, refresh-capable credential renewal through that seam, rotated refresh-token persistence through that seam, and one explicit `legacy_db_v0` first-read externalization path for older rows.
-- The only execution handler in the repo is the in-process no-external-I/O `proxy.echo` path.
-
-## Not Implemented
-
-- Rich document parsing beyond the shipped narrow local text/PDF/DOCX/RFC822 ingestion seam.
-- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and Calendar connectors.
-- Removal of the remaining `legacy_db_v0` transition path for older Gmail credential rows.
-- Runner-style orchestration or automatic multi-step progression.
-- Artifact reranking or weighted fusion beyond the current lexical-first hybrid compile merge.
-- Auth beyond the current database user-context model.
+- Continuity stays explicit and thread-scoped: thread create/list/detail plus session and event review are live; thread rename, archive, search, pagination, and event mutation are not.
+- Assistant replies go only through `POST /v0/responses`, persist immutable continuity events, and return linked compile and response traces.
+- Governed actions still route through policy, allowlist, approval, and approved-only proxy execution; `proxy.echo` is still the only live execution handler.
+- Task workspaces and artifacts remain rooted local boundaries. Ingestion remains narrow to plain text, markdown, narrow PDF text, narrow DOCX text from `word/document.xml`, and narrow RFC822 extraction.
+- Gmail remains read-only and selected-message-only, with secret material handled through the dedicated secret-manager seam and the remaining `legacy_db_v0` transition path still present for older credential rows.
 
 ## Active Risks
 
 - Memory extraction and retrieval quality remain the main product risk.
 - Auth is still incomplete beyond database user context.
-- Artifact ingestion and retrieval are intentionally narrow and local; broader document parsing, broader Gmail scope, `legacy_db_v0` cleanup, and any retrieval changes beyond the shipped hybrid compile contract still need their own accepted seams.
+- Connector breadth, richer parsing, and orchestration are still deferred, but the bigger short-term risk is planning from stale docs instead of the shipped API-plus-web baseline.
 
-## Latest Accepted Verification
+## Repo Evidence To Trust
 
-- Latest accepted runtime verification totals for the shipped Sprint 5T seams were:
-  - `./.venv/bin/python -m pytest tests/unit` -> `446 passed`
-  - `./.venv/bin/python -m pytest tests/integration` -> `141 passed`
-- Sprint 5U is documentation-only truth synchronization; it does not change runtime, schema, or API behavior.
+- Backend continuity and response seams: `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`
+- Web continuity adoption: `apps/web/app/chat/page.tsx`, `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`, `apps/web/components/thread-event-list.tsx`, `apps/web/components/response-composer.tsx`
+- Broader shipped shell: `apps/web/app/approvals/page.tsx`, `apps/web/app/tasks/page.tsx`, `apps/web/app/traces/page.tsx`
 
 ## Planning Guardrails
 
-- Plan from the implemented Sprint 5T repo state, not from older milestone narratives.
-- Do not describe broader Gmail scope, Calendar work, runner work, UI work, `legacy_db_v0` cleanup, or artifact reranking beyond the current lexical-first hybrid compile merge as shipped.
-- The immediate next move after this truth-sync sprint is one more narrow Gmail auth-adjacent sprint, most likely removal of the remaining `legacy_db_v0` transition path for the existing credential seam, without combining it with search, sync, Calendar, or UI expansion.
+- Plan from the implemented Sprint 6I repo state, not from older Sprint 5-era narratives.
+- Do not describe broader Gmail scope, Calendar work, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
+- The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, not assumed to be leftover Gmail cleanup by default.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,330 +2,83 @@
 
 ## Current Implemented Slice
 
-AliceBot now implements the accepted repo slice through Sprint 6H. The shipped backend includes:
+AliceBot now implements the accepted repo slice through Sprint 6I.
 
-- foundation continuity storage over `users`, `threads`, `sessions`, and append-only `events`
-- narrow continuity APIs for thread create/list/detail plus thread session/event review over those durable continuity records
-- deterministic tracing and context compilation over durable continuity, memory, entity, and entity-edge records
-- governed memory admission, explicit-preference extraction, memory review labels, review queue reads, evaluation summary reads, explicit embedding config and memory-embedding storage, direct semantic retrieval, and deterministic hybrid compile-path memory merge
-- deterministic prompt assembly and one no-tools response path that persists assistant replies as immutable continuity events
-- user-scoped consents, policies, policy evaluation, tool registry, allowlist evaluation, tool routing, approval request persistence, approval resolution, approved-only proxy execution through the in-process `proxy.echo` handler, durable execution review, and execution-budget lifecycle plus enforcement
-- a narrow read-only Gmail connector seam with user-scoped `gmail_accounts` metadata persistence, separate user-scoped `gmail_account_credentials` locator metadata for the primary credential path, one explicit Gmail secret-manager adapter seam for secret reads and writes, deterministic account reads without secret exposure, refresh-token-capable credential renewal for expired access tokens, rotated refresh-token persistence when the provider returns a replacement token, an explicit `legacy_db_v0` transition path externalized on first credential read for older rows, and one explicit selected-message ingestion path that materializes one Gmail message as a rooted `.eml` task artifact and then reuses the existing RFC822 artifact ingestion pipeline
-- durable `tasks`, `task_steps`, `task_workspaces`, `task_artifacts`, `task_artifact_chunks`, and `task_artifact_chunk_embeddings`, deterministic task-step sequencing, explicit task-step transitions, explicit manual continuation with lineage through `parent_step_id`, `source_approval_id`, and `source_execution_id`, explicit `tool_executions.task_step_id` linkage for execution synchronization, deterministic rooted local task-workspace provisioning, explicit rooted local artifact registration, deterministic local plain-text, markdown, narrow PDF text, narrow DOCX text, and narrow RFC822 email text ingestion into durable chunk rows, deterministic lexical artifact-chunk retrieval over durable chunk rows, explicit user-scoped artifact-chunk embedding persistence tied to existing embedding configs, explicit task-scoped or artifact-scoped semantic artifact-chunk retrieval over those durable embeddings, and compile-path artifact retrieval that can include lexical results, semantic results, or one deterministic hybrid lexical-plus-semantic merged artifact section with per-chunk source provenance
+- `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and the narrow read-only Gmail seam with external-secret-backed credentials plus selected-message ingestion into the RFC822 artifact pipeline.
+- `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
+- `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, and shows bounded thread continuity review through thread detail, session, and event reads.
+- `workers` remains scaffold-only. No background runner, automatic multi-step progression, or asynchronous job system is implemented.
 
-The current multi-step boundary is narrow and explicit. Manual continuation is implemented and review-passed. Approval resolution and proxy execution now both use explicit task-step linkage rather than first-step inference. Task workspaces are now implemented only as deterministic rooted local boundaries, and task artifacts are now implemented only as explicit rooted local-file registrations, narrow deterministic artifact ingestion under those workspaces, lexical retrieval over persisted chunk rows, explicit artifact-chunk embedding storage tied to existing embedding configs, direct semantic retrieval over those durable artifact-chunk embeddings for one visible task or one visible artifact at a time, and compile-path artifact retrieval that deterministically merges lexical and semantic candidates into one artifact section when both are requested for the same scope. The live richer-document boundary is still intentionally narrow: plain text and markdown ingest directly, PDF support is limited to narrow local text extraction, DOCX support is limited to narrow local text extraction from `word/document.xml`, RFC822 email support is limited to top-level selected headers plus extractable plain-text body content while excluding nested `message/rfc822` content, and the live connector boundary is limited to one read-only Gmail account seam plus one explicit selected-message ingestion path into the rooted RFC822 artifact pipeline, with the primary Gmail credential path now storing only locator metadata on `gmail_account_credentials`, resolving secrets through one explicit Gmail secret-manager adapter seam before fetches continue, renewing expired refresh-capable credentials through that same seam, persisting any provider-returned rotated refresh token back through that same seam, keeping a narrow `legacy_db_v0` first-read externalization path for older rows only, and never exposing secret material on the normal account metadata table surface. OCR, image extraction, layout reconstruction, Gmail search, mailbox sync, attachments, Calendar connectors, reranking beyond the current lexical-first hybrid merge, and new side-effect surfaces are still planned later and must not be described as live behavior.
+The repo is intentionally still narrow. Document ingestion remains local and deterministic. The only live execution handler is the no-external-I/O `proxy.echo` path. Gmail remains read-only and selected-message-only. Rich parsing, mailbox sync, attachments, Calendar, broader proxying, and runner-style orchestration are still planned later.
 
 ## Implemented Now
 
 ### Runtime
 
 - `docker-compose.yml` starts local Postgres with `pgvector`, Redis, and MinIO.
-- `scripts/dev_up.sh`, `scripts/migrate.sh`, and `scripts/api_dev.sh` provide the local startup path, with readiness gating before migrations.
+- `scripts/dev_up.sh`, `scripts/migrate.sh`, and `scripts/api_dev.sh` provide the local startup path.
 - `apps/api` exposes FastAPI endpoints for:
-  - health, continuity, and compile: `/healthz`, `POST /v0/threads`, `GET /v0/threads`, `GET /v0/threads/{thread_id}`, `GET /v0/threads/{thread_id}/sessions`, `GET /v0/threads/{thread_id}/events`, `POST /v0/context/compile`, `POST /v0/responses`
-  - memory and retrieval: `POST /v0/memories/admit`, `POST /v0/memories/extract-explicit-preferences`, `GET /v0/memories`, `GET /v0/memories/review-queue`, `GET /v0/memories/evaluation-summary`, `POST /v0/memories/semantic-retrieval`, `GET /v0/memories/{memory_id}`, `GET /v0/memories/{memory_id}/revisions`, `POST /v0/memories/{memory_id}/labels`, `GET /v0/memories/{memory_id}/labels`
-  - embeddings and graph seams: `POST /v0/embedding-configs`, `GET /v0/embedding-configs`, `POST /v0/memory-embeddings`, `GET /v0/memories/{memory_id}/embeddings`, `GET /v0/memory-embeddings/{memory_embedding_id}`, `POST /v0/entities`, `GET /v0/entities`, `GET /v0/entities/{entity_id}`, `POST /v0/entity-edges`, `GET /v0/entities/{entity_id}/edges`
-  - governance: `POST /v0/consents`, `GET /v0/consents`, `POST /v0/policies`, `GET /v0/policies`, `GET /v0/policies/{policy_id}`, `POST /v0/policies/evaluate`, `POST /v0/tools`, `GET /v0/tools`, `GET /v0/tools/{tool_id}`, `POST /v0/tools/allowlist/evaluate`, `POST /v0/tools/route`, `POST /v0/approvals/requests`, `GET /v0/approvals`, `GET /v0/approvals/{approval_id}`, `POST /v0/approvals/{approval_id}/approve`, `POST /v0/approvals/{approval_id}/reject`, `POST /v0/approvals/{approval_id}/execute`
-  - Gmail and task execution review: `POST /v0/gmail-accounts`, `GET /v0/gmail-accounts`, `GET /v0/gmail-accounts/{gmail_account_id}`, `POST /v0/gmail-accounts/{gmail_account_id}/messages/{provider_message_id}/ingest`, `GET /v0/tasks`, `GET /v0/tasks/{task_id}`, `POST /v0/tasks/{task_id}/workspace`, `GET /v0/task-workspaces`, `GET /v0/task-workspaces/{task_workspace_id}`, `POST /v0/task-workspaces/{task_workspace_id}/artifacts`, `GET /v0/task-artifacts`, `GET /v0/task-artifacts/{task_artifact_id}`, `POST /v0/task-artifacts/{task_artifact_id}/ingest`, `GET /v0/task-artifacts/{task_artifact_id}/chunks`, `POST /v0/tasks/{task_id}/artifact-chunks/retrieve`, `POST /v0/task-artifacts/{task_artifact_id}/chunks/retrieve`, `POST /v0/tasks/{task_id}/artifact-chunks/semantic-retrieval`, `POST /v0/task-artifacts/{task_artifact_id}/chunks/semantic-retrieval`, `POST /v0/task-artifact-chunk-embeddings`, `GET /v0/task-artifacts/{task_artifact_id}/chunk-embeddings`, `GET /v0/task-artifact-chunks/{task_artifact_chunk_id}/embeddings`, `GET /v0/task-artifact-chunk-embeddings/{task_artifact_chunk_embedding_id}`, `GET /v0/tasks/{task_id}/steps`, `GET /v0/task-steps/{task_step_id}`, `POST /v0/tasks/{task_id}/steps`, `POST /v0/task-steps/{task_step_id}/transition`, `POST /v0/execution-budgets`, `GET /v0/execution-budgets`, `GET /v0/execution-budgets/{execution_budget_id}`, `POST /v0/execution-budgets/{execution_budget_id}/deactivate`, `POST /v0/execution-budgets/{execution_budget_id}/supersede`, `GET /v0/tool-executions`, `GET /v0/tool-executions/{execution_id}`
-- `apps/web` and `workers` remain starter shells only.
+  - continuity and response generation: `/healthz`, `POST /v0/threads`, `GET /v0/threads`, `GET /v0/threads/{thread_id}`, `GET /v0/threads/{thread_id}/sessions`, `GET /v0/threads/{thread_id}/events`, `POST /v0/context/compile`, `POST /v0/responses`
+  - memory, embeddings, and graph seams
+  - policy, tool, approval, execution-budget, and proxy execution governance
+  - task, task-step, task-workspace, task-artifact, artifact-chunk, and trace review reads and mutations
+  - narrow Gmail account connect/read plus selected-message ingestion
+- `apps/web` exposes the current operator shell:
+  - `/`: bounded home view over the shipped shell surfaces
+  - `/chat`: assistant mode, governed request mode, thread selection, thread creation, bounded continuity review, and response/request history
+  - `/approvals`: approval inbox and execution review
+  - `/tasks`: task summary and ordered task-step review
+  - `/traces`: trace summary, detail, and ordered event review
+- `tests` cover both the backend seams and the web shell. Durable repo evidence includes integration coverage for continuity and responses plus Vitest coverage for `/chat`, thread selection, bounded continuity review, and assistant-response submission.
 
-### Data Foundation
+### Data And Safety Boundaries
 
-- Postgres is the current system of record.
-- Alembic manages schema changes through `apps/api/alembic`.
-- The live schema includes:
-  - continuity tables: `users`, `threads`, `sessions`, `events`
-  - trace tables: `traces`, `trace_events`
-  - memory and retrieval tables: `memories`, `memory_revisions`, `memory_review_labels`, `embedding_configs`, `memory_embeddings`
-  - graph tables: `entities`, `entity_edges`
-  - governance tables: `consents`, `policies`, `tools`, `approvals`, `tool_executions`, `execution_budgets`
-  - connector tables: `gmail_accounts`, `gmail_account_credentials`
-  - task lifecycle tables: `tasks`, `task_steps`, `task_workspaces`, `task_artifacts`, `task_artifact_chunks`, `task_artifact_chunk_embeddings`
-- `events`, `trace_events`, and `memory_revisions` are append-only by application contract and database enforcement.
-- `memory_review_labels` are append-only by database enforcement.
-- `tasks` are explicit user-scoped lifecycle records keyed to one thread and one tool, with durable request/tool snapshots, status in `pending_approval | approved | executed | denied | blocked`, and latest approval/execution pointers for the current narrow lifecycle seam.
-- `task_steps` are explicit user-scoped ordered lifecycle records keyed by `(user_id, task_id, sequence_no)`, with `kind = 'governed_request'`, status in `created | approved | executed | blocked | denied`, durable request/outcome snapshots, and one trace reference describing the latest mutation.
-- Sprint 4O added lineage columns on `task_steps`:
-  - `parent_step_id`
-  - `source_approval_id`
-  - `source_execution_id`
-- Lineage fields are guarded by composite user-scoped foreign keys and a self-reference check so a step cannot cite itself as its parent.
-- `tool_executions` now persist an explicit `task_step_id` linked by a composite foreign key to `task_steps(id, user_id)`.
-- `task_workspaces` persist one active workspace record per visible task and user, store a deterministic `local_path`, and enforce that active uniqueness through a partial unique index on `(user_id, task_id)`.
-- `task_artifacts` persist explicit user-scoped artifact rows linked to both `tasks` and `task_workspaces`, store `status = registered`, `ingestion_status in ('pending', 'ingested')`, store only a workspace-relative `relative_path` plus optional `media_type_hint`, and enforce deterministic duplicate rejection through a unique index on `(user_id, task_workspace_id, relative_path)`.
-- `task_artifact_chunks` persist explicit user-scoped durable chunk rows linked to one artifact, store ordered `sequence_no`, zero-based `char_start`, exclusive `char_end_exclusive`, and chunk `text`, and enforce deterministic uniqueness through a unique index on `(user_id, task_artifact_id, sequence_no)`.
-- `task_artifact_chunk_embeddings` persist explicit user-scoped durable embedding rows linked to one visible chunk and one visible embedding config, store validated `dimensions` and `vector`, and enforce deterministic uniqueness through a unique index on `(user_id, task_artifact_chunk_id, embedding_config_id)`.
-- `execution_budgets` enforce at most one active budget per `(user_id, tool_key, domain_hint)` selector scope through a partial unique index.
-- Per-request user context is set in the database through `app.current_user_id()`.
-- `TASK_WORKSPACE_ROOT` defines the only allowed base directory for workspace provisioning, and the live path rule is `resolved_root / user_id / task_id`.
-
-### Repo Boundaries In This Slice
-
-- `apps/api`: implemented API, store, contracts, service logic, and migrations for continuity, tracing, memory, embeddings, entities, policies, tools, approvals, proxy execution, execution budgets, a narrow read-only Gmail connector seam with protected refresh-token lifecycle and refresh-token rotation handling support, tasks, task steps, task workspaces, task artifacts, artifact-chunk embeddings, deterministic lexical artifact chunk retrieval, deterministic semantic artifact chunk retrieval over durable embeddings, compile-path semantic artifact retrieval, and deterministic hybrid lexical-plus-semantic artifact merge in compile.
-- `apps/web`: minimal shell only; no shipped workflow UI.
-- `workers`: scaffold only; no background jobs or runner logic are implemented.
-- `infra`: local development bootstrap assets only.
-- `tests`: unit and Postgres-backed integration coverage for the shipped seams above, including Sprint 4O task-step lineage/manual continuation, Sprint 4S step-linked execution synchronization, Sprint 5A task-workspace provisioning, Sprint 5C task-artifact registration, Sprint 5D local artifact ingestion plus chunk reads, Sprint 5E lexical artifact-chunk retrieval, Sprint 5F compile-path artifact chunk integration, Sprint 5G artifact-chunk embedding persistence and reads, Sprint 5H direct semantic artifact-chunk retrieval, Sprint 5I compile-path semantic artifact retrieval, Sprint 5J deterministic hybrid lexical-plus-semantic artifact merge in compile, Sprint 5L narrow PDF artifact ingestion, Sprint 5M narrow DOCX artifact ingestion, Sprint 5N narrow RFC822 email artifact ingestion, Sprint 5O read-only Gmail account plus single-message ingestion coverage, Sprint 5P Gmail credential hardening coverage, Sprint 5Q Gmail refresh-token lifecycle coverage, Sprint 5R Gmail refresh-token rotation handling coverage, Sprint 5T Gmail external secret-manager coverage, and Sprint 6H continuity API create/list/detail plus thread session/event review coverage.
+- Postgres is the system of record.
+- Row-level security is enforced on user-owned continuity, trace, memory, governance, task, workspace, artifact, and Gmail tables.
+- `events`, `trace_events`, and `memory_revisions` are append-only by contract.
+- Task-step lineage and execution linkage stay explicit through `parent_step_id`, `source_approval_id`, `source_execution_id`, and `tool_executions.task_step_id`.
+- Task workspaces are rooted local directories under `TASK_WORKSPACE_ROOT`.
+- Task artifacts are explicit rooted local-file registrations only; compile and retrieval read persisted chunk rows, not raw files.
+- Gmail credential material stays off normal metadata tables and flows through the dedicated secret-manager seam.
 
 ## Core Flows Implemented Now
 
-### Continuity Review
+### Continuity And Chat
 
-1. Accept a user-scoped `POST /v0/threads` request with one caller-supplied thread title.
-2. Persist exactly one visible `threads` row through the existing continuity store.
-3. List visible threads through `GET /v0/threads` in deterministic `created_at DESC, id DESC` order.
-4. Read one visible thread through `GET /v0/threads/{thread_id}`.
-5. Read visible sessions for one visible thread through `GET /v0/threads/{thread_id}/sessions` in deterministic `started_at ASC, created_at ASC, id ASC` order.
-6. Read immutable visible events for one visible thread through `GET /v0/threads/{thread_id}/events` in deterministic `sequence_no ASC` order.
-7. Return stable summary metadata for thread, session, and event list reads.
-8. Reuse only already-persisted continuity data; session mutation, event mutation, rename, archive, pagination, and search remain out of scope.
+1. `POST /v0/threads` creates one visible thread.
+2. `GET /v0/threads`, `GET /v0/threads/{thread_id}`, `GET /v0/threads/{thread_id}/sessions`, and `GET /v0/threads/{thread_id}/events` expose bounded continuity review over persisted records.
+3. `POST /v0/responses` compiles context deterministically, persists the submitted user message plus the assistant reply as immutable events, and returns linked compile and response trace metadata.
+4. `/chat` consumes those shipped seams directly. Selected-thread identity stays explicit across assistant and governed-request modes, and recent continuity review stays bounded instead of becoming an unbounded transcript.
 
-### Deterministic Context Compilation
+### Governance, Tasks, And Explainability
 
-1. Accept a user-scoped `POST /v0/context/compile` request.
-2. Read durable continuity records in deterministic order.
-3. Merge in active memories, entities, and entity edges through the currently shipped symbolic and optional semantic retrieval paths.
-4. Optionally retrieve artifact chunks through lexical retrieval, semantic retrieval, or both, scoped to exactly one visible task or one visible artifact per request.
-5. Reuse only persisted `task_artifact_chunks` rows and persisted artifact-chunk embeddings during compile; compile does not read raw files.
-6. When both artifact retrieval modes are present for the same scope, merge candidates by durable chunk id into one `artifact_chunks` section, preserve lexical match and semantic score provenance, and apply deterministic lexical-first source precedence.
-7. Keep retrieved artifact chunks separate from memory and entity sections, with deterministic per-section limits, ordering, and summary metadata.
-8. Persist a `context.compile` trace plus explicit inclusion and exclusion events, including artifact chunk deduplication, inclusion, and exclusion decisions.
-9. Return one deterministic `context_pack` describing scope, limits, selected context, artifact chunk results, and trace metadata.
+1. `POST /v0/approvals/requests` creates one task and one initial task step for each governed request.
+2. Approval resolution and approved execution reuse explicit task-step linkage instead of inferring from first-step-only assumptions.
+3. `GET /v0/approvals`, `GET /v0/tasks`, `GET /v0/tasks/{task_id}/steps`, `GET /v0/traces`, and related detail reads expose durable review state through the web shell.
+4. The shipped explainability surface is calm and bounded: summary first, detail second, ordered trace events last.
 
-### Artifact Chunk Retrieval
+### Workspaces, Artifacts, And Gmail
 
-1. Register and ingest visible local artifacts into durable `task_artifacts` and `task_artifact_chunks`.
-2. Persist explicit artifact-chunk embeddings in `task_artifact_chunk_embeddings`, keyed to an existing visible embedding config.
-3. Support deterministic lexical artifact-chunk retrieval for one visible task or one visible artifact.
-4. Support deterministic semantic artifact-chunk retrieval for one visible task or one visible artifact, using a caller-supplied query vector plus explicit `embedding_config_id`.
-5. Exclude artifacts whose `ingestion_status` is not `ingested`.
-6. Reuse those same persisted lexical and semantic retrieval seams inside compile for one visible task or one visible artifact.
-7. When compile receives both lexical and semantic artifact retrieval for the same scope, deduplicate by durable chunk id, preserve per-chunk source provenance, and count dual-source inclusions explicitly.
-8. Order hybrid compile candidates deterministically by source precedence, lexical rank, semantic rank, `relative_path`, `sequence_no`, and `id`.
-9. Return stable summary metadata covering scope, query terms, embedding config, query-vector dimensions, candidate counts, deduplication counts, inclusion counts, exclusion counts, and ordering rules.
-
-### Narrow Gmail Connector
-
-1. Accept a user-scoped `POST /v0/gmail-accounts` request for one read-only Gmail account metadata record.
-2. Persist exactly the narrow connector metadata required for later reads on `gmail_accounts`: `provider_account_id`, `email_address`, optional `display_name`, and the fixed Gmail read-only scope.
-3. Persist only Gmail credential locator metadata on `gmail_account_credentials` for the primary path, and store the secret payload itself through one explicit Gmail secret-manager adapter seam bound to the same visible user/account ownership scope.
-4. Expose deterministic user-scoped Gmail account list and detail reads without secret material.
-5. Accept a user-scoped `POST /v0/gmail-accounts/{gmail_account_id}/messages/{provider_message_id}/ingest` request for one visible Gmail account and one visible task workspace.
-6. Resolve the Gmail access token through the Gmail secret-manager adapter seam before any Gmail fetch, file write, or artifact registration, and renew it first through one explicit refresh path when the visible refresh-capable credential is expired.
-7. When the refresh provider returns a replacement refresh token, persist that rotated token back through the same Gmail secret-manager adapter seam before Gmail fetches continue.
-8. Derive one deterministic workspace-relative artifact path as `gmail/<sanitized-provider-account-id>/<sanitized-provider-message-id>.eml`.
-9. Reject duplicate `(task_workspace_id, relative_path)` collisions before any Gmail fetch or file write.
-10. Fetch exactly one selected Gmail message through the read-only Gmail API path `users/me/messages/{provider_message_id}?format=raw`.
-11. Require Gmail to return RFC822 `raw` content, validate it against the existing narrow `message/rfc822` extraction rules, and reject unsupported content deterministically.
-12. Materialize the message as one rooted `.eml` file inside the selected task workspace and then reuse the existing task-artifact registration plus artifact-ingestion seam.
-13. Persist only the resulting `task_artifacts` and `task_artifact_chunks` rows; account-wide sync, search, attachments, Calendar, and write-capable actions remain out of scope.
-
-### Governed Memory And Retrieval
-
-1. Accept explicit memory candidates through `POST /v0/memories/admit`.
-2. Require cited source events, default to `NOOP`, and persist `memory_revisions` only for evidence-backed non-`NOOP` mutations.
-3. Support a narrow deterministic explicit-preference extractor over stored `message.user` events.
-4. Persist user-scoped embedding configs and memory embeddings explicitly.
-5. Support direct semantic retrieval over active memories for a caller-selected embedding config.
-6. Merge symbolic and semantic memory results deterministically into the compile path with trace-visible source provenance.
-7. Expose review reads, unlabeled review queue reads, evaluation summary reads, and append-only memory-review labels.
-
-### Policy, Tool, Approval, And Execution Governance
-
-1. Evaluate policies deterministically over active user-scoped policy and consent state.
-2. Evaluate tool allowlists against active tool metadata plus policy decisions.
-3. Route one requested invocation deterministically to `ready`, `denied`, or `approval_required`.
-4. Persist durable approval rows only for `approval_required` outcomes.
-5. Resolve approvals explicitly through approve and reject endpoints.
-6. Execute approved requests only through the registered proxy-handler map.
-7. In the current repo, only `proxy.echo` is enabled, and it performs no external I/O.
-8. Persist one durable `tool_executions` row for every approved execution attempt, including budget-blocked attempts.
-9. Enforce narrow execution budgets by selector scope and optional rolling window before approved dispatch.
-
-### Task Lifecycle Creation
-
-1. `POST /v0/approvals/requests` always creates one durable `tasks` row and one initial `task_steps` row, even when no approval row is persisted.
-2. The initial task and task step reflect the routing decision:
-  - `approval_required` creates `task.status = pending_approval` and `task_step.status = created`
-  - `ready` creates `task.status = approved` and `task_step.status = approved`
-  - `denied` creates `task.status = denied` and `task_step.status = denied`
-3. The initial task step is always `sequence_no = 1`.
-4. Approval-request traces include task lifecycle and task-step lifecycle events alongside the approval request events.
-
-### Approval Resolution And Proxy Execution Synchronization
-
-1. Approval resolution reuses the existing task seam and updates the durable task plus the explicitly linked task step from `approvals.task_step_id`.
-2. Approval resolution rejects missing, invisible, cross-task, and inconsistent approval-to-step linkage deterministically.
-3. Approved proxy execution validates the approval’s linked task step before dispatch and persists `tool_executions.task_step_id` on every durable execution row.
-4. Execution synchronization now reuses `tool_executions.task_step_id` and updates the explicitly linked step by id rather than inferring `sequence_no = 1`.
-5. Execution synchronization rejects missing, invisible, cross-task, and inconsistent execution-to-step linkage deterministically before mutating task or task-step state.
-
-### Task-Step Manual Continuation
-
-1. Accept a user-scoped `POST /v0/tasks/{task_id}/steps` request to append exactly one next step to an existing task.
-2. Lock the task-step sequence before allocating the next `sequence_no`.
-3. Require the task to already have visible steps.
-4. Allow append only when the latest visible step is in `executed`, `blocked`, or `denied`.
-5. Require explicit lineage:
-  - `lineage.parent_step_id` must be present
-  - the parent step must belong to the same visible task
-  - the parent step must be the latest visible task step
-6. Optionally allow `lineage.source_approval_id` and `lineage.source_execution_id`, but only when:
-  - the referenced records are visible in the current user scope
-  - the referenced records already appear on the parent step outcome
-7. Persist the new `task_steps` row with the lineage fields and incremented `sequence_no`.
-8. Update the parent `tasks` row to the task status implied by the appended step status.
-9. Persist one `task.step.continuation` trace plus request, lineage, summary, task lifecycle, and task-step lifecycle events.
-10. Return the updated task, the appended step, deterministic sequencing metadata, and trace summary.
-
-### Task-Step Transition
-
-1. Accept a user-scoped `POST /v0/task-steps/{task_step_id}/transition` request.
-2. Require the referenced step to be the latest visible step on its task.
-3. Enforce the explicit status graph:
-  - `created -> approved | denied`
-  - `approved -> executed | blocked`
-  - terminal states have no further transitions
-4. Require approval linkage when the step must reflect approval state and execution linkage when the step must reflect execution state.
-5. Update the target step in place with a new trace reference and outcome snapshot.
-6. Update the parent task status and latest approval/execution pointers consistently.
-7. Persist one `task.step.transition` trace plus request, state, summary, task lifecycle, and task-step lifecycle events.
-
-### Task And Task-Step Reads
-
-1. `GET /v0/tasks` lists durable task rows in deterministic `created_at ASC, id ASC` order.
-2. `GET /v0/tasks/{task_id}` returns one user-visible task detail record.
-3. `GET /v0/tasks/{task_id}/steps` returns task steps in deterministic `sequence_no ASC, created_at ASC, id ASC` order plus sequencing summary metadata.
-4. `GET /v0/task-steps/{task_step_id}` returns one user-visible task-step detail record.
-5. Task-step list and detail reads expose lineage fields directly.
-
-### Task Workspace Provisioning
-
-1. Accept a user-scoped `POST /v0/tasks/{task_id}/workspace` request for one visible task.
-2. Resolve the configured `TASK_WORKSPACE_ROOT`.
-3. Build the deterministic local path as `resolved_root / user_id / task_id`.
-4. Reject provisioning if the resolved workspace path escapes the resolved workspace root.
-5. Lock workspace creation for the target task before checking for an existing active workspace.
-6. Reject duplicate active workspace creation for the same visible task deterministically.
-7. Create the local directory boundary and persist one `task_workspaces` row with `status = active` and the rooted `local_path`.
-8. `GET /v0/task-workspaces` lists visible workspaces in deterministic `created_at ASC, id ASC` order.
-9. `GET /v0/task-workspaces/{task_workspace_id}` returns one user-visible workspace detail record.
-
-### Task Artifact Registration And Reads
-
-1. Accept a user-scoped `POST /v0/task-workspaces/{task_workspace_id}/artifacts` request for one visible workspace.
-2. Resolve the provided local file path and require it to exist as a regular file.
-3. Resolve the persisted workspace `local_path` and reject registration if the file path escapes that rooted workspace boundary.
-4. Persist only the workspace-relative POSIX path plus optional `media_type_hint`; no absolute artifact path is stored.
-5. Lock registration for the target workspace before checking for an existing artifact with the same relative path.
-6. Reject duplicate registration for the same visible `(task_workspace_id, relative_path)` deterministically.
-7. Persist one `task_artifacts` row with `status = registered` and `ingestion_status = pending`.
-8. `GET /v0/task-artifacts` lists visible artifact rows in deterministic `created_at ASC, id ASC` order.
-9. `GET /v0/task-artifacts/{task_artifact_id}` returns one user-visible artifact detail record.
-
-### Task Artifact Ingestion And Chunk Reads
-
-1. Accept a user-scoped `POST /v0/task-artifacts/{task_artifact_id}/ingest` request for one visible registered artifact.
-2. Lock ingestion for that artifact before deciding whether work is needed.
-3. Resolve the persisted workspace `local_path` plus persisted artifact `relative_path`, and reject any rooted-path escape deterministically.
-4. Support only the current narrow explicit set: `text/plain`, `text/markdown`, narrow local `application/pdf` text extraction, narrow local `application/vnd.openxmlformats-officedocument.wordprocessingml.document` text extraction from `word/document.xml`, and narrow local `message/rfc822` extraction.
-5. For plain text and markdown, read file bytes deterministically and require valid UTF-8 text.
-6. For PDFs, extract only narrow local text content; OCR, image extraction, and broader PDF compatibility remain out of scope.
-7. For DOCX, extract only narrow local text from `word/document.xml`; OCR, image extraction, headers/footers/comments expansion, and layout reconstruction remain out of scope.
-8. For RFC822 email, extract only the selected top-level headers plus extractable plain-text body content; nested `message/rfc822` content, HTML rendering, and attachment extraction remain out of scope.
-9. Reject malformed or textless richer-document inputs deterministically instead of producing misleading chunks.
-10. Normalize line endings by rewriting `\r\n` and `\r` to `\n`.
-11. Chunk normalized text deterministically with rule `normalized_utf8_text_fixed_window_1000_chars_v1`.
-12. Persist ordered `task_artifact_chunks` rows with `sequence_no`, `char_start`, `char_end_exclusive`, and `text`.
-13. Update the parent artifact to `ingestion_status = ingested`.
-14. If the artifact is already ingested, return the existing artifact and chunk summary without reinserting chunks.
-15. `GET /v0/task-artifacts/{task_artifact_id}/chunks` returns visible chunk rows in deterministic `sequence_no ASC, id ASC` order plus stable summary metadata.
-
-### Artifact Chunk Retrieval
-
-1. Accept a user-scoped retrieval request scoped to exactly one visible task or one visible artifact.
-2. Normalize the query deterministically by casefolding and extracting unique lexical `\w+` terms in first-occurrence order.
-3. Read only persisted `task_artifact_chunks` rows for visible artifacts; compile and retrieval paths do not read raw files.
-4. Exclude artifacts whose `ingestion_status != 'ingested'`.
-5. Match chunks by lexical query-term overlap and record match metadata including matched query terms and first match offset.
-6. Order matches deterministically by matched query term count desc, first match offset asc, relative path asc, sequence no asc, and id asc.
-7. Return stable summary metadata describing query terms, scope, searched artifact count, and ordering.
-
-### Artifact Chunk Embedding Storage
-
-1. Accept a user-scoped `POST /v0/task-artifact-chunk-embeddings` request.
-2. Require `task_artifact_chunk_id` to reference one visible persisted chunk.
-3. Require `embedding_config_id` to reference one visible persisted embedding config.
-4. Normalize the submitted vector as finite numeric values only.
-5. Reject writes unless the vector length matches `embedding_config.dimensions`.
-6. Persist or update exactly one embedding per visible `(task_artifact_chunk_id, embedding_config_id)` pair.
-7. Expose deterministic reads by artifact scope, chunk scope, and embedding id.
-8. Order list reads by chunk sequence first, then `created_at ASC`, then `id ASC`.
-
-## Security Model Implemented Now
-
-- User-owned continuity, trace, memory, embedding, entity, governance, task, task-step, task-workspace, task-artifact, task-artifact-chunk, and task-artifact-chunk-embedding tables enforce row-level security.
-- The runtime role is limited to the narrow `SELECT` / `INSERT` / `UPDATE` permissions required by the shipped seams; there is no broad DDL or unrestricted table access at runtime.
-- Cross-user references are constrained through composite foreign keys on `(id, user_id)` where the schema needs ownership-linked joins.
-- Approval, execution, memory, entity, task/task-step, task-workspace, task-artifact, task-artifact-chunk, and task-artifact-chunk-embedding reads all operate only inside the current user scope.
-- Task-step manual continuation adds both schema-level and service-level lineage protection:
-  - schema-level: user-scoped foreign keys and parent-not-self check
-  - service-level: same-task, latest-step, visible-approval, visible-execution, and parent-outcome-match validation
-- In-place updates and deletes remain blocked for append-only continuity and trace records.
+1. Tasks can provision one rooted local workspace and register local artifacts under that boundary.
+2. Artifact ingestion supports the narrow current set only: plain text, markdown, narrow local PDF text extraction, narrow DOCX text extraction from `word/document.xml`, and narrow RFC822 email extraction.
+3. Artifact retrieval works over persisted chunk rows and persisted chunk embeddings, including deterministic lexical retrieval, direct semantic retrieval, and the current lexical-first hybrid compile merge.
+4. Gmail remains narrow: one read-only account seam, secret-free account reads, external-secret-backed primary credentials, refresh-token renewal and rotation handling, and one selected-message ingestion path that lands in the existing RFC822 artifact workflow.
 
 ## Testing Coverage Implemented Now
 
-- Unit and integration tests cover continuity, compiler, response generation, memory admission, review labels, review queue, embeddings, semantic retrieval, compile-path hybrid memory retrieval, artifact lexical retrieval, artifact semantic retrieval, compile-path semantic artifact retrieval, hybrid artifact compile merge, entities, policies, tools, approvals, proxy execution, execution budgets, and execution review.
-- Sprints 4O through 5R added explicit task lifecycle, artifact retrieval, richer-document ingestion, and narrow Gmail coverage:
-  - migrations for `tasks`, `task_steps`, and task-step lineage
-  - staged/backfilled migration coverage for `tool_executions.task_step_id`
-  - task and task-step store contracts
-  - task list/detail and task-step list/detail reads
-  - deterministic sequencing summaries
-  - manual continuation success paths
-  - task-step transition success paths
-  - explicit later-step execution synchronization by linked `task_step_id`
-  - deterministic task-workspace path generation and rooted-path enforcement
-  - workspace create/list/detail response shape
-  - duplicate active workspace rejection
-  - task-workspace per-user isolation
-  - artifact register/list/detail response shape
-  - rooted artifact-path enforcement beneath the persisted workspace path
-  - duplicate artifact registration rejection for the same workspace-relative path
-  - supported `text/plain` and `text/markdown` ingestion
-  - deterministic line-ending normalization and fixed-window chunk boundaries
-  - invalid UTF-8 rejection
-  - idempotent re-ingestion of already ingested artifacts
-  - deterministic lexical artifact-chunk retrieval by task and by artifact
-  - compile-path artifact chunk inclusion, exclusion, ordering, and per-user isolation
-  - artifact-chunk embedding write and read coverage
-  - direct semantic artifact-chunk retrieval by task and by artifact
-  - compile-path semantic artifact retrieval including trace visibility, exclusion rules, and scope isolation
-  - deterministic hybrid artifact compile merge with dual-source provenance, deduplication, lexical-first precedence, and shared limit enforcement
-  - narrow PDF ingestion success and failure paths
-  - narrow DOCX ingestion success and failure paths
-  - narrow RFC822 ingestion success and failure paths
-  - read-only Gmail account connect/list/detail coverage with secret-free reads
-  - selected Gmail message ingestion through the rooted RFC822 artifact path
-  - primary Gmail credential locator storage isolation in `gmail_account_credentials`
-  - refresh-token renewal for expired refresh-capable Gmail credentials
-  - rotated refresh-token persistence when the provider returns a replacement token
-  - external Gmail secret-manager reference persistence and resolution
-  - task-artifact and task-artifact-chunk per-user isolation
-  - trace visibility for continuation and transition events
-  - user isolation for task and task-step reads and mutations
-  - adversarial lineage validation for cross-task, cross-user, and parent-step mismatch cases
+- Backend continuity and response seams are covered in `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`, and related unit coverage under `tests/unit`.
+- Web continuity adoption is covered in `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.test.tsx`, `apps/web/components/thread-summary.test.tsx`, `apps/web/components/thread-event-list.test.tsx`, `apps/web/components/thread-create.test.tsx`, and `apps/web/components/response-composer.test.tsx`.
+- The shell also has route and API-client coverage for approvals, tasks, traces, and shared API utilities under `apps/web`.
 
 ## Planned Later
 
-The following areas remain planned later and must not be described as implemented:
+The following remain planned later and must not be described as implemented:
 
-- runner-style orchestration and automatic multi-step progression beyond the current explicit manual continuation seam
-- artifact reranking, weighted fusion, or precedence changes beyond the current lexical-first hybrid compile merge and direct lexical/direct semantic ordering seams
-- rich document parsing beyond the current narrow UTF-8 text and markdown ingestion boundary
+- runner-style orchestration and automatic multi-step progression
+- auth beyond the current database user-context model
+- richer document parsing, OCR, image extraction, or layout reconstruction
 - Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and Calendar connectors
-- broader tool proxying and real-world side effects beyond the current no-I/O `proxy.echo` handler
-- model-driven extraction, reranking, and broader memory review automation
-- production deployment automation beyond the local developer stack
+- broader proxy execution breadth or real-world side effects beyond `proxy.echo`
+- retrieval reranking or weighted fusion beyond the current lexical-first hybrid compile merge
 
-Future docs and code should continue to distinguish the implemented seams above from these later milestones.
+Future planning should start from the shipped API-plus-web-shell baseline above, not from older Gmail-era or scaffold-era descriptions.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -2,100 +2,89 @@
 
 ## sprint objective
 
-Implement Sprint 6I by extending `/chat` with visible thread selection, compact thread creation, and bounded continuity review using only the shipped continuity APIs, while preserving the existing assistant-response and governed-request seams.
+Synchronize the canonical truth artifacts with the implemented repo state through Sprint 6I and compact active documentation so future planning starts from the shipped API-plus-web-shell baseline instead of stale Sprint 5-era or Sprint 6H-only narratives.
 
-## exact `/chat` files and components updated
+## completed work
 
-- `apps/web/app/chat/page.tsx`
-- `apps/web/app/chat/page.test.tsx`
-- `apps/web/app/globals.css`
-- `apps/web/components/mode-toggle.tsx`
-- `apps/web/components/request-composer.tsx`
-- `apps/web/components/request-composer.test.tsx`
-- `apps/web/components/response-composer.tsx`
-- `apps/web/components/response-composer.test.tsx`
-- `apps/web/components/thread-list.tsx`
-- `apps/web/components/thread-list.test.tsx`
-- `apps/web/components/thread-create.tsx`
-- `apps/web/components/thread-create.test.tsx`
-- `apps/web/components/thread-summary.tsx`
-- `apps/web/components/thread-summary.test.tsx`
-- `apps/web/components/thread-event-list.tsx`
-- `apps/web/components/thread-event-list.test.tsx`
-- `apps/web/lib/api.ts`
-- `apps/web/lib/api.test.ts`
-- `apps/web/lib/fixtures.ts`
+- Updated `ARCHITECTURE.md` to reflect the shipped repo state through Sprint 6I, including the continuity APIs, assistant-response seam, shipped web shell, and `/chat` thread-selection plus bounded continuity-review adoption.
+- Rewrote `ROADMAP.md` so current position starts from Sprint 6I and the next focus is framed from the shipped backend-plus-web-shell baseline instead of the stale Gmail-cleanup-only storyline.
+- Compressed and corrected `.ai/handoff/CURRENT_STATE.md` so it no longer describes `apps/web` as scaffold-only, now points at durable repo evidence, and now states that live sprint reports stay at repo root until archival.
+- Updated `README.md` so onboarding-level repo status is truthful and compact, and so the current-vs-archived sprint report locations are explicit.
+- Rewrote `REVIEW_REPORT.md` so it reviews this documentation compaction sprint instead of the prior `/chat` UI sprint.
+- Left `RULES.md` unchanged because no concrete stale or duplicated rule required modification.
+- Made no archive moves because the current sprint reports intentionally remain live at repo root until archival and older accepted history already remains traceable through `docs/archive/sprints`.
+
+## incomplete work
+
+- No in-scope documentation deliverable was left incomplete.
+- `RULES.md` and `docs/archive/**` were intentionally not changed because no required update or archival move was identified.
+
+## files changed
+
+- `REVIEW_REPORT.md`
+- `ARCHITECTURE.md`
+- `ROADMAP.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `README.md`
 - `BUILD_REPORT.md`
 
-## continuity data mode
+## unrelated pre-existing worktree drift
 
-- live API-backed when the web API base URL and user ID are configured
-- fixture-backed for thread selection, thread summary, continuity review, and history when API configuration is absent
-- explicit unavailable state for thread creation when API configuration is absent
+- `.ai/active/SPRINT_PACKET.md` was already locally modified as a control artifact and was not edited by this sprint implementation.
 
-## shipped backend continuity endpoints consumed
+## accepted repo evidence used
 
-- `POST /v0/threads`
-- `GET /v0/threads`
-- `GET /v0/threads/{thread_id}`
-- `GET /v0/threads/{thread_id}/sessions`
-- `GET /v0/threads/{thread_id}/events`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/response_generation.py`
+- `apps/web/app/chat/page.tsx`
+- `apps/web/app/approvals/page.tsx`
+- `apps/web/app/tasks/page.tsx`
+- `apps/web/app/traces/page.tsx`
+- `apps/web/components/thread-list.tsx`
+- `apps/web/components/thread-summary.tsx`
+- `apps/web/components/thread-event-list.tsx`
+- `apps/web/components/response-composer.tsx`
+- `tests/integration/test_continuity_api.py`
+- `tests/integration/test_continuity_store.py`
+- `tests/integration/test_responses_api.py`
+- `apps/web/app/chat/page.test.tsx`
+- `apps/web/components/thread-list.test.tsx`
+- `apps/web/components/thread-summary.test.tsx`
+- `apps/web/components/thread-event-list.test.tsx`
+- `apps/web/components/response-composer.test.tsx`
 
-## additional existing seams preserved
+## stale claims corrected
 
-- `POST /v0/responses`
-- `POST /v0/approvals/requests`
+- `ARCHITECTURE.md` no longer says the repo is current only through Sprint 6H.
+- `ARCHITECTURE.md`, `README.md`, and `.ai/handoff/CURRENT_STATE.md` no longer describe `apps/web` as scaffold-only.
+- `ROADMAP.md` and `.ai/handoff/CURRENT_STATE.md` no longer plan from Sprint 5T or from the Gmail-era “next move” by default.
+- `README.md` no longer claims the repo is current only through Sprint 5A.
 
-## completed UI work
+## files moved to docs/archive
 
-- replaced the raw manual thread-ID-first assistant flow with a selected-thread-driven `/chat` surface
-- added a bounded right-rail continuity stack:
-  - visible thread list
-  - compact thread-create card
-  - selected-thread identity summary
-  - bounded recent continuity review for sessions and events
-- updated assistant mode to submit against the selected thread instead of a typed UUID field
-- updated governed mode to reuse the selected thread explicitly while keeping tool/action/scope controls unchanged
-- preserved thread continuity across mode switches by carrying the selected thread in the route query
-- added fixture continuity data so fallback states remain explicit and readable when the live API is not configured
-- tightened spacing, containment, overflow handling, and responsive stacking for long IDs, pills, and continuity cards
+- None.
+- Current sprint reports intentionally remain live at repo root; `docs/archive/sprints` is the home for older accepted sprint reports after archival.
 
-## exact commands run
+## tests run
 
-- `cd apps/web && npm run lint`
-- `cd apps/web && npm test`
-- `cd apps/web && npm run build`
+- `./.venv/bin/python -m pytest tests/unit/test_events.py tests/unit/test_main.py tests/unit/test_response_generation.py`
+- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py`
+- `pnpm --dir apps/web test`
 
-## verification results
+## blockers/issues
 
-- `npm run lint`: PASS
-- `npm test`: PASS (`40` tests)
-- `npm run build`: PASS
+- No implementation blockers inside sprint scope.
+- `./.venv/bin/python -m pytest tests/unit/test_events.py tests/unit/test_main.py tests/unit/test_response_generation.py` passed: `48 passed`
+- `pnpm --dir apps/web test` passed: `40 passed`
+- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py` could not run in this sandbox because localhost Postgres connections to `127.0.0.1:5432` were blocked with `psycopg.OperationalError: Operation not permitted`
+- No runtime, schema, API, or UI behavior was changed; this sprint was documentation-only.
 
-## concise desktop visual verification notes
+## intentionally deferred
 
-- `/chat` now reads with a clearer hierarchy: composer/history on the left, continuity selection/review on the right
-- selected thread identity is repeated in a controlled way at the page header, composer, and summary card so context stays explicit without relying on a raw UUID input
-- long thread IDs and metadata pills wrap inside their containers instead of leaking outside cards
-- continuity review remains bounded and readable rather than becoming a transcript-style event dump
+- `RULES.md` changes, because no concrete stale rule required adjustment
+- archive moves, because existing archived sprint artifacts already preserve traceability
+- any runtime, schema, API, UI, Gmail, Calendar, auth, or orchestration work outside the truth-sync scope
 
-## concise mobile visual verification notes
+## recommended next step
 
-- the wide layout collapses to one column at the existing responsive breakpoints
-- thread review subpanels collapse from two columns to one column on small screens
-- composer actions and secondary buttons expand to full width on mobile to avoid cramped wrapping
-- selected-thread banners and summary toplines stack cleanly instead of forcing horizontal overflow
-
-## blockers or issues
-
-- no remaining blockers inside sprint scope
-- no screenshot automation or browser capture was run during this pass; visual notes are based on the implemented layout, CSS breakpoints, and successful web build/test verification
-
-## intentionally deferred after this sprint
-
-- thread rename, archive, search, filter, and pagination
-- full transcript tooling or unbounded event review
-- thread-event mutation UI
-- new backend continuity endpoints
-- unrelated route redesigns
-- Gmail, Calendar, auth, runner, connector, task-orchestration, or broader workflow scope expansion
+Plan the next sprint from the shipped Sprint 6I backend-plus-web-shell baseline and choose one narrow product seam on top of existing continuity, response, approval, task, or trace contracts rather than reopening stale Gmail-cleanup assumptions by default.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted backend slice through Sprint 5A plus local developer tooling.
+AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6I: a FastAPI backend plus a bounded Next.js operator shell.
 
 ## Current Implemented Slice
 
-- `apps/api` is the shipped surface. It includes continuity storage, tracing, deterministic context compilation, governed memory admission and review, embeddings, semantic retrieval, entities, policy and tool governance, approval persistence and resolution, approved-only `proxy.echo` execution, execution budgets, tasks, task steps, explicit manual continuation lineage, step-linked approval/execution synchronization, and deterministic rooted local task-workspace provisioning.
-- `apps/web` and `workers` are starter scaffolds only.
-- Task workspaces are currently local rooted directories plus durable records. Artifact indexing, document ingestion, connectors, and runner orchestration are not shipped.
+- `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and the narrow read-only Gmail seam.
+- `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
+- `/chat` supports both assistant and governed-request modes, selected-thread continuity, compact thread creation, and bounded continuity review.
+- `workers` remains scaffold-only.
 
 ## Quick Start
 
@@ -19,23 +20,25 @@ AliceBot is a private, permissioned personal AI operating system. The current re
 Useful checks:
 
 - API health: [http://127.0.0.1:8000/healthz](http://127.0.0.1:8000/healthz)
-- Full backend tests: `./.venv/bin/python -m pytest tests/unit tests/integration`
+- Backend tests: `./.venv/bin/python -m pytest tests/unit tests/integration`
+- Web tests: `pnpm --dir apps/web test`
 - Web shell: `pnpm --dir apps/web dev`
 
 ## Repo Map
 
-- [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md): stable product scope and ship gates.
-- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md): implemented technical boundaries and planned-later boundaries.
-- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md): forward-looking milestone direction from the current repo position.
-- [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md): durable engineering and scope rules.
-- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md): compact current-state recovery snapshot.
-- [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md): active builder scope.
-- [docs/archive/sprints](/Users/samirusani/Desktop/Codex/AliceBot/docs/archive/sprints): archived sprint build and review history.
+- [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md): stable product scope and ship gates
+- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md): implemented technical boundaries
+- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md): forward planning from the current repo state
+- [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md): durable engineering and scope rules
+- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md): compact recovery snapshot
+- [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md): current sprint build report
+- [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md): current sprint review report
+- [docs/archive/sprints](/Users/samirusani/Desktop/Codex/AliceBot/docs/archive/sprints): accepted historical sprint build and review artifacts
 
 ## Environment Notes
 
 - Postgres is the system of record.
 - Local Docker Compose includes Postgres with `pgvector`, Redis, and MinIO.
-- The helper scripts source the repo-root `.env` and prefer `.venv/bin/python` when present.
-- `TASK_WORKSPACE_ROOT` defaults to `/tmp/alicebot/task-workspaces` and is the only allowed root for task-workspace provisioning.
+- Helper scripts source the repo-root `.env` and prefer `.venv/bin/python` when present.
+- `TASK_WORKSPACE_ROOT` defaults to `/tmp/alicebot/task-workspaces`.
 - `/healthz` performs a live Postgres check; Redis and MinIO are reported as configured but not live-checked.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -6,63 +6,42 @@ PASS
 
 ## criteria met
 
-- Implemented the exact in-scope continuity API surface:
-  - `POST /v0/threads`
-  - `GET /v0/threads`
-  - `GET /v0/threads/{thread_id}`
-  - `GET /v0/threads/{thread_id}/sessions`
-  - `GET /v0/threads/{thread_id}/events`
-- Kept the change narrow to continuity scope in the reviewed code diff:
-  - `apps/api/src/alicebot_api/contracts.py`
-  - `apps/api/src/alicebot_api/store.py`
-  - `apps/api/src/alicebot_api/main.py`
-  - `tests/unit/test_20260310_0001_foundation_continuity.py`
-  - `tests/unit/test_events.py`
-  - `tests/integration/test_continuity_api.py`
-  - `BUILD_REPORT.md`
-- Added typed contracts and stable summary metadata for thread create/list/detail, session list, and event list responses.
-- Added deterministic thread list ordering in the store: `created_at DESC, id DESC`.
-- Reused existing durable continuity data plus narrow thread creation only; no session or event mutation surface was added.
-- Preserved user isolation through the existing user-scoped connection and continuity store path.
-- Added unit and Postgres-backed integration coverage for create, detail, ordering, event/session reads, not-found behavior, and cross-user isolation.
-- Acceptance verification passed in this review:
-  - `./.venv/bin/python -m pytest tests/unit/test_main.py -q` -> PASS (`41` passed)
-  - `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py` -> PASS (`2` passed)
-  - `./.venv/bin/python -m pytest tests/unit` -> PASS (`454` passed)
-  - `./.venv/bin/python -m pytest tests/integration` -> PASS (`145` passed)
+- The sprint stayed documentation-only; no runtime, schema, API, or UI source files were changed.
+- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md) now reflects the implemented repo state through Sprint 6I instead of stopping at Sprint 6H.
+- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md) now plans from the shipped backend-plus-web-shell baseline instead of the older Sprint 5T and Gmail-cleanup-only framing.
+- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md) no longer describes `apps/web` as scaffold-only and now points to durable repo evidence.
+- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md) no longer claims the repo is current only through Sprint 5A and now explains where live versus archived sprint reports live.
+- [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md) now matches the sprint-owned file set and distinguishes unrelated pre-existing worktree drift.
+- The active docs are materially more compact and less redundant than the prior versions.
 
 ## criteria missed
 
-- None functionally against the active Sprint 6H packet.
+- No blocking acceptance criteria missed.
 
 ## quality issues
 
-- No material implementation defects or unsafe behavior were found in the scoped API, store, or tests.
-- `tests/unit/test_events.py` now carries thread continuity endpoint tests in addition to event-contract tests. This is not a blocker, but the file is becoming semantically overloaded.
+- No blocking quality issues remain in the sprint-owned documentation diff.
+- The remaining local modification in `.ai/active/SPRINT_PACKET.md` is a control artifact outside sprint ownership and is now called out explicitly in the build report.
 
 ## regression risks
 
-- Low regression risk in the shipped continuity slice.
-- The new reads are deterministic and test-backed for ordering and isolation.
-- User visibility still depends on the existing RLS-backed continuity path; the integration suite passing reduces risk materially.
-- No additional regression risk was introduced by the follow-up documentation-only edits.
+- Low. The sprint is documentation-only.
+- The only verification caveat is environmental: focused backend integration tests requiring localhost Postgres could not run in this sandbox, but backend unit checks and the web test suite passed.
 
 ## docs issues
 
-- None.
-- `BUILD_REPORT.md` meets the sprint packet requirements.
-- `ARCHITECTURE.md` now reflects Sprint 6H and documents the `/v0/threads*` continuity surface accurately.
+- No blocking docs issues remain after the report-location clarification.
+- Live sprint reports now have one explicit home at repo root, while accepted historical reports remain under `docs/archive/sprints`.
 
 ## should anything be added to RULES.md?
 
 - No.
-- The existing rules already cover sprint-packet immutability, narrow scope, typed contracts, and test-backed delivery.
 
 ## should anything update ARCHITECTURE.md?
 
-- No further architecture updates are required for this sprint.
+- No.
 
 ## recommended next action
 
-- Sprint 6H is review-passed and ready for the normal merge/approval path.
-- Follow-up work should move to the next scoped sprint that consumes these continuity endpoints in `/chat`.
+- Proceed with the sprint as passed.
+- Archive the current root `BUILD_REPORT.md` and `REVIEW_REPORT.md` into `docs/archive/sprints` once this sprint is accepted, so the next sprint can reuse the repo-root report paths cleanly.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,42 +2,36 @@
 
 ## Current Position
 
-- The accepted repo state is current through Sprint 5T.
-- Milestone 5 now ships the rooted local workspace and artifact baseline end to end: workspace provisioning, artifact registration, narrow text ingestion, narrow PDF/DOCX/RFC822 ingestion, durable chunk storage, lexical artifact retrieval, compile-path artifact inclusion, artifact-chunk embeddings, direct semantic artifact retrieval, compile-path semantic artifact retrieval, and deterministic hybrid lexical-plus-semantic artifact merge in compile.
-- The same milestone also now ships the narrow Gmail seam: read-only Gmail account persistence, secret-free account reads, external-secret-backed primary credential storage with locator metadata in `gmail_account_credentials`, refresh-token renewal for expired access tokens through the externalized seam, rotated refresh-token persistence when the provider returns a replacement token, one narrow `legacy_db_v0` transition path for older rows, and one explicit selected-message ingestion path that lands in the existing RFC822 artifact pipeline.
-- This roadmap is future-facing from that shipped baseline; historical sprint-by-sprint detail lives in accepted build and review artifacts, not here.
+- The accepted repo state is current through Sprint 6I.
+- The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, the narrow read-only Gmail seam, and the no-tools assistant-response seam.
+- The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
+- `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, and it keeps bounded thread review visible beside both assistant and governed-request composition.
+- Historical sprint detail belongs in build and review artifacts, not in this roadmap.
 
 ## Next Delivery Focus
 
-### Remove The Remaining Narrow Gmail Transition Path Without Widening Scope
+### Build From The Shipped API Plus Web-Shell Baseline
 
-- Keep the next sprint auth-adjacent and narrow, building on the shipped external-secret-backed Gmail seam rather than widening connector breadth.
-- The next best seam is deliberate cleanup of the remaining `legacy_db_v0` transition boundary for older `gmail_account_credentials` rows, without changing the read-only account contract or the single-message ingestion contract.
-- Do not combine that cleanup with Gmail search, mailbox sync, attachment ingestion, Calendar scope, UI work, or broader connector orchestration.
+- Plan the next sprint from the current backend-plus-web baseline, not from the older Gmail-cleanup-only narrative.
+- Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.
+- Reuse the existing continuity, response, approval, task, execution, and trace surfaces instead of introducing parallel contracts.
 
-### Preserve Current Document, Compile, Governance, And Task Guarantees
+### Keep New Scope Narrow
 
-- Keep the shipped PDF, DOCX, and RFC822 ingestion seams narrow and deterministic; richer parsing, OCR, layout reconstruction, attachment handling, and broader email processing still need separate later seams.
-- Keep approvals, execution budgets, task/task-step state, and trace visibility deterministic as Milestone 5 continues.
-- Preserve the shipped compile contract of one merged artifact section with explicit source provenance, deterministic lexical-first precedence, and trace-visible inclusion and exclusion decisions.
-- Do not widen the current no-external-I/O proxy surface or introduce broader connector, runner, or UI scope until those areas are explicitly opened.
-
-## After The Next Narrow Sprint
-
-- Reassess broader connector work only after the current Gmail external-secret-backed credential boundary remains stable without the `legacy_db_v0` transition path and the truth artifacts stay synchronized.
-- Revisit workflow UI only after backend document and connector seams are accepted and the truth artifacts stay current.
-- Revisit broader task orchestration only after the current explicit task-step seams remain stable under workspace, artifact, document, and connector flows.
-- Continue to defer broader tool execution breadth and production auth/deployment hardening until the current governed surface remains stable.
-
-## Dependencies
-
-- Live truth docs must stay synchronized with accepted repo state so sprint planning does not start from stale assumptions.
-- Rich document parsing work should continue to build on the shipped rooted local workspace, durable artifact chunk, and hybrid compile retrieval contracts.
-- Connector work should remain read-only, single-message-only, approval-aware, and external-secret-backed until a later sprint explicitly opens broader scope.
-- Runner-style orchestration should stay deferred until the repo no longer depends on narrow current-step assumptions for safety and explainability.
+- Do not bundle broader Gmail work, Calendar work, auth expansion, richer document parsing, runner orchestration, or proxy breadth into the next sprint by default.
+- Do not reopen schema or API design unless the next sprint explicitly requires it.
+- Keep live docs synchronized with shipped reality so planning does not drift behind the repo again.
 
 ## Ongoing Risks
 
-- Memory extraction and retrieval quality remain the largest product risk.
-- Auth beyond database user context is still missing.
-- Milestone 5 can drift if `legacy_db_v0` cleanup, broader Gmail breadth, UI, richer parsing, and orchestration work are mixed into one sprint instead of landing as narrow seams on top of the shipped document-ingestion and Gmail externalization baseline.
+- Memory extraction and retrieval quality remain the main product risk.
+- Auth remains incomplete beyond the current database user-context model.
+- The operator shell is now shipped surface, so future drift between web UI behavior, backend seams, and canonical docs is a planning and review risk.
+- Connector and document boundaries are still intentionally narrow; broadening them safely will require separate explicit sprints.
+
+## Deferred Until Explicitly Opened
+
+- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and Calendar connectors
+- runner-style orchestration and automatic multi-step progression
+- richer document parsing, OCR, and layout-aware ingestion
+- broader tool execution breadth beyond the current governed `proxy.echo` seam


### PR DESCRIPTION
## Summary
- synchronize ARCHITECTURE.md, ROADMAP.md, CURRENT_STATE.md, README.md, and the live sprint reports to the shipped Sprint 6I baseline
- compact the active docs so they are materially shorter, less redundant, and clearer about live versus archived report locations
- keep the sprint documentation-only with no runtime, schema, API, or UI behavior changes

## Review Outcome
- verdict: PASS
- merge call: MERGE_APPROVED

## Verification
- focused backend unit checks: PASS
- web test suite: PASS
- no runtime, schema, API, or UI behavior changes were introduced