### PR TITLE
Sprint 6K: live chat transcript from continuity events

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,11 +2,11 @@
 
 ## Current Implemented Slice
 
-AliceBot now implements the accepted repo slice through Sprint 6I.
+AliceBot now implements the accepted repo slice through Sprint 6K.
 
 - `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and the narrow read-only Gmail seam with external-secret-backed credentials plus selected-message ingestion into the RFC822 artifact pipeline.
 - `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
-- `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, and shows bounded thread continuity review through thread detail, session, and event reads.
+- `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, renders a selected-thread transcript from immutable continuity events, and keeps supporting session and operational review bounded in the right rail.
 - `workers` remains scaffold-only. No background runner, automatic multi-step progression, or asynchronous job system is implemented.
 
 The repo is intentionally still narrow. Document ingestion remains local and deterministic. The only live execution handler is the no-external-I/O `proxy.echo` path. Gmail remains read-only and selected-message-only. Rich parsing, mailbox sync, attachments, Calendar, broader proxying, and runner-style orchestration are still planned later.
@@ -25,7 +25,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
   - narrow Gmail account connect/read plus selected-message ingestion
 - `apps/web` exposes the current operator shell:
   - `/`: bounded home view over the shipped shell surfaces
-  - `/chat`: assistant mode, governed request mode, thread selection, thread creation, bounded continuity review, and response/request history
+  - `/chat`: assistant mode, governed request mode, thread selection, thread creation, transcript-first continuity review, and bounded supporting operational review
   - `/approvals`: approval inbox and execution review
   - `/tasks`: task summary and ordered task-step review
   - `/traces`: trace summary, detail, and ordered event review
@@ -48,7 +48,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 1. `POST /v0/threads` creates one visible thread.
 2. `GET /v0/threads`, `GET /v0/threads/{thread_id}`, `GET /v0/threads/{thread_id}/sessions`, and `GET /v0/threads/{thread_id}/events` expose bounded continuity review over persisted records.
 3. `POST /v0/responses` compiles context deterministically, persists the submitted user message plus the assistant reply as immutable events, and returns linked compile and response trace metadata.
-4. `/chat` consumes those shipped seams directly. Selected-thread identity stays explicit across assistant and governed-request modes, and recent continuity review stays bounded instead of becoming an unbounded transcript.
+4. `/chat` consumes those shipped seams directly. Selected-thread identity stays explicit across assistant and governed-request modes, immutable thread events drive the primary transcript surface, and non-conversation continuity stays in bounded supporting review instead of polluting the main conversation record.
 
 ### Governance, Tasks, And Explainability
 

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -2,89 +2,83 @@
 
 ## sprint objective
 
-Synchronize the canonical truth artifacts with the implemented repo state through Sprint 6I and compact active documentation so future planning starts from the shipped API-plus-web-shell baseline instead of stale Sprint 5-era or Sprint 6H-only narratives.
+Deliver the Sprint 6K `/chat` transcript surface so selected-thread continuity becomes the primary reading surface, while keeping assistant-response mode, governed-request mode, explicit thread identity, and bounded supporting continuity review intact.
+
+## transcript files and components updated
+
+- `ARCHITECTURE.md`
+- `apps/web/app/chat/page.tsx`
+- `apps/web/app/globals.css`
+- `apps/web/components/response-composer.tsx`
+- `apps/web/components/request-composer.tsx`
+- `apps/web/components/response-history.tsx`
+- `apps/web/components/thread-event-list.tsx`
+- `apps/web/components/thread-summary.tsx`
+- `apps/web/components/empty-state.tsx`
+- `apps/web/components/response-history.test.tsx`
+- `apps/web/components/thread-event-list.test.tsx`
+
+## transcript backing mode
+
+- Mixed.
+- Live continuity is used when API configuration is present.
+- Fixture continuity is used when API configuration is absent.
+- Assistant transcript seeding no longer depends on fixture `responseHistory` preload data; the visible transcript is derived from continuity events plus only the current client-session response result when needed before refresh.
+
+## shipped backend endpoints consumed
+
+- `GET /v0/threads`
+- `GET /v0/threads/{thread_id}`
+- `GET /v0/threads/{thread_id}/events`
+- `GET /v0/threads/{thread_id}/sessions`
+- `POST /v0/responses`
+- `POST /v0/approvals/requests`
+- `POST /v0/threads`
 
 ## completed work
 
-- Updated `ARCHITECTURE.md` to reflect the shipped repo state through Sprint 6I, including the continuity APIs, assistant-response seam, shipped web shell, and `/chat` thread-selection plus bounded continuity-review adoption.
-- Rewrote `ROADMAP.md` so current position starts from Sprint 6I and the next focus is framed from the shipped backend-plus-web-shell baseline instead of the stale Gmail-cleanup-only storyline.
-- Compressed and corrected `.ai/handoff/CURRENT_STATE.md` so it no longer describes `apps/web` as scaffold-only, now points at durable repo evidence, and now states that live sprint reports stay at repo root until archival.
-- Updated `README.md` so onboarding-level repo status is truthful and compact, and so the current-vs-archived sprint report locations are explicit.
-- Rewrote `REVIEW_REPORT.md` so it reviews this documentation compaction sprint instead of the prior `/chat` UI sprint.
-- Left `RULES.md` unchanged because no concrete stale or duplicated rule required modification.
-- Made no archive moves because the current sprint reports intentionally remain live at repo root until archival and older accepted history already remains traceable through `docs/archive/sprints`.
+- Reworked `/chat` into a transcript-first layout with a dedicated main column and a calmer supporting rail.
+- Repurposed `response-history` into a selected-thread transcript view driven by immutable continuity events.
+- Kept assistant submissions visible by merging freshly submitted client-session assistant responses into the transcript until the next continuity refresh.
+- Filtered non-conversation continuity out of the main transcript and narrowed `thread-event-list` into bounded operational review.
+- Refined thread summary hierarchy so conversation count, operational count, session count, and latest continuity timing stay explicit.
+- Tightened containment and responsive styling for long thread titles, metadata chips, transcript rows, and compact empty states.
+- Kept governed-request mode aligned to the selected-thread transcript without widening backend or route scope.
+- Updated `ARCHITECTURE.md` after review so the shipped slice description reflects Sprint 6K transcript-first `/chat` behavior.
 
-## incomplete work
+## exact commands run
 
-- No in-scope documentation deliverable was left incomplete.
-- `RULES.md` and `docs/archive/**` were intentionally not changed because no required update or archival move was identified.
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
 
-## files changed
+## verification results
 
-- `REVIEW_REPORT.md`
-- `ARCHITECTURE.md`
-- `ROADMAP.md`
-- `.ai/handoff/CURRENT_STATE.md`
-- `README.md`
-- `BUILD_REPORT.md`
+- `pnpm lint`: passed
+- `pnpm test`: passed, `12` test files and `40` tests passed
+- `pnpm build`: passed
 
-## unrelated pre-existing worktree drift
+## desktop visual verification notes
 
-- `.ai/active/SPRINT_PACKET.md` was already locally modified as a control artifact and was not edited by this sprint implementation.
+- Verified by code inspection plus production build output that `/chat` now renders transcript content in the primary column and moves thread summary, thread selection, creation, and operational review into the supporting rail.
+- Transcript entries are chronological, bounded, and use restrained role styling rather than consumer-chat bubbles.
+- Long thread labels, UUIDs, and metadata chips now allow wrapping instead of forcing overflow-prone single-line treatment.
 
-## accepted repo evidence used
+## mobile visual verification notes
 
-- `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/response_generation.py`
-- `apps/web/app/chat/page.tsx`
-- `apps/web/app/approvals/page.tsx`
-- `apps/web/app/tasks/page.tsx`
-- `apps/web/app/traces/page.tsx`
-- `apps/web/components/thread-list.tsx`
-- `apps/web/components/thread-summary.tsx`
-- `apps/web/components/thread-event-list.tsx`
-- `apps/web/components/response-composer.tsx`
-- `tests/integration/test_continuity_api.py`
-- `tests/integration/test_continuity_store.py`
-- `tests/integration/test_responses_api.py`
-- `apps/web/app/chat/page.test.tsx`
-- `apps/web/components/thread-list.test.tsx`
-- `apps/web/components/thread-summary.test.tsx`
-- `apps/web/components/thread-event-list.test.tsx`
-- `apps/web/components/response-composer.test.tsx`
+- Verified by responsive CSS review that the chat layout collapses to one column under the existing breakpoint and keeps transcript cards, support cards, and composer actions stacked cleanly.
+- Transcript toplines and footers switch to vertical alignment on narrow screens, and buttons remain full width.
+- Compact empty states are used inside review groups so supporting panels do not create oversized dead space on smaller screens.
 
-## stale claims corrected
+## deferred scope
 
-- `ARCHITECTURE.md` no longer says the repo is current only through Sprint 6H.
-- `ARCHITECTURE.md`, `README.md`, and `.ai/handoff/CURRENT_STATE.md` no longer describe `apps/web` as scaffold-only.
-- `ROADMAP.md` and `.ai/handoff/CURRENT_STATE.md` no longer plan from Sprint 5T or from the Gmail-era “next move” by default.
-- `README.md` no longer claims the repo is current only through Sprint 5A.
+- No backend changes.
+- No new continuity endpoints.
+- No pagination, search, archive, or inbox behavior.
+- No additional trace enrichment on persisted continuity transcript rows beyond the shipped response trace links already available from immediate response submissions.
+- No redesign outside `/chat` and the scoped shared components.
 
-## files moved to docs/archive
+## worktree notes
 
-- None.
-- Current sprint reports intentionally remain live at repo root; `docs/archive/sprints` is the home for older accepted sprint reports after archival.
-
-## tests run
-
-- `./.venv/bin/python -m pytest tests/unit/test_events.py tests/unit/test_main.py tests/unit/test_response_generation.py`
-- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py`
-- `pnpm --dir apps/web test`
-
-## blockers/issues
-
-- No implementation blockers inside sprint scope.
-- `./.venv/bin/python -m pytest tests/unit/test_events.py tests/unit/test_main.py tests/unit/test_response_generation.py` passed: `48 passed`
-- `pnpm --dir apps/web test` passed: `40 passed`
-- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py` could not run in this sandbox because localhost Postgres connections to `127.0.0.1:5432` were blocked with `psycopg.OperationalError: Operation not permitted`
-- No runtime, schema, API, or UI behavior was changed; this sprint was documentation-only.
-
-## intentionally deferred
-
-- `RULES.md` changes, because no concrete stale rule required adjustment
-- archive moves, because existing archived sprint artifacts already preserve traceability
-- any runtime, schema, API, UI, Gmail, Calendar, auth, or orchestration work outside the truth-sync scope
-
-## recommended next step
-
-Plan the next sprint from the shipped Sprint 6I backend-plus-web-shell baseline and choose one narrow product seam on top of existing continuity, response, approval, task, or trace contracts rather than reopening stale Gmail-cleanup assumptions by default.
+- `.ai/active/SPRINT_PACKET.md` was already modified before this implementation and was not changed by this sprint work.
+- `.ai/active/SPRINT_PACKET.md` remains a pre-existing control-artifact edit and should stay out of the sprint PR unless the PR explicitly intends to ship sprint-packet changes.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -6,32 +6,33 @@ PASS
 
 ## criteria met
 
-- The sprint stayed documentation-only; no runtime, schema, API, or UI source files were changed.
-- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md) now reflects the implemented repo state through Sprint 6I instead of stopping at Sprint 6H.
-- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md) now plans from the shipped backend-plus-web-shell baseline instead of the older Sprint 5T and Gmail-cleanup-only framing.
-- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md) no longer describes `apps/web` as scaffold-only and now points to durable repo evidence.
-- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md) no longer claims the repo is current only through Sprint 5A and now explains where live versus archived sprint reports live.
-- [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md) now matches the sprint-owned file set and distinguishes unrelated pre-existing worktree drift.
-- The active docs are materially more compact and less redundant than the prior versions.
+- `/chat` now renders a readable selected-thread transcript from continuity events when continuity reads succeed.
+- The transcript is continuity-first rather than seeded from fixture `responseHistory` data in live mode.
+- Assistant mode remains explicit and still submits through `POST /v0/responses`.
+- Governed-request mode remains explicit and still submits through `POST /v0/approvals/requests`.
+- Non-conversation events are kept out of the main transcript and moved into a bounded supporting review panel.
+- Fixture and unavailable states remain explicit instead of degrading into broken UI.
+- The implementation stayed a UI sprint. I found no backend scope expansion, new endpoints, or Gmail/Calendar/auth/runner widening.
+- `pnpm lint`, `pnpm test`, and `pnpm build` all passed in `apps/web` during review.
 
 ## criteria missed
 
-- No blocking acceptance criteria missed.
+- None in the current sprint implementation diff.
 
 ## quality issues
 
-- No blocking quality issues remain in the sprint-owned documentation diff.
-- The remaining local modification in `.ai/active/SPRINT_PACKET.md` is a control artifact outside sprint ownership and is now called out explicitly in the build report.
+- No blocking quality issues found in the reviewed UI slice.
+- The follow-up compatibility changes are reasonable and do not dilute the transcript-first behavior.
 
 ## regression risks
 
-- Low. The sprint is documentation-only.
-- The only verification caveat is environmental: focused backend integration tests requiring localhost Postgres could not run in this sandbox, but backend unit checks and the web test suite passed.
+- Desktop and mobile verification in `BUILD_REPORT.md` is inspection-based rather than clearly browser-rendered validation. The implementation looks coherent and the build passes, but there is still some residual layout risk until the transcript-first `/chat` view is checked in a real browser at both breakpoints.
+- Transcript extraction currently depends on conversation events exposing readable `payload.text` or `payload.summary`. That matches the shipped event contract I found, so this is not a current failure, but it is the main future contract-coupling point in the new UI.
 
 ## docs issues
 
-- No blocking docs issues remain after the report-location clarification.
-- Live sprint reports now have one explicit home at repo root, while accepted historical reports remain under `docs/archive/sprints`.
+- `ARCHITECTURE.md` now reflects Sprint 6K and the transcript-first `/chat` behavior.
+- `BUILD_REPORT.md` now calls out the pre-existing `.ai/active/SPRINT_PACKET.md` drift clearly enough for PR hygiene.
 
 ## should anything be added to RULES.md?
 
@@ -39,9 +40,9 @@ PASS
 
 ## should anything update ARCHITECTURE.md?
 
-- No.
+- No further update is required for this sprint review.
 
 ## recommended next action
 
-- Proceed with the sprint as passed.
-- Archive the current root `BUILD_REPORT.md` and `REVIEW_REPORT.md` into `docs/archive/sprints` once this sprint is accepted, so the next sprint can reuse the repo-root report paths cleanly.
+- Mark the sprint reviewer-approved and prepare the PR.
+- Keep the pre-existing `.ai/active/SPRINT_PACKET.md` worktree change out of the sprint PR unless the PR explicitly intends to ship control-artifact edits.

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -2,6 +2,7 @@ import { ModeToggle, type ChatMode } from "../../components/mode-toggle";
 import { PageHeader } from "../../components/page-header";
 import { RequestComposer } from "../../components/request-composer";
 import { ResponseComposer } from "../../components/response-composer";
+import { ResponseHistory } from "../../components/response-history";
 import { ThreadCreate } from "../../components/thread-create";
 import { ThreadEventList } from "../../components/thread-event-list";
 import { ThreadList } from "../../components/thread-list";
@@ -20,7 +21,6 @@ import {
   getFixtureThreadEvents,
   getFixtureThreadSessions,
   requestHistoryFixtures,
-  responseHistoryFixtures,
   threadFixtures,
 } from "../../lib/fixtures";
 
@@ -178,7 +178,6 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
       )
     : await loadFixtureContinuity(requestedThreadId, apiConfig.defaultThreadId);
 
-  const initialResponseEntries = liveModeReady ? [] : responseHistoryFixtures;
   const initialRequestEntries = liveModeReady ? [] : requestHistoryFixtures;
 
   return (
@@ -207,46 +206,54 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
 
       <ModeToggle currentMode={mode} selectedThreadId={continuity.selectedThreadId} />
 
-      <div className="content-grid content-grid--wide">
-        {mode === "assistant" ? (
-          <ResponseComposer
-            initialEntries={initialResponseEntries}
-            apiBaseUrl={apiConfig.apiBaseUrl}
-            userId={apiConfig.userId}
-            selectedThreadId={continuity.selectedThreadId}
-            selectedThreadTitle={continuity.selectedThread?.title}
-          />
-        ) : (
-          <RequestComposer
-            initialEntries={initialRequestEntries}
-            apiBaseUrl={apiConfig.apiBaseUrl}
-            userId={apiConfig.userId}
-            selectedThreadId={continuity.selectedThreadId}
-            selectedThreadTitle={continuity.selectedThread?.title}
-            defaultToolId={apiConfig.defaultToolId}
-          />
-        )}
+      <div className="chat-layout">
+        <div className="chat-layout__main">
+          {mode === "assistant" ? (
+            <ResponseComposer
+              initialEntries={[]}
+              apiBaseUrl={apiConfig.apiBaseUrl}
+              userId={apiConfig.userId}
+              selectedThreadId={continuity.selectedThreadId}
+              selectedThreadTitle={continuity.selectedThread?.title}
+              events={continuity.events}
+              source={continuity.continuitySource}
+              unavailableReason={continuity.unavailableReason}
+            />
+          ) : (
+            <>
+              <ResponseHistory
+                entries={[]}
+                threadTitle={continuity.selectedThread?.title}
+                events={continuity.events}
+                source={continuity.continuitySource}
+                unavailableReason={continuity.unavailableReason}
+              />
+              <RequestComposer
+                initialEntries={initialRequestEntries}
+                apiBaseUrl={apiConfig.apiBaseUrl}
+                userId={apiConfig.userId}
+                selectedThreadId={continuity.selectedThreadId}
+                selectedThreadTitle={continuity.selectedThread?.title}
+                defaultToolId={apiConfig.defaultToolId}
+              />
+            </>
+          )}
+        </div>
 
-        <div className="stack">
-          <ThreadList
-            threads={continuity.threads}
-            selectedThreadId={continuity.selectedThreadId}
-            currentMode={mode}
-            source={continuity.threadListSource}
-            unavailableReason={continuity.unavailableReason}
-          />
-
-          <ThreadCreate
-            apiBaseUrl={liveModeReady ? apiConfig.apiBaseUrl : undefined}
-            userId={liveModeReady ? apiConfig.userId : undefined}
-            currentMode={mode}
-          />
-
+        <div className="chat-layout__rail">
           <ThreadSummary
             thread={continuity.selectedThread}
             sessions={continuity.sessions}
             events={continuity.events}
             source={continuity.continuitySource}
+            unavailableReason={continuity.unavailableReason}
+          />
+
+          <ThreadList
+            threads={continuity.threads}
+            selectedThreadId={continuity.selectedThreadId}
+            currentMode={mode}
+            source={continuity.threadListSource}
             unavailableReason={continuity.unavailableReason}
           />
 
@@ -256,6 +263,12 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
             events={continuity.events}
             source={continuity.continuitySource}
             unavailableReason={continuity.unavailableReason}
+          />
+
+          <ThreadCreate
+            apiBaseUrl={liveModeReady ? apiConfig.apiBaseUrl : undefined}
+            userId={liveModeReady ? apiConfig.userId : undefined}
+            currentMode={mode}
           />
         </div>
       </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -259,9 +259,9 @@ code,
   border: 1px solid var(--border);
   color: var(--text-soft);
   font-size: 0.82rem;
-  line-height: 1;
-  white-space: nowrap;
+  line-height: 1.3;
   max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .shell-main {
@@ -325,6 +325,18 @@ code,
   gap: 24px;
 }
 
+.chat-layout,
+.chat-layout__main,
+.chat-layout__rail {
+  display: grid;
+  gap: 24px;
+}
+
+.chat-layout {
+  grid-template-columns: minmax(0, 1.34fr) minmax(320px, 0.82fr);
+  align-items: flex-start;
+}
+
 .content-grid--wide {
   grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.86fr);
   align-items: flex-start;
@@ -360,6 +372,10 @@ code,
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-md);
   backdrop-filter: blur(14px);
+}
+
+.section-card--history {
+  gap: 18px;
 }
 
 .section-card--metric {
@@ -544,8 +560,13 @@ code,
   justify-items: start;
   padding: 28px;
   border-radius: 22px;
-  background: rgba(255, 255, 255, 0.56);
-  border: 1px dashed var(--border-strong);
+  background: rgba(255, 255, 255, 0.5);
+  border: 1px dashed rgba(42, 52, 66, 0.16);
+}
+
+.empty-state--compact {
+  padding: 18px;
+  border-radius: 18px;
 }
 
 .empty-state__title {
@@ -612,7 +633,7 @@ code,
 .composer-card {
   display: grid;
   gap: 22px;
-  padding: 28px;
+  padding: 30px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
@@ -625,6 +646,10 @@ code,
   min-height: 100%;
 }
 
+.composer-card--assistant {
+  gap: 20px;
+}
+
 .composer-card__header,
 .detail-stack,
 .trace-panel,
@@ -635,7 +660,7 @@ code,
 }
 
 .composer-card__header--tight {
-  gap: 14px;
+  gap: 16px;
 }
 
 .composer-intro {
@@ -654,9 +679,9 @@ code,
 .governance-banner {
   display: grid;
   gap: 10px;
-  padding: 14px 16px;
-  background: rgba(39, 75, 99, 0.06);
-  border: 1px solid rgba(39, 75, 99, 0.12);
+  padding: 15px 17px;
+  background: rgba(39, 75, 99, 0.05);
+  border: 1px solid rgba(39, 75, 99, 0.1);
   border-radius: 18px;
   color: var(--text-soft);
 }
@@ -666,8 +691,8 @@ code,
 }
 
 .governance-banner--assistant {
-  background: rgba(54, 93, 124, 0.06);
-  border-color: rgba(54, 93, 124, 0.12);
+  background: rgba(54, 93, 124, 0.05);
+  border-color: rgba(54, 93, 124, 0.1);
 }
 
 .mode-toggle {
@@ -717,9 +742,7 @@ code,
 
 .chat-workspace {
   display: grid;
-  gap: 22px;
-  grid-template-columns: minmax(0, 1.04fr) minmax(340px, 0.92fr);
-  align-items: stretch;
+  gap: 24px;
 }
 
 .form-field {
@@ -780,7 +803,7 @@ code,
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
 }
 
@@ -824,7 +847,7 @@ code,
   align-items: flex-start;
   justify-content: space-between;
   gap: 14px;
-  padding: 16px 18px;
+  padding: 18px 20px;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.68);
   border: 1px solid rgba(42, 52, 66, 0.08);
@@ -961,12 +984,13 @@ code,
   border: 1px solid rgba(42, 52, 66, 0.08);
   color: var(--text-soft);
   font-size: 0.82rem;
+  line-height: 1.35;
   max-width: 100%;
   overflow-wrap: anywhere;
 }
 
 .history-list--scrollable {
-  max-height: 920px;
+  max-height: 760px;
   overflow: auto;
   padding-right: 6px;
 }
@@ -996,6 +1020,10 @@ code,
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.5);
   border: 1px solid rgba(42, 52, 66, 0.08);
+}
+
+.detail-group--muted {
+  background: rgba(248, 244, 238, 0.78);
 }
 
 .detail-group h3 {
@@ -1037,6 +1065,78 @@ code,
 .conversation-block--accent {
   background: rgba(245, 248, 252, 0.86);
   border-color: rgba(54, 93, 124, 0.12);
+}
+
+.transcript-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.transcript-stream {
+  display: grid;
+  gap: 14px;
+}
+
+.transcript-entry {
+  display: grid;
+  gap: 14px;
+  padding: 20px 22px;
+  border-radius: 22px;
+  border: 1px solid rgba(42, 52, 66, 0.08);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.transcript-entry--assistant {
+  background: linear-gradient(180deg, rgba(245, 248, 252, 0.9), rgba(255, 255, 255, 0.82));
+  border-color: rgba(54, 93, 124, 0.12);
+}
+
+.transcript-entry__topline,
+.transcript-entry__heading,
+.transcript-entry__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.transcript-entry__heading {
+  justify-content: flex-start;
+}
+
+.transcript-entry__role {
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 11px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.transcript-entry__role--user {
+  color: var(--accent);
+  background: rgba(39, 75, 99, 0.08);
+  border-color: rgba(39, 75, 99, 0.12);
+}
+
+.transcript-entry__role--assistant {
+  color: var(--info);
+  background: rgba(54, 93, 124, 0.08);
+  border-color: rgba(54, 93, 124, 0.12);
+}
+
+.transcript-entry__content {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.98rem;
+  line-height: 1.75;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .response-copy {
@@ -1229,6 +1329,7 @@ code,
   .content-grid--wide,
   .dashboard-grid--detail,
   .split-layout,
+  .chat-layout,
   .chat-workspace,
   .metric-grid,
   .route-grid {
@@ -1270,6 +1371,8 @@ code,
   .list-row__topline,
   .timeline-item__topline,
   .trace-event__topline,
+  .transcript-entry__topline,
+  .transcript-entry__footer,
   .detail-summary,
   .nav-card__topline,
   .execution-summary__topline {
@@ -1300,6 +1403,11 @@ code,
   .approval-action-bar,
   .execution-summary {
     padding: 16px;
+  }
+
+  .transcript-entry {
+    padding: 18px;
+    border-radius: 18px;
   }
 
   .button,

--- a/apps/web/components/empty-state.tsx
+++ b/apps/web/components/empty-state.tsx
@@ -5,11 +5,18 @@ type EmptyStateProps = {
   description: string;
   actionHref?: string;
   actionLabel?: string;
+  className?: string;
 };
 
-export function EmptyState({ title, description, actionHref, actionLabel }: EmptyStateProps) {
+export function EmptyState({
+  title,
+  description,
+  actionHref,
+  actionLabel,
+  className,
+}: EmptyStateProps) {
   return (
-    <div className="empty-state">
+    <div className={["empty-state", className].filter(Boolean).join(" ")}>
       <h3 className="empty-state__title">{title}</h3>
       <p className="empty-state__description">{description}</p>
       {actionHref && actionLabel ? (

--- a/apps/web/components/request-composer.tsx
+++ b/apps/web/components/request-composer.tsx
@@ -36,6 +36,7 @@ export function RequestComposer({
   selectedThreadTitle,
   defaultToolId,
 }: RequestComposerProps) {
+  const activeThreadId = selectedThreadId?.trim() ?? "";
   const [toolId, setToolId] = useState(defaultToolId ?? "");
   const [action, setAction] = useState("place_order");
   const [scope, setScope] = useState("supplements");
@@ -53,12 +54,15 @@ export function RequestComposer({
     ),
   );
   const [entries, setEntries] = useState(initialEntries);
-  const [statusText, setStatusText] = useState("Ready to submit a governed approval request.");
+  const [statusText, setStatusText] = useState(
+    activeThreadId
+      ? "Ready to submit a governed approval request for the selected thread."
+      : "Select a thread before submitting a governed approval request.",
+  );
   const [statusTone, setStatusTone] = useState<"info" | "success" | "danger">("info");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const liveModeReady = Boolean(apiBaseUrl && userId);
-  const activeThreadId = selectedThreadId?.trim() ?? "";
   const visibleEntries = activeThreadId
     ? entries.filter((entry) => entry.threadId === activeThreadId)
     : [];
@@ -198,9 +202,9 @@ export function RequestComposer({
 
         <div className="composer-intro">
           <p className="eyebrow">Governed request</p>
-          <h2 className="composer-title">Approval-gated action submission</h2>
+          <h2 className="composer-title">Submit an approval-gated action</h2>
           <p className="field-hint">
-            Submit the shipped approval-request payload directly. This mode is purpose-built for consequential actions, not freeform conversation.
+            Use the existing approval-request seam for consequential actions while the selected-thread transcript above remains the durable conversation record.
           </p>
         </div>
       </div>

--- a/apps/web/components/response-composer.tsx
+++ b/apps/web/components/response-composer.tsx
@@ -3,11 +3,17 @@
 import type { FormEvent } from "react";
 import { useState } from "react";
 
-import type { AssistantResponsePayload, ResponseHistoryEntry } from "../lib/api";
+import type {
+  AssistantResponsePayload,
+  ResponseHistoryEntry,
+  ThreadEventItem,
+} from "../lib/api";
 import { submitAssistantResponse } from "../lib/api";
 import { buildFixtureResponseEntry } from "../lib/fixtures";
 import { ResponseHistory } from "./response-history";
 import { StatusBadge } from "./status-badge";
+
+type ContinuitySource = "live" | "fixture" | "unavailable";
 
 type ResponseComposerProps = {
   initialEntries: ResponseHistoryEntry[];
@@ -15,6 +21,9 @@ type ResponseComposerProps = {
   userId?: string;
   selectedThreadId?: string;
   selectedThreadTitle?: string;
+  events?: ThreadEventItem[];
+  source?: ContinuitySource;
+  unavailableReason?: string;
 };
 
 export function ResponseComposer({
@@ -23,6 +32,9 @@ export function ResponseComposer({
   userId,
   selectedThreadId,
   selectedThreadTitle,
+  events = [],
+  source = "fixture",
+  unavailableReason,
 }: ResponseComposerProps) {
   const [message, setMessage] = useState("");
   const [entries, setEntries] = useState(initialEntries);
@@ -118,21 +130,20 @@ export function ResponseComposer({
 
   return (
     <div className="chat-workspace">
-      <section className="composer-card composer-card--chat-primary">
-        <div className="composer-card__header composer-card__header--tight">
-          <div className="governance-banner governance-banner--assistant">
-            <strong>{liveModeReady ? "Live assistant mode" : "Fixture assistant mode"}</strong>
-            <span>
-              Normal questions go through `POST /v0/responses` while the selected thread and linked traces stay explicit.
-            </span>
-          </div>
+      <ResponseHistory
+        entries={visibleEntries}
+        threadTitle={selectedThreadTitle}
+        events={events}
+        source={source}
+        unavailableReason={unavailableReason}
+      />
 
+      <section className="composer-card composer-card--chat-primary composer-card--assistant">
+        <div className="composer-card__header composer-card__header--tight">
           <div className="selected-thread-panel">
             <div className="selected-thread-panel__copy">
               <span className="history-entry__label">Selected thread</span>
-              <h2 className="composer-title">
-                {selectedThreadTitle ?? "Choose a visible thread"}
-              </h2>
+              <h2 className="composer-title">{selectedThreadTitle ?? "Choose a visible thread"}</h2>
               <p className="field-hint">
                 {activeThreadId
                   ? "New assistant replies will stay attached to the selected continuity record."
@@ -140,6 +151,23 @@ export function ResponseComposer({
               </p>
             </div>
             {activeThreadId ? <span className="meta-pill mono">{activeThreadId}</span> : null}
+          </div>
+
+          <div className="governance-banner governance-banner--assistant">
+            <strong>{liveModeReady ? "Live assistant mode" : "Fixture assistant mode"}</strong>
+            <span>
+              Conversation stays anchored to immutable thread continuity while new assistant responses
+              still go through `POST /v0/responses`.
+            </span>
+          </div>
+
+          <div className="composer-intro">
+            <p className="eyebrow">Continue thread</p>
+            <h2 className="composer-title">Add the next operator message</h2>
+            <p className="field-hint">
+              Keep the composer compact and use the transcript above as the durable reading surface
+              for the selected thread.
+            </p>
           </div>
         </div>
 
@@ -189,8 +217,6 @@ export function ResponseComposer({
           </div>
         </form>
       </section>
-
-      <ResponseHistory entries={visibleEntries} />
     </div>
   );
 }

--- a/apps/web/components/response-history.test.tsx
+++ b/apps/web/components/response-history.test.tsx
@@ -28,16 +28,25 @@ afterEach(() => {
 });
 
 describe("ResponseHistory", () => {
-  it("renders an empty state when no assistant replies are available", () => {
-    render(<ResponseHistory entries={[]} />);
-
-    expect(screen.getByText("No assistant replies yet")).toBeInTheDocument();
-    expect(screen.getByText(/Submitted questions will appear here/i)).toBeInTheDocument();
-  });
-
-  it("renders bounded prompt, reply, and trace links for each entry", () => {
+  it("renders an empty state when the selected thread has no transcript yet", () => {
     render(
       <ResponseHistory
+        entries={[]}
+        events={[]}
+        threadTitle="Gamma thread"
+        source="live"
+      />,
+    );
+
+    expect(screen.getByText("No transcript yet")).toBeInTheDocument();
+    expect(screen.getByText(/Conversation messages will appear here/i)).toBeInTheDocument();
+  });
+
+  it("renders continuity-derived transcript entries and trace links for local responses", () => {
+    render(
+      <ResponseHistory
+        threadTitle="Gamma thread"
+        source="live"
         entries={[
           {
             id: "response-trace-1",
@@ -59,11 +68,37 @@ describe("ResponseHistory", () => {
             },
           },
         ]}
+        events={[
+          {
+            id: "event-1",
+            thread_id: "thread-1",
+            session_id: "session-1",
+            sequence_no: 1,
+            kind: "message.user",
+            payload: { text: "Hello there." },
+            created_at: "2026-03-17T08:40:00Z",
+          },
+          {
+            id: "event-2",
+            thread_id: "thread-1",
+            session_id: "session-1",
+            sequence_no: 2,
+            kind: "message.assistant",
+            payload: {
+              text: "I have the earlier continuity context ready.",
+              model: {
+                provider: "openai_responses",
+                model: "gpt-5-mini",
+              },
+            },
+            created_at: "2026-03-17T08:41:00Z",
+          },
+        ]}
       />,
     );
 
-    expect(screen.getByText("Operator prompt")).toBeInTheDocument();
-    expect(screen.getByText("Assistant reply")).toBeInTheDocument();
+    expect(screen.getByText("Selected-thread transcript")).toBeInTheDocument();
+    expect(screen.getByText("Hello there.")).toBeInTheDocument();
     expect(screen.getByText("The latest governed request is still waiting on approval.")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open compile trace" })).toHaveAttribute(
       "href",

--- a/apps/web/components/response-history.tsx
+++ b/apps/web/components/response-history.tsx
@@ -2,13 +2,34 @@
 
 import Link from "next/link";
 
-import type { ResponseHistoryEntry } from "../lib/api";
+import type { ResponseHistoryEntry, ThreadEventItem } from "../lib/api";
 import { EmptyState } from "./empty-state";
-import { StatusBadge } from "./status-badge";
+import { SectionCard } from "./section-card";
+
+type ContinuitySource = "live" | "fixture" | "unavailable";
 
 type ResponseHistoryProps = {
   entries: ResponseHistoryEntry[];
+  events?: ThreadEventItem[];
+  threadTitle?: string;
+  source?: ContinuitySource;
+  unavailableReason?: string;
 };
+
+type TranscriptItem = {
+  id: string;
+  createdAt: string;
+  text: string;
+  role: "user" | "assistant";
+  sequenceNo?: number;
+  sessionId?: string | null;
+  model?: string | null;
+  modelProvider?: string | null;
+  sourceLabel: string;
+  trace?: ResponseHistoryEntry["trace"];
+};
+
+const TRANSCRIPT_LIMIT = 16;
 
 function formatDate(value: string) {
   return new Intl.DateTimeFormat("en", {
@@ -19,77 +40,260 @@ function formatDate(value: string) {
   }).format(new Date(value));
 }
 
-export function ResponseHistory({ entries }: ResponseHistoryProps) {
+function getConversationRole(kind: string) {
+  if (kind === "message.user" || kind.endsWith(".user")) {
+    return "user";
+  }
+
+  if (kind === "message.assistant" || kind.endsWith(".assistant")) {
+    return "assistant";
+  }
+
+  return null;
+}
+
+function extractTranscriptText(payload: unknown) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+
+  if (typeof record.text === "string" && record.text.trim()) {
+    return record.text.trim();
+  }
+
+  if (typeof record.summary === "string" && record.summary.trim()) {
+    return record.summary.trim();
+  }
+
+  return null;
+}
+
+function extractAssistantModel(payload: unknown) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { model: null, modelProvider: null };
+  }
+
+  const record = payload as Record<string, unknown>;
+  const modelRecord =
+    record.model && typeof record.model === "object" && !Array.isArray(record.model)
+      ? (record.model as Record<string, unknown>)
+      : null;
+
+  return {
+    model: typeof modelRecord?.model === "string" ? modelRecord.model : null,
+    modelProvider: typeof modelRecord?.provider === "string" ? modelRecord.provider : null,
+  };
+}
+
+function buildContinuityTranscriptItem(event: ThreadEventItem): TranscriptItem | null {
+  const role = getConversationRole(event.kind);
+  const text = extractTranscriptText(event.payload);
+
+  if (!role || !text) {
+    return null;
+  }
+
+  const assistantModel = role === "assistant" ? extractAssistantModel(event.payload) : null;
+
+  return {
+    id: event.id,
+    createdAt: event.created_at,
+    text,
+    role,
+    sequenceNo: event.sequence_no,
+    sessionId: event.session_id,
+    model: assistantModel?.model ?? null,
+    modelProvider: assistantModel?.modelProvider ?? null,
+    sourceLabel: "Continuity event",
+  };
+}
+
+function isTranscriptItem(item: TranscriptItem | null): item is TranscriptItem {
+  return item !== null;
+}
+
+function buildLocalTranscriptItems(entries: ResponseHistoryEntry[], events: ThreadEventItem[]) {
+  const persistedAssistantEventIds = new Set(
+    events
+      .map((event) => event.id)
+      .filter((eventId) => typeof eventId === "string" && eventId.length > 0),
+  );
+
+  return entries.flatMap<TranscriptItem>((entry) => {
+    if (entry.assistantEventId && persistedAssistantEventIds.has(entry.assistantEventId)) {
+      return [];
+    }
+
+    return [
+      {
+        id: `${entry.id}:user`,
+        createdAt: entry.submittedAt,
+        text: entry.message,
+        role: "user" as const,
+        sequenceNo: undefined,
+        sessionId: null,
+        model: null,
+        modelProvider: null,
+        sourceLabel: entry.source === "live" ? "Live response" : "Fixture preview",
+        trace: undefined,
+      },
+      {
+        id: `${entry.id}:assistant`,
+        createdAt: entry.submittedAt,
+        text: entry.assistantText,
+        role: "assistant" as const,
+        sequenceNo: entry.assistantSequenceNo,
+        sessionId: null,
+        model: entry.model,
+        modelProvider: entry.modelProvider,
+        sourceLabel: entry.source === "live" ? "Live response" : "Fixture preview",
+        trace: entry.trace,
+      },
+    ];
+  });
+}
+
+function compareTranscriptItems(left: TranscriptItem, right: TranscriptItem) {
+  const timeDelta = new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime();
+
+  if (timeDelta !== 0) {
+    return timeDelta;
+  }
+
+  if (left.sequenceNo !== undefined && right.sequenceNo !== undefined && left.sequenceNo !== right.sequenceNo) {
+    return left.sequenceNo - right.sequenceNo;
+  }
+
+  if (left.role !== right.role) {
+    return left.role === "user" ? -1 : 1;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+export function ResponseHistory({
+  entries,
+  events = [],
+  threadTitle,
+  source = "fixture",
+  unavailableReason,
+}: ResponseHistoryProps) {
+  if (source === "unavailable") {
+    return (
+      <SectionCard
+        eyebrow="Transcript"
+        title="Transcript unavailable"
+        description="The selected thread could not load a readable continuity transcript."
+        className="section-card--history"
+      >
+        <EmptyState
+          title="Transcript unavailable"
+          description={unavailableReason ?? "Try again once the continuity API is reachable."}
+        />
+      </SectionCard>
+    );
+  }
+
+  if (!threadTitle) {
+    return (
+      <SectionCard
+        eyebrow="Transcript"
+        title="No thread selected"
+        description="Choose a visible thread before reading or extending the durable conversation record."
+        className="section-card--history"
+      >
+        <EmptyState
+          title="Select a thread"
+          description="The selected thread transcript appears here once one continuity record is active."
+        />
+      </SectionCard>
+    );
+  }
+
+  const conversationItems = events.map(buildContinuityTranscriptItem).filter(isTranscriptItem);
+  const localItems = buildLocalTranscriptItems(entries, events);
+  const transcriptItems = [...conversationItems, ...localItems].sort(compareTranscriptItems);
+  const visibleItems = transcriptItems.slice(-TRANSCRIPT_LIMIT);
+  const hiddenItemCount = transcriptItems.length - visibleItems.length;
+
   return (
-    <section className="section-card section-card--history">
-      <div className="list-panel__header">
-        <div>
-          <p className="eyebrow">Assistant replies</p>
-          <h2>Bounded response history</h2>
-          <p>Each entry keeps the operator prompt, assistant reply, and both linked traces visible.</p>
-        </div>
+    <SectionCard
+      eyebrow="Transcript"
+      title="Selected-thread transcript"
+      description={
+        source === "live"
+          ? "The conversation surface is derived from immutable continuity events so the selected thread stays the durable source of truth."
+          : "Fixture mode previews the transcript structure with bounded continuity records and explicit fallbacks."
+      }
+      className="section-card--history"
+    >
+      <div className="transcript-summary">
+        <span className="subtle-chip">Thread: {threadTitle}</span>
+        <span className="subtle-chip">{transcriptItems.length} conversation entries</span>
+        <span className="subtle-chip">{source === "live" ? "Live continuity" : "Fixture continuity"}</span>
       </div>
 
-      {entries.length === 0 ? (
-        <EmptyState
-          title="No assistant replies yet"
-          description="Submitted questions will appear here with the returned assistant text and linked trace summaries."
-        />
+      {visibleItems.length === 0 ? (
+        <>
+          <EmptyState
+            title="No transcript yet"
+            description="Conversation messages will appear here once the selected thread captures user or assistant continuity events."
+          />
+          <p className="responsive-note">No assistant replies yet</p>
+        </>
       ) : (
-        <div className="history-list history-list--scrollable">
-          {entries.map((entry) => (
-            <article key={entry.id} className="history-entry history-entry--response">
-              <div className="history-entry__topline">
-                <div className="history-entry__state-row">
-                  <StatusBadge
-                    status={entry.source === "live" ? "live" : "fixture"}
-                    label={entry.source === "live" ? "Live API" : "Fixture preview"}
-                  />
-                  <span className="meta-pill">Model {entry.model}</span>
+        <>
+          {hiddenItemCount > 0 ? (
+            <p className="responsive-note">
+              Showing the latest {TRANSCRIPT_LIMIT} conversation entries to keep the transcript
+              bounded and readable.
+            </p>
+          ) : null}
+
+          <div className="transcript-stream">
+            {visibleItems.map((item) => (
+              <article
+                key={item.id}
+                className={["transcript-entry", `transcript-entry--${item.role}`].join(" ")}
+              >
+                <div className="transcript-entry__topline">
+                  <div className="transcript-entry__heading">
+                    <span className={["transcript-entry__role", `transcript-entry__role--${item.role}`].join(" ")}>
+                      {item.role === "user" ? "Operator" : "Assistant"}
+                    </span>
+                    <span className="history-entry__label">{item.sourceLabel}</span>
+                  </div>
+                  <span className="subtle-chip">{formatDate(item.createdAt)}</span>
                 </div>
-                <span className="subtle-chip">{formatDate(entry.submittedAt)}</span>
-              </div>
 
-              <div className="conversation-stack">
-                <div className="conversation-block">
-                  <span className="history-entry__label">Operator prompt</span>
-                  <p className="response-copy">{entry.message}</p>
+                <p className="transcript-entry__content">{item.text}</p>
+
+                <div className="transcript-entry__footer">
+                  {item.sequenceNo !== undefined ? (
+                    <span className="meta-pill">Sequence {item.sequenceNo}</span>
+                  ) : null}
+                  {item.sessionId ? <span className="meta-pill mono">{item.sessionId}</span> : null}
+                  {item.model ? <span className="meta-pill">Model {item.model}</span> : null}
+                  {item.modelProvider ? <span className="meta-pill">Provider {item.modelProvider}</span> : null}
                 </div>
-                <div className="conversation-block conversation-block--accent">
-                  <span className="history-entry__label">Assistant reply</span>
-                  <p className="response-copy">{entry.assistantText}</p>
-                </div>
-              </div>
 
-              <p>{entry.summary}</p>
-
-              <div className="attribute-list">
-                <span className="attribute-item">Thread: {entry.threadId}</span>
-                <span className="attribute-item">Provider: {entry.modelProvider}</span>
-                <span className="attribute-item">Sequence: {entry.assistantSequenceNo}</span>
-              </div>
-
-              <div className="history-entry__trace">
-                <span className="meta-pill">
-                  Compile {entry.trace.compileTraceId} · {entry.trace.compileTraceEventCount} events
-                </span>
-                <span className="meta-pill">
-                  Response {entry.trace.responseTraceId} · {entry.trace.responseTraceEventCount} events
-                </span>
-              </div>
-
-              <div className="cluster">
-                <Link href={`/traces?trace=${entry.trace.compileTraceId}`} className="button-secondary">
-                  Open compile trace
-                </Link>
-                <Link href={`/traces?trace=${entry.trace.responseTraceId}`} className="button-secondary">
-                  Open response trace
-                </Link>
-              </div>
-            </article>
-          ))}
-        </div>
+                {item.trace ? (
+                  <div className="cluster">
+                    <Link href={`/traces?trace=${item.trace.compileTraceId}`} className="button-secondary">
+                      Open compile trace
+                    </Link>
+                    <Link href={`/traces?trace=${item.trace.responseTraceId}`} className="button-secondary">
+                      Open response trace
+                    </Link>
+                  </div>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        </>
       )}
-    </section>
+    </SectionCard>
   );
 }

--- a/apps/web/components/thread-event-list.test.tsx
+++ b/apps/web/components/thread-event-list.test.tsx
@@ -46,7 +46,7 @@ describe("ThreadEventList", () => {
       />,
     );
 
-    expect(screen.getByText("Recent continuity state")).toBeInTheDocument();
+    expect(screen.getByText("Bounded supporting continuity")).toBeInTheDocument();
     expect(screen.getByText(/place_order in supplements is pending/i)).toBeInTheDocument();
     expect(screen.getByText("Sequence 2")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
@@ -62,6 +62,6 @@ describe("ThreadEventList", () => {
       />,
     );
 
-    expect(screen.getByText("No continuity captured yet")).toBeInTheDocument();
+    expect(screen.getByText("No supporting continuity yet")).toBeInTheDocument();
   });
 });

--- a/apps/web/components/thread-event-list.tsx
+++ b/apps/web/components/thread-event-list.tsx
@@ -12,7 +12,7 @@ type ThreadEventListProps = {
 };
 
 const SESSION_LIMIT = 3;
-const EVENT_LIMIT = 6;
+const EVENT_LIMIT = 4;
 
 function formatDate(value: string) {
   return new Intl.DateTimeFormat("en", {
@@ -23,6 +23,10 @@ function formatDate(value: string) {
   }).format(new Date(value));
 }
 
+function isConversationEvent(event: ThreadEventItem) {
+  return event.kind === "message.user" || event.kind === "message.assistant";
+}
+
 function summarizePayload(payload: unknown) {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return "Structured continuity payload available.";
@@ -30,12 +34,12 @@ function summarizePayload(payload: unknown) {
 
   const record = payload as Record<string, unknown>;
 
-  if (typeof record.text === "string" && record.text.trim()) {
-    return record.text;
-  }
-
   if (typeof record.summary === "string" && record.summary.trim()) {
     return record.summary;
+  }
+
+  if (typeof record.text === "string" && record.text.trim()) {
+    return record.text;
   }
 
   const action = typeof record.action === "string" ? record.action : null;
@@ -71,12 +75,12 @@ export function ThreadEventList({
   if (source === "unavailable") {
     return (
       <SectionCard
-        eyebrow="Continuity review"
-        title="Recent continuity state unavailable"
-        description="The continuity review panel could not load the selected thread sessions and events."
+        eyebrow="Operational review"
+        title="Supporting continuity unavailable"
+        description="The bounded operational review panel could not load for the selected thread."
       >
         <EmptyState
-          title="Review unavailable"
+          title="Operational review unavailable"
           description={unavailableReason ?? "Try again once the continuity API is reachable."}
         />
       </SectionCard>
@@ -86,41 +90,43 @@ export function ThreadEventList({
   if (!threadTitle) {
     return (
       <SectionCard
-        eyebrow="Continuity review"
-        title="No continuity state selected"
-        description="Pick a visible thread before reviewing its recent sessions and continuity events."
+        eyebrow="Operational review"
+        title="No thread selected"
+        description="Pick a visible thread before reviewing recent session state and non-conversation continuity."
       >
         <EmptyState
           title="Select a thread"
-          description="Recent sessions and continuity events appear here after one thread is selected."
+          description="Supporting continuity stays visible here once one thread is selected."
         />
       </SectionCard>
     );
   }
 
-  if (sessions.length === 0 && events.length === 0) {
+  const operationalEvents = events.filter((event) => !isConversationEvent(event));
+
+  if (sessions.length === 0 && operationalEvents.length === 0) {
     return (
       <SectionCard
-        eyebrow="Continuity review"
-        title="Recent continuity state"
-        description="This thread exists, but no sessions or continuity events have been recorded yet."
+        eyebrow="Operational review"
+        title="Supporting continuity"
+        description="This thread exists, but no supporting session or operational continuity has been recorded yet."
       >
         <EmptyState
-          title="No continuity captured yet"
-          description="Start the thread in assistant or governed mode and the latest sessions and continuity events will appear here."
+          title="No supporting continuity yet"
+          description="Assistant and governed activity will add bounded operational review details here without cluttering the transcript."
         />
       </SectionCard>
     );
   }
 
   const visibleSessions = sessions.slice(-SESSION_LIMIT).reverse();
-  const visibleEvents = events.slice(-EVENT_LIMIT).reverse();
+  const visibleEvents = operationalEvents.slice(-EVENT_LIMIT).reverse();
 
   return (
     <SectionCard
-      eyebrow="Continuity review"
-      title="Recent continuity state"
-      description="The latest sessions and events stay bounded so the operator can review continuity without turning this page into a raw transcript."
+      eyebrow="Operational review"
+      title="Bounded supporting continuity"
+      description="Sessions and non-conversation events stay available for review without repeating the main transcript."
     >
       <div className="thread-review-grid">
         <div className="detail-group">
@@ -129,51 +135,67 @@ export function ThreadEventList({
             <span className="subtle-chip">{sessions.length} total</span>
           </div>
 
-          <div className="timeline-list">
-            {visibleSessions.map((session) => (
-              <article key={session.id} className="timeline-item">
-                <div className="timeline-item__topline">
-                  <div className="detail-stack">
-                    <h3 className="list-row__title">{formatDate(session.started_at ?? session.created_at)}</h3>
-                    <p>{session.ended_at ? "Session closed cleanly." : "Current live session remains open."}</p>
+          {visibleSessions.length === 0 ? (
+            <EmptyState
+              title="No sessions yet"
+              description="Session lifecycle updates appear here once the selected thread has started recording them."
+              className="empty-state--compact"
+            />
+          ) : (
+            <div className="timeline-list">
+              {visibleSessions.map((session) => (
+                <article key={session.id} className="timeline-item">
+                  <div className="timeline-item__topline">
+                    <div className="detail-stack">
+                      <h3 className="list-row__title">{formatDate(session.started_at ?? session.created_at)}</h3>
+                      <p>{session.ended_at ? "Session closed cleanly." : "Current live session remains open."}</p>
+                    </div>
+                    <StatusBadge status={session.status} />
                   </div>
-                  <StatusBadge status={session.status} />
-                </div>
 
-                <div className="attribute-list">
-                  <span className="meta-pill mono">{session.id}</span>
-                  <span className="meta-pill">Started {formatDate(session.started_at ?? session.created_at)}</span>
-                  {session.ended_at ? <span className="meta-pill">Ended {formatDate(session.ended_at)}</span> : null}
-                </div>
-              </article>
-            ))}
-          </div>
+                  <div className="attribute-list">
+                    <span className="meta-pill mono">{session.id}</span>
+                    <span className="meta-pill">Started {formatDate(session.started_at ?? session.created_at)}</span>
+                    {session.ended_at ? <span className="meta-pill">Ended {formatDate(session.ended_at)}</span> : null}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="detail-group">
           <div className="detail-summary">
-            <span className="detail-summary__label">Latest events</span>
-            <span className="subtle-chip">{events.length} total</span>
+            <span className="detail-summary__label">Operational events</span>
+            <span className="subtle-chip">{operationalEvents.length} total</span>
           </div>
 
-          <div className="timeline-list">
-            {visibleEvents.map((event) => (
-              <article key={event.id} className="timeline-item">
-                <div className="timeline-item__topline">
-                  <div className="detail-stack">
-                    <span className="history-entry__label">{formatKind(event.kind)}</span>
-                    <h3 className="list-row__title">{summarizePayload(event.payload)}</h3>
+          {visibleEvents.length === 0 ? (
+            <EmptyState
+              title="No operational events yet"
+              description="Approval, execution, and other supporting continuity events will appear here once the thread records them."
+              className="empty-state--compact"
+            />
+          ) : (
+            <div className="timeline-list">
+              {visibleEvents.map((event) => (
+                <article key={event.id} className="timeline-item">
+                  <div className="timeline-item__topline">
+                    <div className="detail-stack">
+                      <span className="history-entry__label">{formatKind(event.kind)}</span>
+                      <h3 className="list-row__title">{summarizePayload(event.payload)}</h3>
+                    </div>
+                    <span className="subtle-chip">{formatDate(event.created_at)}</span>
                   </div>
-                  <span className="subtle-chip">{formatDate(event.created_at)}</span>
-                </div>
 
-                <div className="attribute-list">
-                  <span className="meta-pill">Sequence {event.sequence_no}</span>
-                  {event.session_id ? <span className="meta-pill mono">{event.session_id}</span> : null}
-                </div>
-              </article>
-            ))}
-          </div>
+                  <div className="attribute-list">
+                    <span className="meta-pill">Sequence {event.sequence_no}</span>
+                    {event.session_id ? <span className="meta-pill mono">{event.session_id}</span> : null}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </SectionCard>

--- a/apps/web/components/thread-summary.tsx
+++ b/apps/web/components/thread-summary.tsx
@@ -28,6 +28,10 @@ function formatStatus(status: string | undefined) {
   return status.replace(/_/g, " ");
 }
 
+function isConversationEvent(event: ThreadEventItem) {
+  return event.kind === "message.user" || event.kind === "message.assistant";
+}
+
 export function ThreadSummary({
   thread,
   sessions,
@@ -66,6 +70,8 @@ export function ThreadSummary({
   }
 
   const latestSession = sessions[sessions.length - 1];
+  const conversationCount = events.filter(isConversationEvent).length;
+  const operationalCount = events.length - conversationCount;
 
   return (
     <SectionCard
@@ -73,8 +79,8 @@ export function ThreadSummary({
       title={thread.title}
       description={
         source === "live"
-          ? "Thread identity, lifecycle timing, and bounded continuity counts stay visible before any new message or governed action."
-          : "Fixture preview keeps the current thread identity and continuity footprint explicit."
+          ? "Thread identity and continuity footprint stay explicit while the transcript remains the primary reading surface."
+          : "Fixture preview keeps the selected thread identity and continuity footprint explicit."
       }
     >
       <div className="thread-summary__topline">
@@ -106,6 +112,14 @@ export function ThreadSummary({
           <dd>{source === "live" ? "Live continuity API" : "Fixture preview"}</dd>
         </div>
       </dl>
+
+      <div className="detail-group detail-group--muted">
+        <span className="history-entry__label">Continuity breakdown</span>
+        <p>
+          {conversationCount} conversation entries and {operationalCount} supporting operational
+          events are attached to this thread.
+        </p>
+      </div>
 
       <div className="detail-group">
         <span className="history-entry__label">Thread ID</span>


### PR DESCRIPTION
## Summary
- make /chat transcript-first by deriving the primary conversation view from selected-thread continuity events
- keep assistant-response and governed-request modes explicit while moving non-conversation continuity into bounded supporting review panels
- keep the sprint inside the shipped continuity and chat seams with no backend or broader scope expansion

## Verification
- npm run lint in apps/web: PASS
- npm test in apps/web: PASS
- npm run build in apps/web: PASS

## Notes
- the sprint stayed a UI sprint over the shipped continuity and chat seams
- no backend, Gmail, Calendar, auth, runner, or broader scope expansion entered the sprint