### PR TITLE
Sprint 6W: Project truth sync after connector UI expansion

### DIFF
--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -2,15 +2,17 @@
 
 ## Canonical Truth
 
-- The working repo state is current through Sprint 6R.
+- The working repo state is current through Sprint 6V.
 - Use [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md) for implemented boundaries, [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md) for forward planning, and [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md) for durable operating rules.
 - The live sprint reports are [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md) and [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md) at repo root; older accepted sprint history belongs in [docs/archive/sprints](/Users/samirusani/Desktop/Codex/AliceBot/docs/archive/sprints), not in this handoff.
 
 ## Implemented Surfaces
 
-- `apps/api` is the core shipped product surface. It implements continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact chunk retrieval and embeddings, traces, and the narrow read-only Gmail seam with selected-message ingestion.
-- `apps/web` is also a shipped surface now. The operator shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/memories`, `/entities`, and `/traces`, with live reads when API config is present and explicit fixture fallback when it is not.
+- `apps/api` is the core shipped product surface. It implements continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact chunk retrieval and embeddings, traces, and narrow read-only Gmail and Calendar seams with selected-item ingestion.
+- `apps/web` is also a shipped surface now. The operator shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live reads when API config is present and explicit fixture fallback when it is not.
 - `/chat` now ships assistant-response mode, governed-request mode, visible thread selection, compact thread creation, selected-thread transcript continuity, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, and bounded supporting continuity review over thread sessions and events.
+- `/gmail` ships a bounded Gmail operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-message ingestion into one selected task workspace.
+- `/calendar` ships a bounded Calendar operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-event ingestion into one selected task workspace.
 - `/memories` ships a bounded memory review workspace: active/queue list posture, selected memory detail, revision review, and memory-label review/submit seams with explicit live/fixture/unavailable states.
 - `/entities` ships a bounded entity review workspace: list, selected entity detail, and related edge review with explicit live/fixture/unavailable states.
 - `/artifacts` ships a bounded artifact review workspace: list, selected artifact detail, linked task-workspace summary, and ordered chunk evidence with explicit live/fixture/unavailable states.
@@ -23,23 +25,25 @@
 - Explain-why in `/chat` is selected-thread scoped and bounded: it reuses shipped trace list/detail/event reads, shows linked trace shortcuts from transcript/workflow/timeline context, and keeps full trace workspace in `/traces`.
 - Governed actions still route through policy, allowlist, approval, and approved-only proxy execution; `proxy.echo` is still the only live execution handler.
 - Task workspaces and artifacts remain rooted local boundaries. Ingestion remains narrow to plain text, markdown, narrow PDF text, narrow DOCX text from `word/document.xml`, and narrow RFC822 extraction.
-- Gmail remains read-only and selected-message-only, with secret material handled through the dedicated secret-manager seam and the remaining `legacy_db_v0` transition path still present for older credential rows.
+- Gmail and Calendar remain read-only and selected-item-only connector surfaces. Secret material stays behind dedicated secret-manager seams, the Gmail `legacy_db_v0` transition path still exists for older credential rows, and the shipped web workspaces stay bounded to account review, explicit connect, and one-item ingestion into one selected task workspace.
 
 ## Active Risks
 
 - Memory extraction and retrieval quality remain the main product risk.
 - Auth is still incomplete beyond database user context.
-- Connector breadth, richer parsing, and orchestration are still deferred; docs must stay synchronized with the shipped API-plus-web baseline so planning does not drift again.
+- Connector breadth, richer parsing, and orchestration are still deferred; docs must stay synchronized with the shipped API-plus-web baseline, including `/gmail` and `/calendar`, so planning does not drift again.
 
 ## Repo Evidence To Trust
 
 - Backend continuity and response seams: `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`
+- Backend Gmail and Calendar seams: `tests/integration/test_gmail_accounts_api.py`, `tests/integration/test_calendar_accounts_api.py`, `tests/unit/test_gmail.py`, `tests/unit/test_calendar.py`, `tests/unit/test_20260316_0026_gmail_accounts.py`, `tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py`
 - Web `/chat` continuity + workflow/timeline/explainability adoption: `apps/web/app/chat/page.tsx`, `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`, `apps/web/components/thread-event-list.tsx`, `apps/web/components/response-composer.tsx`, `apps/web/components/thread-workflow-panel.tsx`, `apps/web/components/task-step-list.tsx`, `apps/web/components/response-history.tsx`, `apps/web/components/thread-trace-panel.tsx`, and matching component tests.
 - Web review workspaces added through the accepted Sprint 6P/6Q/6R sequence: `apps/web/app/memories/page.tsx`, `apps/web/app/memories/page.test.tsx`, `apps/web/app/entities/page.tsx`, `apps/web/app/entities/page.test.tsx`, `apps/web/app/artifacts/page.tsx`, `apps/web/app/artifacts/page.test.tsx`.
+- Web Gmail and Calendar workspaces: `apps/web/app/gmail/page.tsx`, `apps/web/app/calendar/page.tsx`, `apps/web/lib/api.ts`, `apps/web/lib/api.test.ts`, `apps/web/components/gmail-account-list.test.tsx`, `apps/web/components/calendar-account-list.test.tsx`, `apps/web/components/calendar-event-ingest-form.test.tsx`
 - Shell route inventory and discoverability: `apps/web/components/app-shell.tsx`, `apps/web/app/page.tsx`
 
 ## Planning Guardrails
 
-- Plan from the implemented Sprint 6R repo state, not from older Sprint 5-era narratives.
-- Do not describe broader Gmail scope, Calendar work, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
-- The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, including `/memories`, `/entities`, and `/artifacts`, not assumed to be leftover Gmail cleanup by default.
+- Plan from the implemented Sprint 6V repo state, not from older Sprint 5-era narratives.
+- Do not describe broader Gmail scope, broader Calendar scope, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
+- The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, including `/gmail`, `/calendar`, `/memories`, `/entities`, and `/artifacts`, not assumed to be leftover connector cleanup by default.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,11 +2,12 @@
 
 ## Current Implemented Slice
 
-AliceBot now implements the accepted repo slice through Sprint 6U.
+AliceBot now implements the accepted repo slice through Sprint 6V.
 
 - `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and narrow read-only Gmail and Calendar seams with external-secret-backed credentials plus selected-item ingestion into the artifact pipeline.
-- `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/memories`, `/entities`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
+- `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
 - `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, renders a selected-thread transcript from immutable continuity events, and keeps supporting session and operational review, thread-linked governed workflow review, ordered task-step timeline review, and bounded explain-why trace review in the right rail.
+- `/gmail` and `/calendar` are shipped bounded connector workspaces over existing backend seams: visible account list review, selected-account detail, explicit account connection, and explicit single-item ingestion into one chosen task workspace, with live/fixture/unavailable states kept explicit.
 - `/artifacts`, `/memories`, and `/entities` are now shipped bounded review workspaces that expose existing artifact, memory, and entity read seams with explicit live/fixture/unavailable modes.
 - `workers` remains scaffold-only. No background runner, automatic multi-step progression, or asynchronous job system is implemented.
 
@@ -31,6 +32,8 @@ The repo is intentionally still narrow. Document ingestion remains local and det
   - `/approvals`: approval inbox and execution review
   - `/tasks`: task summary and ordered task-step review
   - `/artifacts`: artifact list and selected detail, linked workspace summary, and ordered chunk review
+  - `/gmail`: connected-account review, selected-account detail, explicit connect, and selected-message ingestion into one chosen task workspace
+  - `/calendar`: connected-account review, selected-account detail, explicit connect, and selected-event ingestion into one chosen task workspace
   - `/memories`: memory summary and queue posture, selected detail, revision review, and label review
   - `/entities`: entity list and selected detail with related edge review
   - `/traces`: trace summary, detail, and ordered event review
@@ -75,6 +78,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 - Backend continuity and response seams are covered in `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`, and related unit coverage under `tests/unit`.
 - Web continuity and `/chat` operator review adoption are covered in `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.test.tsx`, `apps/web/components/thread-summary.test.tsx`, `apps/web/components/thread-event-list.test.tsx`, `apps/web/components/thread-create.test.tsx`, `apps/web/components/response-composer.test.tsx`, `apps/web/components/thread-workflow-panel.test.tsx`, `apps/web/components/task-step-list.test.tsx`, `apps/web/components/response-history.test.tsx`, and `apps/web/components/thread-trace-panel.test.tsx`.
 - Review workspaces are covered at route level in `apps/web/app/artifacts/page.test.tsx`, `apps/web/app/memories/page.test.tsx`, and `apps/web/app/entities/page.test.tsx`, with matching component and API-client coverage under `apps/web`.
+- Connector workspaces are covered through `apps/web/lib/api.test.ts`, `apps/web/components/gmail-account-list.test.tsx`, `apps/web/components/calendar-account-list.test.tsx`, and `apps/web/components/calendar-event-ingest-form.test.tsx`.
 - The shell also has route and API-client coverage for approvals, tasks, traces, and shared API utilities under `apps/web`.
 
 ## Planned Later

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,96 +1,61 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Sprint 6V: add a bounded `/calendar` workspace in the web shell for Calendar account review, selected account detail, explicit Calendar account connection, and explicit single-event ingestion into one selected task workspace using only shipped backend seams.
+Synchronize canonical truth artifacts with the accepted repo state through Sprint 6V so roadmap, handoff, README, and architecture docs reflect the shipped Gmail and Calendar operator-shell baseline without changing runtime behavior or product scope.
 
 ## Completed Work
-- Added Calendar API typing + helper methods in `apps/web/lib/api.ts` for:
-  - `POST /v0/calendar-accounts`
-  - `GET /v0/calendar-accounts`
-  - `GET /v0/calendar-accounts/{calendar_account_id}`
-  - `POST /v0/calendar-accounts/{calendar_account_id}/events/{provider_event_id}/ingest`
-  - `GET /v0/task-workspaces` (already present; reused for Calendar ingestion target selection)
-- Added Calendar fixtures/helpers in `apps/web/lib/fixtures.ts`:
-  - `calendarAccountFixtures`
-  - `calendarAccountListSummaryFixture`
-  - `getFixtureCalendarAccount(...)`
-- Added `/calendar` route and loading state:
-  - `apps/web/app/calendar/page.tsx`
-  - `apps/web/app/calendar/loading.tsx`
-- Added scoped Calendar components:
-  - `calendar-account-list`
-  - `calendar-account-detail`
-  - `calendar-account-connect-form`
-  - `calendar-event-ingest-form`
-  - `calendar-ingestion-summary`
-- Added shell integration for discoverability:
-  - Calendar navigation item in `apps/web/components/app-shell.tsx`
-  - Calendar card and updated counts in `apps/web/app/page.tsx`
-  - Calendar mention in `apps/web/app/layout.tsx` metadata
-- Added minimal style integration for Calendar layout wrappers in `apps/web/app/globals.css`:
-  - `calendar-layout`
-  - `calendar-action-grid`
-  - responsive collapse at existing breakpoints
-- Added test coverage:
-  - Calendar API endpoint helper assertions in `apps/web/lib/api.test.ts`
-  - Calendar account list rendering behavior test
-  - Calendar event ingestion form behavior test
+- Updated `ROADMAP.md` to move the stated accepted baseline from Sprint 6R to Sprint 6V, include `/gmail` and `/calendar` in the shipped shell baseline, and frame next planning from the actual current operator surface.
+- Updated `.ai/handoff/CURRENT_STATE.md` to move the stated working baseline from Sprint 6R to Sprint 6V, add shipped Gmail and Calendar web workspaces, and tighten current boundary and planning language around narrow connector seams.
+- Updated `README.md` to move the stated accepted slice from Sprint 6U to Sprint 6V and correct the route inventory to include `/gmail` and `/calendar`.
+- Updated `ARCHITECTURE.md` to move the accepted slice from Sprint 6U to Sprint 6V, include `/gmail` and `/calendar` in the operator-shell route inventory, and keep Gmail/Calendar connector boundaries explicit and narrow.
+- Confirmed no archival move was required; `docs/archive/**` was not changed.
+- Confirmed the sprint stayed documentation-only: no runtime code, schema, API, or UI behavior changed.
 
-## Calendar Surface Backing Mode
-- `calendar-account-list`: live API when configured; fixture-backed fallback when live config is absent or live list read fails; explicit unavailable state when source is unavailable and no accounts are present.
-- `calendar-account-detail`: live API detail when configured and list is live; fixture fallback for selected account detail failure; explicit unavailable state when no fallback exists.
-- `calendar-account-connect-form`: live-only write action (`POST /v0/calendar-accounts`); explicit unavailable/disabled behavior without live API config.
-- `calendar-event-ingest-form`: live-only write action (`POST /v0/calendar-accounts/{id}/events/{provider_event_id}/ingest`) gated on live account detail + live task workspace list + live API config.
-- `calendar-ingestion-summary`: live result display after successful ingestion; explicit idle and unavailable states otherwise.
-- `/calendar` page mode chip: `Live API`, `Fixture-backed`, or `Mixed fallback` via `combinePageModes(...)`.
+## Stale Claims Corrected
+- `ROADMAP.md` no longer says the accepted repo state is current only through Sprint 6R.
+- `.ai/handoff/CURRENT_STATE.md` no longer says the working repo state is current only through Sprint 6R.
+- `README.md` no longer says the accepted slice is only through Sprint 6U.
+- `README.md` and `ARCHITECTURE.md` no longer omit `/gmail` and `/calendar` from the shipped shell route inventory.
+- Roadmap and handoff planning language no longer imply Calendar is still pre-shell or that next planning should start from the older Sprint 6R baseline.
+
+## Accepted Repo Evidence Used
+- `apps/web/components/app-shell.tsx`
+- `apps/web/app/page.tsx`
+- `apps/web/app/gmail/page.tsx`
+- `apps/web/app/calendar/page.tsx`
+- `apps/web/lib/api.ts`
+- `apps/web/lib/api.test.ts`
+- `tests/integration/test_gmail_accounts_api.py`
+- `tests/integration/test_calendar_accounts_api.py`
+- `tests/unit/test_gmail.py`
+- `tests/unit/test_calendar.py`
+- `tests/unit/test_20260316_0026_gmail_accounts.py`
+- `tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py`
 
 ## Incomplete Work
-- None for Sprint 6V in-scope deliverables.
+- None within Sprint 6W scope.
 
 ## Files Changed
-- `apps/web/app/layout.tsx`
-- `apps/web/app/page.tsx`
-- `apps/web/app/calendar/page.tsx`
-- `apps/web/app/calendar/loading.tsx`
-- `apps/web/app/globals.css`
-- `apps/web/components/app-shell.tsx`
-- `apps/web/components/calendar-account-list.tsx`
-- `apps/web/components/calendar-account-detail.tsx`
-- `apps/web/components/calendar-account-connect-form.tsx`
-- `apps/web/components/calendar-event-ingest-form.tsx`
-- `apps/web/components/calendar-ingestion-summary.tsx`
-- `apps/web/lib/api.ts`
-- `apps/web/lib/fixtures.ts`
-- `apps/web/lib/api.test.ts`
-- `apps/web/components/calendar-account-list.test.tsx`
-- `apps/web/components/calendar-event-ingest-form.test.tsx`
+- `ROADMAP.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `README.md`
+- `ARCHITECTURE.md`
 - `BUILD_REPORT.md`
 
 ## Tests Run
-### Exact Commands
-- `npm run lint` (run in `apps/web`)
-- `npm test` (run in `apps/web`)
-- `npm run build` (run in `apps/web`)
-
-### Results
-- `npm run lint`: PASS
-- `npm test`: PASS (`29` files, `89` tests)
-- `npm run build`: PASS (Next.js production build succeeded; `/calendar` route generated)
-
-## Desktop and Mobile Visual Verification Notes
-- Desktop verification (code-level): `/calendar` uses two-column `calendar-layout` (account list + selected detail) and two-column `calendar-action-grid` (connect + ingest stack), matching existing bounded workspace patterns.
-- Mobile/tablet verification (code-level): `calendar-layout` and `calendar-action-grid` collapse to one column under `@media (max-width: 1120px)`; form two-up fields collapse to single column under `@media (max-width: 740px)`.
+- `git diff --check -- ROADMAP.md .ai/handoff/CURRENT_STATE.md README.md ARCHITECTURE.md BUILD_REPORT.md`: PASS
+- `rg -n "Sprint 6R|Sprint 6U|/gmail|/calendar|current through Sprint 6V|accepted slice through Sprint 6V" ROADMAP.md .ai/handoff/CURRENT_STATE.md README.md ARCHITECTURE.md BUILD_REPORT.md`: PASS
+- No runtime or UI test suites were run because this sprint is documentation-only.
 
 ## Blockers / Issues
-- No implementation blockers.
-- No backend changes were required.
+- No blockers.
+- Existing unrelated modifications remain in `.ai/active/SPRINT_PACKET.md` and `REVIEW_REPORT.md`; they were left untouched.
 
-## Intentionally Deferred Scope
-- Calendar event list/search UI.
-- Recurrence expansion, sync, or backfill controls.
-- Calendar write actions.
-- Artifact editing from Calendar workspace.
-- Gmail/auth/runner/backend scope expansion.
+## Intentionally Deferred After This Truth-Sync Sprint
+- Any runtime, schema, API, or UI work.
+- Broader Gmail scope beyond the shipped read-only account review and selected-message ingestion seam.
+- Broader Calendar scope beyond the shipped read-only account review and selected-event ingestion seam.
+- Auth expansion, richer parsing, runner orchestration, or broader proxy execution work.
 
 ## Recommended Next Step
-Run sprint review against `/calendar` UI behavior and scope boundaries, then open/merge the sprint PR per Control Tower policy if reviewer outcome is `PASS`.
+Run review against the synchronized truth artifacts, then choose the next narrow sprint from the actual shipped Sprint 6V baseline rather than reopening doc drift or older Sprint 6R assumptions.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6U: a FastAPI backend plus a bounded Next.js operator shell.
+AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6V: a FastAPI backend plus a bounded Next.js operator shell.
 
 ## Current Implemented Slice
 
-- `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and narrow read-only Gmail and Calendar seams.
-- `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
+- `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and narrow read-only Gmail and Calendar seams with selected-item ingestion.
+- `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
 - `/chat` supports both assistant and governed-request modes, selected-thread continuity, compact thread creation, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, and bounded supporting continuity review.
+- `/gmail` and `/calendar` are shipped bounded connector workspaces for account review, selected-account detail, explicit account connection, and explicit single-item ingestion into one selected task workspace.
 - `/artifacts`, `/memories`, and `/entities` are shipped bounded operator review workspaces for artifact, memory, and entity evidence.
 - `workers` remains scaffold-only.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,10 +2,11 @@
 
 ## Current Position
 
-- The accepted repo state is current through Sprint 6R.
-- The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, the narrow read-only Gmail seam, and the no-tools assistant-response seam.
-- The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
+- The accepted repo state is current through Sprint 6V.
+- The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, narrow read-only Gmail and Calendar seams with selected-item ingestion, and the no-tools assistant-response seam.
+- The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
 - `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, keeps bounded thread review visible beside both assistant and governed-request composition, and ships thread-linked governed workflow, ordered task-step timeline review, and bounded explain-why trace embedding.
+- `/gmail` and `/calendar` are shipped bounded connector workspaces in the shell: account review, selected-account detail, explicit connect, and one selected-item ingestion path into one chosen task workspace.
 - `/memories`, `/entities`, and `/artifacts` are shipped bounded review workspaces in the shell, not planned surface.
 - Historical sprint detail belongs in build and review artifacts, not in this roadmap.
 
@@ -13,14 +14,14 @@
 
 ### Build From The Shipped API Plus Web-Shell Baseline
 
-- Plan the next sprint from the implemented Sprint 6R backend-plus-web baseline, not from the older Gmail-cleanup-only narrative.
-- Treat transcript continuity, thread-linked workflow review, task-step timeline review, bounded explain-why embedding in `/chat`, and the shipped review workspaces (`/memories`, `/entities`, `/artifacts`) as baseline, not pending work.
+- Plan the next sprint from the implemented Sprint 6V backend-plus-web baseline, not from the older Sprint 6R narrative.
+- Treat transcript continuity, thread-linked workflow review, task-step timeline review, bounded explain-why embedding in `/chat`, the shipped review workspaces (`/memories`, `/entities`, `/artifacts`), and the shipped connector workspaces (`/gmail`, `/calendar`) as baseline, not pending work.
 - Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.
 - Reuse the existing continuity, response, approval, task, workspace-artifact, memory, entity, execution, and trace surfaces instead of introducing parallel contracts.
 
 ### Keep New Scope Narrow
 
-- Do not bundle broader Gmail work, Calendar work, auth expansion, richer document parsing, runner orchestration, or proxy breadth into the next sprint by default.
+- Do not bundle broader Gmail or Calendar breadth, auth expansion, richer document parsing, runner orchestration, or proxy breadth into the next sprint by default.
 - Do not reopen schema or API design unless the next sprint explicitly requires it.
 - Keep live docs synchronized with shipped reality so planning does not drift behind the repo again.
 
@@ -28,12 +29,12 @@
 
 - Memory extraction and retrieval quality remain the main product risk.
 - Auth remains incomplete beyond the current database user-context model.
-- The operator shell is now shipped surface, so future drift between web UI behavior, backend seams, and canonical docs is a planning and review risk.
+- The operator shell is now shipped surface, including `/gmail` and `/calendar`, so future drift between web UI behavior, backend seams, and canonical docs is a planning and review risk.
 - Connector and document boundaries are still intentionally narrow; broadening them safely will require separate explicit sprints.
 
 ## Deferred Until Explicitly Opened
 
-- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and Calendar connectors
+- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and broader Calendar capabilities such as event listing/search, recurrence expansion, sync, and write actions
 - runner-style orchestration and automatic multi-step progression
 - richer document parsing, OCR, and layout-aware ingestion
 - broader tool execution breadth beyond the current governed `proxy.echo` seam


### PR DESCRIPTION
Documentation-only sprint. Canonical truth files synchronized to implemented repo state through Sprint 6V, with no runtime/schema/API/UI/Gmail-Calendar scope expansion.