### PR TITLE
Sprint 6L: thread-linked governed workflow in chat

### DIFF
--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -2,28 +2,26 @@
 
 ## sprint objective
 
-Deliver the Sprint 6K `/chat` transcript surface so selected-thread continuity becomes the primary reading surface, while keeping assistant-response mode, governed-request mode, explicit thread identity, and bounded supporting continuity review intact.
+Deliver Sprint 6L by extending `/chat` with bounded selected-thread governed workflow review so approval, task, and execution state stay visible beside the durable transcript without widening backend scope.
 
-## transcript files and components updated
+## exact `/chat` workflow files and components updated
 
-- `ARCHITECTURE.md`
 - `apps/web/app/chat/page.tsx`
 - `apps/web/app/globals.css`
-- `apps/web/components/response-composer.tsx`
-- `apps/web/components/request-composer.tsx`
-- `apps/web/components/response-history.tsx`
-- `apps/web/components/thread-event-list.tsx`
-- `apps/web/components/thread-summary.tsx`
-- `apps/web/components/empty-state.tsx`
-- `apps/web/components/response-history.test.tsx`
-- `apps/web/components/thread-event-list.test.tsx`
+- `apps/web/components/approval-detail.tsx`
+- `apps/web/components/task-summary.tsx`
+- `apps/web/components/thread-workflow-panel.tsx`
+- `apps/web/components/thread-workflow-panel.test.tsx`
+- `apps/web/lib/api.ts`
+- `apps/web/lib/api.test.ts`
+- `BUILD_REPORT.md`
 
-## transcript backing mode
+## thread-linked workflow backing mode
 
 - Mixed.
-- Live continuity is used when API configuration is present.
-- Fixture continuity is used when API configuration is absent.
-- Assistant transcript seeding no longer depends on fixture `responseHistory` preload data; the visible transcript is derived from continuity events plus only the current client-session response result when needed before refresh.
+- Live workflow review uses existing shipped reads from approvals, tasks, and tool executions when API configuration is present.
+- Fixture workflow review is used when API configuration is absent.
+- Live workflow failures degrade to explicit unavailable states inside the chat workflow panel instead of implying missing workflow.
 
 ## shipped backend endpoints consumed
 
@@ -31,54 +29,59 @@ Deliver the Sprint 6K `/chat` transcript surface so selected-thread continuity b
 - `GET /v0/threads/{thread_id}`
 - `GET /v0/threads/{thread_id}/events`
 - `GET /v0/threads/{thread_id}/sessions`
-- `POST /v0/responses`
+- `GET /v0/approvals`
+- `GET /v0/tasks`
+- `GET /v0/tool-executions`
+- `POST /v0/approvals/{approval_id}/approve`
+- `POST /v0/approvals/{approval_id}/reject`
+- `POST /v0/approvals/{approval_id}/execute`
 - `POST /v0/approvals/requests`
 - `POST /v0/threads`
+- `POST /v0/responses`
 
 ## completed work
 
-- Reworked `/chat` into a transcript-first layout with a dedicated main column and a calmer supporting rail.
-- Repurposed `response-history` into a selected-thread transcript view driven by immutable continuity events.
-- Kept assistant submissions visible by merging freshly submitted client-session assistant responses into the transcript until the next continuity refresh.
-- Filtered non-conversation continuity out of the main transcript and narrowed `thread-event-list` into bounded operational review.
-- Refined thread summary hierarchy so conversation count, operational count, session count, and latest continuity timing stay explicit.
-- Tightened containment and responsive styling for long thread titles, metadata chips, transcript rows, and compact empty states.
-- Kept governed-request mode aligned to the selected-thread transcript without widening backend or route scope.
-- Updated `ARCHITECTURE.md` after review so the shipped slice description reflects Sprint 6K transcript-first `/chat` behavior.
+- Added a new `thread-workflow-panel` to `/chat` so selected-thread workflow state now appears in the rail as a bounded secondary review surface.
+- Derived the latest relevant approval and task state client-side from shipped list endpoints and existing fixtures, keyed by the selected thread.
+- Restricted execution review to explicit linkage only: selected-task `latest_execution_id` first, then execution records explicitly linked to the selected approval, with no thread-level fallback.
+- Reused `approval-detail`, `approval-actions`, `task-summary`, and `execution-summary` inside compact embedded cards so the chat route inherits the same workflow semantics as `/approvals` and `/tasks`.
+- Restored bounded execution review when approval detail is absent by rendering execution review through the task summary or a standalone embedded execution block when needed.
+- Preserved transcript-first hierarchy by keeping workflow review secondary and visually quieter than the conversation column.
+- Tightened rail containment with embedded card chrome, single-column key-value layouts, bounded execution code blocks, and full-width action layouts that avoid cramped wrapping.
+- Added in-scope regression coverage for mixed-history execution linkage and approval-missing execution review in `apps/web/lib/api.test.ts` and `apps/web/components/thread-workflow-panel.test.tsx`.
 
 ## exact commands run
 
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
+- `npm run lint`
+- `npm test`
+- `npm run build`
 
 ## verification results
 
-- `pnpm lint`: passed
-- `pnpm test`: passed, `12` test files and `40` tests passed
-- `pnpm build`: passed
+- `npm run lint`: passed
+- `npm test`: passed, `13` test files and `46` tests passed
+- `npm run build`: passed
 
-## desktop visual verification notes
+## concise desktop visual verification notes
 
-- Verified by code inspection plus production build output that `/chat` now renders transcript content in the primary column and moves thread summary, thread selection, creation, and operational review into the supporting rail.
-- Transcript entries are chronological, bounded, and use restrained role styling rather than consumer-chat bubbles.
-- Long thread labels, UUIDs, and metadata chips now allow wrapping instead of forcing overflow-prone single-line treatment.
+- No fresh interactive desktop browser verification was performed during this fix turn.
+- Desktop layout expectations were reviewed by component and CSS inspection only, alongside a successful production build.
+- A manual desktop pass for real long-thread and long-execution payloads remains advisable before merge.
 
-## mobile visual verification notes
+## concise mobile visual verification notes
 
-- Verified by responsive CSS review that the chat layout collapses to one column under the existing breakpoint and keeps transcript cards, support cards, and composer actions stacked cleanly.
-- Transcript toplines and footers switch to vertical alignment on narrow screens, and buttons remain full width.
-- Compact empty states are used inside review groups so supporting panels do not create oversized dead space on smaller screens.
+- No fresh interactive mobile or responsive browser verification was performed during this fix turn.
+- Mobile behavior expectations were reviewed from the existing responsive CSS and component structure only.
+- A manual narrow-viewport pass remains advisable before merge.
 
 ## deferred scope
 
-- No backend changes.
-- No new continuity endpoints.
-- No pagination, search, archive, or inbox behavior.
-- No additional trace enrichment on persisted continuity transcript rows beyond the shipped response trace links already available from immediate response submissions.
-- No redesign outside `/chat` and the scoped shared components.
+- No backend changes or new thread-specific workflow endpoints.
+- No redesign of `/approvals` or `/tasks`.
+- No task-step mutation UI beyond the shipped approval resolution and execute actions.
+- No inbox, dashboard, pagination, search, or broader workflow surfacing beyond the selected thread.
+- No changes to `DESIGN_SYSTEM.md`; the sprint did not reveal a concrete contradiction that required rewriting the design system.
 
 ## worktree notes
 
-- `.ai/active/SPRINT_PACKET.md` was already modified before this implementation and was not changed by this sprint work.
-- `.ai/active/SPRINT_PACKET.md` remains a pre-existing control-artifact edit and should stay out of the sprint PR unless the PR explicitly intends to ship sprint-packet changes.
+- `.ai/active/SPRINT_PACKET.md` was already modified before this sprint work and was not changed here.

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -3,24 +3,41 @@ import { PageHeader } from "../../components/page-header";
 import { RequestComposer } from "../../components/request-composer";
 import { ResponseComposer } from "../../components/response-composer";
 import { ResponseHistory } from "../../components/response-history";
+import { ThreadWorkflowPanel } from "../../components/thread-workflow-panel";
 import { ThreadCreate } from "../../components/thread-create";
 import { ThreadEventList } from "../../components/thread-event-list";
 import { ThreadList } from "../../components/thread-list";
 import { ThreadSummary } from "../../components/thread-summary";
-import type { ThreadEventItem, ThreadItem, ThreadSessionItem } from "../../lib/api";
+import type {
+  ApiSource,
+  ApprovalItem,
+  TaskItem,
+  ThreadEventItem,
+  ThreadItem,
+  ThreadSessionItem,
+  ToolExecutionItem,
+} from "../../lib/api";
 import {
+  deriveThreadWorkflowState,
   getApiConfig,
   getThreadDetail,
   getThreadEvents,
   getThreadSessions,
   hasLiveApiConfig,
+  listApprovals,
   listThreads,
+  listTasks,
+  listToolExecutions,
+  shouldExpectThreadExecutionReview,
 } from "../../lib/api";
 import {
+  approvalFixtures,
+  executionFixtures,
   getFixtureThread,
   getFixtureThreadEvents,
   getFixtureThreadSessions,
   requestHistoryFixtures,
+  taskFixtures,
   threadFixtures,
 } from "../../lib/fixtures";
 
@@ -39,6 +56,20 @@ type ContinuityViewModel = {
   selectedThread: ThreadItem | null;
   sessions: ThreadSessionItem[];
   events: ThreadEventItem[];
+};
+
+type WorkflowSource = ApiSource | "unavailable";
+
+type WorkflowViewModel = {
+  approval: ApprovalItem | null;
+  approvalSource: WorkflowSource;
+  approvalUnavailableReason?: string;
+  task: TaskItem | null;
+  taskSource: WorkflowSource;
+  taskUnavailableReason?: string;
+  execution: ToolExecutionItem | null;
+  executionSource: WorkflowSource | null;
+  executionUnavailableReason?: string;
 };
 
 function normalizeMode(value: string | string[] | undefined): ChatMode {
@@ -73,6 +104,110 @@ function resolveSelectedThreadId(
   }
 
   return threads[0]?.id ?? "";
+}
+
+async function loadFixtureWorkflow(selectedThreadId: string): Promise<WorkflowViewModel> {
+  if (!selectedThreadId) {
+    return {
+      approval: null,
+      approvalSource: "fixture",
+      task: null,
+      taskSource: "fixture",
+      execution: null,
+      executionSource: null,
+    };
+  }
+
+  const { approval, task, execution } = deriveThreadWorkflowState(
+    selectedThreadId,
+    approvalFixtures,
+    taskFixtures,
+    executionFixtures,
+  );
+
+  return {
+    approval,
+    approvalSource: "fixture",
+    task,
+    taskSource: "fixture",
+    execution,
+    executionSource: execution ? "fixture" : null,
+  };
+}
+
+async function loadLiveWorkflow(
+  apiBaseUrl: string,
+  userId: string,
+  selectedThreadId: string,
+): Promise<WorkflowViewModel> {
+  if (!selectedThreadId) {
+    return {
+      approval: null,
+      approvalSource: "live",
+      task: null,
+      taskSource: "live",
+      execution: null,
+      executionSource: null,
+    };
+  }
+
+  const [approvalsResult, tasksResult, executionsResult] = await Promise.allSettled([
+    listApprovals(apiBaseUrl, userId),
+    listTasks(apiBaseUrl, userId),
+    listToolExecutions(apiBaseUrl, userId),
+  ]);
+
+  const approvalItems = approvalsResult.status === "fulfilled" ? approvalsResult.value.items : [];
+  const taskItems = tasksResult.status === "fulfilled" ? tasksResult.value.items : [];
+  const executionItems = executionsResult.status === "fulfilled" ? executionsResult.value.items : [];
+  const derivedWorkflow = deriveThreadWorkflowState(
+    selectedThreadId,
+    approvalItems,
+    taskItems,
+    executionItems,
+  );
+
+  const expectsExecutionReview = shouldExpectThreadExecutionReview(
+    derivedWorkflow.approval,
+    derivedWorkflow.task,
+  );
+
+  return {
+    approval: derivedWorkflow.approval,
+    approvalSource:
+      approvalsResult.status === "fulfilled"
+        ? "live"
+        : "unavailable",
+    approvalUnavailableReason:
+      approvalsResult.status === "rejected"
+        ? approvalsResult.reason instanceof Error
+          ? approvalsResult.reason.message
+          : "Approvals could not be loaded."
+        : undefined,
+    task: derivedWorkflow.task,
+    taskSource: tasksResult.status === "fulfilled" ? "live" : "unavailable",
+    taskUnavailableReason:
+      tasksResult.status === "rejected"
+        ? tasksResult.reason instanceof Error
+          ? tasksResult.reason.message
+          : "Tasks could not be loaded."
+        : undefined,
+    execution: derivedWorkflow.execution,
+    executionSource:
+      executionsResult.status === "fulfilled"
+        ? derivedWorkflow.execution
+          ? "live"
+          : null
+        : expectsExecutionReview
+          ? "unavailable"
+          : null,
+    executionUnavailableReason:
+      executionsResult.status === "rejected" && expectsExecutionReview
+        ? executionsResult.reason instanceof Error
+          ? executionsResult.reason.message
+          : "Execution state could not be loaded."
+        : undefined,
+  };
 }
 
 async function loadFixtureContinuity(
@@ -177,6 +312,9 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
         apiConfig.defaultThreadId,
       )
     : await loadFixtureContinuity(requestedThreadId, apiConfig.defaultThreadId);
+  const workflow = liveModeReady
+    ? await loadLiveWorkflow(apiConfig.apiBaseUrl, apiConfig.userId, continuity.selectedThreadId)
+    : await loadFixtureWorkflow(continuity.selectedThreadId);
 
   const initialRequestEntries = liveModeReady ? [] : requestHistoryFixtures;
 
@@ -241,6 +379,21 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
         </div>
 
         <div className="chat-layout__rail">
+          <ThreadWorkflowPanel
+            thread={continuity.selectedThread}
+            approval={workflow.approval}
+            approvalSource={workflow.approvalSource}
+            approvalUnavailableReason={workflow.approvalUnavailableReason}
+            task={workflow.task}
+            taskSource={workflow.taskSource}
+            taskUnavailableReason={workflow.taskUnavailableReason}
+            execution={workflow.execution}
+            executionSource={workflow.executionSource}
+            executionUnavailableReason={workflow.executionUnavailableReason}
+            apiBaseUrl={liveModeReady ? apiConfig.apiBaseUrl : undefined}
+            userId={liveModeReady ? apiConfig.userId : undefined}
+          />
+
           <ThreadSummary
             thread={continuity.selectedThread}
             sessions={continuity.sessions}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -332,6 +332,10 @@ code,
   gap: 24px;
 }
 
+.chat-layout__rail {
+  align-content: start;
+}
+
 .chat-layout {
   grid-template-columns: minmax(0, 1.34fr) minmax(320px, 0.82fr);
   align-items: flex-start;
@@ -372,6 +376,15 @@ code,
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-md);
   backdrop-filter: blur(14px);
+}
+
+.section-card--embedded {
+  gap: 16px;
+  padding: 20px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.56);
+  box-shadow: none;
+  backdrop-filter: blur(10px);
 }
 
 .section-card--history {
@@ -1005,6 +1018,55 @@ code,
 .detail-grid {
   display: grid;
   gap: 20px;
+}
+
+.thread-workflow-panel {
+  gap: 18px;
+}
+
+.thread-workflow-panel__summary {
+  display: grid;
+  gap: 14px;
+  padding: 18px 20px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(42, 52, 66, 0.08);
+}
+
+.thread-workflow-panel__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.thread-workflow-panel__stack {
+  display: grid;
+  gap: 16px;
+}
+
+.thread-workflow-panel .detail-grid,
+.thread-workflow-panel .detail-group,
+.thread-workflow-panel .approval-action-bar,
+.thread-workflow-panel .execution-summary {
+  gap: 14px;
+}
+
+.thread-workflow-panel .key-value-grid {
+  grid-template-columns: 1fr;
+}
+
+.thread-workflow-panel .approval-action-bar__buttons {
+  align-items: stretch;
+}
+
+.thread-workflow-panel .approval-action-bar__buttons > .button,
+.thread-workflow-panel .approval-action-bar__buttons > .button-secondary,
+.thread-workflow-panel .cluster > .button-secondary {
+  width: 100%;
+}
+
+.thread-workflow-panel .execution-summary__code {
+  max-height: 220px;
 }
 
 .thread-review-grid {

--- a/apps/web/components/approval-detail.tsx
+++ b/apps/web/components/approval-detail.tsx
@@ -38,6 +38,7 @@ type ApprovalDetailProps = {
   executionUnavailableMessage?: string | null;
   apiBaseUrl?: string;
   userId?: string;
+  chrome?: "card" | "embedded";
 };
 
 export function ApprovalDetail({
@@ -48,6 +49,7 @@ export function ApprovalDetail({
   executionUnavailableMessage,
   apiBaseUrl,
   userId,
+  chrome = "card",
 }: ApprovalDetailProps) {
   const [approval, setApproval] = useState(initialApproval);
   const [execution, setExecution] = useState(initialExecution);
@@ -65,6 +67,7 @@ export function ApprovalDetail({
         eyebrow="Approval detail"
         title="No approval selected"
         description="Choose an approval from the inbox to inspect its governing request and resolution state."
+        className={chrome === "embedded" ? "section-card--embedded" : undefined}
       >
         <EmptyState
           title="Approval inspector is idle"
@@ -79,6 +82,7 @@ export function ApprovalDetail({
       eyebrow="Approval detail"
       title={approval.tool.name}
       description="Request detail, routing rationale, resolution, and execution review stay composed inside one bounded inspector."
+      className={chrome === "embedded" ? "section-card--embedded" : undefined}
     >
       <div className="detail-grid">
         <div className="detail-summary">

--- a/apps/web/components/task-summary.tsx
+++ b/apps/web/components/task-summary.tsx
@@ -13,6 +13,8 @@ type TaskSummaryProps = {
   execution: ToolExecutionItem | null;
   executionSource?: ApiSource | null;
   executionUnavailableMessage?: string | null;
+  chrome?: "card" | "embedded";
+  showExecutionReview?: boolean;
 };
 
 export function TaskSummary({
@@ -22,6 +24,8 @@ export function TaskSummary({
   execution,
   executionSource,
   executionUnavailableMessage,
+  chrome = "card",
+  showExecutionReview = true,
 }: TaskSummaryProps) {
   if (!task) {
     return (
@@ -29,6 +33,7 @@ export function TaskSummary({
         eyebrow="Selected task"
         title="No task selected"
         description="Choose a task to inspect its current governed state and ordered task steps."
+        className={chrome === "embedded" ? "section-card--embedded" : undefined}
       >
         <EmptyState
           title="Task inspector is idle"
@@ -43,6 +48,7 @@ export function TaskSummary({
       eyebrow="Selected task"
       title={task.tool.name}
       description="Latest task state, approval linkage, and execution review stay grouped in one bounded task summary."
+      className={chrome === "embedded" ? "section-card--embedded" : undefined}
     >
       <div className="detail-grid">
         <div className="detail-summary">
@@ -95,16 +101,18 @@ export function TaskSummary({
           ) : null}
         </div>
 
-        <div className="detail-group">
-          <h3>Execution review</h3>
-          <ExecutionSummary
-            execution={execution}
-            source={executionSource}
-            unavailableMessage={executionUnavailableMessage}
-            emptyTitle="Task has not executed yet"
-            emptyDescription="When execution runs for this task, the latest execution record and output snapshot will appear here."
-          />
-        </div>
+        {showExecutionReview ? (
+          <div className="detail-group">
+            <h3>Execution review</h3>
+            <ExecutionSummary
+              execution={execution}
+              source={executionSource}
+              unavailableMessage={executionUnavailableMessage}
+              emptyTitle="Task has not executed yet"
+              emptyDescription="When execution runs for this task, the latest execution record and output snapshot will appear here."
+            />
+          </div>
+        ) : null}
       </div>
     </SectionCard>
   );

--- a/apps/web/components/thread-workflow-panel.test.tsx
+++ b/apps/web/components/thread-workflow-panel.test.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  approvalFixtures,
+  executionFixtures,
+  taskFixtures,
+  threadFixtures,
+} from "../lib/fixtures";
+import { ThreadWorkflowPanel } from "./thread-workflow-panel";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: vi.fn(),
+  }),
+}));
+
+describe("ThreadWorkflowPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders embedded approval and task review for a thread with linked workflow", () => {
+    render(
+      <ThreadWorkflowPanel
+        thread={threadFixtures[1]}
+        approval={approvalFixtures[1]}
+        approvalSource="fixture"
+        task={taskFixtures[1]}
+        taskSource="fixture"
+        execution={executionFixtures[0]}
+        executionSource="fixture"
+      />,
+    );
+
+    expect(screen.getByText("Governed workflow review")).toBeInTheDocument();
+    expect(screen.getByText("Fixture workflow")).toBeInTheDocument();
+    expect(screen.getByText("Approval: approved")).toBeInTheDocument();
+    expect(screen.getByText("Task: executed")).toBeInTheDocument();
+    expect(screen.getByText("Execution: completed")).toBeInTheDocument();
+    expect(screen.getByText("Approval detail")).toBeInTheDocument();
+    expect(screen.getByText("Selected task")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Executed" })).toBeDisabled();
+    expect(screen.getByText("Open linked approval")).toBeInTheDocument();
+  });
+
+  it("shows an explicit empty state when the selected thread has no linked workflow", () => {
+    render(
+      <ThreadWorkflowPanel
+        thread={threadFixtures[2]}
+        approval={null}
+        approvalSource="fixture"
+        task={null}
+        taskSource="fixture"
+        execution={null}
+        executionSource={null}
+      />,
+    );
+
+    expect(screen.getByText("No governed workflow linked yet")).toBeInTheDocument();
+    expect(
+      screen.getByText(/When this thread produces an approval-gated request/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders partial unavailable states without hiding the rest of the live workflow review", () => {
+    render(
+      <ThreadWorkflowPanel
+        thread={threadFixtures[0]}
+        approval={null}
+        approvalSource="unavailable"
+        approvalUnavailableReason="Approval API timed out."
+        task={taskFixtures[0]}
+        taskSource="live"
+        execution={null}
+        executionSource="unavailable"
+        executionUnavailableReason="Execution API timed out."
+        apiBaseUrl="https://api.example.com"
+        userId="user-1"
+      />,
+    );
+
+    expect(screen.getByText("Partial workflow review")).toBeInTheDocument();
+    expect(screen.getByText("Approval review unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Approval API timed out.")).toBeInTheDocument();
+    expect(screen.getByText("Selected task")).toBeInTheDocument();
+    expect(screen.getByText("Execution review could not be loaded")).toBeInTheDocument();
+    expect(screen.getByText("Execution API timed out.")).toBeInTheDocument();
+  });
+
+  it("shows execution review inside task summary when approval detail is absent but execution data exists", () => {
+    render(
+      <ThreadWorkflowPanel
+        thread={threadFixtures[1]}
+        approval={null}
+        approvalSource="fixture"
+        task={taskFixtures[1]}
+        taskSource="fixture"
+        execution={executionFixtures[0]}
+        executionSource="fixture"
+      />,
+    );
+
+    expect(screen.getByText("Selected task")).toBeInTheDocument();
+    expect(screen.getByText("Execution review")).toBeInTheDocument();
+    expect(screen.getByText("Execution record in review")).toBeInTheDocument();
+    expect(screen.getByText("Fixture execution detail")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/thread-workflow-panel.tsx
+++ b/apps/web/components/thread-workflow-panel.tsx
@@ -1,0 +1,169 @@
+import type { ApiSource, ApprovalItem, TaskItem, ThreadItem, ToolExecutionItem } from "../lib/api";
+import { ApprovalDetail } from "./approval-detail";
+import { EmptyState } from "./empty-state";
+import { ExecutionSummary } from "./execution-summary";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+import { TaskSummary } from "./task-summary";
+
+type WorkflowSource = ApiSource | "unavailable";
+
+type ThreadWorkflowPanelProps = {
+  thread: ThreadItem | null;
+  approval: ApprovalItem | null;
+  approvalSource: WorkflowSource;
+  approvalUnavailableReason?: string;
+  task: TaskItem | null;
+  taskSource: WorkflowSource;
+  taskUnavailableReason?: string;
+  execution: ToolExecutionItem | null;
+  executionSource: WorkflowSource | null;
+  executionUnavailableReason?: string;
+  apiBaseUrl?: string;
+  userId?: string;
+};
+
+function workflowModeLabel(
+  approvalSource: WorkflowSource,
+  taskSource: WorkflowSource,
+  executionSource: WorkflowSource | null,
+) {
+  const sources = [approvalSource, taskSource, executionSource].filter(Boolean);
+
+  if (sources.some((source) => source === "unavailable")) {
+    return "Partial workflow review";
+  }
+
+  return sources.every((source) => source === "fixture") ? "Fixture workflow" : "Live workflow";
+}
+
+export function ThreadWorkflowPanel({
+  thread,
+  approval,
+  approvalSource,
+  approvalUnavailableReason,
+  task,
+  taskSource,
+  taskUnavailableReason,
+  execution,
+  executionSource,
+  executionUnavailableReason,
+  apiBaseUrl,
+  userId,
+}: ThreadWorkflowPanelProps) {
+  if (!thread) {
+    return (
+      <SectionCard
+        eyebrow="Thread-linked workflow"
+        title="Governed workflow stays with the thread"
+        description="Approval, task, and execution review appears here once one visible thread is selected."
+      >
+        <EmptyState
+          title="Select a thread"
+          description="Choose or create a thread first so workflow review stays attached to one durable conversation."
+        />
+      </SectionCard>
+    );
+  }
+
+  const hasWorkflow = Boolean(approval || task || execution);
+  const hasUnavailableState =
+    approvalSource === "unavailable" || taskSource === "unavailable" || executionSource === "unavailable";
+
+  return (
+    <SectionCard
+      eyebrow="Thread-linked workflow"
+      title="Governed workflow review"
+      description="The latest approval, task, and execution state stays visible beside the selected thread without turning chat into a separate operations dashboard."
+      className="thread-workflow-panel"
+    >
+      <div className="thread-workflow-panel__summary">
+        <StatusBadge status={approval?.status ?? task?.status ?? execution?.status ?? "info"} />
+        <div className="thread-workflow-panel__chips">
+          <span className="subtle-chip">{workflowModeLabel(approvalSource, taskSource, executionSource)}</span>
+          <span className="subtle-chip">Thread: {thread.title}</span>
+          {approval ? <span className="subtle-chip">Approval: {approval.status.replace(/_/g, " ")}</span> : null}
+          {task ? <span className="subtle-chip">Task: {task.status.replace(/_/g, " ")}</span> : null}
+          {execution ? (
+            <span className="subtle-chip">Execution: {execution.status.replace(/_/g, " ")}</span>
+          ) : null}
+        </div>
+      </div>
+
+      {!hasWorkflow && !hasUnavailableState ? (
+        <EmptyState
+          title="No governed workflow linked yet"
+          description="When this thread produces an approval-gated request, the latest approval, task, and execution review will appear here."
+        />
+      ) : (
+        <div className="thread-workflow-panel__stack">
+          {approval ? (
+            <ApprovalDetail
+              initialApproval={approval}
+              detailSource={approvalSource === "fixture" ? "fixture" : "live"}
+              initialExecution={execution}
+              executionSource={executionSource === "fixture" || executionSource === "live" ? executionSource : null}
+              executionUnavailableMessage={executionUnavailableReason}
+              apiBaseUrl={apiBaseUrl}
+              userId={userId}
+              chrome="embedded"
+            />
+          ) : approvalSource === "unavailable" ? (
+            <EmptyState
+              title="Approval review unavailable"
+              description={
+                approvalUnavailableReason ??
+                "Approval state could not be loaded for the selected thread from the configured backend."
+              }
+              className="empty-state--compact"
+            />
+          ) : null}
+
+          {task ? (
+            <TaskSummary
+              task={task}
+              taskSource={taskSource === "fixture" ? "fixture" : "live"}
+              stepSource={taskSource === "fixture" ? "fixture" : "live"}
+              execution={execution}
+              executionSource={executionSource === "fixture" || executionSource === "live" ? executionSource : null}
+              executionUnavailableMessage={executionUnavailableReason}
+              chrome="embedded"
+              showExecutionReview={!approval}
+            />
+          ) : taskSource === "unavailable" ? (
+            <EmptyState
+              title="Task review unavailable"
+              description={
+                taskUnavailableReason ??
+                "Task state could not be loaded for the selected thread from the configured backend."
+              }
+              className="empty-state--compact"
+            />
+          ) : null}
+
+          {!approval && !task && (execution || executionSource === "unavailable") ? (
+            <SectionCard
+              eyebrow="Execution review"
+              title={execution ? "Latest execution record" : "Execution review unavailable"}
+              description="Execution outcome stays visible even when approval or task detail is missing from the selected-thread workflow review."
+              className="section-card--embedded"
+            >
+              <ExecutionSummary
+                execution={execution}
+                source={executionSource === "fixture" || executionSource === "live" ? executionSource : null}
+                unavailableMessage={
+                  execution
+                    ? null
+                    : executionUnavailableReason ??
+                      "Execution state could not be loaded for the selected thread from the configured backend."
+                }
+                emptyTitle="Execution record is unavailable"
+                emptyDescription="Execution review appears here when a selected-thread execution record can be loaded."
+              />
+            </SectionCard>
+          ) : null}
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -4,6 +4,7 @@ import {
   ApiError,
   combinePageModes,
   createThread,
+  deriveThreadWorkflowState,
   getThreadDetail,
   getThreadEvents,
   getThreadSessions,
@@ -15,6 +16,7 @@ import {
   listTraces,
   pageModeLabel,
   resolveApproval,
+  shouldExpectThreadExecutionReview,
   submitAssistantResponse,
   submitApprovalRequest,
 } from "./api";
@@ -34,6 +36,202 @@ describe("api helpers", () => {
   it("combines live and fixture sources into a mixed page mode", () => {
     expect(combinePageModes("live", "fixture")).toBe("mixed");
     expect(pageModeLabel("mixed")).toBe("Mixed fallback");
+  });
+
+  it("does not borrow an older unrelated execution from the same thread", () => {
+    const approval = {
+      id: "approval-new",
+      thread_id: "thread-1",
+      task_step_id: "step-new",
+      status: "approved",
+      request: {
+        thread_id: "thread-1",
+        tool_id: "tool-1",
+        action: "place_order",
+        scope: "supplements",
+        domain_hint: "ecommerce",
+        risk_hint: "purchase",
+        attributes: {},
+      },
+      tool: {
+        id: "tool-1",
+        tool_key: "merchant_proxy",
+        name: "Merchant Proxy",
+        description: "Proxy",
+        version: "0.1.0",
+        metadata_version: "tool_metadata_v0",
+        active: true,
+        tags: [],
+        action_hints: [],
+        scope_hints: [],
+        domain_hints: [],
+        risk_hints: [],
+        metadata: {},
+        created_at: "2026-03-17T00:00:00Z",
+      },
+      routing: {
+        decision: "require_approval",
+        reasons: [],
+        trace: {
+          trace_id: "trace-approval-new",
+          trace_event_count: 3,
+        },
+      },
+      created_at: "2026-03-18T10:00:00Z",
+      resolution: {
+        resolved_at: "2026-03-18T10:05:00Z",
+        resolved_by_user_id: "user-1",
+      },
+    };
+
+    const olderApproval = {
+      ...approval,
+      id: "approval-old",
+      task_step_id: "step-old",
+      created_at: "2026-03-17T10:00:00Z",
+    };
+
+    const task = {
+      id: "task-new",
+      thread_id: "thread-1",
+      tool_id: "tool-1",
+      status: "approved",
+      request: approval.request,
+      tool: approval.tool,
+      latest_approval_id: "approval-new",
+      latest_execution_id: null,
+      created_at: "2026-03-18T10:00:00Z",
+      updated_at: "2026-03-18T10:05:00Z",
+    };
+
+    const olderTask = {
+      ...task,
+      id: "task-old",
+      latest_approval_id: "approval-old",
+      latest_execution_id: "execution-old",
+      created_at: "2026-03-17T10:00:00Z",
+      updated_at: "2026-03-17T10:10:00Z",
+    };
+
+    const olderExecution = {
+      id: "execution-old",
+      approval_id: "approval-old",
+      task_step_id: "step-old",
+      thread_id: "thread-1",
+      tool_id: "tool-1",
+      trace_id: "trace-execution-old",
+      request_event_id: "request-event-old",
+      result_event_id: "result-event-old",
+      status: "completed",
+      handler_key: "proxy.echo",
+      request: approval.request,
+      tool: approval.tool,
+      result: {
+        handler_key: "proxy.echo",
+        status: "completed",
+        output: { ok: true },
+        reason: null,
+      },
+      executed_at: "2026-03-17T10:10:00Z",
+    };
+
+    const workflow = deriveThreadWorkflowState(
+      "thread-1",
+      [olderApproval, approval],
+      [olderTask, task],
+      [olderExecution],
+    );
+
+    expect(workflow.approval?.id).toBe("approval-new");
+    expect(workflow.task?.id).toBe("task-new");
+    expect(workflow.execution).toBeNull();
+    expect(shouldExpectThreadExecutionReview(workflow.approval, workflow.task)).toBe(true);
+  });
+
+  it("returns explicitly linked execution when the selected task carries latest_execution_id", () => {
+    const approval = {
+      id: "approval-1",
+      thread_id: "thread-1",
+      task_step_id: "step-1",
+      status: "approved",
+      request: {
+        thread_id: "thread-1",
+        tool_id: "tool-1",
+        action: "place_order",
+        scope: "supplements",
+        domain_hint: "ecommerce",
+        risk_hint: "purchase",
+        attributes: {},
+      },
+      tool: {
+        id: "tool-1",
+        tool_key: "merchant_proxy",
+        name: "Merchant Proxy",
+        description: "Proxy",
+        version: "0.1.0",
+        metadata_version: "tool_metadata_v0",
+        active: true,
+        tags: [],
+        action_hints: [],
+        scope_hints: [],
+        domain_hints: [],
+        risk_hints: [],
+        metadata: {},
+        created_at: "2026-03-17T00:00:00Z",
+      },
+      routing: {
+        decision: "require_approval",
+        reasons: [],
+        trace: {
+          trace_id: "trace-approval-1",
+          trace_event_count: 3,
+        },
+      },
+      created_at: "2026-03-18T10:00:00Z",
+      resolution: {
+        resolved_at: "2026-03-18T10:05:00Z",
+        resolved_by_user_id: "user-1",
+      },
+    };
+
+    const task = {
+      id: "task-1",
+      thread_id: "thread-1",
+      tool_id: "tool-1",
+      status: "executed",
+      request: approval.request,
+      tool: approval.tool,
+      latest_approval_id: "approval-1",
+      latest_execution_id: "execution-1",
+      created_at: "2026-03-18T10:00:00Z",
+      updated_at: "2026-03-18T10:06:00Z",
+    };
+
+    const execution = {
+      id: "execution-1",
+      approval_id: "approval-1",
+      task_step_id: "step-1",
+      thread_id: "thread-1",
+      tool_id: "tool-1",
+      trace_id: "trace-execution-1",
+      request_event_id: "request-event-1",
+      result_event_id: "result-event-1",
+      status: "completed",
+      handler_key: "proxy.echo",
+      request: approval.request,
+      tool: approval.tool,
+      result: {
+        handler_key: "proxy.echo",
+        status: "completed",
+        output: { ok: true },
+        reason: null,
+      },
+      executed_at: "2026-03-18T10:06:00Z",
+    };
+
+    const workflow = deriveThreadWorkflowState("thread-1", [approval], [task], [execution]);
+
+    expect(workflow.execution?.id).toBe("execution-1");
   });
 
   it("posts governed approval requests to the shipped endpoint", async () => {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -274,6 +274,12 @@ export type ApprovalRequestResponse = {
   };
 };
 
+export type ThreadWorkflowState = {
+  approval: ApprovalItem | null;
+  task: TaskItem | null;
+  execution: ToolExecutionItem | null;
+};
+
 export type ApprovalResolutionResponse = {
   approval: ApprovalItem;
   trace: {
@@ -419,6 +425,97 @@ export function pageModeLabel(mode: PageDataMode) {
   }
 
   return "Fixture-backed";
+}
+
+function compareIsoDatesDesc(left: string, right: string) {
+  return new Date(right).getTime() - new Date(left).getTime();
+}
+
+function pickLatestApproval(items: ApprovalItem[]) {
+  return [...items].sort((left, right) => compareIsoDatesDesc(left.created_at, right.created_at))[0] ?? null;
+}
+
+function pickLatestTask(items: TaskItem[], approval: ApprovalItem | null) {
+  if (approval) {
+    const linkedTask =
+      [...items]
+        .filter((item) => item.latest_approval_id === approval.id)
+        .sort((left, right) => {
+          const updatedDelta = compareIsoDatesDesc(left.updated_at, right.updated_at);
+          if (updatedDelta !== 0) {
+            return updatedDelta;
+          }
+
+          return compareIsoDatesDesc(left.created_at, right.created_at);
+        })[0] ?? null;
+
+    if (linkedTask) {
+      return linkedTask;
+    }
+  }
+
+  return [...items].sort((left, right) => {
+    const updatedDelta = compareIsoDatesDesc(left.updated_at, right.updated_at);
+    if (updatedDelta !== 0) {
+      return updatedDelta;
+    }
+
+    return compareIsoDatesDesc(left.created_at, right.created_at);
+  })[0] ?? null;
+}
+
+function pickExplicitlyLinkedExecution(
+  items: ToolExecutionItem[],
+  task: TaskItem | null,
+  approval: ApprovalItem | null,
+) {
+  if (task?.latest_execution_id) {
+    return items.find((item) => item.id === task.latest_execution_id) ?? null;
+  }
+
+  if (approval) {
+    return (
+      [...items]
+        .filter((item) => item.approval_id === approval.id)
+        .sort((left, right) => compareIsoDatesDesc(left.executed_at, right.executed_at))[0] ?? null
+    );
+  }
+
+  return null;
+}
+
+export function deriveThreadWorkflowState(
+  threadId: string,
+  approvals: ApprovalItem[],
+  tasks: TaskItem[],
+  executions: ToolExecutionItem[],
+): ThreadWorkflowState {
+  const threadApprovals = approvals.filter((item) => item.thread_id === threadId);
+  const approval = pickLatestApproval(threadApprovals);
+  const threadTasks = tasks.filter((item) => item.thread_id === threadId);
+  const task = pickLatestTask(threadTasks, approval);
+  const threadExecutions = executions.filter((item) => item.thread_id === threadId);
+  const execution = pickExplicitlyLinkedExecution(threadExecutions, task, approval);
+
+  return {
+    approval,
+    task,
+    execution,
+  };
+}
+
+export function shouldExpectThreadExecutionReview(
+  approval: ApprovalItem | null,
+  task: TaskItem | null,
+) {
+  const normalizedApprovalStatus = approval?.status.trim().toLowerCase() ?? "";
+  const normalizedTaskStatus = task?.status.trim().toLowerCase() ?? "";
+
+  return Boolean(
+    task?.latest_execution_id ||
+      ["approved", "executed", "completed"].includes(normalizedApprovalStatus) ||
+      ["executed", "completed"].includes(normalizedTaskStatus),
+  );
 }
 
 function buildApiUrl(


### PR DESCRIPTION
## Summary
- add a bounded selected-thread workflow panel inside /chat using the shipped approval, task, execution, and continuity seams
- keep transcript primary while surfacing inline approve, reject, and execute actions only where the existing backend already permits them
- keep the sprint inside the existing web and backend surface with no broader scope expansion

## Verification
- npm run lint in apps/web: PASS
- npm test in apps/web: PASS
- npm run build in apps/web: PASS

## Notes
- the sprint stayed a UI sprint over shipped approval, task, execution, and continuity seams
- no backend, Gmail, Calendar, auth, runner, or broader scope expansion entered the sprint