### PR TITLE
Sprint 6U: Calendar connection and single-event ingestion seam

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,15 +2,15 @@
 
 ## Current Implemented Slice
 
-AliceBot now implements the accepted repo slice through Sprint 6R.
+AliceBot now implements the accepted repo slice through Sprint 6U.
 
-- `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and the narrow read-only Gmail seam with external-secret-backed credentials plus selected-message ingestion into the RFC822 artifact pipeline.
+- `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and narrow read-only Gmail and Calendar seams with external-secret-backed credentials plus selected-item ingestion into the artifact pipeline.
 - `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/memories`, `/entities`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
 - `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, renders a selected-thread transcript from immutable continuity events, and keeps supporting session and operational review, thread-linked governed workflow review, ordered task-step timeline review, and bounded explain-why trace review in the right rail.
 - `/artifacts`, `/memories`, and `/entities` are now shipped bounded review workspaces that expose existing artifact, memory, and entity read seams with explicit live/fixture/unavailable modes.
 - `workers` remains scaffold-only. No background runner, automatic multi-step progression, or asynchronous job system is implemented.
 
-The repo is intentionally still narrow. Document ingestion remains local and deterministic. The only live execution handler is the no-external-I/O `proxy.echo` path. Gmail remains read-only and selected-message-only. Rich parsing, mailbox sync, attachments, Calendar, broader proxying, and runner-style orchestration are still planned later.
+The repo is intentionally still narrow. Document ingestion remains local and deterministic. The only live execution handler is the no-external-I/O `proxy.echo` path. Gmail and Calendar remain read-only and selected-item-only. Rich parsing, mailbox sync, attachments, broader Calendar capabilities, broader proxying, and runner-style orchestration are still planned later.
 
 ## Implemented Now
 
@@ -24,6 +24,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
   - policy, tool, approval, execution-budget, and proxy execution governance
   - task, task-step, task-workspace, task-artifact, artifact-chunk, and trace review reads and mutations
   - narrow Gmail account connect/read plus selected-message ingestion
+  - narrow Calendar account connect/read plus selected-event ingestion
 - `apps/web` exposes the current operator shell:
   - `/`: bounded home view over the shipped shell surfaces
   - `/chat`: assistant mode, governed request mode, thread selection, thread creation, transcript-first continuity review, thread-linked governed workflow and task-step timeline review, bounded explain-why embedding, and bounded supporting operational review
@@ -38,12 +39,12 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 ### Data And Safety Boundaries
 
 - Postgres is the system of record.
-- Row-level security is enforced on user-owned continuity, trace, memory, governance, task, workspace, artifact, and Gmail tables.
+- Row-level security is enforced on user-owned continuity, trace, memory, governance, task, workspace, artifact, Gmail, and Calendar tables.
 - `events`, `trace_events`, and `memory_revisions` are append-only by contract.
 - Task-step lineage and execution linkage stay explicit through `parent_step_id`, `source_approval_id`, `source_execution_id`, and `tool_executions.task_step_id`.
 - Task workspaces are rooted local directories under `TASK_WORKSPACE_ROOT`.
 - Task artifacts are explicit rooted local-file registrations only; compile and retrieval read persisted chunk rows, not raw files.
-- Gmail credential material stays off normal metadata tables and flows through the dedicated secret-manager seam.
+- Gmail and Calendar credential material stay off normal metadata tables and flow through dedicated secret-manager seams.
 
 ## Core Flows Implemented Now
 
@@ -61,12 +62,13 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 3. `GET /v0/approvals`, `GET /v0/tasks`, `GET /v0/tasks/{task_id}/steps`, `GET /v0/tool-executions`, `GET /v0/traces`, and related detail reads expose durable review state through the web shell, including thread-linked workflow review and ordered task-step timeline review in `/chat`.
 4. The shipped explainability surface is calm and bounded: `/chat` embeds selected-thread explain-why review over linked trace targets, with summary first, detail second, and ordered trace events last.
 
-### Workspaces, Artifacts, And Gmail
+### Workspaces, Artifacts, Gmail, And Calendar
 
 1. Tasks can provision one rooted local workspace and register local artifacts under that boundary.
 2. Artifact ingestion supports the narrow current set only: plain text, markdown, narrow local PDF text extraction, narrow DOCX text extraction from `word/document.xml`, and narrow RFC822 email extraction.
 3. Artifact retrieval works over persisted chunk rows and persisted chunk embeddings, including deterministic lexical retrieval, direct semantic retrieval, and the current lexical-first hybrid compile merge.
 4. Gmail remains narrow: one read-only account seam, secret-free account reads, external-secret-backed primary credentials, refresh-token renewal and rotation handling, and one selected-message ingestion path that lands in the existing RFC822 artifact workflow.
+5. Calendar remains narrow: one read-only account seam, secret-free account reads, external-secret-backed credentials, and one selected-event ingestion path that lands in the existing text artifact/chunk workflow.
 
 ## Testing Coverage Implemented Now
 
@@ -82,7 +84,7 @@ The following remain planned later and must not be described as implemented:
 - runner-style orchestration and automatic multi-step progression
 - auth beyond the current database user-context model
 - richer document parsing, OCR, image extraction, or layout reconstruction
-- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and Calendar connectors
+- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and broader Calendar capabilities such as event listing/search, recurrence expansion, sync, and write actions
 - broader proxy execution breadth or real-world side effects beyond `proxy.echo`
 - retrieval reranking or weighted fusion beyond the current lexical-first hybrid compile merge
 

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,93 +1,181 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement a bounded `/gmail` operator workspace that supports Gmail account review (list + selected detail), explicit account connection, and explicit single-message ingestion into one selected task workspace using only shipped backend seams.
+Implement Sprint 6U: add a narrow read-only Calendar connector seam that supports user-scoped calendar account connection metadata and explicit single-event ingestion into existing task artifact/chunk seams.
 
 ## Completed Work
-- Added Gmail route and loading state:
-  - `apps/web/app/gmail/page.tsx`
-  - `apps/web/app/gmail/loading.tsx`
-- Added Gmail components:
-  - `apps/web/components/gmail-account-list.tsx`
-  - `apps/web/components/gmail-account-detail.tsx`
-  - `apps/web/components/gmail-account-connect-form.tsx`
-  - `apps/web/components/gmail-message-ingest-form.tsx`
-  - `apps/web/components/gmail-ingestion-summary.tsx`
-- Extended shared API client with typed Gmail contracts and calls:
-  - `connectGmailAccount`
-  - `listGmailAccounts`
-  - `getGmailAccountDetail`
-  - `ingestGmailMessage`
-- Added Gmail fixtures and helper selectors for explicit fallback mode.
-- Updated shell discoverability and route metadata to include Gmail:
-  - navigation entry in `app-shell.tsx`
-  - home route cards/counts in `app/page.tsx`
-  - shell metadata text in `app/layout.tsx`
-- Added/updated tests in scope:
-  - `apps/web/lib/api.test.ts` (Gmail endpoint coverage)
-  - `apps/web/components/gmail-account-list.test.tsx`
-  - `apps/web/components/gmail-message-ingest-form.test.tsx`
-- Added Gmail layout classes in `apps/web/app/globals.css` with responsive collapse at existing breakpoints.
+- Added Calendar schema + migration support:
+  - `calendar_accounts`
+  - `calendar_account_credentials`
+  - RLS, owner policies, and runtime grants aligned with existing connector patterns.
+- Added Calendar protected credential storage path with file-based external secret manager semantics:
+  - secret ref format: `users/{user_id}/calendar-account-credentials/{calendar_account_id}.json`
+  - credential metadata persisted in `calendar_account_credentials`
+  - credential payload externalized (`credential_blob` remains `NULL`)
+- Added stable Calendar contracts:
+  - account connect input/response
+  - account list/detail responses
+  - selected-event ingestion input/response
+- Added Calendar store seams:
+  - create/list/detail account methods
+  - credential create/read methods
+- Added Calendar service seam (`calendar.py`):
+  - deterministic create/list/detail account behavior
+  - explicit event fetch by provider event id only
+  - event conversion into `text/plain` artifact content
+  - registration + ingestion through existing task artifact/chunk pipeline
+  - deterministic error surfaces for not-found/unsupported/credential/fetch cases
+- Added Calendar secret manager module mirroring existing connector secret-manager rules.
+- Added Calendar API endpoints:
+  - `POST /v0/calendar-accounts`
+  - `GET /v0/calendar-accounts`
+  - `GET /v0/calendar-accounts/{calendar_account_id}`
+  - `POST /v0/calendar-accounts/{calendar_account_id}/events/{provider_event_id}/ingest`
+- Added unit and integration tests for persistence, deterministic listing, ingestion routing, stable response shape, cross-user isolation, and deterministic missing/unsupported failures.
+- Synced docs to implemented state so Calendar is no longer described as future/absent:
+  - `ARCHITECTURE.md`
+  - `README.md`
 
-## Gmail Surface Mode Matrix
-- `/gmail` account list: **mixed** (live API when configured; fixture fallback when not configured or live read fails).
-- `/gmail` selected account detail: **mixed** (live API detail when available; fixture/unavailable fallback on failure).
-- Connect account form: **live + unavailable fallback** (writes only in live-config mode; explicit unavailable state otherwise).
-- Single-message ingestion form: **live + unavailable fallback** (writes only when live config + live selected account + live workspace list are present).
-- Ingestion summary: **live result + explicit unavailable/error state**.
-- Task workspace selector: **mixed** (live list when available; fixture fallback for route continuity).
+## Exact Contract Changes Introduced
+- New constants in `apps/api/src/alicebot_api/contracts.py`:
+  - `CALENDAR_ACCOUNT_LIST_ORDER = ["created_at_asc", "id_asc"]`
+  - `CALENDAR_PROVIDER = "google_calendar"`
+  - `CALENDAR_AUTH_KIND_OAUTH_ACCESS_TOKEN = "oauth_access_token"`
+  - `CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"`
+  - `CALENDAR_PROTECTED_CREDENTIAL_KIND = "calendar_oauth_access_token_v1"`
+- New dataclasses:
+  - `CalendarAccountConnectInput`
+  - `CalendarEventIngestInput`
+- New typed responses/records:
+  - `CalendarAccountRecord`
+  - `CalendarAccountConnectResponse`
+  - `CalendarAccountListSummary`
+  - `CalendarAccountListResponse`
+  - `CalendarAccountDetailResponse`
+  - `CalendarEventIngestionRecord`
+  - `CalendarEventIngestionResponse`
 
-## Backend Endpoints Consumed
-- `POST /v0/gmail-accounts`
-- `GET /v0/gmail-accounts`
-- `GET /v0/gmail-accounts/{gmail_account_id}`
-- `POST /v0/gmail-accounts/{gmail_account_id}/messages/{provider_message_id}/ingest`
-- `GET /v0/task-workspaces`
+## Calendar Event-to-Artifact Conversion Rule
+- Fetch one explicit provider event id from Google Calendar events API (`/calendar/v3/calendars/primary/events/{event_id}`).
+- Require event shape to include:
+  - non-empty `id`
+  - `start.dateTime` or `start.date`
+  - `end.dateTime` or `end.date`
+- If shape is missing required fields, fail deterministically with:
+  - `calendar event {provider_event_id} is not supported for ingestion`
+- Convert event payload into normalized UTF-8 `text/plain` document containing deterministic labeled lines:
+  - provider metadata
+  - requested/source event ids
+  - status/summary/location/start/end/organizer/html link
+  - description block
+- Persist to workspace path:
+  - `calendar/{sanitized_provider_account_id}/{sanitized_provider_event_id}.txt`
+- Register and ingest through existing `task_artifacts` and `task_artifact_chunks` seams.
 
 ## Incomplete Work
-- None within Sprint 6T scope.
+- None for the scoped Sprint 6U deliverables.
 
 ## Files Changed
-- `apps/web/app/layout.tsx`
-- `apps/web/app/page.tsx`
-- `apps/web/app/gmail/page.tsx`
-- `apps/web/app/gmail/loading.tsx`
-- `apps/web/app/globals.css`
-- `apps/web/components/app-shell.tsx`
-- `apps/web/components/gmail-account-list.tsx`
-- `apps/web/components/gmail-account-detail.tsx`
-- `apps/web/components/gmail-account-connect-form.tsx`
-- `apps/web/components/gmail-message-ingest-form.tsx`
-- `apps/web/components/gmail-ingestion-summary.tsx`
-- `apps/web/lib/api.ts`
-- `apps/web/lib/fixtures.ts`
-- `apps/web/lib/api.test.ts`
-- `apps/web/components/gmail-account-list.test.tsx`
-- `apps/web/components/gmail-message-ingest-form.test.tsx`
+- `apps/api/alembic/versions/20260319_0030_calendar_accounts_and_credentials.py`
+- `ARCHITECTURE.md`
+- `README.md`
+- `apps/api/src/alicebot_api/calendar.py`
+- `apps/api/src/alicebot_api/calendar_secret_manager.py`
+- `apps/api/src/alicebot_api/config.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/store.py`
+- `tests/integration/test_calendar_accounts_api.py`
+- `tests/integration/test_migrations.py`
+- `tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py`
+- `tests/unit/test_calendar.py`
+- `tests/unit/test_calendar_main.py`
+- `tests/unit/test_calendar_secret_manager.py`
+- `tests/unit/test_config.py`
 - `BUILD_REPORT.md`
 
 ## Tests Run
-### Commands Run
-- `npm run lint` (in `apps/web`)
-- `npm test` (in `apps/web`)
-- `npm run build` (in `apps/web`)
+### Exact Commands
+- `./.venv/bin/python -m pytest tests/unit/test_calendar.py tests/unit/test_calendar_main.py tests/unit/test_calendar_secret_manager.py tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py tests/unit/test_config.py -q`
+- `./.venv/bin/python -m pytest tests/unit`
+- `./.venv/bin/python -m pytest tests/integration`
 
 ### Results
-- `npm run lint`: PASS
-- `npm test`: PASS (`27` files, `84` tests)
-- `npm run build`: PASS (Next.js production build completed; `/gmail` route generated)
+- Targeted unit tests: PASS (`28 passed`)
+- Full unit suite: PASS (`478 passed`)
+- Full integration suite: PASS (`150 passed`)
 
-## Desktop and Mobile Visual Verification Notes
-- Desktop: `/gmail` uses a two-column review layout (`gmail-layout`) for account list/detail and a two-column action layout (`gmail-action-grid`) for connect + ingestion surfaces.
-- Mobile/tablet: existing responsive breakpoint behavior applies; both Gmail grids collapse to single-column stacks at `max-width: 1120px`, with existing small-screen stacking behavior preserved at `max-width: 740px`.
+## Example Calendar Account Response
+```json
+{
+  "account": {
+    "id": "3e4c7d67-cf56-4cd5-a8c0-8d4d18e7f1f2",
+    "provider": "google_calendar",
+    "auth_kind": "oauth_access_token",
+    "provider_account_id": "acct-owner-001",
+    "email_address": "owner@gmail.example",
+    "display_name": "Owner",
+    "scope": "https://www.googleapis.com/auth/calendar.readonly",
+    "created_at": "2026-03-19T10:00:00+00:00",
+    "updated_at": "2026-03-19T10:00:00+00:00"
+  }
+}
+```
+
+## Example Selected-Event Ingestion Response
+```json
+{
+  "account": {
+    "id": "3e4c7d67-cf56-4cd5-a8c0-8d4d18e7f1f2",
+    "provider": "google_calendar",
+    "auth_kind": "oauth_access_token",
+    "provider_account_id": "acct-owner-001",
+    "email_address": "owner@gmail.example",
+    "display_name": "Owner",
+    "scope": "https://www.googleapis.com/auth/calendar.readonly",
+    "created_at": "2026-03-19T10:00:00+00:00",
+    "updated_at": "2026-03-19T10:00:00+00:00"
+  },
+  "event": {
+    "provider_event_id": "evt-001",
+    "artifact_relative_path": "calendar/acct-owner-001/evt-001.txt",
+    "media_type": "text/plain"
+  },
+  "artifact": {
+    "id": "6fd2c8f1-a3a1-4272-8e46-7900f8f6d2c9",
+    "task_id": "fb3f9ab8-55ce-4237-b43e-f393dcb5a6d2",
+    "task_workspace_id": "c6b542ff-7d67-42ed-a7ea-cf0a6f3b0366",
+    "status": "registered",
+    "ingestion_status": "ingested",
+    "relative_path": "calendar/acct-owner-001/evt-001.txt",
+    "media_type_hint": "text/plain",
+    "created_at": "2026-03-19T10:00:00+00:00",
+    "updated_at": "2026-03-19T10:00:01+00:00"
+  },
+  "summary": {
+    "total_count": 1,
+    "total_characters": 312,
+    "media_type": "text/plain",
+    "chunking_rule": "normalized_utf8_text_fixed_window_1000_chars_v1",
+    "order": ["sequence_no_asc", "id_asc"]
+  }
+}
+```
 
 ## Blockers / Issues
-- No implementation blockers encountered.
+- No functional implementation blockers.
+- Note: integration tests require reachable local Postgres; once available, full integration suite passes.
 
-## Intentionally Deferred After This Sprint
-- Gmail search, mailbox browsing, mailbox sync, attachment ingestion, write-capable Gmail actions, and Calendar UI.
-- Backend/schema changes, auth redesign, and broader connector management.
-- Any artifact editing workflows beyond displaying ingestion result metadata.
+## Intentionally Deferred Scope
+- Calendar UI.
+- Calendar search/list-events APIs.
+- Recurring event expansion.
+- Background sync/backfill.
+- Write-capable calendar actions.
+- Gmail scope expansion.
+- Compile contract changes.
+- Runner orchestration changes.
+- Auth redesign.
 
 ## Recommended Next Step
-Run reviewer verification against Sprint 6T acceptance criteria and merge after reviewer PASS and explicit Control Tower approval.
+Proceed to reviewer verification focused on sprint-scope boundaries and deterministic isolation behavior, then open the sprint PR for Control Tower approval.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6R: a FastAPI backend plus a bounded Next.js operator shell.
+AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6U: a FastAPI backend plus a bounded Next.js operator shell.
 
 ## Current Implemented Slice
 
-- `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and the narrow read-only Gmail seam.
+- `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and narrow read-only Gmail and Calendar seams.
 - `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
 - `/chat` supports both assistant and governed-request modes, selected-thread continuity, compact thread creation, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, and bounded supporting continuity review.
 - `/artifacts`, `/memories`, and `/entities` are shipped bounded operator review workspaces for artifact, memory, and entity evidence.

--- a/apps/api/alembic/versions/20260319_0030_calendar_accounts_and_credentials.py
+++ b/apps/api/alembic/versions/20260319_0030_calendar_accounts_and_credentials.py
@@ -1,0 +1,119 @@
+"""Add user-scoped Calendar account records with protected credentials."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260319_0030"
+down_revision = "20260316_0029"
+branch_labels = None
+depends_on = None
+
+CALENDAR_AUTH_KIND_OAUTH_ACCESS_TOKEN = "oauth_access_token"
+CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
+CALENDAR_PROTECTED_CREDENTIAL_KIND = "calendar_oauth_access_token_v1"
+CALENDAR_SECRET_MANAGER_KIND_FILE_V1 = "file_v1"
+
+_RLS_TABLES = ("calendar_accounts", "calendar_account_credentials")
+
+_UPGRADE_SCHEMA_STATEMENT = f"""
+        CREATE TABLE calendar_accounts (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          provider_account_id text NOT NULL,
+          email_address text NOT NULL,
+          display_name text,
+          scope text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (id, user_id),
+          CONSTRAINT calendar_accounts_provider_account_id_nonempty_check
+            CHECK (length(provider_account_id) > 0),
+          CONSTRAINT calendar_accounts_email_address_nonempty_check
+            CHECK (length(email_address) > 0),
+          CONSTRAINT calendar_accounts_display_name_nonempty_check
+            CHECK (display_name IS NULL OR length(display_name) > 0),
+          CONSTRAINT calendar_accounts_scope_readonly_check
+            CHECK (scope = '{CALENDAR_READONLY_SCOPE}')
+        );
+
+        CREATE INDEX calendar_accounts_user_created_idx
+          ON calendar_accounts (user_id, created_at, id);
+
+        CREATE UNIQUE INDEX calendar_accounts_provider_account_idx
+          ON calendar_accounts (user_id, provider_account_id);
+
+        CREATE TABLE calendar_account_credentials (
+          calendar_account_id uuid PRIMARY KEY REFERENCES calendar_accounts(id) ON DELETE CASCADE,
+          user_id uuid NOT NULL,
+          auth_kind text NOT NULL,
+          credential_kind text NOT NULL,
+          secret_manager_kind text NOT NULL,
+          secret_ref text,
+          credential_blob jsonb,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          FOREIGN KEY (calendar_account_id, user_id)
+            REFERENCES calendar_accounts (id, user_id)
+            ON DELETE CASCADE,
+          CONSTRAINT calendar_account_credentials_auth_kind_check
+            CHECK (auth_kind = '{CALENDAR_AUTH_KIND_OAUTH_ACCESS_TOKEN}'),
+          CONSTRAINT calendar_account_credentials_storage_shape_check
+            CHECK (
+              credential_kind = '{CALENDAR_PROTECTED_CREDENTIAL_KIND}'
+              AND secret_manager_kind = '{CALENDAR_SECRET_MANAGER_KIND_FILE_V1}'
+              AND secret_ref IS NOT NULL
+              AND length(secret_ref) > 0
+              AND credential_blob IS NULL
+            )
+        );
+
+        CREATE INDEX calendar_account_credentials_user_created_idx
+          ON calendar_account_credentials (user_id, created_at, calendar_account_id);
+        """
+
+_UPGRADE_GRANT_STATEMENTS = (
+    "GRANT SELECT, INSERT ON calendar_accounts TO alicebot_app",
+    "GRANT SELECT, INSERT ON calendar_account_credentials TO alicebot_app",
+)
+
+_UPGRADE_POLICY_STATEMENTS = (
+    """
+        CREATE POLICY calendar_accounts_is_owner ON calendar_accounts
+          USING (user_id = app.current_user_id())
+          WITH CHECK (user_id = app.current_user_id());
+    """,
+    """
+        CREATE POLICY calendar_account_credentials_is_owner ON calendar_account_credentials
+          USING (user_id = app.current_user_id())
+          WITH CHECK (user_id = app.current_user_id());
+    """,
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP TABLE IF EXISTS calendar_account_credentials",
+    "DROP TABLE IF EXISTS calendar_accounts",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def _enable_row_level_security() -> None:
+    for table_name in _RLS_TABLES:
+        op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+
+
+def upgrade() -> None:
+    op.execute(_UPGRADE_SCHEMA_STATEMENT)
+    _execute_statements(_UPGRADE_GRANT_STATEMENTS)
+    _enable_row_level_security()
+    _execute_statements(_UPGRADE_POLICY_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/calendar.py
+++ b/apps/api/src/alicebot_api/calendar.py
@@ -1,0 +1,504 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+from uuid import UUID
+
+import psycopg
+
+from alicebot_api.artifacts import (
+    SUPPORTED_TEXT_ARTIFACT_MEDIA_TYPES,
+    TaskArtifactAlreadyExistsError,
+    TaskArtifactValidationError,
+    ensure_artifact_path_is_rooted,
+    extract_artifact_text_from_bytes,
+    ingest_task_artifact_record,
+    register_task_artifact_record,
+)
+from alicebot_api.calendar_secret_manager import (
+    CALENDAR_SECRET_MANAGER_KIND_FILE_V1,
+    CalendarSecretManager,
+    CalendarSecretManagerError,
+)
+from alicebot_api.contracts import (
+    CALENDAR_ACCOUNT_LIST_ORDER,
+    CALENDAR_AUTH_KIND_OAUTH_ACCESS_TOKEN,
+    CALENDAR_PROTECTED_CREDENTIAL_KIND,
+    CALENDAR_PROVIDER,
+    CALENDAR_READONLY_SCOPE,
+    CalendarAccountConnectInput,
+    CalendarAccountConnectResponse,
+    CalendarAccountDetailResponse,
+    CalendarAccountListResponse,
+    CalendarAccountRecord,
+    CalendarEventIngestInput,
+    CalendarEventIngestionResponse,
+    TaskArtifactIngestInput,
+    TaskArtifactRegisterInput,
+)
+from alicebot_api.store import (
+    CalendarAccountRow,
+    ContinuityStore,
+    ContinuityStoreInvariantError,
+    JsonObject,
+)
+from alicebot_api.workspaces import TaskWorkspaceNotFoundError
+
+CALENDAR_EVENT_FETCH_TIMEOUT_SECONDS = 30
+CALENDAR_EVENT_ARTIFACT_ROOT = "calendar"
+CALENDAR_EVENT_ARTIFACT_MEDIA_TYPE = SUPPORTED_TEXT_ARTIFACT_MEDIA_TYPES[0]
+_PATH_SEGMENT_PATTERN = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class CalendarAccountNotFoundError(LookupError):
+    """Raised when a Calendar account is not visible inside the current user scope."""
+
+
+class CalendarAccountAlreadyExistsError(RuntimeError):
+    """Raised when the same provider account is connected twice for one user."""
+
+
+class CalendarEventNotFoundError(LookupError):
+    """Raised when a Calendar event cannot be found in the current account."""
+
+
+class CalendarEventUnsupportedError(ValueError):
+    """Raised when Calendar content cannot be converted into the text artifact seam."""
+
+
+class CalendarEventFetchError(RuntimeError):
+    """Raised when the Calendar API call fails for non-deterministic upstream reasons."""
+
+
+class CalendarCredentialNotFoundError(RuntimeError):
+    """Raised when Calendar protected credentials are missing for a visible account."""
+
+
+class CalendarCredentialInvalidError(RuntimeError):
+    """Raised when Calendar protected credentials are malformed for a visible account."""
+
+
+class CalendarCredentialPersistenceError(RuntimeError):
+    """Raised when Calendar protected credentials cannot be persisted."""
+
+
+class CalendarCredentialValidationError(ValueError):
+    """Raised when Calendar connect input contains an invalid credential payload."""
+
+
+def serialize_calendar_account_row(row: CalendarAccountRow) -> CalendarAccountRecord:
+    return {
+        "id": str(row["id"]),
+        "provider": CALENDAR_PROVIDER,
+        "auth_kind": CALENDAR_AUTH_KIND_OAUTH_ACCESS_TOKEN,
+        "provider_account_id": row["provider_account_id"],
+        "email_address": row["email_address"],
+        "display_name": row["display_name"],
+        "scope": row["scope"],
+        "created_at": row["created_at"].isoformat(),
+        "updated_at": row["updated_at"].isoformat(),
+    }
+
+
+def _coerce_nonempty_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if normalized == "":
+        return None
+    return normalized
+
+
+def build_calendar_protected_credential_blob(*, access_token: str) -> dict[str, str]:
+    normalized_access_token = _coerce_nonempty_string(access_token)
+    if normalized_access_token is None:
+        raise CalendarCredentialValidationError("calendar access token must be non-empty")
+    return {
+        "credential_kind": CALENDAR_PROTECTED_CREDENTIAL_KIND,
+        "access_token": normalized_access_token,
+    }
+
+
+def build_calendar_secret_ref(*, user_id: UUID, calendar_account_id: UUID) -> str:
+    return f"users/{user_id}/calendar-account-credentials/{calendar_account_id}.json"
+
+
+def _parse_calendar_credential(*, calendar_account_id: UUID, credential_blob: object) -> str:
+    if not isinstance(credential_blob, dict):
+        raise CalendarCredentialInvalidError(
+            f"calendar account {calendar_account_id} has invalid protected credentials"
+        )
+    credential_kind = credential_blob.get("credential_kind")
+    access_token = _coerce_nonempty_string(credential_blob.get("access_token"))
+    if credential_kind != CALENDAR_PROTECTED_CREDENTIAL_KIND or access_token is None:
+        raise CalendarCredentialInvalidError(
+            f"calendar account {calendar_account_id} has invalid protected credentials"
+        )
+    return access_token
+
+
+def _write_external_calendar_secret(
+    secret_manager: CalendarSecretManager,
+    *,
+    calendar_account_id: UUID,
+    secret_ref: str,
+    credential_blob: JsonObject,
+) -> None:
+    try:
+        secret_manager.write_secret(secret_ref=secret_ref, payload=credential_blob)
+    except CalendarSecretManagerError as exc:
+        raise CalendarCredentialPersistenceError(
+            f"calendar account {calendar_account_id} protected credentials could not be persisted"
+        ) from exc
+
+
+def resolve_calendar_access_token(
+    store: ContinuityStore,
+    secret_manager: CalendarSecretManager,
+    *,
+    calendar_account_id: UUID,
+) -> str:
+    credential = store.get_calendar_account_credential_optional(calendar_account_id)
+    if credential is None:
+        raise CalendarCredentialNotFoundError(
+            f"calendar account {calendar_account_id} is missing protected credentials"
+        )
+    if credential["auth_kind"] != CALENDAR_AUTH_KIND_OAUTH_ACCESS_TOKEN:
+        raise CalendarCredentialInvalidError(
+            f"calendar account {calendar_account_id} has invalid protected credentials"
+        )
+    if credential["secret_manager_kind"] != CALENDAR_SECRET_MANAGER_KIND_FILE_V1:
+        raise CalendarCredentialInvalidError(
+            f"calendar account {calendar_account_id} has invalid protected credentials"
+        )
+    secret_ref = _coerce_nonempty_string(credential["secret_ref"])
+    if secret_ref is None:
+        raise CalendarCredentialInvalidError(
+            f"calendar account {calendar_account_id} has invalid protected credentials"
+        )
+
+    try:
+        payload = secret_manager.load_secret(secret_ref=secret_ref)
+    except CalendarSecretManagerError as exc:
+        message = str(exc)
+        if message.endswith("was not found"):
+            raise CalendarCredentialNotFoundError(
+                f"calendar account {calendar_account_id} is missing protected credentials"
+            ) from exc
+        raise CalendarCredentialInvalidError(
+            f"calendar account {calendar_account_id} has invalid protected credentials"
+        ) from exc
+    return _parse_calendar_credential(
+        calendar_account_id=calendar_account_id,
+        credential_blob=payload,
+    )
+
+
+def create_calendar_account_record(
+    store: ContinuityStore,
+    secret_manager: CalendarSecretManager,
+    *,
+    user_id: UUID,
+    request: CalendarAccountConnectInput,
+) -> CalendarAccountConnectResponse:
+    del user_id
+
+    existing = store.get_calendar_account_by_provider_account_id_optional(request.provider_account_id)
+    if existing is not None:
+        raise CalendarAccountAlreadyExistsError(
+            f"calendar account {request.provider_account_id} is already connected"
+        )
+
+    row: CalendarAccountRow | None = None
+    secret_ref: str | None = None
+    try:
+        row = store.create_calendar_account(
+            provider_account_id=request.provider_account_id,
+            email_address=request.email_address,
+            display_name=request.display_name,
+            scope=request.scope,
+        )
+        credential_blob = build_calendar_protected_credential_blob(
+            access_token=request.access_token,
+        )
+        secret_ref = build_calendar_secret_ref(
+            user_id=row["user_id"],
+            calendar_account_id=row["id"],
+        )
+        _write_external_calendar_secret(
+            secret_manager,
+            calendar_account_id=row["id"],
+            secret_ref=secret_ref,
+            credential_blob=credential_blob,
+        )
+        store.create_calendar_account_credential(
+            calendar_account_id=row["id"],
+            auth_kind=CALENDAR_AUTH_KIND_OAUTH_ACCESS_TOKEN,
+            credential_kind=credential_blob["credential_kind"],
+            secret_manager_kind=secret_manager.kind,
+            secret_ref=secret_ref,
+            credential_blob=None,
+        )
+    except psycopg.errors.UniqueViolation as exc:
+        raise CalendarAccountAlreadyExistsError(
+            f"calendar account {request.provider_account_id} is already connected"
+        ) from exc
+    except CalendarCredentialPersistenceError:
+        raise
+    except (ContinuityStoreInvariantError, psycopg.Error) as exc:
+        if secret_ref is not None:
+            try:
+                secret_manager.delete_secret(secret_ref=secret_ref)
+            except CalendarSecretManagerError:
+                pass
+        raise CalendarCredentialPersistenceError(
+            "calendar protected credentials could not be persisted"
+        ) from exc
+
+    return {"account": serialize_calendar_account_row(row)}
+
+
+def list_calendar_account_records(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+) -> CalendarAccountListResponse:
+    del user_id
+
+    items = [serialize_calendar_account_row(row) for row in store.list_calendar_accounts()]
+    return {
+        "items": items,
+        "summary": {
+            "total_count": len(items),
+            "order": list(CALENDAR_ACCOUNT_LIST_ORDER),
+        },
+    }
+
+
+def get_calendar_account_record(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    calendar_account_id: UUID,
+) -> CalendarAccountDetailResponse:
+    del user_id
+
+    row = store.get_calendar_account_optional(calendar_account_id)
+    if row is None:
+        raise CalendarAccountNotFoundError(f"calendar account {calendar_account_id} was not found")
+    return {"account": serialize_calendar_account_row(row)}
+
+
+def _sanitize_path_segment(value: str) -> str:
+    sanitized = _PATH_SEGMENT_PATTERN.sub("_", value.strip())
+    return sanitized.strip("._") or "event"
+
+
+def build_calendar_event_artifact_relative_path(
+    *,
+    provider_account_id: str,
+    provider_event_id: str,
+) -> str:
+    return (
+        f"{CALENDAR_EVENT_ARTIFACT_ROOT}/"
+        f"{_sanitize_path_segment(provider_account_id)}/"
+        f"{_sanitize_path_segment(provider_event_id)}.txt"
+    )
+
+
+def fetch_calendar_event_payload(*, access_token: str, provider_event_id: str) -> JsonObject:
+    request = Request(
+        (
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events/"
+            f"{quote(provider_event_id, safe='')}"
+        ),
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+        },
+        method="GET",
+    )
+
+    try:
+        with urlopen(request, timeout=CALENDAR_EVENT_FETCH_TIMEOUT_SECONDS) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        if exc.code == 404:
+            raise CalendarEventNotFoundError(
+                f"calendar event {provider_event_id} was not found"
+            ) from exc
+        raise CalendarEventFetchError(
+            f"calendar event {provider_event_id} could not be fetched"
+        ) from exc
+    except (OSError, URLError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CalendarEventFetchError(
+            f"calendar event {provider_event_id} could not be fetched"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise CalendarEventUnsupportedError(
+            f"calendar event {provider_event_id} is not supported for ingestion"
+        )
+    return payload
+
+
+def _extract_calendar_event_time(
+    *,
+    provider_event_id: str,
+    payload: JsonObject,
+    key: str,
+) -> str:
+    field = payload.get(key)
+    if not isinstance(field, dict):
+        raise CalendarEventUnsupportedError(
+            f"calendar event {provider_event_id} is not supported for ingestion"
+        )
+    date_time = _coerce_nonempty_string(field.get("dateTime"))
+    if date_time is not None:
+        return date_time
+    date = _coerce_nonempty_string(field.get("date"))
+    if date is not None:
+        return date
+    raise CalendarEventUnsupportedError(
+        f"calendar event {provider_event_id} is not supported for ingestion"
+    )
+
+
+def _optional_event_text(value: object) -> str:
+    normalized = _coerce_nonempty_string(value)
+    if normalized is None:
+        return "(none)"
+    return normalized.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def build_calendar_event_artifact_text(*, provider_event_id: str, payload: JsonObject) -> str:
+    source_event_id = _coerce_nonempty_string(payload.get("id"))
+    if source_event_id is None:
+        raise CalendarEventUnsupportedError(
+            f"calendar event {provider_event_id} is not supported for ingestion"
+        )
+    start_value = _extract_calendar_event_time(
+        provider_event_id=provider_event_id,
+        payload=payload,
+        key="start",
+    )
+    end_value = _extract_calendar_event_time(
+        provider_event_id=provider_event_id,
+        payload=payload,
+        key="end",
+    )
+    organizer_email = None
+    organizer = payload.get("organizer")
+    if isinstance(organizer, dict):
+        organizer_email = _coerce_nonempty_string(organizer.get("email"))
+
+    lines = [
+        f"Provider: {CALENDAR_PROVIDER}",
+        f"Requested Event ID: {provider_event_id}",
+        f"Source Event ID: {source_event_id}",
+        f"Status: {_optional_event_text(payload.get('status'))}",
+        f"Summary: {_optional_event_text(payload.get('summary'))}",
+        f"Location: {_optional_event_text(payload.get('location'))}",
+        f"Start: {start_value}",
+        f"End: {end_value}",
+        f"Organizer Email: {_optional_event_text(organizer_email)}",
+        f"HTML Link: {_optional_event_text(payload.get('htmlLink'))}",
+        "Description:",
+        _optional_event_text(payload.get("description")),
+    ]
+    return "\n".join(lines).strip()
+
+
+def ingest_calendar_event_record(
+    store: ContinuityStore,
+    secret_manager: CalendarSecretManager,
+    *,
+    user_id: UUID,
+    request: CalendarEventIngestInput,
+) -> CalendarEventIngestionResponse:
+    account = store.get_calendar_account_optional(request.calendar_account_id)
+    if account is None:
+        raise CalendarAccountNotFoundError(f"calendar account {request.calendar_account_id} was not found")
+
+    workspace = store.get_task_workspace_optional(request.task_workspace_id)
+    if workspace is None:
+        raise TaskWorkspaceNotFoundError(
+            f"task workspace {request.task_workspace_id} was not found"
+        )
+
+    access_token = resolve_calendar_access_token(
+        store,
+        secret_manager,
+        calendar_account_id=request.calendar_account_id,
+    )
+    store.lock_task_artifacts(workspace["id"])
+
+    relative_path = build_calendar_event_artifact_relative_path(
+        provider_account_id=account["provider_account_id"],
+        provider_event_id=request.provider_event_id,
+    )
+    existing_artifact = store.get_task_artifact_by_workspace_relative_path_optional(
+        task_workspace_id=request.task_workspace_id,
+        relative_path=relative_path,
+    )
+    if existing_artifact is not None:
+        raise TaskArtifactAlreadyExistsError(
+            f"artifact {relative_path} is already registered for task workspace {request.task_workspace_id}"
+        )
+
+    event_payload = fetch_calendar_event_payload(
+        access_token=access_token,
+        provider_event_id=request.provider_event_id,
+    )
+    artifact_text = build_calendar_event_artifact_text(
+        provider_event_id=request.provider_event_id,
+        payload=event_payload,
+    )
+    artifact_bytes = artifact_text.encode("utf-8")
+    extract_artifact_text_from_bytes(
+        relative_path=relative_path,
+        payload=artifact_bytes,
+        media_type=CALENDAR_EVENT_ARTIFACT_MEDIA_TYPE,
+    )
+
+    workspace_path = Path(workspace["local_path"]).expanduser().resolve()
+    artifact_path = (workspace_path / relative_path).resolve()
+    ensure_artifact_path_is_rooted(
+        workspace_path=workspace_path,
+        artifact_path=artifact_path,
+    )
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    if artifact_path.exists():
+        raise TaskArtifactValidationError(
+            f"artifact path {artifact_path} already exists before Calendar ingestion registration"
+        )
+    artifact_path.write_bytes(artifact_bytes)
+
+    artifact_payload = register_task_artifact_record(
+        store,
+        user_id=user_id,
+        request=TaskArtifactRegisterInput(
+            task_workspace_id=request.task_workspace_id,
+            local_path=str(artifact_path),
+            media_type_hint=CALENDAR_EVENT_ARTIFACT_MEDIA_TYPE,
+        ),
+    )
+    ingestion_payload = ingest_task_artifact_record(
+        store,
+        user_id=user_id,
+        request=TaskArtifactIngestInput(task_artifact_id=UUID(artifact_payload["artifact"]["id"])),
+    )
+    return {
+        "account": serialize_calendar_account_row(account),
+        "event": {
+            "provider_event_id": request.provider_event_id,
+            "artifact_relative_path": ingestion_payload["artifact"]["relative_path"],
+            "media_type": CALENDAR_EVENT_ARTIFACT_MEDIA_TYPE,
+        },
+        "artifact": ingestion_payload["artifact"],
+        "summary": ingestion_payload["summary"],
+    }

--- a/apps/api/src/alicebot_api/calendar_secret_manager.py
+++ b/apps/api/src/alicebot_api/calendar_secret_manager.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from alicebot_api.store import JsonObject
+
+CALENDAR_SECRET_MANAGER_KIND_FILE_V1 = "file_v1"
+
+
+class CalendarSecretManagerError(RuntimeError):
+    """Raised when the configured Calendar secret manager cannot service a request."""
+
+
+class CalendarSecretManager:
+    kind: str
+
+    def load_secret(self, *, secret_ref: str) -> JsonObject:
+        raise NotImplementedError
+
+    def write_secret(self, *, secret_ref: str, payload: JsonObject) -> None:
+        raise NotImplementedError
+
+    def delete_secret(self, *, secret_ref: str) -> None:
+        raise NotImplementedError
+
+
+class FileCalendarSecretManager(CalendarSecretManager):
+    kind = CALENDAR_SECRET_MANAGER_KIND_FILE_V1
+
+    def __init__(self, *, root: Path) -> None:
+        self._root = root.expanduser().resolve()
+
+    def load_secret(self, *, secret_ref: str) -> JsonObject:
+        path = self._resolve_secret_path(secret_ref)
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise CalendarSecretManagerError(f"calendar secret {secret_ref} was not found") from exc
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise CalendarSecretManagerError(f"calendar secret {secret_ref} could not be loaded") from exc
+        if not isinstance(payload, dict):
+            raise CalendarSecretManagerError(f"calendar secret {secret_ref} could not be loaded")
+        return payload
+
+    def write_secret(self, *, secret_ref: str, payload: JsonObject) -> None:
+        path = self._resolve_secret_path(secret_ref)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        try:
+            temp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+            temp_path.replace(path)
+        except OSError as exc:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise CalendarSecretManagerError(f"calendar secret {secret_ref} could not be written") from exc
+
+    def delete_secret(self, *, secret_ref: str) -> None:
+        path = self._resolve_secret_path(secret_ref)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise CalendarSecretManagerError(f"calendar secret {secret_ref} could not be deleted") from exc
+
+    def _resolve_secret_path(self, secret_ref: str) -> Path:
+        candidate = (self._root / secret_ref).resolve()
+        try:
+            candidate.relative_to(self._root)
+        except ValueError as exc:
+            raise CalendarSecretManagerError(
+                f"calendar secret {secret_ref} is outside the configured root"
+            ) from exc
+        return candidate
+
+
+def build_calendar_secret_manager(secret_manager_url: str) -> CalendarSecretManager:
+    if secret_manager_url.strip() == "":
+        raise ValueError("CALENDAR_SECRET_MANAGER_URL must be configured")
+
+    parsed = urlparse(secret_manager_url)
+    if parsed.scheme != "file":
+        raise ValueError("CALENDAR_SECRET_MANAGER_URL must use the file:// scheme")
+
+    root_path = Path(unquote(parsed.path or "/"))
+    if parsed.netloc not in ("", "localhost"):
+        root_path = Path(f"/{parsed.netloc}{root_path.as_posix()}")
+
+    return FileCalendarSecretManager(root=root_path)

--- a/apps/api/src/alicebot_api/config.py
+++ b/apps/api/src/alicebot_api/config.py
@@ -32,6 +32,7 @@ DEFAULT_MODEL_API_KEY = ""
 DEFAULT_MODEL_TIMEOUT_SECONDS = 30
 DEFAULT_TASK_WORKSPACE_ROOT = "/tmp/alicebot/task-workspaces"
 DEFAULT_GMAIL_SECRET_MANAGER_URL = ""
+DEFAULT_CALENDAR_SECRET_MANAGER_URL = ""
 
 Environment = Mapping[str, str]
 
@@ -71,6 +72,7 @@ class Settings:
     model_timeout_seconds: int = DEFAULT_MODEL_TIMEOUT_SECONDS
     task_workspace_root: str = DEFAULT_TASK_WORKSPACE_ROOT
     gmail_secret_manager_url: str = DEFAULT_GMAIL_SECRET_MANAGER_URL
+    calendar_secret_manager_url: str = DEFAULT_CALENDAR_SECRET_MANAGER_URL
 
     @classmethod
     def from_env(cls, env: Environment | None = None) -> "Settings":
@@ -117,6 +119,11 @@ class Settings:
                 current_env,
                 "GMAIL_SECRET_MANAGER_URL",
                 cls.gmail_secret_manager_url,
+            ),
+            calendar_secret_manager_url=_get_env_value(
+                current_env,
+                "CALENDAR_SECRET_MANAGER_URL",
+                cls.calendar_secret_manager_url,
             ),
         )
 

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -142,6 +142,7 @@ APPROVAL_LIST_ORDER = ["created_at_asc", "id_asc"]
 TASK_LIST_ORDER = ["created_at_asc", "id_asc"]
 TASK_WORKSPACE_LIST_ORDER = ["created_at_asc", "id_asc"]
 GMAIL_ACCOUNT_LIST_ORDER = ["created_at_asc", "id_asc"]
+CALENDAR_ACCOUNT_LIST_ORDER = ["created_at_asc", "id_asc"]
 TASK_ARTIFACT_LIST_ORDER = ["created_at_asc", "id_asc"]
 TASK_ARTIFACT_CHUNK_LIST_ORDER = ["sequence_no_asc", "id_asc"]
 TASK_ARTIFACT_CHUNK_EMBEDDING_LIST_ORDER = [
@@ -185,6 +186,10 @@ GMAIL_AUTH_KIND_OAUTH_ACCESS_TOKEN = "oauth_access_token"
 GMAIL_READONLY_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
 GMAIL_PROTECTED_CREDENTIAL_KIND = "gmail_oauth_access_token_v1"
 GMAIL_REFRESHABLE_PROTECTED_CREDENTIAL_KIND = "gmail_oauth_refresh_token_v2"
+CALENDAR_PROVIDER = "google_calendar"
+CALENDAR_AUTH_KIND_OAUTH_ACCESS_TOKEN = "oauth_access_token"
+CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
+CALENDAR_PROTECTED_CREDENTIAL_KIND = "calendar_oauth_access_token_v1"
 TASK_STEP_SEQUENCE_VERSION_V0 = "task_step_sequence_v0"
 TRACE_KIND_TASK_STEP_SEQUENCE = "task.step.sequence"
 TASK_STEP_CONTINUATION_VERSION_V0 = "task_step_continuation_v0"
@@ -1958,6 +1963,65 @@ class GmailMessageIngestionRecord(TypedDict):
 class GmailMessageIngestionResponse(TypedDict):
     account: GmailAccountRecord
     message: GmailMessageIngestionRecord
+    artifact: TaskArtifactRecord
+    summary: TaskArtifactChunkListSummary
+
+
+@dataclass(frozen=True, slots=True)
+class CalendarAccountConnectInput:
+    provider_account_id: str
+    email_address: str
+    display_name: str | None
+    scope: str
+    access_token: str
+
+
+@dataclass(frozen=True, slots=True)
+class CalendarEventIngestInput:
+    calendar_account_id: UUID
+    task_workspace_id: UUID
+    provider_event_id: str
+
+
+class CalendarAccountRecord(TypedDict):
+    id: str
+    provider: str
+    auth_kind: str
+    provider_account_id: str
+    email_address: str
+    display_name: str | None
+    scope: str
+    created_at: str
+    updated_at: str
+
+
+class CalendarAccountConnectResponse(TypedDict):
+    account: CalendarAccountRecord
+
+
+class CalendarAccountListSummary(TypedDict):
+    total_count: int
+    order: list[str]
+
+
+class CalendarAccountListResponse(TypedDict):
+    items: list[CalendarAccountRecord]
+    summary: CalendarAccountListSummary
+
+
+class CalendarAccountDetailResponse(TypedDict):
+    account: CalendarAccountRecord
+
+
+class CalendarEventIngestionRecord(TypedDict):
+    provider_event_id: str
+    artifact_relative_path: str
+    media_type: str
+
+
+class CalendarEventIngestionResponse(TypedDict):
+    account: CalendarAccountRecord
+    event: CalendarEventIngestionRecord
     artifact: TaskArtifactRecord
     summary: TaskArtifactChunkListSummary
 

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -45,7 +45,10 @@ from alicebot_api.contracts import (
     EntityCreateInput,
     EntityType,
     ExplicitPreferenceExtractionRequestInput,
+    CALENDAR_READONLY_SCOPE,
     GMAIL_READONLY_SCOPE,
+    CalendarAccountConnectInput,
+    CalendarEventIngestInput,
     GmailAccountConnectInput,
     GmailMessageIngestInput,
     MemoryCandidateInput,
@@ -169,6 +172,22 @@ from alicebot_api.gmail import (
     ingest_gmail_message_record,
     list_gmail_account_records,
 )
+from alicebot_api.calendar import (
+    CalendarAccountAlreadyExistsError,
+    CalendarAccountNotFoundError,
+    CalendarCredentialInvalidError,
+    CalendarCredentialNotFoundError,
+    CalendarCredentialPersistenceError,
+    CalendarCredentialValidationError,
+    CalendarEventFetchError,
+    CalendarEventNotFoundError,
+    CalendarEventUnsupportedError,
+    create_calendar_account_record,
+    get_calendar_account_record,
+    ingest_calendar_event_record,
+    list_calendar_account_records,
+)
+from alicebot_api.calendar_secret_manager import build_calendar_secret_manager
 from alicebot_api.gmail_secret_manager import build_gmail_secret_manager
 from alicebot_api.embedding import (
     EmbeddingConfigValidationError,
@@ -601,6 +620,20 @@ class ConnectGmailAccountRequest(BaseModel):
 
 
 class IngestGmailMessageRequest(BaseModel):
+    user_id: UUID
+    task_workspace_id: UUID
+
+
+class ConnectCalendarAccountRequest(BaseModel):
+    user_id: UUID
+    provider_account_id: str = Field(min_length=1, max_length=320)
+    email_address: str = Field(min_length=1, max_length=320)
+    display_name: str | None = Field(default=None, min_length=1, max_length=200)
+    scope: Literal["https://www.googleapis.com/auth/calendar.readonly"] = CALENDAR_READONLY_SCOPE
+    access_token: str = Field(min_length=1, max_length=8000)
+
+
+class IngestCalendarEventRequest(BaseModel):
     user_id: UUID
     task_workspace_id: UUID
 
@@ -1646,6 +1679,122 @@ def ingest_gmail_message(
     except TaskArtifactValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
     except (GmailMessageFetchError, GmailCredentialRefreshError) as exc:
+        return JSONResponse(status_code=502, content={"detail": str(exc)})
+    except TaskArtifactAlreadyExistsError as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.post("/v0/calendar-accounts")
+def connect_calendar_account(request: ConnectCalendarAccountRequest) -> JSONResponse:
+    settings = get_settings()
+    secret_manager = build_calendar_secret_manager(settings.calendar_secret_manager_url)
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            payload = create_calendar_account_record(
+                ContinuityStore(conn),
+                secret_manager,
+                user_id=request.user_id,
+                request=CalendarAccountConnectInput(
+                    provider_account_id=request.provider_account_id,
+                    email_address=request.email_address,
+                    display_name=request.display_name,
+                    scope=request.scope,
+                    access_token=request.access_token,
+                ),
+            )
+    except CalendarCredentialValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except CalendarCredentialPersistenceError as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    except CalendarAccountAlreadyExistsError as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=201,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/calendar-accounts")
+def list_calendar_accounts(user_id: UUID) -> JSONResponse:
+    settings = get_settings()
+
+    with user_connection(settings.database_url, user_id) as conn:
+        payload = list_calendar_account_records(
+            ContinuityStore(conn),
+            user_id=user_id,
+        )
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/calendar-accounts/{calendar_account_id}")
+def get_calendar_account(calendar_account_id: UUID, user_id: UUID) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload = get_calendar_account_record(
+                ContinuityStore(conn),
+                user_id=user_id,
+                calendar_account_id=calendar_account_id,
+            )
+    except CalendarAccountNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.post("/v0/calendar-accounts/{calendar_account_id}/events/{provider_event_id}/ingest")
+def ingest_calendar_event(
+    calendar_account_id: UUID,
+    provider_event_id: str,
+    request: IngestCalendarEventRequest,
+) -> JSONResponse:
+    settings = get_settings()
+    secret_manager = build_calendar_secret_manager(settings.calendar_secret_manager_url)
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            payload = ingest_calendar_event_record(
+                ContinuityStore(conn),
+                secret_manager,
+                user_id=request.user_id,
+                request=CalendarEventIngestInput(
+                    calendar_account_id=calendar_account_id,
+                    task_workspace_id=request.task_workspace_id,
+                    provider_event_id=provider_event_id,
+                ),
+            )
+    except CalendarAccountNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except TaskWorkspaceNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except CalendarEventNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except CalendarEventUnsupportedError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except (
+        CalendarCredentialNotFoundError,
+        CalendarCredentialInvalidError,
+        CalendarCredentialPersistenceError,
+    ) as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    except TaskArtifactValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except CalendarEventFetchError as exc:
         return JSONResponse(status_code=502, content={"detail": str(exc)})
     except TaskArtifactAlreadyExistsError as exc:
         return JSONResponse(status_code=409, content={"detail": str(exc)})

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -268,8 +268,31 @@ class GmailAccountRow(TypedDict):
     updated_at: datetime
 
 
+class CalendarAccountRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    provider_account_id: str
+    email_address: str
+    display_name: str | None
+    scope: str
+    created_at: datetime
+    updated_at: datetime
+
+
 class ProtectedGmailCredentialRow(TypedDict):
     gmail_account_id: UUID
+    user_id: UUID
+    auth_kind: str
+    credential_kind: str
+    secret_manager_kind: str
+    secret_ref: str | None
+    credential_blob: JsonObject | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProtectedCalendarCredentialRow(TypedDict):
+    calendar_account_id: UUID
     user_id: UUID
     auth_kind: str
     credential_kind: str
@@ -1707,6 +1730,130 @@ LIST_GMAIL_ACCOUNTS_SQL = """
                   created_at,
                   updated_at
                 FROM gmail_accounts
+                ORDER BY created_at ASC, id ASC
+                """
+
+INSERT_CALENDAR_ACCOUNT_SQL = """
+                INSERT INTO calendar_accounts (
+                  user_id,
+                  provider_account_id,
+                  email_address,
+                  display_name,
+                  scope,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  clock_timestamp(),
+                  clock_timestamp()
+                )
+                RETURNING
+                  id,
+                  user_id,
+                  provider_account_id,
+                  email_address,
+                  display_name,
+                  scope,
+                  created_at,
+                  updated_at
+                """
+
+INSERT_CALENDAR_ACCOUNT_CREDENTIAL_SQL = """
+                INSERT INTO calendar_account_credentials (
+                  calendar_account_id,
+                  user_id,
+                  auth_kind,
+                  credential_kind,
+                  secret_manager_kind,
+                  secret_ref,
+                  credential_blob,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  %s,
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  clock_timestamp(),
+                  clock_timestamp()
+                )
+                RETURNING
+                  calendar_account_id,
+                  user_id,
+                  auth_kind,
+                  credential_kind,
+                  secret_manager_kind,
+                  secret_ref,
+                  credential_blob,
+                  created_at,
+                  updated_at
+                """
+
+GET_CALENDAR_ACCOUNT_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  provider_account_id,
+                  email_address,
+                  display_name,
+                  scope,
+                  created_at,
+                  updated_at
+                FROM calendar_accounts
+                WHERE id = %s
+                """
+
+GET_CALENDAR_ACCOUNT_BY_PROVIDER_ACCOUNT_ID_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  provider_account_id,
+                  email_address,
+                  display_name,
+                  scope,
+                  created_at,
+                  updated_at
+                FROM calendar_accounts
+                WHERE provider_account_id = %s
+                ORDER BY created_at ASC, id ASC
+                LIMIT 1
+                """
+
+GET_CALENDAR_ACCOUNT_CREDENTIAL_SQL = """
+                SELECT
+                  calendar_account_id,
+                  user_id,
+                  auth_kind,
+                  credential_kind,
+                  secret_manager_kind,
+                  secret_ref,
+                  credential_blob,
+                  created_at,
+                  updated_at
+                FROM calendar_account_credentials
+                WHERE calendar_account_id = %s
+                """
+
+LIST_CALENDAR_ACCOUNTS_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  provider_account_id,
+                  email_address,
+                  display_name,
+                  scope,
+                  created_at,
+                  updated_at
+                FROM calendar_accounts
                 ORDER BY created_at ASC, id ASC
                 """
 
@@ -3317,6 +3464,67 @@ class ContinuityStore:
 
     def list_gmail_accounts(self) -> list[GmailAccountRow]:
         return self._fetch_all(LIST_GMAIL_ACCOUNTS_SQL)
+
+    def create_calendar_account(
+        self,
+        *,
+        provider_account_id: str,
+        email_address: str,
+        display_name: str | None,
+        scope: str,
+    ) -> CalendarAccountRow:
+        return self._fetch_one(
+            "create_calendar_account",
+            INSERT_CALENDAR_ACCOUNT_SQL,
+            (provider_account_id, email_address, display_name, scope),
+        )
+
+    def create_calendar_account_credential(
+        self,
+        *,
+        calendar_account_id: UUID,
+        auth_kind: str,
+        credential_kind: str,
+        secret_manager_kind: str,
+        secret_ref: str | None,
+        credential_blob: JsonObject | None,
+    ) -> ProtectedCalendarCredentialRow:
+        return self._fetch_one(
+            "create_calendar_account_credential",
+            INSERT_CALENDAR_ACCOUNT_CREDENTIAL_SQL,
+            (
+                calendar_account_id,
+                auth_kind,
+                credential_kind,
+                secret_manager_kind,
+                secret_ref,
+                None if credential_blob is None else Jsonb(credential_blob),
+            ),
+        )
+
+    def get_calendar_account_optional(self, calendar_account_id: UUID) -> CalendarAccountRow | None:
+        return self._fetch_optional_one(GET_CALENDAR_ACCOUNT_SQL, (calendar_account_id,))
+
+    def get_calendar_account_credential_optional(
+        self,
+        calendar_account_id: UUID,
+    ) -> ProtectedCalendarCredentialRow | None:
+        return self._fetch_optional_one(
+            GET_CALENDAR_ACCOUNT_CREDENTIAL_SQL,
+            (calendar_account_id,),
+        )
+
+    def get_calendar_account_by_provider_account_id_optional(
+        self,
+        provider_account_id: str,
+    ) -> CalendarAccountRow | None:
+        return self._fetch_optional_one(
+            GET_CALENDAR_ACCOUNT_BY_PROVIDER_ACCOUNT_ID_SQL,
+            (provider_account_id,),
+        )
+
+    def list_calendar_accounts(self) -> list[CalendarAccountRow]:
+        return self._fetch_all(LIST_CALENDAR_ACCOUNTS_SQL)
 
     def lock_task_workspaces(self, task_id: UUID) -> None:
         with self.conn.cursor() as cur:

--- a/tests/integration/test_calendar_accounts_api.py
+++ b/tests/integration/test_calendar_accounts_api.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+from uuid import UUID, uuid4
+
+import anyio
+import psycopg
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+import alicebot_api.calendar as calendar_module
+from alicebot_api.db import user_connection
+from alicebot_api.store import ContinuityStore
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+
+        request_received = True
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def _build_calendar_secret_manager_url(root: Path) -> str:
+    return root.resolve().as_uri()
+
+
+def seed_user(database_url: str, *, email: str) -> dict[str, UUID]:
+    user_id = uuid4()
+
+    with user_connection(database_url, user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, email, email.split("@", 1)[0].title())
+
+    return {"user_id": user_id}
+
+
+def seed_task(database_url: str, *, email: str) -> dict[str, UUID]:
+    user_id = uuid4()
+
+    with user_connection(database_url, user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, email, email.split("@", 1)[0].title())
+        thread = store.create_thread("Calendar thread")
+        tool = store.create_tool(
+            tool_key="proxy.echo",
+            name="Proxy Echo",
+            description="Deterministic proxy handler.",
+            version="1.0.0",
+            metadata_version="tool_metadata_v0",
+            active=True,
+            tags=["proxy"],
+            action_hints=["tool.run"],
+            scope_hints=["workspace"],
+            domain_hints=[],
+            risk_hints=[],
+            metadata={"transport": "proxy"},
+        )
+        task = store.create_task(
+            thread_id=thread["id"],
+            tool_id=tool["id"],
+            status="approved",
+            request={
+                "thread_id": str(thread["id"]),
+                "tool_id": str(tool["id"]),
+                "action": "tool.run",
+                "scope": "workspace",
+                "domain_hint": None,
+                "risk_hint": None,
+                "attributes": {},
+            },
+            tool={
+                "id": str(tool["id"]),
+                "tool_key": "proxy.echo",
+                "name": "Proxy Echo",
+                "description": "Deterministic proxy handler.",
+                "version": "1.0.0",
+                "metadata_version": "tool_metadata_v0",
+                "active": True,
+                "tags": ["proxy"],
+                "action_hints": ["tool.run"],
+                "scope_hints": ["workspace"],
+                "domain_hints": [],
+                "risk_hints": [],
+                "metadata": {"transport": "proxy"},
+                "created_at": tool["created_at"].isoformat(),
+            },
+            latest_approval_id=None,
+            latest_execution_id=None,
+        )
+
+    return {
+        "user_id": user_id,
+        "task_id": task["id"],
+    }
+
+
+def _connect_calendar_account(
+    *,
+    user_id: UUID,
+    provider_account_id: str,
+    email_address: str,
+) -> tuple[int, dict[str, Any]]:
+    return invoke_request(
+        "POST",
+        "/v0/calendar-accounts",
+        payload={
+            "user_id": str(user_id),
+            "provider_account_id": provider_account_id,
+            "email_address": email_address,
+            "display_name": email_address.split("@", 1)[0].title(),
+            "scope": "https://www.googleapis.com/auth/calendar.readonly",
+            "access_token": f"token-for-{provider_account_id}",
+        },
+    )
+
+
+def test_calendar_account_endpoints_connect_list_detail_and_isolate(
+    migrated_database_urls,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    owner = seed_user(migrated_database_urls["app"], email="owner@example.com")
+    intruder = seed_user(migrated_database_urls["app"], email="intruder@example.com")
+    calendar_secret_root = tmp_path / "calendar-secrets"
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            database_url=migrated_database_urls["app"],
+            calendar_secret_manager_url=_build_calendar_secret_manager_url(calendar_secret_root),
+        ),
+    )
+
+    create_status, create_payload = _connect_calendar_account(
+        user_id=owner["user_id"],
+        provider_account_id="acct-owner-001",
+        email_address="owner@gmail.example",
+    )
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v0/calendar-accounts",
+        query_params={"user_id": str(owner["user_id"])},
+    )
+    detail_status, detail_payload = invoke_request(
+        "GET",
+        f"/v0/calendar-accounts/{create_payload['account']['id']}",
+        query_params={"user_id": str(owner["user_id"])},
+    )
+    duplicate_status, duplicate_payload = _connect_calendar_account(
+        user_id=owner["user_id"],
+        provider_account_id="acct-owner-001",
+        email_address="owner@gmail.example",
+    )
+    isolated_list_status, isolated_list_payload = invoke_request(
+        "GET",
+        "/v0/calendar-accounts",
+        query_params={"user_id": str(intruder["user_id"])},
+    )
+    isolated_detail_status, isolated_detail_payload = invoke_request(
+        "GET",
+        f"/v0/calendar-accounts/{create_payload['account']['id']}",
+        query_params={"user_id": str(intruder["user_id"])},
+    )
+
+    assert create_status == 201
+    assert create_payload == {
+        "account": {
+            "id": create_payload["account"]["id"],
+            "provider": "google_calendar",
+            "auth_kind": "oauth_access_token",
+            "provider_account_id": "acct-owner-001",
+            "email_address": "owner@gmail.example",
+            "display_name": "Owner",
+            "scope": "https://www.googleapis.com/auth/calendar.readonly",
+            "created_at": create_payload["account"]["created_at"],
+            "updated_at": create_payload["account"]["updated_at"],
+        }
+    }
+    assert list_status == 200
+    assert list_payload == {
+        "items": [create_payload["account"]],
+        "summary": {"total_count": 1, "order": ["created_at_asc", "id_asc"]},
+    }
+    assert detail_status == 200
+    assert detail_payload == {"account": create_payload["account"]}
+    assert duplicate_status == 409
+    assert duplicate_payload == {"detail": "calendar account acct-owner-001 is already connected"}
+    assert isolated_list_status == 200
+    assert isolated_list_payload == {
+        "items": [],
+        "summary": {"total_count": 0, "order": ["created_at_asc", "id_asc"]},
+    }
+    assert isolated_detail_status == 404
+    assert isolated_detail_payload == {
+        "detail": f"calendar account {create_payload['account']['id']} was not found"
+    }
+    assert '"access_token":' not in json.dumps(create_payload)
+    assert '"access_token":' not in json.dumps(list_payload)
+    assert '"access_token":' not in json.dumps(detail_payload)
+
+    with psycopg.connect(migrated_database_urls["admin"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                  auth_kind,
+                  credential_kind,
+                  secret_manager_kind,
+                  secret_ref,
+                  credential_blob IS NULL
+                FROM calendar_account_credentials
+                WHERE calendar_account_id = %s
+                """,
+                (UUID(create_payload["account"]["id"]),),
+            )
+            credential_row = cur.fetchone()
+
+    assert credential_row is not None
+    assert credential_row[0] == "oauth_access_token"
+    assert credential_row[1] == "calendar_oauth_access_token_v1"
+    assert credential_row[2] == "file_v1"
+    assert credential_row[4] is True
+    assert credential_row[3] is not None
+    secret_payload = json.loads((calendar_secret_root / credential_row[3]).read_text(encoding="utf-8"))
+    assert secret_payload == {
+        "credential_kind": "calendar_oauth_access_token_v1",
+        "access_token": "token-for-acct-owner-001",
+    }
+
+
+def test_calendar_event_ingestion_endpoint_persists_artifact_and_chunks(
+    migrated_database_urls,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    owner = seed_task(migrated_database_urls["app"], email="owner@example.com")
+    workspace_root = tmp_path / "task-workspaces"
+    calendar_secret_root = tmp_path / "calendar-secrets"
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            database_url=migrated_database_urls["app"],
+            task_workspace_root=str(workspace_root),
+            calendar_secret_manager_url=_build_calendar_secret_manager_url(calendar_secret_root),
+        ),
+    )
+    monkeypatch.setattr(
+        calendar_module,
+        "fetch_calendar_event_payload",
+        lambda **_kwargs: {
+            "id": "evt-001",
+            "summary": "Sprint Planning",
+            "description": "Discuss sprint scope and timelines.",
+            "location": "Room 1",
+            "status": "confirmed",
+            "start": {"dateTime": "2026-03-20T09:00:00+00:00"},
+            "end": {"dateTime": "2026-03-20T09:30:00+00:00"},
+            "organizer": {"email": "owner@gmail.example"},
+            "htmlLink": "https://calendar.google.com/event?eid=evt-001",
+        },
+    )
+
+    account_status, account_payload = _connect_calendar_account(
+        user_id=owner["user_id"],
+        provider_account_id="acct-owner-001",
+        email_address="owner@gmail.example",
+    )
+    workspace_status, workspace_payload = invoke_request(
+        "POST",
+        f"/v0/tasks/{owner['task_id']}/workspace",
+        payload={"user_id": str(owner["user_id"])},
+    )
+    ingest_status, ingest_payload = invoke_request(
+        "POST",
+        f"/v0/calendar-accounts/{account_payload['account']['id']}/events/evt-001/ingest",
+        payload={
+            "user_id": str(owner["user_id"]),
+            "task_workspace_id": workspace_payload["workspace"]["id"],
+        },
+    )
+
+    assert account_status == 201
+    assert workspace_status == 201
+    assert ingest_status == 200
+    assert ingest_payload == {
+        "account": account_payload["account"],
+        "event": {
+            "provider_event_id": "evt-001",
+            "artifact_relative_path": "calendar/acct-owner-001/evt-001.txt",
+            "media_type": "text/plain",
+        },
+        "artifact": {
+            "id": ingest_payload["artifact"]["id"],
+            "task_id": str(owner["task_id"]),
+            "task_workspace_id": workspace_payload["workspace"]["id"],
+            "status": "registered",
+            "ingestion_status": "ingested",
+            "relative_path": "calendar/acct-owner-001/evt-001.txt",
+            "media_type_hint": "text/plain",
+            "created_at": ingest_payload["artifact"]["created_at"],
+            "updated_at": ingest_payload["artifact"]["updated_at"],
+        },
+        "summary": {
+            "total_count": ingest_payload["summary"]["total_count"],
+            "total_characters": ingest_payload["summary"]["total_characters"],
+            "media_type": "text/plain",
+            "chunking_rule": "normalized_utf8_text_fixed_window_1000_chars_v1",
+            "order": ["sequence_no_asc", "id_asc"],
+        },
+    }
+    assert ingest_payload["summary"]["total_count"] >= 1
+    artifact_file = (
+        Path(workspace_payload["workspace"]["local_path"]) / "calendar" / "acct-owner-001" / "evt-001.txt"
+    )
+    assert artifact_file.is_file()
+    artifact_text = artifact_file.read_text(encoding="utf-8")
+    assert "Summary: Sprint Planning" in artifact_text
+    assert "Start: 2026-03-20T09:00:00+00:00" in artifact_text
+
+    with user_connection(migrated_database_urls["app"], owner["user_id"]) as conn:
+        store = ContinuityStore(conn)
+        artifact_rows = store.list_task_artifacts_for_task(owner["task_id"])
+        assert len(artifact_rows) == 1
+        assert artifact_rows[0]["relative_path"] == "calendar/acct-owner-001/evt-001.txt"
+        assert artifact_rows[0]["ingestion_status"] == "ingested"
+        chunk_rows = store.list_task_artifact_chunks(artifact_rows[0]["id"])
+        assert len(chunk_rows) == ingest_payload["summary"]["total_count"]
+        assert chunk_rows[0]["text"].startswith("Provider: google_calendar")
+
+
+def test_calendar_event_ingestion_endpoint_rejects_cross_user_workspace_access(
+    migrated_database_urls,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    owner = seed_task(migrated_database_urls["app"], email="owner@example.com")
+    intruder = seed_task(migrated_database_urls["app"], email="intruder@example.com")
+    workspace_root = tmp_path / "task-workspaces"
+    calendar_secret_root = tmp_path / "calendar-secrets"
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            database_url=migrated_database_urls["app"],
+            task_workspace_root=str(workspace_root),
+            calendar_secret_manager_url=_build_calendar_secret_manager_url(calendar_secret_root),
+        ),
+    )
+    monkeypatch.setattr(
+        calendar_module,
+        "fetch_calendar_event_payload",
+        lambda **_kwargs: {
+            "id": "evt-001",
+            "start": {"dateTime": "2026-03-20T09:00:00+00:00"},
+            "end": {"dateTime": "2026-03-20T09:30:00+00:00"},
+        },
+    )
+
+    _, owner_workspace_payload = invoke_request(
+        "POST",
+        f"/v0/tasks/{owner['task_id']}/workspace",
+        payload={"user_id": str(owner["user_id"])},
+    )
+    _, intruder_account_payload = _connect_calendar_account(
+        user_id=intruder["user_id"],
+        provider_account_id="acct-intruder-001",
+        email_address="intruder@gmail.example",
+    )
+    ingest_status, ingest_payload = invoke_request(
+        "POST",
+        f"/v0/calendar-accounts/{intruder_account_payload['account']['id']}/events/evt-001/ingest",
+        payload={
+            "user_id": str(intruder["user_id"]),
+            "task_workspace_id": owner_workspace_payload["workspace"]["id"],
+        },
+    )
+
+    assert ingest_status == 404
+    assert ingest_payload == {
+        "detail": f"task workspace {owner_workspace_payload['workspace']['id']} was not found"
+    }
+
+
+def test_calendar_event_ingestion_endpoint_rejects_missing_and_unsupported_events(
+    migrated_database_urls,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    owner = seed_task(migrated_database_urls["app"], email="owner@example.com")
+    workspace_root = tmp_path / "task-workspaces"
+    calendar_secret_root = tmp_path / "calendar-secrets"
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            database_url=migrated_database_urls["app"],
+            task_workspace_root=str(workspace_root),
+            calendar_secret_manager_url=_build_calendar_secret_manager_url(calendar_secret_root),
+        ),
+    )
+
+    _, account_payload = _connect_calendar_account(
+        user_id=owner["user_id"],
+        provider_account_id="acct-owner-001",
+        email_address="owner@gmail.example",
+    )
+    _, workspace_payload = invoke_request(
+        "POST",
+        f"/v0/tasks/{owner['task_id']}/workspace",
+        payload={"user_id": str(owner["user_id"])},
+    )
+
+    monkeypatch.setattr(
+        calendar_module,
+        "fetch_calendar_event_payload",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            calendar_module.CalendarEventNotFoundError("calendar event evt-missing was not found")
+        ),
+    )
+    missing_status, missing_payload = invoke_request(
+        "POST",
+        f"/v0/calendar-accounts/{account_payload['account']['id']}/events/evt-missing/ingest",
+        payload={
+            "user_id": str(owner["user_id"]),
+            "task_workspace_id": workspace_payload["workspace"]["id"],
+        },
+    )
+
+    monkeypatch.setattr(
+        calendar_module,
+        "fetch_calendar_event_payload",
+        lambda **_kwargs: {
+            "id": "evt-unsupported",
+            "start": {"dateTime": "2026-03-20T09:00:00+00:00"},
+        },
+    )
+    unsupported_status, unsupported_payload = invoke_request(
+        "POST",
+        f"/v0/calendar-accounts/{account_payload['account']['id']}/events/evt-unsupported/ingest",
+        payload={
+            "user_id": str(owner["user_id"]),
+            "task_workspace_id": workspace_payload["workspace"]["id"],
+        },
+    )
+
+    assert missing_status == 404
+    assert missing_payload == {"detail": "calendar event evt-missing was not found"}
+    assert unsupported_status == 400
+    assert unsupported_payload == {
+        "detail": "calendar event evt-unsupported is not supported for ingestion"
+    }
+
+    with user_connection(migrated_database_urls["app"], owner["user_id"]) as conn:
+        store = ContinuityStore(conn)
+        assert store.list_task_artifacts_for_task(owner["task_id"]) == []

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -577,6 +577,102 @@ def test_gmail_external_secret_manager_migration_round_trip_preserves_legacy_tra
             )
 
 
+def test_calendar_account_migration_round_trip_preserves_table_shape(database_urls):
+    config = make_alembic_config(database_urls["admin"])
+    user_id = "00000000-0000-0000-0000-000000000401"
+    calendar_account_id = "00000000-0000-0000-0000-000000000402"
+
+    command.upgrade(config, "20260316_0029")
+    command.upgrade(config, "20260319_0030")
+
+    with psycopg.connect(database_urls["admin"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO users (id, email, display_name)
+                VALUES (%s, 'calendar-migration@example.com', 'Calendar Migration User')
+                """,
+                (user_id,),
+            )
+            cur.execute(
+                """
+                INSERT INTO calendar_accounts (
+                  id,
+                  user_id,
+                  provider_account_id,
+                  email_address,
+                  display_name,
+                  scope
+                )
+                VALUES (
+                  %s,
+                  %s,
+                  'acct-calendar-001',
+                  'owner@gmail.example',
+                  'Owner',
+                  'https://www.googleapis.com/auth/calendar.readonly'
+                )
+                """,
+                (calendar_account_id, user_id),
+            )
+            cur.execute(
+                """
+                INSERT INTO calendar_account_credentials (
+                  calendar_account_id,
+                  user_id,
+                  auth_kind,
+                  credential_kind,
+                  secret_manager_kind,
+                  secret_ref,
+                  credential_blob
+                )
+                VALUES (
+                  %s,
+                  %s,
+                  'oauth_access_token',
+                  'calendar_oauth_access_token_v1',
+                  'file_v1',
+                  'users/00000000-0000-0000-0000-000000000401/calendar-account-credentials/cred.json',
+                  NULL
+                )
+                """,
+                (calendar_account_id, user_id),
+            )
+        conn.commit()
+
+    with psycopg.connect(database_urls["admin"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                  auth_kind,
+                  credential_kind,
+                  secret_manager_kind,
+                  secret_ref,
+                  credential_blob IS NULL
+                FROM calendar_account_credentials
+                WHERE calendar_account_id = %s
+                """,
+                (calendar_account_id,),
+            )
+            assert cur.fetchone() == (
+                "oauth_access_token",
+                "calendar_oauth_access_token_v1",
+                "file_v1",
+                "users/00000000-0000-0000-0000-000000000401/calendar-account-credentials/cred.json",
+                True,
+            )
+
+    command.downgrade(config, "20260316_0029")
+
+    with psycopg.connect(database_urls["admin"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT to_regclass('public.calendar_account_credentials')")
+            assert cur.fetchone() == (None,)
+            cur.execute("SELECT to_regclass('public.calendar_accounts')")
+            assert cur.fetchone() == (None,)
+
+
 def test_migrations_upgrade_and_downgrade(database_urls):
     config = make_alembic_config(database_urls["admin"])
 

--- a/tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py
+++ b/tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260319_0030_calendar_accounts_and_credentials"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == [
+        module._UPGRADE_SCHEMA_STATEMENT,
+        *module._UPGRADE_GRANT_STATEMENTS,
+        "ALTER TABLE calendar_accounts ENABLE ROW LEVEL SECURITY",
+        "ALTER TABLE calendar_accounts FORCE ROW LEVEL SECURITY",
+        "ALTER TABLE calendar_account_credentials ENABLE ROW LEVEL SECURITY",
+        "ALTER TABLE calendar_account_credentials FORCE ROW LEVEL SECURITY",
+        *module._UPGRADE_POLICY_STATEMENTS,
+    ]
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_calendar_account_privileges_allow_only_expected_runtime_writes() -> None:
+    module = load_migration_module()
+
+    assert module._UPGRADE_GRANT_STATEMENTS == (
+        "GRANT SELECT, INSERT ON calendar_accounts TO alicebot_app",
+        "GRANT SELECT, INSERT ON calendar_account_credentials TO alicebot_app",
+    )

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -1,0 +1,626 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from alicebot_api.artifacts import TaskArtifactAlreadyExistsError
+from alicebot_api.calendar import (
+    CALENDAR_EVENT_ARTIFACT_MEDIA_TYPE,
+    CalendarAccountAlreadyExistsError,
+    CalendarAccountNotFoundError,
+    CalendarCredentialInvalidError,
+    CalendarCredentialNotFoundError,
+    CalendarEventUnsupportedError,
+    build_calendar_event_artifact_relative_path,
+    build_calendar_protected_credential_blob,
+    build_calendar_secret_ref,
+    create_calendar_account_record,
+    get_calendar_account_record,
+    ingest_calendar_event_record,
+    list_calendar_account_records,
+    resolve_calendar_access_token,
+)
+from alicebot_api.calendar_secret_manager import (
+    CALENDAR_SECRET_MANAGER_KIND_FILE_V1,
+    CalendarSecretManagerError,
+)
+from alicebot_api.contracts import CALENDAR_PROTECTED_CREDENTIAL_KIND, CALENDAR_READONLY_SCOPE
+from alicebot_api.contracts import CalendarAccountConnectInput, CalendarEventIngestInput
+from alicebot_api.workspaces import TaskWorkspaceNotFoundError
+
+
+class CalendarStoreStub:
+    def __init__(self) -> None:
+        self.base_time = datetime(2026, 3, 19, 10, 0, tzinfo=UTC)
+        self.calendar_accounts: list[dict[str, object]] = []
+        self.calendar_account_credentials: dict[UUID, dict[str, object]] = {}
+        self.task_workspaces: list[dict[str, object]] = []
+        self.task_artifacts: list[dict[str, object]] = []
+        self.operations: list[tuple[str, object]] = []
+
+    def create_calendar_account(
+        self,
+        *,
+        provider_account_id: str,
+        email_address: str,
+        display_name: str | None,
+        scope: str,
+    ) -> dict[str, object]:
+        row = {
+            "id": uuid4(),
+            "user_id": uuid4(),
+            "provider_account_id": provider_account_id,
+            "email_address": email_address,
+            "display_name": display_name,
+            "scope": scope,
+            "created_at": self.base_time + timedelta(minutes=len(self.calendar_accounts)),
+            "updated_at": self.base_time + timedelta(minutes=len(self.calendar_accounts)),
+        }
+        self.calendar_accounts.append(row)
+        return row
+
+    def create_calendar_account_credential(
+        self,
+        *,
+        calendar_account_id: UUID,
+        auth_kind: str,
+        credential_kind: str,
+        secret_manager_kind: str,
+        secret_ref: str | None,
+        credential_blob: dict[str, object] | None,
+    ) -> dict[str, object]:
+        row = {
+            "calendar_account_id": calendar_account_id,
+            "user_id": next(
+                account["user_id"]
+                for account in self.calendar_accounts
+                if account["id"] == calendar_account_id
+            ),
+            "auth_kind": auth_kind,
+            "credential_kind": credential_kind,
+            "secret_manager_kind": secret_manager_kind,
+            "secret_ref": secret_ref,
+            "credential_blob": credential_blob,
+            "created_at": self.base_time + timedelta(minutes=len(self.calendar_account_credentials)),
+            "updated_at": self.base_time + timedelta(minutes=len(self.calendar_account_credentials)),
+        }
+        self.calendar_account_credentials[calendar_account_id] = row
+        self.operations.append(("create_calendar_account_credential", calendar_account_id))
+        return row
+
+    def get_calendar_account_optional(self, calendar_account_id: UUID) -> dict[str, object] | None:
+        return next(
+            (row for row in self.calendar_accounts if row["id"] == calendar_account_id),
+            None,
+        )
+
+    def get_calendar_account_credential_optional(
+        self,
+        calendar_account_id: UUID,
+    ) -> dict[str, object] | None:
+        self.operations.append(("get_calendar_account_credential_optional", calendar_account_id))
+        return self.calendar_account_credentials.get(calendar_account_id)
+
+    def get_calendar_account_by_provider_account_id_optional(
+        self,
+        provider_account_id: str,
+    ) -> dict[str, object] | None:
+        return next(
+            (
+                row
+                for row in self.calendar_accounts
+                if row["provider_account_id"] == provider_account_id
+            ),
+            None,
+        )
+
+    def list_calendar_accounts(self) -> list[dict[str, object]]:
+        return sorted(
+            self.calendar_accounts,
+            key=lambda row: (row["created_at"], row["id"]),
+        )
+
+    def create_task_workspace(self, *, task_workspace_id: UUID, local_path: str) -> dict[str, object]:
+        row = {
+            "id": task_workspace_id,
+            "user_id": uuid4(),
+            "task_id": uuid4(),
+            "status": "active",
+            "local_path": local_path,
+            "created_at": self.base_time,
+            "updated_at": self.base_time,
+        }
+        self.task_workspaces.append(row)
+        return row
+
+    def get_task_workspace_optional(self, task_workspace_id: UUID) -> dict[str, object] | None:
+        return next(
+            (row for row in self.task_workspaces if row["id"] == task_workspace_id),
+            None,
+        )
+
+    def lock_task_artifacts(self, task_workspace_id: UUID) -> None:
+        self.operations.append(("lock_task_artifacts", task_workspace_id))
+
+    def create_task_artifact(
+        self,
+        *,
+        task_workspace_id: UUID,
+        relative_path: str,
+    ) -> dict[str, object]:
+        row = {
+            "id": uuid4(),
+            "user_id": uuid4(),
+            "task_id": uuid4(),
+            "task_workspace_id": task_workspace_id,
+            "status": "registered",
+            "ingestion_status": "ingested",
+            "relative_path": relative_path,
+            "media_type_hint": CALENDAR_EVENT_ARTIFACT_MEDIA_TYPE,
+            "created_at": self.base_time,
+            "updated_at": self.base_time,
+        }
+        self.task_artifacts.append(row)
+        return row
+
+    def get_task_artifact_by_workspace_relative_path_optional(
+        self,
+        *,
+        task_workspace_id: UUID,
+        relative_path: str,
+    ) -> dict[str, object] | None:
+        self.operations.append(
+            ("get_task_artifact_by_workspace_relative_path_optional", task_workspace_id)
+        )
+        return next(
+            (
+                row
+                for row in self.task_artifacts
+                if row["task_workspace_id"] == task_workspace_id
+                and row["relative_path"] == relative_path
+            ),
+            None,
+        )
+
+
+class CalendarSecretManagerStub:
+    def __init__(self) -> None:
+        self.secrets: dict[str, dict[str, object]] = {}
+        self.operations: list[tuple[str, str]] = []
+
+    @property
+    def kind(self) -> str:
+        return CALENDAR_SECRET_MANAGER_KIND_FILE_V1
+
+    def load_secret(self, *, secret_ref: str) -> dict[str, object]:
+        self.operations.append(("load_secret", secret_ref))
+        try:
+            return dict(self.secrets[secret_ref])
+        except KeyError as exc:
+            raise CalendarSecretManagerError(f"calendar secret {secret_ref} was not found") from exc
+
+    def write_secret(self, *, secret_ref: str, payload: dict[str, object]) -> None:
+        self.operations.append(("write_secret", secret_ref))
+        self.secrets[secret_ref] = dict(payload)
+
+    def delete_secret(self, *, secret_ref: str) -> None:
+        self.operations.append(("delete_secret", secret_ref))
+        self.secrets.pop(secret_ref, None)
+
+
+def test_create_list_and_get_calendar_account_records_are_deterministic() -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    user_id = uuid4()
+
+    first = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=user_id,
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )
+    second = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=user_id,
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-002",
+            email_address="owner+2@example.com",
+            display_name=None,
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-2",
+        ),
+    )
+
+    assert list_calendar_account_records(store, user_id=user_id) == {
+        "items": [first["account"], second["account"]],
+        "summary": {"total_count": 2, "order": ["created_at_asc", "id_asc"]},
+    }
+    assert get_calendar_account_record(
+        store,
+        user_id=user_id,
+        calendar_account_id=UUID(second["account"]["id"]),
+    ) == {"account": second["account"]}
+
+
+def test_create_calendar_account_record_persists_protected_credential_and_hides_secret() -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    user_id = uuid4()
+
+    response = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=user_id,
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )
+
+    account_id = UUID(response["account"]["id"])
+    assert response["account"]["provider"] == "google_calendar"
+    secret_ref = build_calendar_secret_ref(
+        user_id=store.calendar_account_credentials[account_id]["user_id"],
+        calendar_account_id=account_id,
+    )
+    assert store.calendar_account_credentials[account_id]["credential_blob"] is None
+    assert store.calendar_account_credentials[account_id]["credential_kind"] == (
+        CALENDAR_PROTECTED_CREDENTIAL_KIND
+    )
+    assert store.calendar_account_credentials[account_id]["secret_ref"] == secret_ref
+    assert secret_manager.secrets[secret_ref] == {
+        "credential_kind": CALENDAR_PROTECTED_CREDENTIAL_KIND,
+        "access_token": "token-1",
+    }
+
+
+def test_create_calendar_account_record_rejects_duplicate_provider_account_id() -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    request = CalendarAccountConnectInput(
+        provider_account_id="acct-001",
+        email_address="owner@example.com",
+        display_name="Owner",
+        scope=CALENDAR_READONLY_SCOPE,
+        access_token="token-1",
+    )
+    create_calendar_account_record(store, secret_manager, user_id=uuid4(), request=request)
+
+    with pytest.raises(
+        CalendarAccountAlreadyExistsError,
+        match="calendar account acct-001 is already connected",
+    ):
+        create_calendar_account_record(store, secret_manager, user_id=uuid4(), request=request)
+
+
+def test_get_calendar_account_record_raises_when_account_is_missing() -> None:
+    with pytest.raises(CalendarAccountNotFoundError, match="was not found"):
+        get_calendar_account_record(
+            CalendarStoreStub(),
+            user_id=uuid4(),
+            calendar_account_id=uuid4(),
+        )
+
+
+def test_resolve_calendar_access_token_reads_protected_credential() -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    account = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=uuid4(),
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )["account"]
+
+    assert resolve_calendar_access_token(
+        store,
+        secret_manager,
+        calendar_account_id=UUID(account["id"]),
+    ) == "token-1"
+
+
+def test_resolve_calendar_access_token_rejects_missing_and_invalid_protected_credentials() -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    account = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=uuid4(),
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )["account"]
+    account_id = UUID(account["id"])
+
+    store.calendar_account_credentials.pop(account_id)
+    with pytest.raises(
+        CalendarCredentialNotFoundError,
+        match=f"calendar account {account_id} is missing protected credentials",
+    ):
+        resolve_calendar_access_token(store, secret_manager, calendar_account_id=account_id)
+
+    secret_ref = build_calendar_secret_ref(
+        user_id=uuid4(),
+        calendar_account_id=account_id,
+    )
+    store.calendar_account_credentials[account_id] = {
+        "calendar_account_id": account_id,
+        "user_id": uuid4(),
+        "auth_kind": "oauth_access_token",
+        "credential_kind": CALENDAR_PROTECTED_CREDENTIAL_KIND,
+        "secret_manager_kind": CALENDAR_SECRET_MANAGER_KIND_FILE_V1,
+        "secret_ref": secret_ref,
+        "credential_blob": None,
+        "created_at": store.base_time,
+        "updated_at": store.base_time,
+    }
+    secret_manager.secrets[secret_ref] = {
+        "credential_kind": CALENDAR_PROTECTED_CREDENTIAL_KIND,
+        "access_token": "",
+    }
+
+    with pytest.raises(
+        CalendarCredentialInvalidError,
+        match=f"calendar account {account_id} has invalid protected credentials",
+    ):
+        resolve_calendar_access_token(store, secret_manager, calendar_account_id=account_id)
+
+
+def test_ingest_calendar_event_record_writes_text_artifact_and_reuses_artifact_seam(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    user_id = uuid4()
+    workspace_id = uuid4()
+    workspace = store.create_task_workspace(
+        task_workspace_id=workspace_id,
+        local_path=str((tmp_path / "workspace").resolve()),
+    )
+    account = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=user_id,
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )["account"]
+
+    monkeypatch.setattr(
+        "alicebot_api.calendar.fetch_calendar_event_payload",
+        lambda **_kwargs: {
+            "id": "evt-001",
+            "summary": "Sprint planning",
+            "description": "Discuss sprint goals",
+            "status": "confirmed",
+            "start": {"dateTime": "2026-03-20T09:00:00+00:00"},
+            "end": {"dateTime": "2026-03-20T09:30:00+00:00"},
+        },
+    )
+
+    def fake_register(_store, *, user_id: UUID, request):
+        path = Path(request.local_path)
+        assert "Summary: Sprint planning" in path.read_text(encoding="utf-8")
+        return {
+            "artifact": {
+                "id": "00000000-0000-0000-0000-000000000123",
+                "task_id": str(workspace["task_id"]),
+                "task_workspace_id": str(workspace_id),
+                "status": "registered",
+                "ingestion_status": "pending",
+                "relative_path": path.relative_to(Path(workspace["local_path"])).as_posix(),
+                "media_type_hint": CALENDAR_EVENT_ARTIFACT_MEDIA_TYPE,
+                "created_at": "2026-03-19T10:00:00+00:00",
+                "updated_at": "2026-03-19T10:00:00+00:00",
+            }
+        }
+
+    monkeypatch.setattr("alicebot_api.calendar.register_task_artifact_record", fake_register)
+    monkeypatch.setattr(
+        "alicebot_api.calendar.ingest_task_artifact_record",
+        lambda _store, *, user_id, request: {
+            "artifact": {
+                "id": "00000000-0000-0000-0000-000000000123",
+                "task_id": str(workspace["task_id"]),
+                "task_workspace_id": str(workspace_id),
+                "status": "registered",
+                "ingestion_status": "ingested",
+                "relative_path": build_calendar_event_artifact_relative_path(
+                    provider_account_id="acct-001",
+                    provider_event_id="evt-001",
+                ),
+                "media_type_hint": CALENDAR_EVENT_ARTIFACT_MEDIA_TYPE,
+                "created_at": "2026-03-19T10:00:00+00:00",
+                "updated_at": "2026-03-19T10:00:01+00:00",
+            },
+            "summary": {
+                "total_count": 1,
+                "total_characters": 32,
+                "media_type": CALENDAR_EVENT_ARTIFACT_MEDIA_TYPE,
+                "chunking_rule": "normalized_utf8_text_fixed_window_1000_chars_v1",
+                "order": ["sequence_no_asc", "id_asc"],
+            },
+        },
+    )
+
+    response = ingest_calendar_event_record(
+        store,
+        secret_manager,
+        user_id=user_id,
+        request=CalendarEventIngestInput(
+            calendar_account_id=UUID(account["id"]),
+            task_workspace_id=workspace_id,
+            provider_event_id="evt-001",
+        ),
+    )
+
+    assert response["account"] == account
+    assert response["event"] == {
+        "provider_event_id": "evt-001",
+        "artifact_relative_path": "calendar/acct-001/evt-001.txt",
+        "media_type": CALENDAR_EVENT_ARTIFACT_MEDIA_TYPE,
+    }
+    assert response["artifact"]["relative_path"] == "calendar/acct-001/evt-001.txt"
+
+
+def test_ingest_calendar_event_record_rejects_duplicate_sanitized_path_before_fetch_or_write(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    workspace_id = uuid4()
+    workspace_path = (tmp_path / "workspace").resolve()
+    store.create_task_workspace(
+        task_workspace_id=workspace_id,
+        local_path=str(workspace_path),
+    )
+    account = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=uuid4(),
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )["account"]
+    relative_path = build_calendar_event_artifact_relative_path(
+        provider_account_id="acct-001",
+        provider_event_id="evt/001",
+    )
+    store.create_task_artifact(
+        task_workspace_id=workspace_id,
+        relative_path=relative_path,
+    )
+
+    monkeypatch.setattr(
+        "alicebot_api.calendar.fetch_calendar_event_payload",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("fetch_calendar_event_payload should not be called")
+        ),
+    )
+
+    with pytest.raises(
+        TaskArtifactAlreadyExistsError,
+        match=f"artifact {relative_path} is already registered for task workspace {workspace_id}",
+    ):
+        ingest_calendar_event_record(
+            store,
+            secret_manager,
+            user_id=uuid4(),
+            request=CalendarEventIngestInput(
+                calendar_account_id=UUID(account["id"]),
+                task_workspace_id=workspace_id,
+                provider_event_id="evt:001",
+            ),
+        )
+
+
+def test_ingest_calendar_event_record_requires_visible_workspace() -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    account = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=uuid4(),
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )["account"]
+
+    with pytest.raises(TaskWorkspaceNotFoundError, match="task workspace .* was not found"):
+        ingest_calendar_event_record(
+            store,
+            secret_manager,
+            user_id=uuid4(),
+            request=CalendarEventIngestInput(
+                calendar_account_id=UUID(account["id"]),
+                task_workspace_id=uuid4(),
+                provider_event_id="evt-001",
+            ),
+        )
+
+
+def test_ingest_calendar_event_record_rejects_unsupported_event(monkeypatch, tmp_path) -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    workspace_id = uuid4()
+    store.create_task_workspace(
+        task_workspace_id=workspace_id,
+        local_path=str((tmp_path / "workspace").resolve()),
+    )
+    account = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=uuid4(),
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )["account"]
+
+    monkeypatch.setattr(
+        "alicebot_api.calendar.fetch_calendar_event_payload",
+        lambda **_kwargs: {"id": "evt-unsupported", "start": {"dateTime": "2026-03-20T09:00:00+00:00"}},
+    )
+
+    with pytest.raises(
+        CalendarEventUnsupportedError,
+        match="calendar event evt-unsupported is not supported for ingestion",
+    ):
+        ingest_calendar_event_record(
+            store,
+            secret_manager,
+            user_id=uuid4(),
+            request=CalendarEventIngestInput(
+                calendar_account_id=UUID(account["id"]),
+                task_workspace_id=workspace_id,
+                provider_event_id="evt-unsupported",
+            ),
+        )
+
+
+def test_build_calendar_protected_credential_blob_rejects_empty_token() -> None:
+    with pytest.raises(
+        ValueError,
+        match="calendar access token must be non-empty",
+    ):
+        build_calendar_protected_credential_blob(access_token="")

--- a/tests/unit/test_calendar_main.py
+++ b/tests/unit/test_calendar_main.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from uuid import uuid4
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+from alicebot_api.calendar import (
+    CalendarAccountAlreadyExistsError,
+    CalendarAccountNotFoundError,
+    CalendarCredentialInvalidError,
+    CalendarCredentialNotFoundError,
+    CalendarCredentialPersistenceError,
+    CalendarCredentialValidationError,
+    CalendarEventFetchError,
+    CalendarEventNotFoundError,
+    CalendarEventUnsupportedError,
+)
+from alicebot_api.workspaces import TaskWorkspaceNotFoundError
+
+
+def _settings() -> Settings:
+    return Settings(
+        database_url="postgresql://app",
+        calendar_secret_manager_url="file:///tmp/test-calendar-secrets",
+    )
+
+
+def test_list_calendar_accounts_endpoint_returns_payload(monkeypatch) -> None:
+    user_id = uuid4()
+    settings = _settings()
+
+    @contextmanager
+    def fake_user_connection(*_args, **_kwargs):
+        yield object()
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(
+        main_module,
+        "list_calendar_account_records",
+        lambda *_args, **_kwargs: {
+            "items": [],
+            "summary": {"total_count": 0, "order": ["created_at_asc", "id_asc"]},
+        },
+    )
+
+    response = main_module.list_calendar_accounts(user_id)
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {
+        "items": [],
+        "summary": {"total_count": 0, "order": ["created_at_asc", "id_asc"]},
+    }
+
+
+def test_connect_calendar_account_endpoint_maps_duplicate_to_409(monkeypatch) -> None:
+    user_id = uuid4()
+    settings = _settings()
+
+    @contextmanager
+    def fake_user_connection(*_args, **_kwargs):
+        yield object()
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(
+        main_module,
+        "create_calendar_account_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarAccountAlreadyExistsError("calendar account acct-001 is already connected")
+        ),
+    )
+
+    response = main_module.connect_calendar_account(
+        main_module.ConnectCalendarAccountRequest(
+            user_id=user_id,
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            access_token="token-1",
+        )
+    )
+
+    assert response.status_code == 409
+    assert json.loads(response.body) == {
+        "detail": "calendar account acct-001 is already connected"
+    }
+
+
+def test_connect_calendar_account_endpoint_maps_validation_and_persistence_errors(monkeypatch) -> None:
+    user_id = uuid4()
+    settings = _settings()
+
+    @contextmanager
+    def fake_user_connection(*_args, **_kwargs):
+        yield object()
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+
+    monkeypatch.setattr(
+        main_module,
+        "create_calendar_account_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarCredentialValidationError("calendar access token must be non-empty")
+        ),
+    )
+    response = main_module.connect_calendar_account(
+        main_module.ConnectCalendarAccountRequest(
+            user_id=user_id,
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            access_token="token-1",
+        )
+    )
+    assert response.status_code == 400
+    assert json.loads(response.body) == {"detail": "calendar access token must be non-empty"}
+
+    monkeypatch.setattr(
+        main_module,
+        "create_calendar_account_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarCredentialPersistenceError("calendar protected credentials could not be persisted")
+        ),
+    )
+    response = main_module.connect_calendar_account(
+        main_module.ConnectCalendarAccountRequest(
+            user_id=user_id,
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            access_token="token-1",
+        )
+    )
+    assert response.status_code == 409
+    assert json.loads(response.body) == {
+        "detail": "calendar protected credentials could not be persisted"
+    }
+
+
+def test_get_calendar_account_endpoint_maps_not_found_to_404(monkeypatch) -> None:
+    user_id = uuid4()
+    calendar_account_id = uuid4()
+    settings = _settings()
+
+    @contextmanager
+    def fake_user_connection(*_args, **_kwargs):
+        yield object()
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(
+        main_module,
+        "get_calendar_account_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarAccountNotFoundError(f"calendar account {calendar_account_id} was not found")
+        ),
+    )
+
+    response = main_module.get_calendar_account(calendar_account_id, user_id)
+
+    assert response.status_code == 404
+    assert json.loads(response.body) == {
+        "detail": f"calendar account {calendar_account_id} was not found"
+    }
+
+
+def test_ingest_calendar_event_endpoint_maps_workspace_not_found_to_404(monkeypatch) -> None:
+    user_id = uuid4()
+    calendar_account_id = uuid4()
+    task_workspace_id = uuid4()
+    settings = _settings()
+
+    @contextmanager
+    def fake_user_connection(*_args, **_kwargs):
+        yield object()
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(
+        main_module,
+        "ingest_calendar_event_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            TaskWorkspaceNotFoundError(f"task workspace {task_workspace_id} was not found")
+        ),
+    )
+
+    response = main_module.ingest_calendar_event(
+        calendar_account_id,
+        "evt-001",
+        main_module.IngestCalendarEventRequest(
+            user_id=user_id,
+            task_workspace_id=task_workspace_id,
+        ),
+    )
+
+    assert response.status_code == 404
+    assert json.loads(response.body) == {
+        "detail": f"task workspace {task_workspace_id} was not found"
+    }
+
+
+def test_ingest_calendar_event_endpoint_maps_upstream_errors(monkeypatch) -> None:
+    user_id = uuid4()
+    calendar_account_id = uuid4()
+    task_workspace_id = uuid4()
+    settings = _settings()
+
+    @contextmanager
+    def fake_user_connection(*_args, **_kwargs):
+        yield object()
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+
+    monkeypatch.setattr(
+        main_module,
+        "ingest_calendar_event_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarEventNotFoundError("calendar event evt-missing was not found")
+        ),
+    )
+    response = main_module.ingest_calendar_event(
+        calendar_account_id,
+        "evt-missing",
+        main_module.IngestCalendarEventRequest(
+            user_id=user_id,
+            task_workspace_id=task_workspace_id,
+        ),
+    )
+    assert response.status_code == 404
+    assert json.loads(response.body) == {"detail": "calendar event evt-missing was not found"}
+
+    monkeypatch.setattr(
+        main_module,
+        "ingest_calendar_event_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarEventUnsupportedError("calendar event evt-unsupported is not supported for ingestion")
+        ),
+    )
+    response = main_module.ingest_calendar_event(
+        calendar_account_id,
+        "evt-unsupported",
+        main_module.IngestCalendarEventRequest(
+            user_id=user_id,
+            task_workspace_id=task_workspace_id,
+        ),
+    )
+    assert response.status_code == 400
+    assert json.loads(response.body) == {
+        "detail": "calendar event evt-unsupported is not supported for ingestion"
+    }
+
+    monkeypatch.setattr(
+        main_module,
+        "ingest_calendar_event_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarCredentialNotFoundError(
+                f"calendar account {calendar_account_id} is missing protected credentials"
+            )
+        ),
+    )
+    response = main_module.ingest_calendar_event(
+        calendar_account_id,
+        "evt-001",
+        main_module.IngestCalendarEventRequest(
+            user_id=user_id,
+            task_workspace_id=task_workspace_id,
+        ),
+    )
+    assert response.status_code == 409
+    assert json.loads(response.body) == {
+        "detail": f"calendar account {calendar_account_id} is missing protected credentials"
+    }
+
+    monkeypatch.setattr(
+        main_module,
+        "ingest_calendar_event_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarCredentialInvalidError(
+                f"calendar account {calendar_account_id} has invalid protected credentials"
+            )
+        ),
+    )
+    response = main_module.ingest_calendar_event(
+        calendar_account_id,
+        "evt-001",
+        main_module.IngestCalendarEventRequest(
+            user_id=user_id,
+            task_workspace_id=task_workspace_id,
+        ),
+    )
+    assert response.status_code == 409
+    assert json.loads(response.body) == {
+        "detail": f"calendar account {calendar_account_id} has invalid protected credentials"
+    }
+
+    monkeypatch.setattr(
+        main_module,
+        "ingest_calendar_event_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarCredentialPersistenceError(
+                f"calendar account {calendar_account_id} protected credentials could not be persisted"
+            )
+        ),
+    )
+    response = main_module.ingest_calendar_event(
+        calendar_account_id,
+        "evt-001",
+        main_module.IngestCalendarEventRequest(
+            user_id=user_id,
+            task_workspace_id=task_workspace_id,
+        ),
+    )
+    assert response.status_code == 409
+    assert json.loads(response.body) == {
+        "detail": f"calendar account {calendar_account_id} protected credentials could not be persisted"
+    }
+
+    monkeypatch.setattr(
+        main_module,
+        "ingest_calendar_event_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarEventFetchError("calendar event evt-001 could not be fetched")
+        ),
+    )
+    response = main_module.ingest_calendar_event(
+        calendar_account_id,
+        "evt-001",
+        main_module.IngestCalendarEventRequest(
+            user_id=user_id,
+            task_workspace_id=task_workspace_id,
+        ),
+    )
+    assert response.status_code == 502
+    assert json.loads(response.body) == {
+        "detail": "calendar event evt-001 could not be fetched"
+    }

--- a/tests/unit/test_calendar_secret_manager.py
+++ b/tests/unit/test_calendar_secret_manager.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from alicebot_api.calendar_secret_manager import (
+    CalendarSecretManagerError,
+    build_calendar_secret_manager,
+)
+
+
+def test_build_calendar_secret_manager_rejects_non_file_schemes() -> None:
+    with pytest.raises(ValueError, match="CALENDAR_SECRET_MANAGER_URL must use the file:// scheme"):
+        build_calendar_secret_manager("memory://calendar-secrets")
+
+
+def test_build_calendar_secret_manager_requires_explicit_configuration() -> None:
+    with pytest.raises(ValueError, match="CALENDAR_SECRET_MANAGER_URL must be configured"):
+        build_calendar_secret_manager("")
+
+
+def test_file_calendar_secret_manager_round_trips_secret_payload(tmp_path) -> None:
+    manager = build_calendar_secret_manager(tmp_path.resolve().as_uri())
+    secret_ref = "users/00000000-0000-0000-0000-000000000001/calendar-account-credentials/cred.json"
+    payload = {
+        "credential_kind": "calendar_oauth_access_token_v1",
+        "access_token": "token-001",
+    }
+
+    manager.write_secret(secret_ref=secret_ref, payload=payload)
+
+    assert manager.load_secret(secret_ref=secret_ref) == payload
+
+
+def test_file_calendar_secret_manager_rejects_missing_or_escaped_refs(tmp_path) -> None:
+    manager = build_calendar_secret_manager(tmp_path.resolve().as_uri())
+
+    with pytest.raises(CalendarSecretManagerError, match="was not found"):
+        manager.load_secret(secret_ref="users/u/calendar-account-credentials/missing.json")
+
+    with pytest.raises(CalendarSecretManagerError, match="outside the configured root"):
+        manager.write_secret(
+            secret_ref="../../escape.json",
+            payload={"credential_kind": "calendar_oauth_access_token_v1", "access_token": "token"},
+        )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,6 +25,7 @@ def test_settings_defaults(monkeypatch):
         "MODEL_TIMEOUT_SECONDS",
         "TASK_WORKSPACE_ROOT",
         "GMAIL_SECRET_MANAGER_URL",
+        "CALENDAR_SECRET_MANAGER_URL",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -41,6 +42,7 @@ def test_settings_defaults(monkeypatch):
     assert settings.model_timeout_seconds == 30
     assert settings.task_workspace_root == "/tmp/alicebot/task-workspaces"
     assert settings.gmail_secret_manager_url == ""
+    assert settings.calendar_secret_manager_url == ""
 
 
 def test_settings_honor_environment_overrides(monkeypatch):
@@ -53,6 +55,7 @@ def test_settings_honor_environment_overrides(monkeypatch):
     monkeypatch.setenv("MODEL_TIMEOUT_SECONDS", "45")
     monkeypatch.setenv("TASK_WORKSPACE_ROOT", "/tmp/custom-workspaces")
     monkeypatch.setenv("GMAIL_SECRET_MANAGER_URL", "file:///tmp/custom-gmail-secrets")
+    monkeypatch.setenv("CALENDAR_SECRET_MANAGER_URL", "file:///tmp/custom-calendar-secrets")
 
     settings = Settings.from_env()
 
@@ -65,6 +68,7 @@ def test_settings_honor_environment_overrides(monkeypatch):
     assert settings.model_timeout_seconds == 45
     assert settings.task_workspace_root == "/tmp/custom-workspaces"
     assert settings.gmail_secret_manager_url == "file:///tmp/custom-gmail-secrets"
+    assert settings.calendar_secret_manager_url == "file:///tmp/custom-calendar-secrets"
 
 
 def test_settings_can_be_loaded_from_an_explicit_environment_mapping() -> None:
@@ -77,6 +81,7 @@ def test_settings_can_be_loaded_from_an_explicit_environment_mapping() -> None:
             "MODEL_NAME": "gpt-5-mini",
             "TASK_WORKSPACE_ROOT": "/tmp/mapped-workspaces",
             "GMAIL_SECRET_MANAGER_URL": "file:///tmp/mapped-gmail-secrets",
+            "CALENDAR_SECRET_MANAGER_URL": "file:///tmp/mapped-calendar-secrets",
         }
     )
 
@@ -87,6 +92,7 @@ def test_settings_can_be_loaded_from_an_explicit_environment_mapping() -> None:
     assert settings.model_name == "gpt-5-mini"
     assert settings.task_workspace_root == "/tmp/mapped-workspaces"
     assert settings.gmail_secret_manager_url == "file:///tmp/mapped-gmail-secrets"
+    assert settings.calendar_secret_manager_url == "file:///tmp/mapped-calendar-secrets"
 
 
 def test_settings_raise_clear_error_for_invalid_integer_values() -> None:


### PR DESCRIPTION
Backend sprint limited to read-only Calendar account connection metadata and selected-event ingestion over shipped seams. Verification passed: ./.venv/bin/python -m pytest tests/unit and ./.venv/bin/python -m pytest tests/integration.