### PR TITLE
Sprint 6O: Project Truth Synchronization After Chat Explainability

### DIFF
--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -2,7 +2,7 @@
 
 ## Canonical Truth
 
-- The working repo state is current through Sprint 6I.
+- The working repo state is current through Sprint 6N.
 - Use [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md) for implemented boundaries, [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md) for forward planning, and [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md) for durable operating rules.
 - The live sprint reports are [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md) and [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md) at repo root; older accepted sprint history belongs in [docs/archive/sprints](/Users/samirusani/Desktop/Codex/AliceBot/docs/archive/sprints), not in this handoff.
 
@@ -10,13 +10,14 @@
 
 - `apps/api` is the core shipped product surface. It implements continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact chunk retrieval and embeddings, traces, and the narrow read-only Gmail seam with selected-message ingestion.
 - `apps/web` is also a shipped surface now. The operator shell includes `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`, with live reads when API config is present and explicit fixture fallback when it is not.
-- `/chat` now ships assistant-response mode, governed-request mode, visible thread selection, compact thread creation, and bounded continuity review over thread sessions and events.
+- `/chat` now ships assistant-response mode, governed-request mode, visible thread selection, compact thread creation, selected-thread transcript continuity, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, and bounded supporting continuity review over thread sessions and events.
 - `workers` remains scaffold-only.
 
 ## Current Boundaries
 
 - Continuity stays explicit and thread-scoped: thread create/list/detail plus session and event review are live; thread rename, archive, search, pagination, and event mutation are not.
 - Assistant replies go only through `POST /v0/responses`, persist immutable continuity events, and return linked compile and response traces.
+- Explain-why in `/chat` is selected-thread scoped and bounded: it reuses shipped trace list/detail/event reads, shows linked trace shortcuts from transcript/workflow/timeline context, and keeps full trace workspace in `/traces`.
 - Governed actions still route through policy, allowlist, approval, and approved-only proxy execution; `proxy.echo` is still the only live execution handler.
 - Task workspaces and artifacts remain rooted local boundaries. Ingestion remains narrow to plain text, markdown, narrow PDF text, narrow DOCX text from `word/document.xml`, and narrow RFC822 extraction.
 - Gmail remains read-only and selected-message-only, with secret material handled through the dedicated secret-manager seam and the remaining `legacy_db_v0` transition path still present for older credential rows.
@@ -30,11 +31,11 @@
 ## Repo Evidence To Trust
 
 - Backend continuity and response seams: `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`
-- Web continuity adoption: `apps/web/app/chat/page.tsx`, `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`, `apps/web/components/thread-event-list.tsx`, `apps/web/components/response-composer.tsx`
+- Web `/chat` continuity + workflow/timeline/explainability adoption: `apps/web/app/chat/page.tsx`, `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`, `apps/web/components/thread-event-list.tsx`, `apps/web/components/response-composer.tsx`, `apps/web/components/thread-workflow-panel.tsx`, `apps/web/components/task-step-list.tsx`, `apps/web/components/response-history.tsx`, `apps/web/components/thread-trace-panel.tsx`, and matching component tests.
 - Broader shipped shell: `apps/web/app/approvals/page.tsx`, `apps/web/app/tasks/page.tsx`, `apps/web/app/traces/page.tsx`
 
 ## Planning Guardrails
 
-- Plan from the implemented Sprint 6I repo state, not from older Sprint 5-era narratives.
+- Plan from the implemented Sprint 6N repo state, not from older Sprint 5-era narratives.
 - Do not describe broader Gmail scope, Calendar work, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
 - The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, not assumed to be leftover Gmail cleanup by default.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,11 +2,11 @@
 
 ## Current Implemented Slice
 
-AliceBot now implements the accepted repo slice through Sprint 6K.
+AliceBot now implements the accepted repo slice through Sprint 6N.
 
 - `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and the narrow read-only Gmail seam with external-secret-backed credentials plus selected-message ingestion into the RFC822 artifact pipeline.
 - `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
-- `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, renders a selected-thread transcript from immutable continuity events, and keeps supporting session and operational review bounded in the right rail.
+- `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, renders a selected-thread transcript from immutable continuity events, and keeps supporting session and operational review, thread-linked governed workflow review, ordered task-step timeline review, and bounded explain-why trace review in the right rail.
 - `workers` remains scaffold-only. No background runner, automatic multi-step progression, or asynchronous job system is implemented.
 
 The repo is intentionally still narrow. Document ingestion remains local and deterministic. The only live execution handler is the no-external-I/O `proxy.echo` path. Gmail remains read-only and selected-message-only. Rich parsing, mailbox sync, attachments, Calendar, broader proxying, and runner-style orchestration are still planned later.
@@ -25,7 +25,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
   - narrow Gmail account connect/read plus selected-message ingestion
 - `apps/web` exposes the current operator shell:
   - `/`: bounded home view over the shipped shell surfaces
-  - `/chat`: assistant mode, governed request mode, thread selection, thread creation, transcript-first continuity review, and bounded supporting operational review
+  - `/chat`: assistant mode, governed request mode, thread selection, thread creation, transcript-first continuity review, thread-linked governed workflow and task-step timeline review, bounded explain-why embedding, and bounded supporting operational review
   - `/approvals`: approval inbox and execution review
   - `/tasks`: task summary and ordered task-step review
   - `/traces`: trace summary, detail, and ordered event review
@@ -54,8 +54,8 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 
 1. `POST /v0/approvals/requests` creates one task and one initial task step for each governed request.
 2. Approval resolution and approved execution reuse explicit task-step linkage instead of inferring from first-step-only assumptions.
-3. `GET /v0/approvals`, `GET /v0/tasks`, `GET /v0/tasks/{task_id}/steps`, `GET /v0/traces`, and related detail reads expose durable review state through the web shell.
-4. The shipped explainability surface is calm and bounded: summary first, detail second, ordered trace events last.
+3. `GET /v0/approvals`, `GET /v0/tasks`, `GET /v0/tasks/{task_id}/steps`, `GET /v0/tool-executions`, `GET /v0/traces`, and related detail reads expose durable review state through the web shell, including thread-linked workflow review and ordered task-step timeline review in `/chat`.
+4. The shipped explainability surface is calm and bounded: `/chat` embeds selected-thread explain-why review over linked trace targets, with summary first, detail second, and ordered trace events last.
 
 ### Workspaces, Artifacts, And Gmail
 
@@ -67,7 +67,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 ## Testing Coverage Implemented Now
 
 - Backend continuity and response seams are covered in `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`, and related unit coverage under `tests/unit`.
-- Web continuity adoption is covered in `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.test.tsx`, `apps/web/components/thread-summary.test.tsx`, `apps/web/components/thread-event-list.test.tsx`, `apps/web/components/thread-create.test.tsx`, and `apps/web/components/response-composer.test.tsx`.
+- Web continuity and `/chat` operator review adoption are covered in `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.test.tsx`, `apps/web/components/thread-summary.test.tsx`, `apps/web/components/thread-event-list.test.tsx`, `apps/web/components/thread-create.test.tsx`, `apps/web/components/response-composer.test.tsx`, `apps/web/components/thread-workflow-panel.test.tsx`, `apps/web/components/task-step-list.test.tsx`, `apps/web/components/response-history.test.tsx`, and `apps/web/components/thread-trace-panel.test.tsx`.
 - The shell also has route and API-client coverage for approvals, tasks, traces, and shared API utilities under `apps/web`.
 
 ## Planned Later

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -2,88 +2,74 @@
 
 ## sprint objective
 
-Deliver Sprint 6N by extending `/chat` with a bounded selected-thread explain-why panel for the latest relevant linked trace, while keeping transcript-first hierarchy and reusing shipped trace review reads.
-
-## exact `/chat` explain-why files and components updated
-
-- `apps/web/app/chat/page.tsx`
-- `apps/web/app/globals.css`
-- `apps/web/components/thread-workflow-panel.tsx`
-- `apps/web/components/task-step-list.tsx`
-- `apps/web/components/response-history.tsx`
-- `apps/web/components/thread-trace-panel.tsx`
-- `apps/web/components/thread-trace-panel.test.tsx`
-- `BUILD_REPORT.md`
-
-## selected-thread explainability backing mode
-
-- Mixed.
-- Live mode: selected-thread explainability uses shipped trace list/detail/event reads and degrades explicitly when list/detail/event calls are unavailable.
-- Fixture mode: selected-thread explainability uses fixture trace records and explicit unavailable states for unresolved linked trace IDs.
-- Selection mode: `/chat` supports bounded trace selection via query parameter (`trace`) and thread-scoped shortcuts from workflow/timeline/transcript request view.
-
-## shipped backend endpoints consumed
-
-- `GET /v0/threads`
-- `GET /v0/threads/{thread_id}`
-- `GET /v0/threads/{thread_id}/events`
-- `GET /v0/threads/{thread_id}/sessions`
-- `GET /v0/approvals`
-- `GET /v0/tasks`
-- `GET /v0/tasks/{task_id}/steps`
-- `GET /v0/tool-executions`
-- `GET /v0/traces`
-- `GET /v0/traces/{trace_id}`
-- `GET /v0/traces/{trace_id}/events`
-- `POST /v0/approvals/{approval_id}/approve`
-- `POST /v0/approvals/{approval_id}/reject`
-- `POST /v0/approvals/{approval_id}/execute`
-- `POST /v0/approvals/requests`
-- `POST /v0/threads`
-- `POST /v0/responses`
+Synchronize canonical project-truth docs to the accepted implemented repo state through Sprint 6N (including `/chat` transcript continuity, thread-linked governed workflow review, thread-linked task-step timeline review, and thread-linked explain-why embedding) without changing runtime behavior or product scope.
 
 ## completed work
 
-- Added bounded `thread-trace-panel` to `/chat` right rail for selected-thread explain-why review.
-- Added thread-scoped trace target derivation from workflow and task-step records, with fixture transcript/request trace targets in fixture mode.
-- Added explain-why shortcuts in `thread-workflow-panel` and task-step trace links in `task-step-list` to open the chat-level trace panel.
-- Updated request-mode transcript trace links in `response-history` to target the bounded chat explain-why panel instead of forcing route change.
-- Enforced selected-thread explainability scoping so unrelated `?trace=` values are ignored outside selected-thread linked/owned trace candidates.
-- Tightened chat rail visual hierarchy and containment for chips, cards, compact actions, and embedded panel readability.
-- Added coverage for `thread-trace-panel` fixture rendering, explicit unresolved-link behavior, and live-mode unrelated-trace rejection.
+- Updated `ARCHITECTURE.md` to align the implemented slice from Sprint 6K to Sprint 6N and explicitly describe shipped `/chat` behavior through transcript continuity, thread-linked workflow review, task-step timeline review, and bounded explain-why embedding.
+- Updated `ROADMAP.md` current-position language from Sprint 6I to Sprint 6N and reframed next-delivery baseline from the already-shipped chat-plus-governance surface.
+- Updated `.ai/handoff/CURRENT_STATE.md` to reflect Sprint 6N as current, refreshed implemented `/chat` surfaces, and aligned planning guardrails to the current baseline.
+- Updated `README.md` onboarding status from Sprint 6I to Sprint 6N and refreshed the `/chat` implemented-surface summary.
+- Corrected stale canonical claims that the repo was only current through Sprint 6I / Sprint 6K.
 
-## exact commands run
+## incomplete work
 
-- `npm run lint` (in `apps/web`)
-- `npm test` (in `apps/web`)
-- `npm run build` (in `apps/web`)
+- None in sprint scope.
 
-## verification results
+## files changed
 
-- `npm run lint`: passed
-- `npm test`: passed, `15` test files and `54` tests passed
-- `npm run build`: passed
+- `ARCHITECTURE.md`
+- `ROADMAP.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `README.md`
+- `BUILD_REPORT.md`
 
-## concise desktop visual verification notes
+## accepted repo evidence used
 
-- Interactive desktop browser QA was not run in this environment.
-- Desktop containment and hierarchy were validated through component-level rendering, style inspection, and production build checks.
-- Recommended before merge: manual desktop pass on `/chat` with long thread titles and long trace metadata/event payload strings.
+- `/chat` composition and right-rail integration through selected thread continuity, workflow, timeline, and explainability: `apps/web/app/chat/page.tsx`
+- Thread-linked governed workflow panel: `apps/web/components/thread-workflow-panel.tsx`
+- Thread-linked task-step timeline panel: `apps/web/components/task-step-list.tsx`
+- Transcript continuity and trace shortcuts: `apps/web/components/response-history.tsx`
+- Thread-linked explain-why panel and thread-scoped trace selection: `apps/web/components/thread-trace-panel.tsx`
+- Supporting operational continuity panel: `apps/web/components/thread-event-list.tsx`
+- `/chat` and explainability regression coverage: `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-workflow-panel.test.tsx`, `apps/web/components/task-step-list.test.tsx`, `apps/web/components/response-history.test.tsx`, `apps/web/components/thread-trace-panel.test.tsx`
+- Backend continuity/response durability references still in place: `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`
 
-## concise mobile visual verification notes
+## stale claims corrected
 
-- Interactive mobile viewport QA was not run in this environment.
-- Mobile behavior was validated against existing responsive CSS breakpoints and new embedded-panel/compact-control styles.
-- Recommended before merge: manual viewport pass at `<=740px` on `/chat` with populated transcript/workflow/trace panel data.
+- `ARCHITECTURE.md`: corrected “accepted repo slice through Sprint 6K” to Sprint 6N and removed implied omission of shipped `/chat` workflow/timeline/explainability.
+- `ROADMAP.md`: corrected “accepted repo state is current through Sprint 6I” to Sprint 6N.
+- `.ai/handoff/CURRENT_STATE.md`: corrected “working repo state is current through Sprint 6I” to Sprint 6N and updated guardrail baseline text.
+- `README.md`: corrected “accepted slice through Sprint 6I” to Sprint 6N.
 
-## deferred scope
+## files archived
 
-- No backend changes or new endpoints.
-- No broad trace search/filter experience inside `/chat`.
-- No redesign of `/traces`.
-- No Gmail, Calendar, auth, runner, connector, or orchestration scope expansion.
-- No `DESIGN_SYSTEM.md` rewrite; no concrete contradiction required a spec change.
+- None. No concrete stale document required archival for this sprint.
 
-## worktree notes
+## tests run
 
-- `.ai/active/SPRINT_PACKET.md` and `REVIEW_REPORT.md` were already modified before this implementation and were not edited as part of this sprint change.
+- No runtime or UI test suite rerun in this sprint because changes were documentation-only and did not modify runtime code, schema, API contracts, or UI behavior.
+- Evidence audit commands were run to validate shipped-state claims against implementation and tests.
+
+## blockers/issues
+
+- No blockers.
+- Pre-existing unrelated worktree modifications were present before implementation and were left untouched: `.ai/active/SPRINT_PACKET.md`, `REVIEW_REPORT.md`.
+
+## scope and behavior confirmation
+
+- Confirmed documentation-only sprint.
+- Confirmed no runtime code changes.
+- Confirmed no schema changes.
+- Confirmed no API changes.
+- Confirmed no UI behavior changes.
+- Confirmed no Gmail, Calendar, auth, runner, or connector scope expansion.
+
+## intentionally deferred after this truth-sync sprint
+
+- Any new feature delivery beyond synchronization (including roadmap reprioritization or broader compaction/archive work).
+- Runtime validation work unrelated to this docs synchronization sprint.
+
+## recommended next step
+
+Start the next builder sprint from the synchronized Sprint 6N baseline and keep future canonical-doc updates coupled to accepted sprint completion to avoid renewed truth drift.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6I: a FastAPI backend plus a bounded Next.js operator shell.
+AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6N: a FastAPI backend plus a bounded Next.js operator shell.
 
 ## Current Implemented Slice
 
 - `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and the narrow read-only Gmail seam.
 - `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
-- `/chat` supports both assistant and governed-request modes, selected-thread continuity, compact thread creation, and bounded continuity review.
+- `/chat` supports both assistant and governed-request modes, selected-thread continuity, compact thread creation, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, and bounded supporting continuity review.
 - `workers` remains scaffold-only.
 
 ## Quick Start

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,10 +2,10 @@
 
 ## Current Position
 
-- The accepted repo state is current through Sprint 6I.
+- The accepted repo state is current through Sprint 6N.
 - The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, the narrow read-only Gmail seam, and the no-tools assistant-response seam.
 - The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
-- `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, and it keeps bounded thread review visible beside both assistant and governed-request composition.
+- `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, keeps bounded thread review visible beside both assistant and governed-request composition, and ships thread-linked governed workflow, ordered task-step timeline review, and bounded explain-why trace embedding.
 - Historical sprint detail belongs in build and review artifacts, not in this roadmap.
 
 ## Next Delivery Focus
@@ -13,6 +13,7 @@
 ### Build From The Shipped API Plus Web-Shell Baseline
 
 - Plan the next sprint from the current backend-plus-web baseline, not from the older Gmail-cleanup-only narrative.
+- Treat transcript continuity, thread-linked workflow review, task-step timeline review, and bounded explain-why embedding in `/chat` as the baseline to build from, not as pending work.
 - Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.
 - Reuse the existing continuity, response, approval, task, execution, and trace surfaces instead of introducing parallel contracts.
 


### PR DESCRIPTION
Documentation-only sprint. Canonical truth files were synchronized to the accepted repo state through Sprint 6N. No runtime/schema/API/UI/Gmail/Calendar/auth/runner changes.