### PR TITLE
Sprint 6V: Calendar account review and single-event ingestion UI

### DIFF
--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,181 +1,96 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Sprint 6U: add a narrow read-only Calendar connector seam that supports user-scoped calendar account connection metadata and explicit single-event ingestion into existing task artifact/chunk seams.
+Implement Sprint 6V: add a bounded `/calendar` workspace in the web shell for Calendar account review, selected account detail, explicit Calendar account connection, and explicit single-event ingestion into one selected task workspace using only shipped backend seams.
 
 ## Completed Work
-- Added Calendar schema + migration support:
-  - `calendar_accounts`
-  - `calendar_account_credentials`
-  - RLS, owner policies, and runtime grants aligned with existing connector patterns.
-- Added Calendar protected credential storage path with file-based external secret manager semantics:
-  - secret ref format: `users/{user_id}/calendar-account-credentials/{calendar_account_id}.json`
-  - credential metadata persisted in `calendar_account_credentials`
-  - credential payload externalized (`credential_blob` remains `NULL`)
-- Added stable Calendar contracts:
-  - account connect input/response
-  - account list/detail responses
-  - selected-event ingestion input/response
-- Added Calendar store seams:
-  - create/list/detail account methods
-  - credential create/read methods
-- Added Calendar service seam (`calendar.py`):
-  - deterministic create/list/detail account behavior
-  - explicit event fetch by provider event id only
-  - event conversion into `text/plain` artifact content
-  - registration + ingestion through existing task artifact/chunk pipeline
-  - deterministic error surfaces for not-found/unsupported/credential/fetch cases
-- Added Calendar secret manager module mirroring existing connector secret-manager rules.
-- Added Calendar API endpoints:
+- Added Calendar API typing + helper methods in `apps/web/lib/api.ts` for:
   - `POST /v0/calendar-accounts`
   - `GET /v0/calendar-accounts`
   - `GET /v0/calendar-accounts/{calendar_account_id}`
   - `POST /v0/calendar-accounts/{calendar_account_id}/events/{provider_event_id}/ingest`
-- Added unit and integration tests for persistence, deterministic listing, ingestion routing, stable response shape, cross-user isolation, and deterministic missing/unsupported failures.
-- Synced docs to implemented state so Calendar is no longer described as future/absent:
-  - `ARCHITECTURE.md`
-  - `README.md`
+  - `GET /v0/task-workspaces` (already present; reused for Calendar ingestion target selection)
+- Added Calendar fixtures/helpers in `apps/web/lib/fixtures.ts`:
+  - `calendarAccountFixtures`
+  - `calendarAccountListSummaryFixture`
+  - `getFixtureCalendarAccount(...)`
+- Added `/calendar` route and loading state:
+  - `apps/web/app/calendar/page.tsx`
+  - `apps/web/app/calendar/loading.tsx`
+- Added scoped Calendar components:
+  - `calendar-account-list`
+  - `calendar-account-detail`
+  - `calendar-account-connect-form`
+  - `calendar-event-ingest-form`
+  - `calendar-ingestion-summary`
+- Added shell integration for discoverability:
+  - Calendar navigation item in `apps/web/components/app-shell.tsx`
+  - Calendar card and updated counts in `apps/web/app/page.tsx`
+  - Calendar mention in `apps/web/app/layout.tsx` metadata
+- Added minimal style integration for Calendar layout wrappers in `apps/web/app/globals.css`:
+  - `calendar-layout`
+  - `calendar-action-grid`
+  - responsive collapse at existing breakpoints
+- Added test coverage:
+  - Calendar API endpoint helper assertions in `apps/web/lib/api.test.ts`
+  - Calendar account list rendering behavior test
+  - Calendar event ingestion form behavior test
 
-## Exact Contract Changes Introduced
-- New constants in `apps/api/src/alicebot_api/contracts.py`:
-  - `CALENDAR_ACCOUNT_LIST_ORDER = ["created_at_asc", "id_asc"]`
-  - `CALENDAR_PROVIDER = "google_calendar"`
-  - `CALENDAR_AUTH_KIND_OAUTH_ACCESS_TOKEN = "oauth_access_token"`
-  - `CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"`
-  - `CALENDAR_PROTECTED_CREDENTIAL_KIND = "calendar_oauth_access_token_v1"`
-- New dataclasses:
-  - `CalendarAccountConnectInput`
-  - `CalendarEventIngestInput`
-- New typed responses/records:
-  - `CalendarAccountRecord`
-  - `CalendarAccountConnectResponse`
-  - `CalendarAccountListSummary`
-  - `CalendarAccountListResponse`
-  - `CalendarAccountDetailResponse`
-  - `CalendarEventIngestionRecord`
-  - `CalendarEventIngestionResponse`
-
-## Calendar Event-to-Artifact Conversion Rule
-- Fetch one explicit provider event id from Google Calendar events API (`/calendar/v3/calendars/primary/events/{event_id}`).
-- Require event shape to include:
-  - non-empty `id`
-  - `start.dateTime` or `start.date`
-  - `end.dateTime` or `end.date`
-- If shape is missing required fields, fail deterministically with:
-  - `calendar event {provider_event_id} is not supported for ingestion`
-- Convert event payload into normalized UTF-8 `text/plain` document containing deterministic labeled lines:
-  - provider metadata
-  - requested/source event ids
-  - status/summary/location/start/end/organizer/html link
-  - description block
-- Persist to workspace path:
-  - `calendar/{sanitized_provider_account_id}/{sanitized_provider_event_id}.txt`
-- Register and ingest through existing `task_artifacts` and `task_artifact_chunks` seams.
+## Calendar Surface Backing Mode
+- `calendar-account-list`: live API when configured; fixture-backed fallback when live config is absent or live list read fails; explicit unavailable state when source is unavailable and no accounts are present.
+- `calendar-account-detail`: live API detail when configured and list is live; fixture fallback for selected account detail failure; explicit unavailable state when no fallback exists.
+- `calendar-account-connect-form`: live-only write action (`POST /v0/calendar-accounts`); explicit unavailable/disabled behavior without live API config.
+- `calendar-event-ingest-form`: live-only write action (`POST /v0/calendar-accounts/{id}/events/{provider_event_id}/ingest`) gated on live account detail + live task workspace list + live API config.
+- `calendar-ingestion-summary`: live result display after successful ingestion; explicit idle and unavailable states otherwise.
+- `/calendar` page mode chip: `Live API`, `Fixture-backed`, or `Mixed fallback` via `combinePageModes(...)`.
 
 ## Incomplete Work
-- None for the scoped Sprint 6U deliverables.
+- None for Sprint 6V in-scope deliverables.
 
 ## Files Changed
-- `apps/api/alembic/versions/20260319_0030_calendar_accounts_and_credentials.py`
-- `ARCHITECTURE.md`
-- `README.md`
-- `apps/api/src/alicebot_api/calendar.py`
-- `apps/api/src/alicebot_api/calendar_secret_manager.py`
-- `apps/api/src/alicebot_api/config.py`
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/store.py`
-- `tests/integration/test_calendar_accounts_api.py`
-- `tests/integration/test_migrations.py`
-- `tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py`
-- `tests/unit/test_calendar.py`
-- `tests/unit/test_calendar_main.py`
-- `tests/unit/test_calendar_secret_manager.py`
-- `tests/unit/test_config.py`
+- `apps/web/app/layout.tsx`
+- `apps/web/app/page.tsx`
+- `apps/web/app/calendar/page.tsx`
+- `apps/web/app/calendar/loading.tsx`
+- `apps/web/app/globals.css`
+- `apps/web/components/app-shell.tsx`
+- `apps/web/components/calendar-account-list.tsx`
+- `apps/web/components/calendar-account-detail.tsx`
+- `apps/web/components/calendar-account-connect-form.tsx`
+- `apps/web/components/calendar-event-ingest-form.tsx`
+- `apps/web/components/calendar-ingestion-summary.tsx`
+- `apps/web/lib/api.ts`
+- `apps/web/lib/fixtures.ts`
+- `apps/web/lib/api.test.ts`
+- `apps/web/components/calendar-account-list.test.tsx`
+- `apps/web/components/calendar-event-ingest-form.test.tsx`
 - `BUILD_REPORT.md`
 
 ## Tests Run
 ### Exact Commands
-- `./.venv/bin/python -m pytest tests/unit/test_calendar.py tests/unit/test_calendar_main.py tests/unit/test_calendar_secret_manager.py tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py tests/unit/test_config.py -q`
-- `./.venv/bin/python -m pytest tests/unit`
-- `./.venv/bin/python -m pytest tests/integration`
+- `npm run lint` (run in `apps/web`)
+- `npm test` (run in `apps/web`)
+- `npm run build` (run in `apps/web`)
 
 ### Results
-- Targeted unit tests: PASS (`28 passed`)
-- Full unit suite: PASS (`478 passed`)
-- Full integration suite: PASS (`150 passed`)
+- `npm run lint`: PASS
+- `npm test`: PASS (`29` files, `89` tests)
+- `npm run build`: PASS (Next.js production build succeeded; `/calendar` route generated)
 
-## Example Calendar Account Response
-```json
-{
-  "account": {
-    "id": "3e4c7d67-cf56-4cd5-a8c0-8d4d18e7f1f2",
-    "provider": "google_calendar",
-    "auth_kind": "oauth_access_token",
-    "provider_account_id": "acct-owner-001",
-    "email_address": "owner@gmail.example",
-    "display_name": "Owner",
-    "scope": "https://www.googleapis.com/auth/calendar.readonly",
-    "created_at": "2026-03-19T10:00:00+00:00",
-    "updated_at": "2026-03-19T10:00:00+00:00"
-  }
-}
-```
-
-## Example Selected-Event Ingestion Response
-```json
-{
-  "account": {
-    "id": "3e4c7d67-cf56-4cd5-a8c0-8d4d18e7f1f2",
-    "provider": "google_calendar",
-    "auth_kind": "oauth_access_token",
-    "provider_account_id": "acct-owner-001",
-    "email_address": "owner@gmail.example",
-    "display_name": "Owner",
-    "scope": "https://www.googleapis.com/auth/calendar.readonly",
-    "created_at": "2026-03-19T10:00:00+00:00",
-    "updated_at": "2026-03-19T10:00:00+00:00"
-  },
-  "event": {
-    "provider_event_id": "evt-001",
-    "artifact_relative_path": "calendar/acct-owner-001/evt-001.txt",
-    "media_type": "text/plain"
-  },
-  "artifact": {
-    "id": "6fd2c8f1-a3a1-4272-8e46-7900f8f6d2c9",
-    "task_id": "fb3f9ab8-55ce-4237-b43e-f393dcb5a6d2",
-    "task_workspace_id": "c6b542ff-7d67-42ed-a7ea-cf0a6f3b0366",
-    "status": "registered",
-    "ingestion_status": "ingested",
-    "relative_path": "calendar/acct-owner-001/evt-001.txt",
-    "media_type_hint": "text/plain",
-    "created_at": "2026-03-19T10:00:00+00:00",
-    "updated_at": "2026-03-19T10:00:01+00:00"
-  },
-  "summary": {
-    "total_count": 1,
-    "total_characters": 312,
-    "media_type": "text/plain",
-    "chunking_rule": "normalized_utf8_text_fixed_window_1000_chars_v1",
-    "order": ["sequence_no_asc", "id_asc"]
-  }
-}
-```
+## Desktop and Mobile Visual Verification Notes
+- Desktop verification (code-level): `/calendar` uses two-column `calendar-layout` (account list + selected detail) and two-column `calendar-action-grid` (connect + ingest stack), matching existing bounded workspace patterns.
+- Mobile/tablet verification (code-level): `calendar-layout` and `calendar-action-grid` collapse to one column under `@media (max-width: 1120px)`; form two-up fields collapse to single column under `@media (max-width: 740px)`.
 
 ## Blockers / Issues
-- No functional implementation blockers.
-- Note: integration tests require reachable local Postgres; once available, full integration suite passes.
+- No implementation blockers.
+- No backend changes were required.
 
 ## Intentionally Deferred Scope
-- Calendar UI.
-- Calendar search/list-events APIs.
-- Recurring event expansion.
-- Background sync/backfill.
-- Write-capable calendar actions.
-- Gmail scope expansion.
-- Compile contract changes.
-- Runner orchestration changes.
-- Auth redesign.
+- Calendar event list/search UI.
+- Recurrence expansion, sync, or backfill controls.
+- Calendar write actions.
+- Artifact editing from Calendar workspace.
+- Gmail/auth/runner/backend scope expansion.
 
 ## Recommended Next Step
-Proceed to reviewer verification focused on sprint-scope boundaries and deterministic isolation behavior, then open the sprint PR for Control Tower approval.
+Run sprint review against `/calendar` UI behavior and scope boundaries, then open/merge the sprint PR per Control Tower policy if reviewer outcome is `PASS`.

--- a/apps/web/app/calendar/loading.tsx
+++ b/apps/web/app/calendar/loading.tsx
@@ -1,0 +1,78 @@
+import { PageHeader } from "../../components/page-header";
+import { SectionCard } from "../../components/section-card";
+import { StatusBadge } from "../../components/status-badge";
+
+export default function Loading() {
+  return (
+    <div className="page-stack" aria-busy="true">
+      <PageHeader
+        eyebrow="Calendar"
+        title="Calendar account review workspace"
+        description="Loading connected account list, selected account detail, connect controls, and single-event ingestion controls."
+        meta={
+          <div className="header-meta">
+            <span className="subtle-chip">Loading route state</span>
+          </div>
+        }
+      />
+
+      <div className="calendar-layout">
+        <SectionCard
+          eyebrow="Account list"
+          title="Loading connected accounts"
+          description="Calendar account rows are loading from the current source."
+          className="loading-card"
+        >
+          <div className="detail-stack">
+            <StatusBadge status="loading" label="Loading" />
+            <div className="loading-placeholder loading-placeholder--card" />
+            <div className="loading-placeholder loading-placeholder--card" />
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          eyebrow="Selected account"
+          title="Loading selected account"
+          description="Account metadata and scope summary are loading."
+          className="loading-card"
+        >
+          <div className="detail-stack">
+            <StatusBadge status="loading" label="Loading" />
+            <div className="loading-placeholder loading-placeholder--line loading-placeholder--wide" />
+            <div className="loading-placeholder loading-placeholder--line" />
+            <div className="loading-placeholder loading-placeholder--card" />
+          </div>
+        </SectionCard>
+      </div>
+
+      <div className="calendar-action-grid">
+        <SectionCard
+          eyebrow="Connect account"
+          title="Loading connect controls"
+          description="Bounded connect-account fields are loading."
+          className="loading-card"
+        >
+          <div className="detail-stack">
+            <StatusBadge status="loading" label="Loading" />
+            <div className="loading-placeholder loading-placeholder--line loading-placeholder--wide" />
+            <div className="loading-placeholder loading-placeholder--card" />
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          eyebrow="Ingest event"
+          title="Loading ingestion controls"
+          description="Provider-event and task-workspace controls are loading."
+          className="loading-card"
+        >
+          <div className="detail-stack">
+            <StatusBadge status="loading" label="Loading" />
+            <div className="loading-placeholder loading-placeholder--line loading-placeholder--wide" />
+            <div className="loading-placeholder loading-placeholder--line" />
+            <div className="loading-placeholder loading-placeholder--button" />
+          </div>
+        </SectionCard>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/calendar/page.tsx
+++ b/apps/web/app/calendar/page.tsx
@@ -1,0 +1,191 @@
+import { CalendarAccountConnectForm } from "../../components/calendar-account-connect-form";
+import { CalendarAccountDetail } from "../../components/calendar-account-detail";
+import { CalendarAccountList } from "../../components/calendar-account-list";
+import { CalendarEventIngestForm } from "../../components/calendar-event-ingest-form";
+import { PageHeader } from "../../components/page-header";
+import type { ApiSource, CalendarAccountListSummary, CalendarAccountRecord } from "../../lib/api";
+import {
+  combinePageModes,
+  getApiConfig,
+  getCalendarAccountDetail,
+  hasLiveApiConfig,
+  listCalendarAccounts,
+  listTaskWorkspaces,
+  pageModeLabel,
+} from "../../lib/api";
+import {
+  calendarAccountFixtures,
+  calendarAccountListSummaryFixture,
+  getFixtureCalendarAccount,
+  taskWorkspaceFixtures,
+  taskWorkspaceListSummaryFixture,
+} from "../../lib/fixtures";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+function normalizeParam(value: string | string[] | undefined) {
+  if (Array.isArray(value)) {
+    return normalizeParam(value[0]);
+  }
+
+  return value?.trim() ?? "";
+}
+
+function resolveSelectedAccountId(requestedAccountId: string, items: CalendarAccountRecord[]) {
+  if (!items.length) {
+    return "";
+  }
+
+  const availableIds = new Set(items.map((item) => item.id));
+  if (requestedAccountId && availableIds.has(requestedAccountId)) {
+    return requestedAccountId;
+  }
+
+  return items[0]?.id ?? "";
+}
+
+export default async function CalendarPage({
+  searchParams,
+}: {
+  searchParams?: SearchParams;
+}) {
+  const params = (searchParams ? await searchParams : {}) as Record<
+    string,
+    string | string[] | undefined
+  >;
+  const requestedAccountId = normalizeParam(params.account);
+  const apiConfig = getApiConfig();
+  const liveModeReady = hasLiveApiConfig(apiConfig);
+
+  let accounts = calendarAccountFixtures;
+  let accountListSummary: CalendarAccountListSummary | null = calendarAccountListSummaryFixture;
+  let accountListSource: ApiSource | "unavailable" = "fixture";
+  let accountListUnavailableReason: string | undefined;
+
+  if (liveModeReady) {
+    try {
+      const payload = await listCalendarAccounts(apiConfig.apiBaseUrl, apiConfig.userId);
+      accounts = payload.items;
+      accountListSummary = payload.summary;
+      accountListSource = "live";
+    } catch (error) {
+      accountListUnavailableReason =
+        error instanceof Error ? error.message : "Calendar account list could not be loaded.";
+      if (!calendarAccountFixtures.length) {
+        accounts = [];
+        accountListSummary = null;
+        accountListSource = "unavailable";
+      }
+    }
+  }
+
+  const selectedAccountId = resolveSelectedAccountId(requestedAccountId, accounts);
+  const selectedFromList = accounts.find((item) => item.id === selectedAccountId) ?? null;
+
+  let selectedAccount = selectedFromList;
+  let selectedAccountSource: ApiSource | "unavailable" | null =
+    selectedAccount && accountListSource !== "unavailable" ? accountListSource : null;
+  let selectedAccountUnavailableReason: string | undefined;
+
+  if (selectedFromList && liveModeReady && accountListSource === "live") {
+    try {
+      const payload = await getCalendarAccountDetail(
+        apiConfig.apiBaseUrl,
+        selectedFromList.id,
+        apiConfig.userId,
+      );
+      selectedAccount = payload.account;
+      selectedAccountSource = "live";
+    } catch (error) {
+      const fixtureAccount = getFixtureCalendarAccount(selectedFromList.id);
+      if (fixtureAccount) {
+        selectedAccount = fixtureAccount;
+        selectedAccountSource = "fixture";
+      } else {
+        selectedAccountSource = "unavailable";
+      }
+      selectedAccountUnavailableReason =
+        error instanceof Error ? error.message : "Selected Calendar account detail could not be loaded.";
+    }
+  }
+
+  let taskWorkspaces = taskWorkspaceFixtures;
+  let taskWorkspaceSummary = taskWorkspaceListSummaryFixture;
+  let taskWorkspaceSource: ApiSource | "unavailable" = "fixture";
+  let taskWorkspaceUnavailableReason: string | undefined;
+
+  if (liveModeReady) {
+    try {
+      const payload = await listTaskWorkspaces(apiConfig.apiBaseUrl, apiConfig.userId);
+      taskWorkspaces = payload.items;
+      taskWorkspaceSummary = payload.summary;
+      taskWorkspaceSource = "live";
+    } catch (error) {
+      taskWorkspaceUnavailableReason =
+        error instanceof Error ? error.message : "Task workspace list could not be loaded.";
+      if (!taskWorkspaceFixtures.length) {
+        taskWorkspaceSource = "unavailable";
+      }
+    }
+  }
+
+  const pageMode = combinePageModes(
+    accountListSource === "unavailable" ? null : accountListSource,
+    selectedAccountSource === "unavailable" ? null : selectedAccountSource,
+    taskWorkspaceSource === "unavailable" ? null : taskWorkspaceSource,
+  );
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        eyebrow="Calendar"
+        title="Calendar account review workspace"
+        description="Review connected accounts first, inspect one selected account second, then run explicit connect or single-event ingestion actions."
+        meta={
+          <div className="header-meta">
+            <span className="subtle-chip">{pageModeLabel(pageMode)}</span>
+            <span className="subtle-chip">{accounts.length} visible accounts</span>
+            <span className="subtle-chip">{taskWorkspaceSummary.total_count} task workspaces</span>
+            {selectedAccount ? (
+              <span className="subtle-chip">Selected: {selectedAccount.email_address}</span>
+            ) : null}
+          </div>
+        }
+      />
+
+      <div className="calendar-layout">
+        <CalendarAccountList
+          accounts={accounts}
+          selectedAccountId={selectedAccount?.id}
+          summary={accountListSummary}
+          source={accountListSource}
+          unavailableReason={accountListUnavailableReason}
+        />
+        <CalendarAccountDetail
+          account={selectedAccount}
+          source={selectedAccountSource}
+          unavailableReason={selectedAccountUnavailableReason}
+        />
+      </div>
+
+      <div className="calendar-action-grid">
+        <CalendarAccountConnectForm
+          apiBaseUrl={apiConfig.apiBaseUrl}
+          userId={apiConfig.userId}
+        />
+        <CalendarEventIngestForm
+          account={selectedAccount}
+          accountSource={selectedAccountSource}
+          taskWorkspaces={taskWorkspaces}
+          taskWorkspaceSource={taskWorkspaceSource}
+          apiBaseUrl={apiConfig.apiBaseUrl}
+          userId={apiConfig.userId}
+        />
+      </div>
+
+      {taskWorkspaceUnavailableReason ? (
+        <p className="responsive-note">Live task workspace list read failed: {taskWorkspaceUnavailableReason}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -342,7 +342,9 @@ code,
 .entity-layout,
 .artifact-layout,
 .gmail-layout,
-.gmail-action-grid {
+.gmail-action-grid,
+.calendar-layout,
+.calendar-action-grid {
   display: grid;
   gap: 24px;
 }
@@ -367,7 +369,8 @@ code,
   align-items: flex-start;
 }
 
-.gmail-layout {
+.gmail-layout,
+.calendar-layout {
   grid-template-columns: minmax(320px, 0.95fr) minmax(0, 1.17fr);
   align-items: flex-start;
 }
@@ -379,7 +382,8 @@ code,
   align-items: flex-start;
 }
 
-.gmail-action-grid {
+.gmail-action-grid,
+.calendar-action-grid {
   grid-template-columns: minmax(300px, 0.95fr) minmax(0, 1.05fr);
   align-items: flex-start;
 }
@@ -1577,6 +1581,8 @@ code,
   .artifact-review-grid,
   .gmail-layout,
   .gmail-action-grid,
+  .calendar-layout,
+  .calendar-action-grid,
   .chat-workspace,
   .metric-grid,
   .route-grid {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -8,7 +8,7 @@ import "./globals.css";
 export const metadata: Metadata = {
   title: "AliceBot Operator Shell",
   description:
-    "Governed operator interface for requests, approvals, tasks, artifacts, Gmail, memories, entities, and explainability.",
+    "Governed operator interface for requests, approvals, tasks, artifacts, Gmail, Calendar, memories, entities, and explainability.",
 };
 
 export default function RootLayout({

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,16 +6,16 @@ import { StatusBadge } from "../components/status-badge";
 
 const summaryCards = [
   {
-    value: "9",
+    value: "10",
     label: "Operator views",
     detail:
-      "Home, request composition, approvals, task inspection, artifact review, Gmail review, memory review, entity review, and explainability are all exposed in one bounded shell.",
+      "Home, request composition, approvals, task inspection, artifact review, Gmail review, Calendar review, memory review, entity review, and explainability are all exposed in one bounded shell.",
   },
   {
-    value: "7",
+    value: "8",
     label: "Governance seams",
     detail:
-      "Requests, approvals, tasks, artifact review, Gmail account/ingestion seams, memory review, and entity review stay visible instead of being hidden behind a consumer chat wrapper.",
+      "Requests, approvals, tasks, artifact review, Gmail account/ingestion seams, Calendar account/ingestion seams, memory review, and entity review stay visible instead of being hidden behind a consumer chat wrapper.",
   },
   {
     value: "2",
@@ -62,6 +62,13 @@ const routeCards = [
     status: "active",
   },
   {
+    href: "/calendar",
+    title: "Calendar Review",
+    description:
+      "Review connected Calendar accounts, inspect one selected account, and explicitly ingest one selected event into a task workspace.",
+    status: "active",
+  },
+  {
     href: "/memories",
     title: "Memory Review",
     description: "Inspect active memory records, revisions, and review labels through the shipped memory-review seam.",
@@ -96,7 +103,7 @@ export default function HomePage() {
         description="The first web surface is intentionally narrow: it exposes existing backend seams with calm hierarchy, strong containment, and clear review paths."
         meta={
           <div className="header-meta">
-            <span className="subtle-chip">Sprint 6T shell</span>
+            <span className="subtle-chip">Sprint 6V shell</span>
             <span className="subtle-chip">Design-system aligned</span>
           </div>
         }

--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -37,6 +37,11 @@ const navigation = [
     caption: "Review connected accounts and ingest one selected message",
   },
   {
+    href: "/calendar",
+    label: "Calendar",
+    caption: "Review connected accounts and ingest one selected event",
+  },
+  {
     href: "/memories",
     label: "Memories",
     caption: "Review memory detail, revisions, and labels",
@@ -75,8 +80,8 @@ export function AppShell({ children }: { children: ReactNode }) {
             <p className="eyebrow">AliceBot</p>
             <h1 className="brand-title">Operator shell</h1>
             <p className="brand-description">
-              Calm, governed views for requests, approvals, tasks, artifacts, Gmail, memories,
-              entities, and explainability.
+              Calm, governed views for requests, approvals, tasks, artifacts, Gmail, Calendar,
+              memories, entities, and explainability.
             </p>
           </div>
 

--- a/apps/web/components/calendar-account-connect-form.tsx
+++ b/apps/web/components/calendar-account-connect-form.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useState } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { connectCalendarAccount } from "../lib/api";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type CalendarAccountConnectFormProps = {
+  apiBaseUrl?: string;
+  userId?: string;
+};
+
+const CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly" as const;
+
+export function CalendarAccountConnectForm({
+  apiBaseUrl,
+  userId,
+}: CalendarAccountConnectFormProps) {
+  const router = useRouter();
+  const liveModeReady = Boolean(apiBaseUrl && userId);
+
+  const [providerAccountId, setProviderAccountId] = useState("");
+  const [emailAddress, setEmailAddress] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [accessToken, setAccessToken] = useState("");
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusTone, setStatusTone] = useState<"info" | "success" | "danger">("info");
+  const [statusText, setStatusText] = useState(
+    liveModeReady
+      ? "Enter one account at a time, including the secret-bearing access token, then connect."
+      : "Calendar connect is unavailable until live API configuration is present.",
+  );
+
+  const canSubmit = liveModeReady && !isSubmitting;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!apiBaseUrl || !userId) {
+      setStatusTone("info");
+      setStatusText("Calendar connect is unavailable until live API configuration is present.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusTone("info");
+    setStatusText("Connecting Calendar account...");
+
+    try {
+      const payload = await connectCalendarAccount(apiBaseUrl, {
+        user_id: userId,
+        provider_account_id: providerAccountId.trim(),
+        email_address: emailAddress.trim(),
+        display_name: displayName.trim() ? displayName.trim() : null,
+        scope: CALENDAR_READONLY_SCOPE,
+        access_token: accessToken.trim(),
+      });
+
+      setStatusTone("success");
+      setStatusText(`Connected ${payload.account.email_address}.`);
+      setAccessToken("");
+      router.push(`/calendar?account=${encodeURIComponent(payload.account.id)}`);
+      router.refresh();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "Connection failed";
+      setStatusTone("danger");
+      setStatusText(`Unable to connect account: ${detail}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <SectionCard
+      eyebrow="Connect account"
+      title="Add Calendar account"
+      description="Connection is explicit and bounded to the shipped read-only scope with one secret-bearing credential field."
+    >
+      <form className="detail-stack" onSubmit={handleSubmit}>
+        <div className="form-field-group form-field-group--two-up">
+          <div className="form-field">
+            <label htmlFor="calendar-provider-account-id">Provider account ID</label>
+            <input
+              id="calendar-provider-account-id"
+              name="calendar-provider-account-id"
+              value={providerAccountId}
+              onChange={(event) => setProviderAccountId(event.target.value)}
+              placeholder="acct-owner-001"
+              required
+              disabled={!liveModeReady || isSubmitting}
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="calendar-email-address">Email address</label>
+            <input
+              id="calendar-email-address"
+              name="calendar-email-address"
+              value={emailAddress}
+              onChange={(event) => setEmailAddress(event.target.value)}
+              placeholder="owner@gmail.example"
+              required
+              disabled={!liveModeReady || isSubmitting}
+            />
+          </div>
+        </div>
+
+        <div className="form-field-group form-field-group--two-up">
+          <div className="form-field">
+            <label htmlFor="calendar-display-name">Display name (optional)</label>
+            <input
+              id="calendar-display-name"
+              name="calendar-display-name"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              placeholder="Owner"
+              disabled={!liveModeReady || isSubmitting}
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="calendar-scope">Scope</label>
+            <input
+              id="calendar-scope"
+              name="calendar-scope"
+              value={CALENDAR_READONLY_SCOPE}
+              readOnly
+              className="mono"
+              disabled
+            />
+          </div>
+        </div>
+
+        <div className="governance-banner">
+          <strong>Credential handling</strong>
+          <span>
+            The access token is submitted only through the shipped connect endpoint and is not
+            surfaced in account metadata reads.
+          </span>
+        </div>
+
+        <div className="form-field">
+          <label htmlFor="calendar-access-token">Access token</label>
+          <input
+            id="calendar-access-token"
+            name="calendar-access-token"
+            type="password"
+            value={accessToken}
+            onChange={(event) => setAccessToken(event.target.value)}
+            placeholder="Enter Google Calendar OAuth access token"
+            autoComplete="off"
+            required
+            disabled={!liveModeReady || isSubmitting}
+          />
+        </div>
+
+        <div className="composer-actions">
+          <div className="composer-status" aria-live="polite">
+            <StatusBadge
+              status={
+                isSubmitting
+                  ? "submitting"
+                  : statusTone === "success"
+                    ? "success"
+                    : statusTone === "danger"
+                      ? "error"
+                      : liveModeReady
+                        ? "info"
+                        : "unavailable"
+              }
+              label={
+                isSubmitting
+                  ? "Submitting"
+                  : statusTone === "success"
+                    ? "Connected"
+                    : statusTone === "danger"
+                      ? "Error"
+                      : liveModeReady
+                        ? "Ready"
+                        : "Unavailable"
+              }
+            />
+            <span>{statusText}</span>
+          </div>
+
+          <button type="submit" className="button" disabled={!canSubmit}>
+            Connect Calendar account
+          </button>
+        </div>
+      </form>
+    </SectionCard>
+  );
+}

--- a/apps/web/components/calendar-account-detail.tsx
+++ b/apps/web/components/calendar-account-detail.tsx
@@ -1,0 +1,125 @@
+import type { ApiSource, CalendarAccountRecord } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type CalendarAccountDetailProps = {
+  account: CalendarAccountRecord | null;
+  source: ApiSource | "unavailable" | null;
+  unavailableReason?: string;
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+export function CalendarAccountDetail({
+  account,
+  source,
+  unavailableReason,
+}: CalendarAccountDetailProps) {
+  if (source === "unavailable") {
+    return (
+      <SectionCard
+        eyebrow="Selected account"
+        title="Account detail unavailable"
+        description="The account list loaded, but selected account detail is currently unavailable."
+      >
+        <div className="detail-stack">
+          <StatusBadge status="unavailable" label="Detail unavailable" />
+          {unavailableReason ? (
+            <div className="execution-summary__note execution-summary__note--danger">
+              <p className="execution-summary__label">Account detail read</p>
+              <p>{unavailableReason}</p>
+            </div>
+          ) : null}
+        </div>
+      </SectionCard>
+    );
+  }
+
+  if (!account) {
+    return (
+      <SectionCard
+        eyebrow="Selected account"
+        title="No account selected"
+        description="Select one connected Calendar account to inspect metadata and scope summary."
+      >
+        <EmptyState
+          title="Account detail is idle"
+          description="Choose one account from the list to open the bounded detail panel."
+        />
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard
+      eyebrow="Selected account"
+      title={account.email_address}
+      description="Account detail stays bounded to connector metadata and scope without expanding into event browsing or scheduling actions."
+    >
+      <div className="detail-grid">
+        <div className="detail-summary">
+          <StatusBadge status={account.provider} />
+          <StatusBadge status={account.auth_kind} />
+          <StatusBadge
+            status={source ?? "unavailable"}
+            label={
+              source === "live"
+                ? "Live detail"
+                : source === "fixture"
+                  ? "Fixture detail"
+                  : "Detail unavailable"
+            }
+          />
+        </div>
+
+        {unavailableReason ? (
+          <p className="responsive-note">Live account detail read failed: {unavailableReason}</p>
+        ) : null}
+
+        <dl className="key-value-grid key-value-grid--compact">
+          <div>
+            <dt>Account ID</dt>
+            <dd className="mono">{account.id}</dd>
+          </div>
+          <div>
+            <dt>Provider account ID</dt>
+            <dd className="mono">{account.provider_account_id}</dd>
+          </div>
+          <div>
+            <dt>Email address</dt>
+            <dd>{account.email_address}</dd>
+          </div>
+          <div>
+            <dt>Display name</dt>
+            <dd>{account.display_name ?? "None"}</dd>
+          </div>
+          <div>
+            <dt>Scope</dt>
+            <dd className="mono">{account.scope}</dd>
+          </div>
+          <div>
+            <dt>Updated</dt>
+            <dd>{formatDate(account.updated_at)}</dd>
+          </div>
+        </dl>
+
+        <div className="detail-group detail-group--muted">
+          <h3>Scope summary</h3>
+          <p className="muted-copy">
+            This route uses the shipped read-only Calendar account seam and explicit single-event
+            ingestion seam only. It does not expand into event listing, search, sync, recurrence,
+            or write actions.
+          </p>
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/components/calendar-account-list.test.tsx
+++ b/apps/web/components/calendar-account-list.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CalendarAccountList } from "./calendar-account-list";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    "aria-current": ariaCurrent,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    "aria-current"?: string;
+  }) => (
+    <a href={href} className={className} aria-current={ariaCurrent}>
+      {children}
+    </a>
+  ),
+}));
+
+const baseAccounts = [
+  {
+    id: "calendar-account-1",
+    provider: "google_calendar",
+    auth_kind: "oauth_access_token",
+    provider_account_id: "acct-owner-001",
+    email_address: "owner@gmail.example",
+    display_name: "Owner",
+    scope: "https://www.googleapis.com/auth/calendar.readonly" as const,
+    created_at: "2026-03-18T10:00:00Z",
+    updated_at: "2026-03-18T10:00:00Z",
+  },
+  {
+    id: "calendar-account-2",
+    provider: "google_calendar",
+    auth_kind: "oauth_access_token",
+    provider_account_id: "acct-ops-002",
+    email_address: "ops@gmail.example",
+    display_name: "Ops",
+    scope: "https://www.googleapis.com/auth/calendar.readonly" as const,
+    created_at: "2026-03-18T11:00:00Z",
+    updated_at: "2026-03-18T11:00:00Z",
+  },
+];
+
+describe("CalendarAccountList", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders account links that preserve selected account state", () => {
+    render(
+      <CalendarAccountList
+        accounts={baseAccounts}
+        selectedAccountId="calendar-account-2"
+        summary={null}
+        source="live"
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /owner@gmail.example/i })).toHaveAttribute(
+      "href",
+      "/calendar?account=calendar-account-1",
+    );
+    expect(screen.getByRole("link", { name: /ops@gmail.example/i })).toHaveAttribute(
+      "href",
+      "/calendar?account=calendar-account-2",
+    );
+    expect(screen.getByRole("link", { name: /ops@gmail.example/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("renders empty state when no Calendar accounts are available", () => {
+    render(<CalendarAccountList accounts={[]} selectedAccountId="" summary={null} source="fixture" />);
+
+    expect(screen.getByText("No connected accounts")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/calendar-account-list.tsx
+++ b/apps/web/components/calendar-account-list.tsx
@@ -1,0 +1,122 @@
+import Link from "next/link";
+
+import type { ApiSource, CalendarAccountListSummary, CalendarAccountRecord } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type CalendarAccountListProps = {
+  accounts: CalendarAccountRecord[];
+  selectedAccountId?: string;
+  summary: CalendarAccountListSummary | null;
+  source: ApiSource | "unavailable";
+  unavailableReason?: string;
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function calendarAccountHref(calendarAccountId: string) {
+  return `/calendar?account=${encodeURIComponent(calendarAccountId)}`;
+}
+
+export function CalendarAccountList({
+  accounts,
+  selectedAccountId,
+  summary,
+  source,
+  unavailableReason,
+}: CalendarAccountListProps) {
+  if (source === "unavailable" && accounts.length === 0) {
+    return (
+      <SectionCard
+        eyebrow="Account list"
+        title="Calendar account list unavailable"
+        description="Connected Calendar accounts could not be loaded in the current workspace state."
+      >
+        <div className="detail-stack">
+          <StatusBadge status="unavailable" label="List unavailable" />
+          {unavailableReason ? (
+            <p className="responsive-note">Calendar account list read failed: {unavailableReason}</p>
+          ) : null}
+        </div>
+      </SectionCard>
+    );
+  }
+
+  if (accounts.length === 0) {
+    return (
+      <SectionCard
+        eyebrow="Account list"
+        title="No Calendar accounts connected"
+        description="Connect one Calendar account to enable bounded account review and selected-event ingestion."
+      >
+        <EmptyState
+          title="No connected accounts"
+          description="Use the connect form to add one Calendar account through the shipped read-only connector seam."
+        />
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard
+      eyebrow="Account list"
+      title="Connected Calendar accounts"
+      description="Select one account to inspect metadata, scope, and bounded ingestion controls."
+    >
+      <div className="list-panel">
+        <div className="list-panel__header">
+          <div className="cluster">
+            <StatusBadge
+              status={source}
+              label={
+                source === "live"
+                  ? "Live list"
+                  : source === "fixture"
+                    ? "Fixture list"
+                    : "List unavailable"
+              }
+            />
+            {summary ? <span className="meta-pill">{summary.total_count} total</span> : null}
+          </div>
+        </div>
+
+        {unavailableReason ? (
+          <p className="responsive-note">Live account list read failed: {unavailableReason}</p>
+        ) : null}
+
+        <div className="list-rows">
+          {accounts.map((account) => (
+            <Link
+              key={account.id}
+              href={calendarAccountHref(account.id)}
+              className={`list-row${account.id === selectedAccountId ? " is-selected" : ""}`}
+              aria-current={account.id === selectedAccountId ? "page" : undefined}
+            >
+              <div className="list-row__topline">
+                <div className="detail-stack">
+                  <span className="list-row__eyebrow">{formatDate(account.updated_at)}</span>
+                  <h3 className="list-row__title">{account.email_address}</h3>
+                </div>
+                <StatusBadge status={account.provider} />
+              </div>
+
+              <div className="list-row__meta">
+                <span className="meta-pill mono">{account.id}</span>
+                <span className="meta-pill mono">{account.provider_account_id}</span>
+                <span className="meta-pill">{account.display_name ?? "No display name"}</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/components/calendar-event-ingest-form.test.tsx
+++ b/apps/web/components/calendar-event-ingest-form.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CalendarEventIngestForm } from "./calendar-event-ingest-form";
+
+const { ingestCalendarEventMock, refreshMock } = vi.hoisted(() => ({
+  ingestCalendarEventMock: vi.fn(),
+  refreshMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual("../lib/api");
+  return {
+    ...actual,
+    ingestCalendarEvent: ingestCalendarEventMock,
+  };
+});
+
+const baseAccount = {
+  id: "calendar-account-1",
+  provider: "google_calendar",
+  auth_kind: "oauth_access_token",
+  provider_account_id: "acct-owner-001",
+  email_address: "owner@gmail.example",
+  display_name: "Owner",
+  scope: "https://www.googleapis.com/auth/calendar.readonly" as const,
+  created_at: "2026-03-18T10:00:00Z",
+  updated_at: "2026-03-18T10:00:00Z",
+};
+
+const baseWorkspaces = [
+  {
+    id: "workspace-1",
+    task_id: "task-1",
+    status: "active" as const,
+    local_path: "/tmp/task-workspaces/task-1",
+    created_at: "2026-03-18T10:00:00Z",
+    updated_at: "2026-03-18T10:00:00Z",
+  },
+];
+
+describe("CalendarEventIngestForm", () => {
+  beforeEach(() => {
+    ingestCalendarEventMock.mockReset();
+    refreshMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("submits selected-event ingestion through the shipped endpoint when live mode is available", async () => {
+    ingestCalendarEventMock.mockResolvedValue({
+      account: baseAccount,
+      event: {
+        provider_event_id: "evt-001",
+        artifact_relative_path: "calendar/acct-owner-001/evt-001.txt",
+        media_type: "text/plain",
+      },
+      artifact: {
+        id: "artifact-1",
+        task_id: "task-1",
+        task_workspace_id: "workspace-1",
+        status: "registered",
+        ingestion_status: "ingested",
+        relative_path: "calendar/acct-owner-001/evt-001.txt",
+        media_type_hint: "text/plain",
+        created_at: "2026-03-18T10:10:00Z",
+        updated_at: "2026-03-18T10:11:00Z",
+      },
+      summary: {
+        total_count: 1,
+        total_characters: 256,
+        media_type: "text/plain",
+        chunking_rule: "normalized_utf8_text_fixed_window_1000_chars_v1",
+        order: ["sequence_no_asc", "id_asc"],
+      },
+    });
+
+    render(
+      <CalendarEventIngestForm
+        account={baseAccount}
+        accountSource="live"
+        taskWorkspaces={baseWorkspaces}
+        taskWorkspaceSource="live"
+        apiBaseUrl="https://api.example.com"
+        userId="user-1"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Provider event ID"), {
+      target: { value: "evt-001" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Ingest selected event" }));
+
+    await waitFor(() => {
+      expect(ingestCalendarEventMock).toHaveBeenCalledWith(
+        "https://api.example.com",
+        "calendar-account-1",
+        "evt-001",
+        {
+          user_id: "user-1",
+          task_workspace_id: "workspace-1",
+        },
+      );
+    });
+
+    expect(refreshMock).toHaveBeenCalled();
+    expect(screen.getByText(/Ingestion completed\./i)).toBeInTheDocument();
+  });
+
+  it("keeps ingestion disabled when live prerequisites are unavailable", () => {
+    render(
+      <CalendarEventIngestForm
+        account={baseAccount}
+        accountSource="fixture"
+        taskWorkspaces={baseWorkspaces}
+        taskWorkspaceSource="fixture"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Ingest selected event" })).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Event ingestion is unavailable until live API configuration, live account detail, and live task workspace list are present.",
+      ),
+    ).toBeInTheDocument();
+    expect(ingestCalendarEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/calendar-event-ingest-form.tsx
+++ b/apps/web/components/calendar-event-ingest-form.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+import { useRouter } from "next/navigation";
+
+import type {
+  ApiSource,
+  CalendarAccountRecord,
+  CalendarEventIngestionResponse,
+  TaskWorkspaceRecord,
+} from "../lib/api";
+import { ingestCalendarEvent } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { CalendarIngestionSummary } from "./calendar-ingestion-summary";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type CalendarEventIngestFormProps = {
+  account: CalendarAccountRecord | null;
+  accountSource: ApiSource | "unavailable" | null;
+  taskWorkspaces: TaskWorkspaceRecord[];
+  taskWorkspaceSource: ApiSource | "unavailable";
+  apiBaseUrl?: string;
+  userId?: string;
+};
+
+export function CalendarEventIngestForm({
+  account,
+  accountSource,
+  taskWorkspaces,
+  taskWorkspaceSource,
+  apiBaseUrl,
+  userId,
+}: CalendarEventIngestFormProps) {
+  const router = useRouter();
+
+  const [providerEventId, setProviderEventId] = useState("");
+  const [taskWorkspaceId, setTaskWorkspaceId] = useState(taskWorkspaces[0]?.id ?? "");
+  const [result, setResult] = useState<CalendarEventIngestionResponse | null>(null);
+  const [resultSource, setResultSource] = useState<ApiSource | "unavailable" | null>(null);
+  const [resultUnavailableReason, setResultUnavailableReason] = useState<string | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusTone, setStatusTone] = useState<"info" | "success" | "danger">("info");
+
+  const liveModeReady = useMemo(
+    () =>
+      Boolean(
+        account &&
+          accountSource === "live" &&
+          apiBaseUrl &&
+          userId &&
+          taskWorkspaceSource === "live" &&
+          taskWorkspaces.length > 0,
+      ),
+    [account, accountSource, apiBaseUrl, userId, taskWorkspaceSource, taskWorkspaces.length],
+  );
+
+  const [statusText, setStatusText] = useState(
+    !account
+      ? "Select a Calendar account to enable single-event ingestion."
+      : taskWorkspaces.length === 0
+        ? "No task workspace is available for ingestion target selection."
+        : liveModeReady
+          ? "Enter one provider event ID and select one task workspace."
+          : "Event ingestion is unavailable until live API configuration, live account detail, and live task workspace list are present.",
+  );
+
+  useEffect(() => {
+    const hasWorkspace = taskWorkspaces.some((workspace) => workspace.id === taskWorkspaceId);
+    if (!hasWorkspace) {
+      setTaskWorkspaceId(taskWorkspaces[0]?.id ?? "");
+    }
+  }, [taskWorkspaceId, taskWorkspaces]);
+
+  useEffect(() => {
+    if (!account) {
+      setStatusTone("info");
+      setStatusText("Select a Calendar account to enable single-event ingestion.");
+      return;
+    }
+
+    if (taskWorkspaces.length === 0) {
+      setStatusTone("info");
+      setStatusText("No task workspace is available for ingestion target selection.");
+      return;
+    }
+
+    if (!liveModeReady) {
+      setStatusTone("info");
+      setStatusText(
+        "Event ingestion is unavailable until live API configuration, live account detail, and live task workspace list are present.",
+      );
+      return;
+    }
+
+    setStatusTone("info");
+    setStatusText("Enter one provider event ID and select one task workspace.");
+  }, [account, liveModeReady, taskWorkspaces.length]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!account) {
+      setStatusTone("danger");
+      setStatusText("Select a Calendar account before submitting ingestion.");
+      return;
+    }
+
+    if (!taskWorkspaceId) {
+      setStatusTone("danger");
+      setStatusText("Select a task workspace before submitting ingestion.");
+      return;
+    }
+
+    if (!apiBaseUrl || !userId || !liveModeReady) {
+      setStatusTone("info");
+      setStatusText(
+        "Event ingestion is unavailable until live API configuration, live account detail, and live task workspace list are present.",
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusTone("info");
+    setStatusText("Submitting event ingestion...");
+    setResultUnavailableReason(undefined);
+
+    try {
+      const payload = await ingestCalendarEvent(apiBaseUrl, account.id, providerEventId.trim(), {
+        user_id: userId,
+        task_workspace_id: taskWorkspaceId,
+      });
+
+      setResult(payload);
+      setResultSource("live");
+      setStatusTone("success");
+      setStatusText(`Ingestion completed. Artifact path: ${payload.event.artifact_relative_path}`);
+      router.refresh();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "Ingestion failed";
+      setResult(null);
+      setResultSource("unavailable");
+      setResultUnavailableReason(detail);
+      setStatusTone("danger");
+      setStatusText(`Unable to ingest event: ${detail}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const canSubmit = Boolean(
+    liveModeReady && taskWorkspaceId && providerEventId.trim() && !isSubmitting,
+  );
+
+  if (!account) {
+    return (
+      <div className="stack">
+        <SectionCard
+          eyebrow="Ingest event"
+          title="No account selected"
+          description="Select one Calendar account before ingesting one provider event into a task workspace."
+        >
+          <EmptyState
+            title="Ingestion form is disabled"
+            description="Choose one account from the list to activate this bounded ingestion action."
+          />
+        </SectionCard>
+        <CalendarIngestionSummary result={null} source={null} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="stack">
+      <SectionCard
+        eyebrow="Ingest event"
+        title="Single-event ingestion"
+        description="Ingest one provider event ID into one selected task workspace through the shipped text artifact seam."
+      >
+        <form className="detail-stack" onSubmit={handleSubmit}>
+          <div className="cluster">
+            <StatusBadge
+              status={accountSource ?? "unavailable"}
+              label={
+                accountSource === "live"
+                  ? "Live account"
+                  : accountSource === "fixture"
+                    ? "Fixture account"
+                    : "Account unavailable"
+              }
+            />
+            <StatusBadge
+              status={taskWorkspaceSource}
+              label={
+                taskWorkspaceSource === "live"
+                  ? "Live workspaces"
+                  : taskWorkspaceSource === "fixture"
+                    ? "Fixture workspaces"
+                    : "Workspaces unavailable"
+              }
+            />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="calendar-provider-event-id">Provider event ID</label>
+            <input
+              id="calendar-provider-event-id"
+              name="calendar-provider-event-id"
+              value={providerEventId}
+              onChange={(event) => setProviderEventId(event.target.value)}
+              placeholder="evt-001"
+              required
+              disabled={!liveModeReady || isSubmitting}
+            />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="calendar-task-workspace-id">Task workspace</label>
+            <select
+              id="calendar-task-workspace-id"
+              name="calendar-task-workspace-id"
+              value={taskWorkspaceId}
+              onChange={(event) => setTaskWorkspaceId(event.target.value)}
+              disabled={!liveModeReady || isSubmitting || taskWorkspaces.length === 0}
+            >
+              {taskWorkspaces.length === 0 ? (
+                <option value="">No task workspace available</option>
+              ) : (
+                taskWorkspaces.map((workspace) => (
+                  <option key={workspace.id} value={workspace.id}>
+                    {workspace.id} · {workspace.local_path}
+                  </option>
+                ))
+              )}
+            </select>
+          </div>
+
+          <div className="composer-actions">
+            <div className="composer-status" aria-live="polite">
+              <StatusBadge
+                status={
+                  isSubmitting
+                    ? "submitting"
+                    : statusTone === "success"
+                      ? "success"
+                      : statusTone === "danger"
+                        ? "error"
+                        : liveModeReady
+                          ? "info"
+                          : "unavailable"
+                }
+                label={
+                  isSubmitting
+                    ? "Submitting"
+                    : statusTone === "success"
+                      ? "Completed"
+                      : statusTone === "danger"
+                        ? "Error"
+                        : liveModeReady
+                          ? "Ready"
+                          : "Unavailable"
+                }
+              />
+              <span>{statusText}</span>
+            </div>
+
+            <button type="submit" className="button" disabled={!canSubmit}>
+              Ingest selected event
+            </button>
+          </div>
+        </form>
+      </SectionCard>
+
+      <CalendarIngestionSummary
+        result={result}
+        source={resultSource}
+        unavailableReason={resultUnavailableReason}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/calendar-ingestion-summary.tsx
+++ b/apps/web/components/calendar-ingestion-summary.tsx
@@ -1,0 +1,102 @@
+import type { ApiSource, CalendarEventIngestionResponse } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type CalendarIngestionSummaryProps = {
+  result: CalendarEventIngestionResponse | null;
+  source: ApiSource | "unavailable" | null;
+  unavailableReason?: string;
+};
+
+export function CalendarIngestionSummary({
+  result,
+  source,
+  unavailableReason,
+}: CalendarIngestionSummaryProps) {
+  if (source === "unavailable") {
+    return (
+      <SectionCard
+        eyebrow="Ingestion summary"
+        title="Latest ingestion unavailable"
+        description="No ingestion result is available because the latest request failed."
+      >
+        <div className="detail-stack">
+          <StatusBadge status="unavailable" label="Result unavailable" />
+          {unavailableReason ? (
+            <div className="execution-summary__note execution-summary__note--danger">
+              <p className="execution-summary__label">Ingestion result</p>
+              <p>{unavailableReason}</p>
+            </div>
+          ) : null}
+        </div>
+      </SectionCard>
+    );
+  }
+
+  if (!result) {
+    return (
+      <SectionCard
+        eyebrow="Ingestion summary"
+        title="No event ingested yet"
+        description="Run one selected-event ingestion to review artifact linkage and media metadata."
+      >
+        <EmptyState
+          title="Summary is idle"
+          description="A successful ingestion will appear here with the resulting artifact path and media type."
+        />
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard
+      eyebrow="Ingestion summary"
+      title="Selected-event ingestion result"
+      description="Review the resulting artifact path, media type, and linked workspace target."
+    >
+      <div className="detail-grid">
+        <div className="detail-summary">
+          <StatusBadge status={result.artifact.ingestion_status} />
+          <StatusBadge
+            status={source ?? "unavailable"}
+            label={
+              source === "live"
+                ? "Live result"
+                : source === "fixture"
+                  ? "Fixture result"
+                  : "Result unavailable"
+            }
+          />
+        </div>
+
+        <dl className="key-value-grid key-value-grid--compact">
+          <div>
+            <dt>Provider event ID</dt>
+            <dd className="mono">{result.event.provider_event_id}</dd>
+          </div>
+          <div>
+            <dt>Account email</dt>
+            <dd>{result.account.email_address}</dd>
+          </div>
+          <div>
+            <dt>Artifact path</dt>
+            <dd className="mono">{result.event.artifact_relative_path}</dd>
+          </div>
+          <div>
+            <dt>Linked artifact target</dt>
+            <dd className="mono">{result.artifact.relative_path}</dd>
+          </div>
+          <div>
+            <dt>Task workspace ID</dt>
+            <dd className="mono">{result.artifact.task_workspace_id}</dd>
+          </div>
+          <div>
+            <dt>Media type</dt>
+            <dd className="mono">{result.event.media_type}</dd>
+          </div>
+        </dl>
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -3,9 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ApiError,
   combinePageModes,
+  connectCalendarAccount,
   connectGmailAccount,
   createThread,
   deriveThreadWorkflowState,
+  getCalendarAccountDetail,
   getGmailAccountDetail,
   getTaskArtifactDetail,
   getTaskWorkspaceDetail,
@@ -18,7 +20,9 @@ import {
   getThreadEvents,
   getThreadSessions,
   executeApproval,
+  ingestCalendarEvent,
   ingestGmailMessage,
+  listCalendarAccounts,
   listEntities,
   listEntityEdges,
   listGmailAccounts,
@@ -1108,6 +1112,172 @@ describe("api helpers", () => {
       email_address: "owner@gmail.example",
       display_name: "Owner",
       scope: "https://www.googleapis.com/auth/gmail.readonly",
+      access_token: "access-token-1",
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[3]?.[1]?.body))).toEqual({
+      user_id: "user-1",
+      task_workspace_id: "workspace-1",
+    });
+  });
+
+  it("reads and writes Calendar account and selected-event ingestion endpoints", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          account: {
+            id: "calendar-account-1",
+            provider: "google_calendar",
+            auth_kind: "oauth_access_token",
+            provider_account_id: "acct-owner-001",
+            email_address: "owner@gmail.example",
+            display_name: "Owner",
+            scope: "https://www.googleapis.com/auth/calendar.readonly",
+            created_at: "2026-03-18T00:00:00Z",
+            updated_at: "2026-03-18T00:00:00Z",
+          },
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "calendar-account-1",
+              provider: "google_calendar",
+              auth_kind: "oauth_access_token",
+              provider_account_id: "acct-owner-001",
+              email_address: "owner@gmail.example",
+              display_name: "Owner",
+              scope: "https://www.googleapis.com/auth/calendar.readonly",
+              created_at: "2026-03-18T00:00:00Z",
+              updated_at: "2026-03-18T00:00:00Z",
+            },
+          ],
+          summary: {
+            total_count: 1,
+            order: ["created_at_asc", "id_asc"],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          account: {
+            id: "calendar-account-1",
+            provider: "google_calendar",
+            auth_kind: "oauth_access_token",
+            provider_account_id: "acct-owner-001",
+            email_address: "owner@gmail.example",
+            display_name: "Owner",
+            scope: "https://www.googleapis.com/auth/calendar.readonly",
+            created_at: "2026-03-18T00:00:00Z",
+            updated_at: "2026-03-18T00:00:00Z",
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          account: {
+            id: "calendar-account-1",
+            provider: "google_calendar",
+            auth_kind: "oauth_access_token",
+            provider_account_id: "acct-owner-001",
+            email_address: "owner@gmail.example",
+            display_name: "Owner",
+            scope: "https://www.googleapis.com/auth/calendar.readonly",
+            created_at: "2026-03-18T00:00:00Z",
+            updated_at: "2026-03-18T00:00:00Z",
+          },
+          event: {
+            provider_event_id: "evt-001",
+            artifact_relative_path: "calendar/acct-owner-001/evt-001.txt",
+            media_type: "text/plain",
+          },
+          artifact: {
+            id: "artifact-1",
+            task_id: "task-1",
+            task_workspace_id: "workspace-1",
+            status: "registered",
+            ingestion_status: "ingested",
+            relative_path: "calendar/acct-owner-001/evt-001.txt",
+            media_type_hint: "text/plain",
+            created_at: "2026-03-18T00:05:00Z",
+            updated_at: "2026-03-18T00:06:00Z",
+          },
+          summary: {
+            total_count: 1,
+            total_characters: 240,
+            media_type: "text/plain",
+            chunking_rule: "normalized_utf8_text_fixed_window_1000_chars_v1",
+            order: ["sequence_no_asc", "id_asc"],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await connectCalendarAccount("https://api.example.com", {
+      user_id: "user-1",
+      provider_account_id: "acct-owner-001",
+      email_address: "owner@gmail.example",
+      display_name: "Owner",
+      scope: "https://www.googleapis.com/auth/calendar.readonly",
+      access_token: "access-token-1",
+    });
+    await listCalendarAccounts("https://api.example.com", "user-1");
+    await getCalendarAccountDetail("https://api.example.com", "calendar-account-1", "user-1");
+    await ingestCalendarEvent(
+      "https://api.example.com",
+      "calendar-account-1",
+      "evt-001",
+      {
+        user_id: "user-1",
+        task_workspace_id: "workspace-1",
+      },
+    );
+
+    expect(fetchMock.mock.calls).toEqual([
+      [
+        "https://api.example.com/v0/calendar-accounts",
+        expect.objectContaining({
+          method: "POST",
+          cache: "no-store",
+        }),
+      ],
+      [
+        "https://api.example.com/v0/calendar-accounts?user_id=user-1",
+        expect.objectContaining({
+          cache: "no-store",
+        }),
+      ],
+      [
+        "https://api.example.com/v0/calendar-accounts/calendar-account-1?user_id=user-1",
+        expect.objectContaining({
+          cache: "no-store",
+        }),
+      ],
+      [
+        "https://api.example.com/v0/calendar-accounts/calendar-account-1/events/evt-001/ingest",
+        expect.objectContaining({
+          method: "POST",
+          cache: "no-store",
+        }),
+      ],
+    ]);
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      user_id: "user-1",
+      provider_account_id: "acct-owner-001",
+      email_address: "owner@gmail.example",
+      display_name: "Owner",
+      scope: "https://www.googleapis.com/auth/calendar.readonly",
       access_token: "access-token-1",
     });
     expect(JSON.parse(String(fetchMock.mock.calls[3]?.[1]?.body))).toEqual({

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -431,6 +431,52 @@ export type GmailMessageIngestionResponse = {
   summary: TaskArtifactChunkListSummary;
 };
 
+export type CalendarReadonlyScope = "https://www.googleapis.com/auth/calendar.readonly";
+
+export type CalendarAccountRecord = {
+  id: string;
+  provider: string;
+  auth_kind: string;
+  provider_account_id: string;
+  email_address: string;
+  display_name: string | null;
+  scope: CalendarReadonlyScope;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CalendarAccountListSummary = {
+  total_count: number;
+  order: string[];
+};
+
+export type CalendarAccountConnectPayload = {
+  user_id: string;
+  provider_account_id: string;
+  email_address: string;
+  display_name?: string | null;
+  scope: CalendarReadonlyScope;
+  access_token: string;
+};
+
+export type CalendarEventIngestPayload = {
+  user_id: string;
+  task_workspace_id: string;
+};
+
+export type CalendarEventIngestionRecord = {
+  provider_event_id: string;
+  artifact_relative_path: string;
+  media_type: string;
+};
+
+export type CalendarEventIngestionResponse = {
+  account: CalendarAccountRecord;
+  event: CalendarEventIngestionRecord;
+  artifact: TaskArtifactRecord;
+  summary: TaskArtifactChunkListSummary;
+};
+
 export type TaskWorkspaceStatus = "active";
 
 export type TaskWorkspaceRecord = {
@@ -1010,6 +1056,54 @@ export function ingestGmailMessage(
   return requestJson<GmailMessageIngestionResponse>(
     apiBaseUrl,
     `/v0/gmail-accounts/${gmailAccountId}/messages/${providerMessageId}/ingest`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export function connectCalendarAccount(
+  apiBaseUrl: string,
+  payload: CalendarAccountConnectPayload,
+) {
+  return requestJson<{ account: CalendarAccountRecord }>(apiBaseUrl, "/v0/calendar-accounts", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function listCalendarAccounts(apiBaseUrl: string, userId: string) {
+  return requestJson<{ items: CalendarAccountRecord[]; summary: CalendarAccountListSummary }>(
+    apiBaseUrl,
+    "/v0/calendar-accounts",
+    undefined,
+    { user_id: userId },
+  );
+}
+
+export function getCalendarAccountDetail(
+  apiBaseUrl: string,
+  calendarAccountId: string,
+  userId: string,
+) {
+  return requestJson<{ account: CalendarAccountRecord }>(
+    apiBaseUrl,
+    `/v0/calendar-accounts/${calendarAccountId}`,
+    undefined,
+    { user_id: userId },
+  );
+}
+
+export function ingestCalendarEvent(
+  apiBaseUrl: string,
+  calendarAccountId: string,
+  providerEventId: string,
+  payload: CalendarEventIngestPayload,
+) {
+  return requestJson<CalendarEventIngestionResponse>(
+    apiBaseUrl,
+    `/v0/calendar-accounts/${calendarAccountId}/events/${providerEventId}/ingest`,
     {
       method: "POST",
       body: JSON.stringify(payload),

--- a/apps/web/lib/fixtures.ts
+++ b/apps/web/lib/fixtures.ts
@@ -1,6 +1,8 @@
 import type {
   ApprovalItem,
   ApprovalRequestPayload,
+  CalendarAccountListSummary,
+  CalendarAccountRecord,
   EntityEdgeListSummary,
   EntityEdgeRecord,
   EntityListSummary,
@@ -557,6 +559,36 @@ export const gmailAccountFixtures: GmailAccountRecord[] = [
 
 export const gmailAccountListSummaryFixture: GmailAccountListSummary = {
   total_count: gmailAccountFixtures.length,
+  order: ["created_at_asc", "id_asc"],
+};
+
+export const calendarAccountFixtures: CalendarAccountRecord[] = [
+  {
+    id: "c1c1c1c1-c1c1-4c1c-8c1c-c1c1c1c1c1c1",
+    provider: "google_calendar",
+    auth_kind: "oauth_access_token",
+    provider_account_id: "acct-owner-001",
+    email_address: "owner@gmail.example",
+    display_name: "Owner",
+    scope: "https://www.googleapis.com/auth/calendar.readonly",
+    created_at: "2026-03-16T14:00:00Z",
+    updated_at: "2026-03-16T14:00:00Z",
+  },
+  {
+    id: "c2c2c2c2-c2c2-4c2c-8c2c-c2c2c2c2c2c2",
+    provider: "google_calendar",
+    auth_kind: "oauth_access_token",
+    provider_account_id: "acct-ops-002",
+    email_address: "ops@gmail.example",
+    display_name: "Ops",
+    scope: "https://www.googleapis.com/auth/calendar.readonly",
+    created_at: "2026-03-17T08:32:00Z",
+    updated_at: "2026-03-17T08:32:00Z",
+  },
+];
+
+export const calendarAccountListSummaryFixture: CalendarAccountListSummary = {
+  total_count: calendarAccountFixtures.length,
   order: ["created_at_asc", "id_asc"],
 };
 
@@ -1346,6 +1378,10 @@ export function getFixtureEntity(entityId: string) {
 
 export function getFixtureGmailAccount(gmailAccountId: string) {
   return gmailAccountFixtures.find((item) => item.id === gmailAccountId) ?? null;
+}
+
+export function getFixtureCalendarAccount(calendarAccountId: string) {
+  return calendarAccountFixtures.find((item) => item.id === calendarAccountId) ?? null;
 }
 
 export function getFixtureTaskWorkspace(taskWorkspaceId: string) {


### PR DESCRIPTION
UI sprint over shipped Calendar account and selected-event-ingestion seams. Verification passed in apps/web: npm run lint, npm test, npm run build. No backend/Calendar search-sync-recurrence-write/Gmail/auth/runner scope expansion.