### PR TITLE
Sprint 6M: thread-linked task-step timeline in chat

### DIFF
--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -2,26 +2,26 @@
 
 ## sprint objective
 
-Deliver Sprint 6L by extending `/chat` with bounded selected-thread governed workflow review so approval, task, and execution state stay visible beside the durable transcript without widening backend scope.
+Deliver Sprint 6M by extending `/chat` with a bounded selected-thread task-step timeline for the latest linked task, while keeping transcript-first hierarchy and reusing shipped task-step reads.
 
-## exact `/chat` workflow files and components updated
+## exact `/chat` task-step files and components updated
 
 - `apps/web/app/chat/page.tsx`
 - `apps/web/app/globals.css`
-- `apps/web/components/approval-detail.tsx`
-- `apps/web/components/task-summary.tsx`
 - `apps/web/components/thread-workflow-panel.tsx`
 - `apps/web/components/thread-workflow-panel.test.tsx`
-- `apps/web/lib/api.ts`
+- `apps/web/components/task-step-list.tsx`
+- `apps/web/components/task-step-list.test.tsx`
+- `apps/web/components/task-summary.tsx`
 - `apps/web/lib/api.test.ts`
 - `BUILD_REPORT.md`
 
-## thread-linked workflow backing mode
+## selected-thread task-step review backing mode
 
 - Mixed.
-- Live workflow review uses existing shipped reads from approvals, tasks, and tool executions when API configuration is present.
-- Fixture workflow review is used when API configuration is absent.
-- Live workflow failures degrade to explicit unavailable states inside the chat workflow panel instead of implying missing workflow.
+- Live mode: selected-thread workflow derives latest linked task from shipped list reads, then loads task-step timeline from shipped task-step endpoint.
+- Fixture mode: selected-thread task and task-step timeline are fixture-backed when API configuration is absent.
+- Partial unavailable mode: live task-step read failures show explicit unavailable state in the workflow panel without breaking transcript or task review.
 
 ## shipped backend endpoints consumed
 
@@ -31,6 +31,7 @@ Deliver Sprint 6L by extending `/chat` with bounded selected-thread governed wor
 - `GET /v0/threads/{thread_id}/sessions`
 - `GET /v0/approvals`
 - `GET /v0/tasks`
+- `GET /v0/tasks/{task_id}/steps`
 - `GET /v0/tool-executions`
 - `POST /v0/approvals/{approval_id}/approve`
 - `POST /v0/approvals/{approval_id}/reject`
@@ -41,47 +42,45 @@ Deliver Sprint 6L by extending `/chat` with bounded selected-thread governed wor
 
 ## completed work
 
-- Added a new `thread-workflow-panel` to `/chat` so selected-thread workflow state now appears in the rail as a bounded secondary review surface.
-- Derived the latest relevant approval and task state client-side from shipped list endpoints and existing fixtures, keyed by the selected thread.
-- Restricted execution review to explicit linkage only: selected-task `latest_execution_id` first, then execution records explicitly linked to the selected approval, with no thread-level fallback.
-- Reused `approval-detail`, `approval-actions`, `task-summary`, and `execution-summary` inside compact embedded cards so the chat route inherits the same workflow semantics as `/approvals` and `/tasks`.
-- Restored bounded execution review when approval detail is absent by rendering execution review through the task summary or a standalone embedded execution block when needed.
-- Preserved transcript-first hierarchy by keeping workflow review secondary and visually quieter than the conversation column.
-- Tightened rail containment with embedded card chrome, single-column key-value layouts, bounded execution code blocks, and full-width action layouts that avoid cramped wrapping.
-- Added in-scope regression coverage for mixed-history execution linkage and approval-missing execution review in `apps/web/lib/api.test.ts` and `apps/web/components/thread-workflow-panel.test.tsx`.
+- Extended chat workflow loading to include selected-thread latest-task step timeline using existing shipped endpoint and explicit unavailable handling.
+- Reused `TaskStepList` inside `thread-workflow-panel` as an embedded bounded tertiary panel.
+- Added explicit embedded empty/unavailable timeline states when task-step data is missing or unreadable.
+- Refined task-step timeline readability with step metadata, calmer embedded chrome, bounded scroll in chat rail, and improved chip/text containment.
+- Tightened chat hierarchy and spacing with chat-specific layout refinements so transcript remains primary and right-rail workflow remains secondary/tertiary.
+- Added regression tests for embedded timeline rendering and task-step API request contract.
 
 ## exact commands run
 
-- `npm run lint`
-- `npm test`
-- `npm run build`
+- `npm run lint` (in `apps/web`)
+- `npm test` (in `apps/web`)
+- `npm run build` (in `apps/web`)
 
 ## verification results
 
 - `npm run lint`: passed
-- `npm test`: passed, `13` test files and `46` tests passed
+- `npm test`: passed, `14` test files and `50` tests passed
 - `npm run build`: passed
 
 ## concise desktop visual verification notes
 
-- No fresh interactive desktop browser verification was performed during this fix turn.
-- Desktop layout expectations were reviewed by component and CSS inspection only, alongside a successful production build.
-- A manual desktop pass for real long-thread and long-execution payloads remains advisable before merge.
+- Interactive desktop browser QA was not run in this environment.
+- Desktop hierarchy/containment was verified via component + CSS inspection and production build output.
+- Recommended before merge: quick manual desktop pass on `/chat` with long thread titles and long task-step attribute values.
 
 ## concise mobile visual verification notes
 
-- No fresh interactive mobile or responsive browser verification was performed during this fix turn.
-- Mobile behavior expectations were reviewed from the existing responsive CSS and component structure only.
-- A manual narrow-viewport pass remains advisable before merge.
+- Interactive mobile viewport QA was not run in this environment.
+- Mobile behavior was checked against responsive CSS rules, including single-column fallback and embedded timeline unbounding.
+- Recommended before merge: quick manual viewport pass at <=`740px` on `/chat` with populated timeline steps.
 
 ## deferred scope
 
-- No backend changes or new thread-specific workflow endpoints.
-- No redesign of `/approvals` or `/tasks`.
-- No task-step mutation UI beyond the shipped approval resolution and execute actions.
-- No inbox, dashboard, pagination, search, or broader workflow surfacing beyond the selected thread.
-- No changes to `DESIGN_SYSTEM.md`; the sprint did not reveal a concrete contradiction that required rewriting the design system.
+- No backend changes or new endpoints.
+- No task-step mutation UI.
+- No redesign of `/tasks`, `/approvals`, or unrelated routes.
+- No Gmail, Calendar, runner, connector, or broader orchestration scope expansion.
+- No `DESIGN_SYSTEM.md` rewrite; no concrete contradiction was introduced.
 
 ## worktree notes
 
-- `.ai/active/SPRINT_PACKET.md` was already modified before this sprint work and was not changed here.
+- `.ai/active/SPRINT_PACKET.md` and `REVIEW_REPORT.md` were already modified before this implementation and were not edited as part of this sprint change.

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -12,6 +12,8 @@ import type {
   ApiSource,
   ApprovalItem,
   TaskItem,
+  TaskStepItem,
+  TaskStepListSummary,
   ThreadEventItem,
   ThreadItem,
   ThreadSessionItem,
@@ -20,6 +22,7 @@ import type {
 import {
   deriveThreadWorkflowState,
   getApiConfig,
+  getTaskSteps,
   getThreadDetail,
   getThreadEvents,
   getThreadSessions,
@@ -36,6 +39,8 @@ import {
   getFixtureThread,
   getFixtureThreadEvents,
   getFixtureThreadSessions,
+  getFixtureTaskStepSummary,
+  getFixtureTaskSteps,
   requestHistoryFixtures,
   taskFixtures,
   threadFixtures,
@@ -70,6 +75,10 @@ type WorkflowViewModel = {
   execution: ToolExecutionItem | null;
   executionSource: WorkflowSource | null;
   executionUnavailableReason?: string;
+  taskSteps: TaskStepItem[];
+  taskStepSummary: TaskStepListSummary | null;
+  taskStepSource: WorkflowSource | null;
+  taskStepUnavailableReason?: string;
 };
 
 function normalizeMode(value: string | string[] | undefined): ChatMode {
@@ -115,6 +124,9 @@ async function loadFixtureWorkflow(selectedThreadId: string): Promise<WorkflowVi
       taskSource: "fixture",
       execution: null,
       executionSource: null,
+      taskSteps: [],
+      taskStepSummary: null,
+      taskStepSource: null,
     };
   }
 
@@ -132,6 +144,9 @@ async function loadFixtureWorkflow(selectedThreadId: string): Promise<WorkflowVi
     taskSource: "fixture",
     execution,
     executionSource: execution ? "fixture" : null,
+    taskSteps: task ? getFixtureTaskSteps(task.id) : [],
+    taskStepSummary: task ? getFixtureTaskStepSummary(task.id) : null,
+    taskStepSource: task ? "fixture" : null,
   };
 }
 
@@ -148,6 +163,9 @@ async function loadLiveWorkflow(
       taskSource: "live",
       execution: null,
       executionSource: null,
+      taskSteps: [],
+      taskStepSummary: null,
+      taskStepSource: null,
     };
   }
 
@@ -166,6 +184,23 @@ async function loadLiveWorkflow(
     taskItems,
     executionItems,
   );
+  let taskSteps: TaskStepItem[] = [];
+  let taskStepSummary: TaskStepListSummary | null = null;
+  let taskStepSource: WorkflowSource | null = derivedWorkflow.task ? "live" : null;
+  let taskStepUnavailableReason: string | undefined;
+
+  if (derivedWorkflow.task) {
+    try {
+      const taskStepPayload = await getTaskSteps(apiBaseUrl, derivedWorkflow.task.id, userId);
+      taskSteps = taskStepPayload.items;
+      taskStepSummary = taskStepPayload.summary;
+      taskStepSource = "live";
+    } catch (error) {
+      taskStepSource = "unavailable";
+      taskStepUnavailableReason =
+        error instanceof Error ? error.message : "Task-step timeline could not be loaded.";
+    }
+  }
 
   const expectsExecutionReview = shouldExpectThreadExecutionReview(
     derivedWorkflow.approval,
@@ -207,6 +242,10 @@ async function loadLiveWorkflow(
           ? executionsResult.reason.message
           : "Execution state could not be loaded."
         : undefined,
+    taskSteps,
+    taskStepSummary,
+    taskStepSource,
+    taskStepUnavailableReason,
   };
 }
 
@@ -319,7 +358,7 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
   const initialRequestEntries = liveModeReady ? [] : requestHistoryFixtures;
 
   return (
-    <div className="page-stack">
+    <div className="page-stack page-stack--chat">
       <PageHeader
         eyebrow="Operator conversation surface"
         title="Chat with the assistant or route a governed request"
@@ -390,6 +429,10 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
             execution={workflow.execution}
             executionSource={workflow.executionSource}
             executionUnavailableReason={workflow.executionUnavailableReason}
+            taskSteps={workflow.taskSteps}
+            taskStepSummary={workflow.taskStepSummary}
+            taskStepSource={workflow.taskStepSource}
+            taskStepUnavailableReason={workflow.taskStepUnavailableReason}
             apiBaseUrl={liveModeReady ? apiConfig.apiBaseUrl : undefined}
             userId={liveModeReady ? apiConfig.userId : undefined}
           />

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -283,6 +283,10 @@ code,
   gap: 28px;
 }
 
+.page-stack--chat {
+  gap: 24px;
+}
+
 .page-header {
   display: flex;
   flex-wrap: wrap;
@@ -329,7 +333,7 @@ code,
 .chat-layout__main,
 .chat-layout__rail {
   display: grid;
-  gap: 24px;
+  gap: 20px;
 }
 
 .chat-layout__rail {
@@ -337,7 +341,7 @@ code,
 }
 
 .chat-layout {
-  grid-template-columns: minmax(0, 1.34fr) minmax(320px, 0.82fr);
+  grid-template-columns: minmax(0, 1.42fr) minmax(320px, 0.78fr);
   align-items: flex-start;
 }
 
@@ -415,6 +419,7 @@ code,
   color: var(--text-soft);
   line-height: 1.6;
   max-width: 72ch;
+  overflow-wrap: anywhere;
 }
 
 .metric-value {
@@ -592,6 +597,7 @@ code,
   margin: 0;
   color: var(--text-soft);
   line-height: 1.6;
+  overflow-wrap: anywhere;
 }
 
 .button,
@@ -1039,6 +1045,11 @@ code,
   gap: 10px;
 }
 
+.thread-workflow-panel__chips .subtle-chip {
+  max-width: 100%;
+  white-space: normal;
+}
+
 .thread-workflow-panel__stack {
   display: grid;
   gap: 16px;
@@ -1067,6 +1078,25 @@ code,
 
 .thread-workflow-panel .execution-summary__code {
   max-height: 220px;
+}
+
+.task-summary--embedded .detail-group {
+  padding: 16px;
+}
+
+.task-step-list {
+  gap: 18px;
+}
+
+.task-step-list--embedded .timeline-list {
+  max-height: 560px;
+  overflow: auto;
+  padding-right: 6px;
+}
+
+.task-step-list--embedded .timeline-item {
+  padding: 16px;
+  border-radius: 16px;
 }
 
 .thread-review-grid {
@@ -1107,6 +1137,8 @@ code,
   font-size: 0.84rem;
   line-height: 1.45;
   overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal;
   max-width: 100%;
 }
 
@@ -1221,11 +1253,30 @@ code,
 .timeline-item {
   display: grid;
   gap: 14px;
+  position: relative;
+  padding-left: 16px;
+}
+
+.timeline-item::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 3px;
+  border-radius: 999px;
+  background: rgba(39, 75, 99, 0.18);
 }
 
 .timeline-item__summary {
   display: grid;
   gap: 12px;
+}
+
+.timeline-item__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .approval-action-bar,
@@ -1396,6 +1447,12 @@ code,
   .metric-grid,
   .route-grid {
     grid-template-columns: 1fr;
+  }
+
+  .task-step-list--embedded .timeline-list {
+    max-height: none;
+    overflow: visible;
+    padding-right: 0;
   }
 }
 

--- a/apps/web/components/task-step-list.test.tsx
+++ b/apps/web/components/task-step-list.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getFixtureTaskStepSummary, getFixtureTaskSteps } from "../lib/fixtures";
+import { TaskStepList } from "./task-step-list";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("TaskStepList", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders an ordered task-step timeline with summary pills and linked approval state", () => {
+    const taskId = "33333333-3333-4333-8333-333333333334";
+    render(
+      <TaskStepList
+        steps={getFixtureTaskSteps(taskId)}
+        summary={getFixtureTaskStepSummary(taskId)}
+        source="fixture"
+      />,
+    );
+
+    expect(screen.getByText("Ordered lifecycle steps")).toBeInTheDocument();
+    expect(screen.getByText("1 steps")).toBeInTheDocument();
+    expect(screen.getByText("Step 1")).toBeInTheDocument();
+    expect(screen.getByText("place_order / supplements")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "approved" })).toHaveAttribute(
+      "href",
+      "/approvals?approval=44444444-4444-4444-8444-444444444445",
+    );
+  });
+
+  it("shows an explicit empty state when the selected task has no steps", () => {
+    render(<TaskStepList steps={[]} summary={null} source="live" />);
+
+    expect(screen.getByText("No task steps available")).toBeInTheDocument();
+    expect(screen.getByText(/Select a task with step records/i)).toBeInTheDocument();
+  });
+
+  it("supports embedded chrome for bounded timeline rendering", () => {
+    const taskId = "33333333-3333-4333-8333-333333333333";
+    const { container } = render(
+      <TaskStepList
+        steps={getFixtureTaskSteps(taskId)}
+        summary={getFixtureTaskStepSummary(taskId)}
+        source="fixture"
+        chrome="embedded"
+      />,
+    );
+
+    const card = container.querySelector(".task-step-list");
+    expect(card).toHaveClass("section-card--embedded");
+    expect(card).toHaveClass("task-step-list--embedded");
+  });
+});

--- a/apps/web/components/task-step-list.tsx
+++ b/apps/web/components/task-step-list.tsx
@@ -17,20 +17,38 @@ function formatAttributeValue(value: unknown) {
   return JSON.stringify(value);
 }
 
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
 export function TaskStepList({
   steps,
   summary,
   source,
+  chrome = "card",
 }: {
   steps: TaskStepItem[];
   summary: TaskStepListSummary | null;
   source: "live" | "fixture";
+  chrome?: "card" | "embedded";
 }) {
   return (
     <SectionCard
       eyebrow="Task steps"
       title="Ordered lifecycle steps"
       description="The timeline preserves request intent, downstream approval or execution state, and trace linkage in one readable sequence."
+      className={[
+        chrome === "embedded" ? "section-card--embedded" : null,
+        "task-step-list",
+        chrome === "embedded" ? "task-step-list--embedded" : null,
+      ]
+        .filter(Boolean)
+        .join(" ")}
     >
       {summary ? (
         <div className="cluster">
@@ -58,6 +76,11 @@ export function TaskStepList({
                   </h3>
                 </div>
                 <StatusBadge status={step.status} />
+              </div>
+
+              <div className="timeline-item__meta">
+                <span className="meta-pill">{step.kind.replace(/_/g, " ")}</span>
+                <span className="meta-pill">{formatDate(step.updated_at)}</span>
               </div>
 
               <div className="timeline-item__summary">

--- a/apps/web/components/task-summary.tsx
+++ b/apps/web/components/task-summary.tsx
@@ -9,7 +9,7 @@ import { StatusBadge } from "./status-badge";
 type TaskSummaryProps = {
   task: TaskItem | null;
   taskSource: ApiSource;
-  stepSource: ApiSource;
+  stepSource: ApiSource | "unavailable";
   execution: ToolExecutionItem | null;
   executionSource?: ApiSource | null;
   executionUnavailableMessage?: string | null;
@@ -47,8 +47,14 @@ export function TaskSummary({
     <SectionCard
       eyebrow="Selected task"
       title={task.tool.name}
-      description="Latest task state, approval linkage, and execution review stay grouped in one bounded task summary."
-      className={chrome === "embedded" ? "section-card--embedded" : undefined}
+      description="Latest task state, approval linkage, and execution review stay grouped in one bounded summary."
+      className={[
+        chrome === "embedded" ? "section-card--embedded" : null,
+        "task-summary",
+        chrome === "embedded" ? "task-summary--embedded" : null,
+      ]
+        .filter(Boolean)
+        .join(" ")}
     >
       <div className="detail-grid">
         <div className="detail-summary">
@@ -81,7 +87,13 @@ export function TaskSummary({
           </div>
           <div>
             <dt>Step source</dt>
-            <dd>{stepSource === "live" ? "Live task-step detail" : "Fixture task-step fallback"}</dd>
+            <dd>
+              {stepSource === "live"
+                ? "Live task-step detail"
+                : stepSource === "fixture"
+                  ? "Fixture task-step fallback"
+                  : "Task-step read unavailable"}
+            </dd>
           </div>
         </dl>
 

--- a/apps/web/components/thread-workflow-panel.test.tsx
+++ b/apps/web/components/thread-workflow-panel.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   approvalFixtures,
   executionFixtures,
+  getFixtureTaskStepSummary,
+  getFixtureTaskSteps,
   taskFixtures,
   threadFixtures,
 } from "../lib/fixtures";
@@ -47,6 +49,9 @@ describe("ThreadWorkflowPanel", () => {
         taskSource="fixture"
         execution={executionFixtures[0]}
         executionSource="fixture"
+        taskSteps={getFixtureTaskSteps(taskFixtures[1].id)}
+        taskStepSummary={getFixtureTaskStepSummary(taskFixtures[1].id)}
+        taskStepSource="fixture"
       />,
     );
 
@@ -59,6 +64,8 @@ describe("ThreadWorkflowPanel", () => {
     expect(screen.getByText("Selected task")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Executed" })).toBeDisabled();
     expect(screen.getByText("Open linked approval")).toBeInTheDocument();
+    expect(screen.getByText("Ordered lifecycle steps")).toBeInTheDocument();
+    expect(screen.getByText("1 steps")).toBeInTheDocument();
   });
 
   it("shows an explicit empty state when the selected thread has no linked workflow", () => {
@@ -92,6 +99,10 @@ describe("ThreadWorkflowPanel", () => {
         execution={null}
         executionSource="unavailable"
         executionUnavailableReason="Execution API timed out."
+        taskSteps={[]}
+        taskStepSummary={null}
+        taskStepSource="unavailable"
+        taskStepUnavailableReason="Task step API timed out."
         apiBaseUrl="https://api.example.com"
         userId="user-1"
       />,
@@ -101,6 +112,8 @@ describe("ThreadWorkflowPanel", () => {
     expect(screen.getByText("Approval review unavailable")).toBeInTheDocument();
     expect(screen.getByText("Approval API timed out.")).toBeInTheDocument();
     expect(screen.getByText("Selected task")).toBeInTheDocument();
+    expect(screen.getByText("Task-step timeline unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Task step API timed out.")).toBeInTheDocument();
     expect(screen.getByText("Execution review could not be loaded")).toBeInTheDocument();
     expect(screen.getByText("Execution API timed out.")).toBeInTheDocument();
   });
@@ -115,6 +128,9 @@ describe("ThreadWorkflowPanel", () => {
         taskSource="fixture"
         execution={executionFixtures[0]}
         executionSource="fixture"
+        taskSteps={getFixtureTaskSteps(taskFixtures[1].id)}
+        taskStepSummary={getFixtureTaskStepSummary(taskFixtures[1].id)}
+        taskStepSource="fixture"
       />,
     );
 

--- a/apps/web/components/thread-workflow-panel.tsx
+++ b/apps/web/components/thread-workflow-panel.tsx
@@ -1,9 +1,18 @@
-import type { ApiSource, ApprovalItem, TaskItem, ThreadItem, ToolExecutionItem } from "../lib/api";
+import type {
+  ApiSource,
+  ApprovalItem,
+  TaskItem,
+  TaskStepItem,
+  TaskStepListSummary,
+  ThreadItem,
+  ToolExecutionItem,
+} from "../lib/api";
 import { ApprovalDetail } from "./approval-detail";
 import { EmptyState } from "./empty-state";
 import { ExecutionSummary } from "./execution-summary";
 import { SectionCard } from "./section-card";
 import { StatusBadge } from "./status-badge";
+import { TaskStepList } from "./task-step-list";
 import { TaskSummary } from "./task-summary";
 
 type WorkflowSource = ApiSource | "unavailable";
@@ -19,6 +28,10 @@ type ThreadWorkflowPanelProps = {
   execution: ToolExecutionItem | null;
   executionSource: WorkflowSource | null;
   executionUnavailableReason?: string;
+  taskSteps?: TaskStepItem[];
+  taskStepSummary?: TaskStepListSummary | null;
+  taskStepSource?: WorkflowSource | null;
+  taskStepUnavailableReason?: string;
   apiBaseUrl?: string;
   userId?: string;
 };
@@ -48,6 +61,10 @@ export function ThreadWorkflowPanel({
   execution,
   executionSource,
   executionUnavailableReason,
+  taskSteps = [],
+  taskStepSummary = null,
+  taskStepSource = null,
+  taskStepUnavailableReason,
   apiBaseUrl,
   userId,
 }: ThreadWorkflowPanelProps) {
@@ -69,6 +86,7 @@ export function ThreadWorkflowPanel({
   const hasWorkflow = Boolean(approval || task || execution);
   const hasUnavailableState =
     approvalSource === "unavailable" || taskSource === "unavailable" || executionSource === "unavailable";
+  const resolvedTaskStepSource = taskStepSource ?? (task ? taskSource : null);
 
   return (
     <SectionCard
@@ -123,7 +141,13 @@ export function ThreadWorkflowPanel({
             <TaskSummary
               task={task}
               taskSource={taskSource === "fixture" ? "fixture" : "live"}
-              stepSource={taskSource === "fixture" ? "fixture" : "live"}
+              stepSource={
+                resolvedTaskStepSource === "fixture"
+                  ? "fixture"
+                  : resolvedTaskStepSource === "unavailable"
+                    ? "unavailable"
+                    : "live"
+              }
               execution={execution}
               executionSource={executionSource === "fixture" || executionSource === "live" ? executionSource : null}
               executionUnavailableMessage={executionUnavailableReason}
@@ -139,6 +163,33 @@ export function ThreadWorkflowPanel({
               }
               className="empty-state--compact"
             />
+          ) : null}
+
+          {task ? (
+            resolvedTaskStepSource === "unavailable" ? (
+              <SectionCard
+                eyebrow="Task steps"
+                title="Task-step timeline unavailable"
+                description="The selected-thread task-step sequence could not be loaded from the configured backend."
+                className="section-card--embedded task-step-list--embedded"
+              >
+                <EmptyState
+                  title="Task-step review unavailable"
+                  description={
+                    taskStepUnavailableReason ??
+                    "Task-step records could not be loaded for the selected thread's latest linked task."
+                  }
+                  className="empty-state--compact"
+                />
+              </SectionCard>
+            ) : (
+              <TaskStepList
+                steps={taskSteps}
+                summary={taskStepSummary}
+                source={resolvedTaskStepSource === "fixture" ? "fixture" : "live"}
+                chrome="embedded"
+              />
+            )
           ) : null}
 
           {!approval && !task && (execution || executionSource === "unavailable") ? (

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -5,6 +5,7 @@ import {
   combinePageModes,
   createThread,
   deriveThreadWorkflowState,
+  getTaskSteps,
   getThreadDetail,
   getThreadEvents,
   getThreadSessions,
@@ -681,6 +682,72 @@ describe("api helpers", () => {
     expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
       user_id: "user-1",
     });
+  });
+
+  it("reads task-step timelines from the shipped endpoint", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "step-1",
+              task_id: "task-1",
+              sequence_no: 1,
+              kind: "governed_request",
+              status: "created",
+              request: {
+                thread_id: "thread-1",
+                tool_id: "tool-1",
+                action: "place_order",
+                scope: "supplements",
+                domain_hint: "ecommerce",
+                risk_hint: "purchase",
+                attributes: {},
+              },
+              outcome: {
+                routing_decision: "require_approval",
+                approval_id: "approval-1",
+                approval_status: "pending",
+                execution_id: null,
+                execution_status: null,
+                blocked_reason: null,
+              },
+              lineage: {
+                parent_step_id: null,
+                source_approval_id: null,
+                source_execution_id: null,
+              },
+              trace: {
+                trace_id: "trace-1",
+                trace_kind: "approval_request",
+              },
+              created_at: "2026-03-17T00:00:00Z",
+              updated_at: "2026-03-17T00:00:00Z",
+            },
+          ],
+          summary: {
+            task_id: "task-1",
+            total_count: 1,
+            latest_sequence_no: 1,
+            latest_status: "created",
+            next_sequence_no: 2,
+            append_allowed: false,
+            order: ["step-1"],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await getTaskSteps("https://api.example.com", "task-1", "user-1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v0/tasks/task-1/steps?user_id=user-1",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+      }),
+    );
   });
 
   it("reads the shipped trace review endpoints with user-scoped query params", async () => {


### PR DESCRIPTION
## Summary
- extend /chat with a bounded selected-thread task-step timeline for the latest linked task
- keep transcript primary, workflow summary secondary, and task-step progression tertiary by reusing the shipped task-step seam and existing UI patterns
- keep the sprint inside shipped task, task-step, continuity, approval, and execution seams with no broader scope expansion

## Verification
- npm run lint in apps/web: PASS
- npm test in apps/web: PASS
- npm run build in apps/web: PASS

## Notes
- the sprint stayed a UI sprint over shipped task, task-step, continuity, approval, and execution seams
- no backend, Gmail, Calendar, auth, runner, or broader scope expansion entered the sprint