### PR TITLE
Sprint 6S: Project Truth Synchronization After Knowledge Review Workspaces

### DIFF
--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -2,15 +2,18 @@
 
 ## Canonical Truth
 
-- The working repo state is current through Sprint 6N.
+- The working repo state is current through Sprint 6R.
 - Use [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md) for implemented boundaries, [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md) for forward planning, and [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md) for durable operating rules.
 - The live sprint reports are [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md) and [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md) at repo root; older accepted sprint history belongs in [docs/archive/sprints](/Users/samirusani/Desktop/Codex/AliceBot/docs/archive/sprints), not in this handoff.
 
 ## Implemented Surfaces
 
 - `apps/api` is the core shipped product surface. It implements continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact chunk retrieval and embeddings, traces, and the narrow read-only Gmail seam with selected-message ingestion.
-- `apps/web` is also a shipped surface now. The operator shell includes `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`, with live reads when API config is present and explicit fixture fallback when it is not.
+- `apps/web` is also a shipped surface now. The operator shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/memories`, `/entities`, and `/traces`, with live reads when API config is present and explicit fixture fallback when it is not.
 - `/chat` now ships assistant-response mode, governed-request mode, visible thread selection, compact thread creation, selected-thread transcript continuity, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, and bounded supporting continuity review over thread sessions and events.
+- `/memories` ships a bounded memory review workspace: active/queue list posture, selected memory detail, revision review, and memory-label review/submit seams with explicit live/fixture/unavailable states.
+- `/entities` ships a bounded entity review workspace: list, selected entity detail, and related edge review with explicit live/fixture/unavailable states.
+- `/artifacts` ships a bounded artifact review workspace: list, selected artifact detail, linked task-workspace summary, and ordered chunk evidence with explicit live/fixture/unavailable states.
 - `workers` remains scaffold-only.
 
 ## Current Boundaries
@@ -26,16 +29,17 @@
 
 - Memory extraction and retrieval quality remain the main product risk.
 - Auth is still incomplete beyond database user context.
-- Connector breadth, richer parsing, and orchestration are still deferred, but the bigger short-term risk is planning from stale docs instead of the shipped API-plus-web baseline.
+- Connector breadth, richer parsing, and orchestration are still deferred; docs must stay synchronized with the shipped API-plus-web baseline so planning does not drift again.
 
 ## Repo Evidence To Trust
 
 - Backend continuity and response seams: `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`
 - Web `/chat` continuity + workflow/timeline/explainability adoption: `apps/web/app/chat/page.tsx`, `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`, `apps/web/components/thread-event-list.tsx`, `apps/web/components/response-composer.tsx`, `apps/web/components/thread-workflow-panel.tsx`, `apps/web/components/task-step-list.tsx`, `apps/web/components/response-history.tsx`, `apps/web/components/thread-trace-panel.tsx`, and matching component tests.
-- Broader shipped shell: `apps/web/app/approvals/page.tsx`, `apps/web/app/tasks/page.tsx`, `apps/web/app/traces/page.tsx`
+- Web review workspaces added through the accepted Sprint 6P/6Q/6R sequence: `apps/web/app/memories/page.tsx`, `apps/web/app/memories/page.test.tsx`, `apps/web/app/entities/page.tsx`, `apps/web/app/entities/page.test.tsx`, `apps/web/app/artifacts/page.tsx`, `apps/web/app/artifacts/page.test.tsx`.
+- Shell route inventory and discoverability: `apps/web/components/app-shell.tsx`, `apps/web/app/page.tsx`
 
 ## Planning Guardrails
 
-- Plan from the implemented Sprint 6N repo state, not from older Sprint 5-era narratives.
+- Plan from the implemented Sprint 6R repo state, not from older Sprint 5-era narratives.
 - Do not describe broader Gmail scope, Calendar work, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
-- The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, not assumed to be leftover Gmail cleanup by default.
+- The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, including `/memories`, `/entities`, and `/artifacts`, not assumed to be leftover Gmail cleanup by default.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,11 +2,12 @@
 
 ## Current Implemented Slice
 
-AliceBot now implements the accepted repo slice through Sprint 6N.
+AliceBot now implements the accepted repo slice through Sprint 6R.
 
 - `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and the narrow read-only Gmail seam with external-secret-backed credentials plus selected-message ingestion into the RFC822 artifact pipeline.
-- `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
+- `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/memories`, `/entities`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
 - `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, renders a selected-thread transcript from immutable continuity events, and keeps supporting session and operational review, thread-linked governed workflow review, ordered task-step timeline review, and bounded explain-why trace review in the right rail.
+- `/artifacts`, `/memories`, and `/entities` are now shipped bounded review workspaces that expose existing artifact, memory, and entity read seams with explicit live/fixture/unavailable modes.
 - `workers` remains scaffold-only. No background runner, automatic multi-step progression, or asynchronous job system is implemented.
 
 The repo is intentionally still narrow. Document ingestion remains local and deterministic. The only live execution handler is the no-external-I/O `proxy.echo` path. Gmail remains read-only and selected-message-only. Rich parsing, mailbox sync, attachments, Calendar, broader proxying, and runner-style orchestration are still planned later.
@@ -28,6 +29,9 @@ The repo is intentionally still narrow. Document ingestion remains local and det
   - `/chat`: assistant mode, governed request mode, thread selection, thread creation, transcript-first continuity review, thread-linked governed workflow and task-step timeline review, bounded explain-why embedding, and bounded supporting operational review
   - `/approvals`: approval inbox and execution review
   - `/tasks`: task summary and ordered task-step review
+  - `/artifacts`: artifact list and selected detail, linked workspace summary, and ordered chunk review
+  - `/memories`: memory summary and queue posture, selected detail, revision review, and label review
+  - `/entities`: entity list and selected detail with related edge review
   - `/traces`: trace summary, detail, and ordered event review
 - `tests` cover both the backend seams and the web shell. Durable repo evidence includes integration coverage for continuity and responses plus Vitest coverage for `/chat`, thread selection, bounded continuity review, and assistant-response submission.
 
@@ -68,6 +72,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 
 - Backend continuity and response seams are covered in `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`, and related unit coverage under `tests/unit`.
 - Web continuity and `/chat` operator review adoption are covered in `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.test.tsx`, `apps/web/components/thread-summary.test.tsx`, `apps/web/components/thread-event-list.test.tsx`, `apps/web/components/thread-create.test.tsx`, `apps/web/components/response-composer.test.tsx`, `apps/web/components/thread-workflow-panel.test.tsx`, `apps/web/components/task-step-list.test.tsx`, `apps/web/components/response-history.test.tsx`, and `apps/web/components/thread-trace-panel.test.tsx`.
+- Review workspaces are covered at route level in `apps/web/app/artifacts/page.test.tsx`, `apps/web/app/memories/page.test.tsx`, and `apps/web/app/entities/page.test.tsx`, with matching component and API-client coverage under `apps/web`.
 - The shell also has route and API-client coverage for approvals, tasks, traces, and shared API utilities under `apps/web`.
 
 ## Planned Later

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,96 +1,79 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Sprint 6R: add a bounded `/artifacts` artifact review workspace UI in the web shell that uses only shipped backend task-workspace/task-artifact/chunk read endpoints, with stable loading/empty/unavailable behavior and explicit live/fixture fallback.
+Synchronize canonical truth artifacts to the implemented repo baseline through Sprint 6R so planning and review start from current shipped reality.
 
 ## Completed Work
-- Added new route files:
+- Updated `ROADMAP.md`:
+  - corrected current-state claim from Sprint 6N to Sprint 6R
+  - updated shipped shell inventory to include `/artifacts`, `/memories`, and `/entities`
+  - reframed next-delivery guidance from the full shipped API + web-shell baseline
+- Updated `.ai/handoff/CURRENT_STATE.md`:
+  - corrected canonical truth from Sprint 6N to Sprint 6R
+  - updated implemented surfaces to include `/artifacts`, `/memories`, and `/entities`
+  - updated planning guardrails to start from Sprint 6R baseline
+  - refreshed repo-evidence section with route/test files for chat plus artifact/entity/memory workspaces
+- Updated `README.md`:
+  - corrected onboarding status from Sprint 6N to Sprint 6R
+  - updated operator-shell route inventory to include `/artifacts`, `/memories`, and `/entities`
+- Updated `ARCHITECTURE.md`:
+  - corrected accepted implemented slice from Sprint 6N to Sprint 6R
+  - updated shipped shell route inventory to include `/artifacts`, `/memories`, and `/entities`
+  - added concise description of bounded review-workspace behavior and corresponding route tests
+- Replaced `BUILD_REPORT.md` with this Sprint 6S truth-sync report.
+
+## Accepted Repo Evidence Used
+- Shell route inventory and discoverability:
+  - `apps/web/components/app-shell.tsx`
+  - `apps/web/app/page.tsx`
   - `apps/web/app/artifacts/page.tsx`
-  - `apps/web/app/artifacts/loading.tsx`
-- Implemented bounded artifact review components:
-  - `apps/web/components/artifact-list.tsx`
-  - `apps/web/components/artifact-detail.tsx`
-  - `apps/web/components/artifact-workspace-summary.tsx`
-  - `apps/web/components/artifact-chunk-list.tsx`
-- Extended shared API layer in `apps/web/lib/api.ts` with typed read functions and contracts for:
-  - task workspace list/detail
-  - task artifact list/detail
-  - task artifact chunk list
-- Added fixture-backed artifact/workspace/chunk data and helpers in `apps/web/lib/fixtures.ts` to preserve explicit fallback behavior when live API is absent or partially unavailable.
-- Integrated `/artifacts` into shell discoverability:
-  - Added navigation entry in `apps/web/components/app-shell.tsx`
-  - Added home route card and summary updates in `apps/web/app/page.tsx`
-  - Updated shell metadata description in `apps/web/app/layout.tsx`
-- Updated styling in `apps/web/app/globals.css` for artifact layouts and readable chunk evidence rendering.
-- Added sprint-scope tests:
-  - `apps/web/components/artifact-list.test.tsx`
-  - `apps/web/components/artifact-chunk-list.test.tsx`
+  - `apps/web/app/memories/page.tsx`
+  - `apps/web/app/entities/page.tsx`
+- Route-level verification for shipped review workspaces:
   - `apps/web/app/artifacts/page.test.tsx`
-  - Expanded `apps/web/lib/api.test.ts` to verify workspace/artifact/chunk endpoint usage.
-- Updated status handling in `apps/web/components/status-badge.tsx` for `ingested` and `registered` badge tones used by artifact surfaces.
+  - `apps/web/app/memories/page.test.tsx`
+  - `apps/web/app/entities/page.test.tsx`
+- Existing chat baseline evidence retained in canonical docs:
+  - `apps/web/app/chat/page.tsx`
+  - `apps/web/app/chat/page.test.tsx`
 
-## Artifact Surface Backing Mode
-- Artifact list (`artifact-list`): mixed-capable (`live` when configured, `fixture` fallback, explicit unavailable note when live list read fails).
-- Selected artifact detail (`artifact-detail`): mixed-capable (`live` detail with fixture fallback when available).
-- Linked workspace summary (`artifact-workspace-summary`): mixed-capable (`live` workspace detail with fixture fallback when available, explicit unavailable state when neither is available).
-- Chunk review (`artifact-chunk-list`): mixed-capable (`live` chunks with fixture fallback when available, explicit unavailable state when neither is available).
-
-## Exact Backend Endpoints Consumed By `/artifacts` Runtime Flow
-- `GET /v0/task-workspaces/{task_workspace_id}`
-- `GET /v0/task-artifacts`
-- `GET /v0/task-artifacts/{task_artifact_id}`
-- `GET /v0/task-artifacts/{task_artifact_id}/chunks`
-
-## Additional Endpoint Implemented/Tested In Shared API Helper Layer
-- `GET /v0/task-workspaces` (implemented in `apps/web/lib/api.ts` and covered by `apps/web/lib/api.test.ts`, but not called in `/artifacts` page orchestration)
+## Stale Claims Corrected
+- `ROADMAP.md`: “current through Sprint 6N” -> “current through Sprint 6R”
+- `.ai/handoff/CURRENT_STATE.md`: “current through Sprint 6N” -> “current through Sprint 6R”
+- `README.md`: “accepted slice through Sprint 6N” -> “accepted slice through Sprint 6R”
+- `ARCHITECTURE.md`: “accepted repo slice through Sprint 6N” -> “accepted repo slice through Sprint 6R”
+- Canonical shell inventory now consistently includes `/memories`, `/entities`, and `/artifacts`.
 
 ## Incomplete Work
-- None within Sprint 6R acceptance scope.
+- None within Sprint 6S scope.
 
 ## Files Changed
-- `apps/web/app/layout.tsx`
-- `apps/web/app/page.tsx`
-- `apps/web/app/artifacts/page.tsx`
-- `apps/web/app/artifacts/loading.tsx`
-- `apps/web/app/artifacts/page.test.tsx`
-- `apps/web/app/globals.css`
-- `apps/web/components/app-shell.tsx`
-- `apps/web/components/status-badge.tsx`
-- `apps/web/components/artifact-list.tsx`
-- `apps/web/components/artifact-detail.tsx`
-- `apps/web/components/artifact-workspace-summary.tsx`
-- `apps/web/components/artifact-chunk-list.tsx`
-- `apps/web/lib/api.ts`
-- `apps/web/lib/fixtures.ts`
-- `apps/web/lib/api.test.ts`
-- `apps/web/components/artifact-list.test.tsx`
-- `apps/web/components/artifact-chunk-list.test.tsx`
+- `ROADMAP.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `README.md`
+- `ARCHITECTURE.md`
 - `BUILD_REPORT.md`
 
-## Exact Commands Run
-- `npm run lint` (in `apps/web`)
-- `npm test` (in `apps/web`)
-- `npm run build` (in `apps/web`)
-
-## Test and Verification Results
-- `npm run lint`: PASS
-- `npm test`: PASS (`25` test files, `79` tests passed)
-- `npm run build`: PASS (Next.js production build completed, `/artifacts` route included in output)
-
-## Desktop and Mobile Visual Verification Notes
-- Desktop: `/artifacts` follows the bounded review flow in two stages: list/detail first, workspace/chunks second; card rhythm, badge patterns, and spacing are consistent with existing shell primitives.
-- Mobile/tablet: artifact layouts collapse to single-column under existing responsive breakpoints; list/detail/chunk content remain contained with readable wrapping and scroll-bounded chunk text blocks.
+## Tests Run
+- `rg -n "Sprint 6R|/memories|/entities|/artifacts" ROADMAP.md .ai/handoff/CURRENT_STATE.md README.md ARCHITECTURE.md` (PASS)
+- `pnpm --dir apps/web test app/memories/page.test.tsx app/entities/page.test.tsx app/artifacts/page.test.tsx` (PASS: 3 files, 7 tests)
 
 ## Blockers / Issues
 - No blockers encountered.
 
-## Intentionally Deferred (Out of Scope)
-- Artifact registration or ingestion actions.
-- Retrieval or semantic retrieval controls.
-- Gmail account management UI.
-- Backend contract changes or new endpoints.
-- Calendar/auth/runner/connector expansion.
-- Broad file-browser/document-manager features.
+## Archive Actions
+- No files archived under `docs/archive/**` in this sprint.
+
+## Scope and Change-Type Confirmation
+- No runtime code changes.
+- No schema changes.
+- No API changes.
+- No UI behavior changes.
+- No Gmail, Calendar, auth, runner, or connector-scope changes.
+
+## Intentionally Deferred After Truth Sync
+- Any new feature delivery beyond the synchronized Sprint 6R baseline.
+- Any broader compaction/archive campaign outside concrete stale-artifact handling.
 
 ## Recommended Next Step
-Run reviewer pass focused on Sprint 6R review criteria (scope containment, endpoint usage, bounded UI behavior), then open PR from `codex/sprint-6r-artifact-review-workspace-ui` once Control Tower approves.
+Run reviewer verification against Sprint 6S acceptance criteria, then open the next delivery sprint from this synchronized Sprint 6R documentation baseline.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6N: a FastAPI backend plus a bounded Next.js operator shell.
+AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6R: a FastAPI backend plus a bounded Next.js operator shell.
 
 ## Current Implemented Slice
 
 - `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and the narrow read-only Gmail seam.
-- `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
+- `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
 - `/chat` supports both assistant and governed-request modes, selected-thread continuity, compact thread creation, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, and bounded supporting continuity review.
+- `/artifacts`, `/memories`, and `/entities` are shipped bounded operator review workspaces for artifact, memory, and entity evidence.
 - `workers` remains scaffold-only.
 
 ## Quick Start

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,20 +2,21 @@
 
 ## Current Position
 
-- The accepted repo state is current through Sprint 6N.
+- The accepted repo state is current through Sprint 6R.
 - The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, the narrow read-only Gmail seam, and the no-tools assistant-response seam.
-- The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
+- The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
 - `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, keeps bounded thread review visible beside both assistant and governed-request composition, and ships thread-linked governed workflow, ordered task-step timeline review, and bounded explain-why trace embedding.
+- `/memories`, `/entities`, and `/artifacts` are shipped bounded review workspaces in the shell, not planned surface.
 - Historical sprint detail belongs in build and review artifacts, not in this roadmap.
 
 ## Next Delivery Focus
 
 ### Build From The Shipped API Plus Web-Shell Baseline
 
-- Plan the next sprint from the current backend-plus-web baseline, not from the older Gmail-cleanup-only narrative.
-- Treat transcript continuity, thread-linked workflow review, task-step timeline review, and bounded explain-why embedding in `/chat` as the baseline to build from, not as pending work.
+- Plan the next sprint from the implemented Sprint 6R backend-plus-web baseline, not from the older Gmail-cleanup-only narrative.
+- Treat transcript continuity, thread-linked workflow review, task-step timeline review, bounded explain-why embedding in `/chat`, and the shipped review workspaces (`/memories`, `/entities`, `/artifacts`) as baseline, not pending work.
 - Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.
-- Reuse the existing continuity, response, approval, task, execution, and trace surfaces instead of introducing parallel contracts.
+- Reuse the existing continuity, response, approval, task, workspace-artifact, memory, entity, execution, and trace surfaces instead of introducing parallel contracts.
 
 ### Keep New Scope Narrow
 


### PR DESCRIPTION
Documentation-only sprint. Canonical truth files were synchronized to accepted repo state through Sprint 6R. No runtime/schema/API/UI/Gmail/Calendar/auth/runner scope changes.