### PR TITLE
Sprint 6X: calendar event discovery API v0

### DIFF
--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,61 +1,125 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Synchronize canonical truth artifacts with the accepted repo state through Sprint 6V so roadmap, handoff, README, and architecture docs reflect the shipped Gmail and Calendar operator-shell baseline without changing runtime behavior or product scope.
+Implement Sprint 6X: a deterministic, user-scoped, read-only Calendar event discovery API for one connected account at `GET /v0/calendar-accounts/{calendar_account_id}/events`, with bounded filters, stable ordering metadata, and no expansion into sync/recurrence/write/UI scope.
 
 ## Completed Work
-- Updated `ROADMAP.md` to move the stated accepted baseline from Sprint 6R to Sprint 6V, include `/gmail` and `/calendar` in the shipped shell baseline, and frame next planning from the actual current operator surface.
-- Updated `.ai/handoff/CURRENT_STATE.md` to move the stated working baseline from Sprint 6R to Sprint 6V, add shipped Gmail and Calendar web workspaces, and tighten current boundary and planning language around narrow connector seams.
-- Updated `README.md` to move the stated accepted slice from Sprint 6U to Sprint 6V and correct the route inventory to include `/gmail` and `/calendar`.
-- Updated `ARCHITECTURE.md` to move the accepted slice from Sprint 6U to Sprint 6V, include `/gmail` and `/calendar` in the operator-shell route inventory, and keep Gmail/Calendar connector boundaries explicit and narrow.
-- Confirmed no archival move was required; `docs/archive/**` was not changed.
-- Confirmed the sprint stayed documentation-only: no runtime code, schema, API, or UI behavior changed.
+- Added Calendar event discovery contracts in `apps/api/src/alicebot_api/contracts.py`:
+  - Constants:
+    - `DEFAULT_CALENDAR_EVENT_LIST_LIMIT = 20`
+    - `MAX_CALENDAR_EVENT_LIST_LIMIT = 50`
+    - `CALENDAR_EVENT_LIST_ORDER = ["start_time_asc", "provider_event_id_asc"]`
+  - Request input contract:
+    - `CalendarEventListInput(calendar_account_id, limit, time_min, time_max)`
+  - Response contracts:
+    - `CalendarEventSummaryRecord`
+    - `CalendarEventListSummary`
+    - `CalendarEventListResponse`
+- Implemented read-only event discovery service logic in `apps/api/src/alicebot_api/calendar.py`:
+  - `fetch_calendar_event_list_payload(...)` using existing credential/secret seams.
+  - `list_calendar_event_records(...)` for one account with user-scoped visibility.
+  - `CalendarEventListValidationError` for invalid time windows.
+  - Deterministic normalization and sorting of events.
+- Added endpoint in `apps/api/src/alicebot_api/main.py`:
+  - `GET /v0/calendar-accounts/{calendar_account_id}/events`
+  - Query params: `user_id`, `limit`, `time_min`, `time_max`
+  - Deterministic error mapping:
+    - 404: missing/non-visible account
+    - 409: credential missing/invalid/persistence issues
+    - 400: invalid query window (`time_min > time_max`)
+    - 502: upstream provider fetch failures
+- Added/updated tests:
+  - `tests/unit/test_calendar.py`
+  - `tests/unit/test_calendar_main.py`
+  - `tests/integration/test_calendar_accounts_api.py`
 
-## Stale Claims Corrected
-- `ROADMAP.md` no longer says the accepted repo state is current only through Sprint 6R.
-- `.ai/handoff/CURRENT_STATE.md` no longer says the working repo state is current only through Sprint 6R.
-- `README.md` no longer says the accepted slice is only through Sprint 6U.
-- `README.md` and `ARCHITECTURE.md` no longer omit `/gmail` and `/calendar` from the shipped shell route inventory.
-- Roadmap and handoff planning language no longer imply Calendar is still pre-shell or that next planning should start from the older Sprint 6R baseline.
+## Ordering And Limit Rule
+- Ordering rule in response summary: `order = ["start_time_asc", "provider_event_id_asc"]`.
+- Deterministic sort key applied server-side after provider fetch:
+  1. `start_time` normalized to UTC datetime ascending (all-day `date` values normalize to midnight UTC)
+  2. `provider_event_id` ascending
+- Limit behavior:
+  - Default `limit=20`
+  - Hard max `limit=50`
+  - Response summary always returns applied `limit`.
 
-## Accepted Repo Evidence Used
-- `apps/web/components/app-shell.tsx`
-- `apps/web/app/page.tsx`
-- `apps/web/app/gmail/page.tsx`
-- `apps/web/app/calendar/page.tsx`
-- `apps/web/lib/api.ts`
-- `apps/web/lib/api.test.ts`
-- `tests/integration/test_gmail_accounts_api.py`
-- `tests/integration/test_calendar_accounts_api.py`
-- `tests/unit/test_gmail.py`
-- `tests/unit/test_calendar.py`
-- `tests/unit/test_20260316_0026_gmail_accounts.py`
-- `tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py`
+## Example Calendar Event List Response
+```json
+{
+  "account": {
+    "id": "2f90c8ea-6f04-4d7f-9e5e-b8e7cbfd4b3e",
+    "provider": "google_calendar",
+    "auth_kind": "oauth_access_token",
+    "provider_account_id": "acct-owner-001",
+    "email_address": "owner@gmail.example",
+    "display_name": "Owner",
+    "scope": "https://www.googleapis.com/auth/calendar.readonly",
+    "created_at": "2026-03-19T11:02:10.100000+00:00",
+    "updated_at": "2026-03-19T11:02:10.100000+00:00"
+  },
+  "items": [
+    {
+      "provider_event_id": "evt-a",
+      "status": "tentative",
+      "summary": "First",
+      "start_time": "2026-03-20",
+      "end_time": "2026-03-21",
+      "html_link": null,
+      "updated_at": "2026-03-19T09:00:00+00:00"
+    },
+    {
+      "provider_event_id": "evt-b",
+      "status": "confirmed",
+      "summary": "Second",
+      "start_time": "2026-03-25T09:00:00+00:00",
+      "end_time": "2026-03-25T09:45:00+00:00",
+      "html_link": null,
+      "updated_at": "2026-03-24T08:30:00+00:00"
+    }
+  ],
+  "summary": {
+    "total_count": 2,
+    "limit": 2,
+    "order": ["start_time_asc", "provider_event_id_asc"],
+    "time_min": "2026-03-20T00:00:00+00:00",
+    "time_max": "2026-03-27T00:00:00+00:00"
+  }
+}
+```
 
 ## Incomplete Work
-- None within Sprint 6W scope.
+- None within Sprint 6X scope.
 
 ## Files Changed
-- `ROADMAP.md`
-- `.ai/handoff/CURRENT_STATE.md`
-- `README.md`
-- `ARCHITECTURE.md`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/calendar.py`
+- `apps/api/src/alicebot_api/main.py`
+- `tests/unit/test_calendar.py`
+- `tests/unit/test_calendar_main.py`
+- `tests/integration/test_calendar_accounts_api.py`
 - `BUILD_REPORT.md`
 
 ## Tests Run
-- `git diff --check -- ROADMAP.md .ai/handoff/CURRENT_STATE.md README.md ARCHITECTURE.md BUILD_REPORT.md`: PASS
-- `rg -n "Sprint 6R|Sprint 6U|/gmail|/calendar|current through Sprint 6V|accepted slice through Sprint 6V" ROADMAP.md .ai/handoff/CURRENT_STATE.md README.md ARCHITECTURE.md BUILD_REPORT.md`: PASS
-- No runtime or UI test suites were run because this sprint is documentation-only.
+- `./.venv/bin/python -m pytest tests/unit/test_calendar.py tests/unit/test_calendar_main.py tests/integration/test_calendar_accounts_api.py` -> PASS (`30 passed`)
+- `./.venv/bin/python -m pytest tests/unit` -> PASS (`484 passed`)
+- `./.venv/bin/python -m pytest tests/integration` -> PASS (`153 passed`)
 
 ## Blockers / Issues
-- No blockers.
-- Existing unrelated modifications remain in `.ai/active/SPRINT_PACKET.md` and `REVIEW_REPORT.md`; they were left untouched.
+- No implementation blockers.
+- Integration tests required DB access outside sandbox to reach local Postgres (`localhost:5432`), then passed with escalated execution.
+- Existing unrelated pre-existing modifications remained untouched in:
+  - `.ai/active/SPRINT_PACKET.md`
+  - `REVIEW_REPORT.md`
 
-## Intentionally Deferred After This Truth-Sync Sprint
-- Any runtime, schema, API, or UI work.
-- Broader Gmail scope beyond the shipped read-only account review and selected-message ingestion seam.
-- Broader Calendar scope beyond the shipped read-only account review and selected-event ingestion seam.
-- Auth expansion, richer parsing, runner orchestration, or broader proxy execution work.
+## Intentionally Deferred After This Sprint
+- UI changes.
+- Event ingestion behavior changes.
+- Recurring event expansion.
+- Background sync/backfill.
+- Write-capable calendar actions.
+- Gmail scope expansion.
+- Auth redesign.
+- Runner orchestration.
 
 ## Recommended Next Step
-Run review against the synchronized truth artifacts, then choose the next narrow sprint from the actual shipped Sprint 6V baseline rather than reopening doc drift or older Sprint 6R assumptions.
+Proceed to reviewer validation focused on deterministic event discovery behavior (ordering/limits/isolation/error mapping), then merge if review is PASS.

--- a/apps/api/src/alicebot_api/calendar.py
+++ b/apps/api/src/alicebot_api/calendar.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import UTC, date, datetime
 from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 from uuid import UUID
 
@@ -26,7 +27,9 @@ from alicebot_api.calendar_secret_manager import (
 )
 from alicebot_api.contracts import (
     CALENDAR_ACCOUNT_LIST_ORDER,
+    CALENDAR_EVENT_LIST_ORDER,
     CALENDAR_AUTH_KIND_OAUTH_ACCESS_TOKEN,
+    MAX_CALENDAR_EVENT_LIST_LIMIT,
     CALENDAR_PROTECTED_CREDENTIAL_KIND,
     CALENDAR_PROVIDER,
     CALENDAR_READONLY_SCOPE,
@@ -35,6 +38,9 @@ from alicebot_api.contracts import (
     CalendarAccountDetailResponse,
     CalendarAccountListResponse,
     CalendarAccountRecord,
+    CalendarEventListInput,
+    CalendarEventListResponse,
+    CalendarEventSummaryRecord,
     CalendarEventIngestInput,
     CalendarEventIngestionResponse,
     TaskArtifactIngestInput,
@@ -72,6 +78,10 @@ class CalendarEventUnsupportedError(ValueError):
 
 class CalendarEventFetchError(RuntimeError):
     """Raised when the Calendar API call fails for non-deterministic upstream reasons."""
+
+
+class CalendarEventListValidationError(ValueError):
+    """Raised when Calendar event list query filters are invalid."""
 
 
 class CalendarCredentialNotFoundError(RuntimeError):
@@ -291,6 +301,161 @@ def get_calendar_account_record(
     if row is None:
         raise CalendarAccountNotFoundError(f"calendar account {calendar_account_id} was not found")
     return {"account": serialize_calendar_account_row(row)}
+
+
+def _extract_optional_calendar_event_time(value: object) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    date_time = _coerce_nonempty_string(value.get("dateTime"))
+    if date_time is not None:
+        return date_time
+    return _coerce_nonempty_string(value.get("date"))
+
+
+def _serialize_calendar_event_summary(payload: object) -> CalendarEventSummaryRecord | None:
+    if not isinstance(payload, dict):
+        return None
+    provider_event_id = _coerce_nonempty_string(payload.get("id"))
+    if provider_event_id is None:
+        return None
+    return {
+        "provider_event_id": provider_event_id,
+        "status": _coerce_nonempty_string(payload.get("status")),
+        "summary": _coerce_nonempty_string(payload.get("summary")),
+        "start_time": _extract_optional_calendar_event_time(payload.get("start")),
+        "end_time": _extract_optional_calendar_event_time(payload.get("end")),
+        "html_link": _coerce_nonempty_string(payload.get("htmlLink")),
+        "updated_at": _coerce_nonempty_string(payload.get("updated")),
+    }
+
+
+def _normalize_start_time_for_sort(start_time: str | None) -> str | None:
+    if start_time is None:
+        return None
+
+    # All-day events use date-only values; normalize to midnight UTC.
+    if len(start_time) == 10:
+        try:
+            parsed_date = date.fromisoformat(start_time)
+        except ValueError:
+            return None
+        return datetime(
+            parsed_date.year,
+            parsed_date.month,
+            parsed_date.day,
+            tzinfo=UTC,
+        ).isoformat()
+
+    normalized = start_time.replace("Z", "+00:00")
+    try:
+        parsed_datetime = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed_datetime.tzinfo is None:
+        parsed_datetime = parsed_datetime.replace(tzinfo=UTC)
+    return parsed_datetime.astimezone(UTC).isoformat()
+
+
+def _calendar_event_sort_key(record: CalendarEventSummaryRecord) -> tuple[str, str]:
+    start_time = record["start_time"]
+    return (
+        _normalize_start_time_for_sort(start_time) or "~",
+        record["provider_event_id"],
+    )
+
+
+def fetch_calendar_event_list_payload(
+    *,
+    access_token: str,
+    limit: int = MAX_CALENDAR_EVENT_LIST_LIMIT,
+    time_min: datetime | None = None,
+    time_max: datetime | None = None,
+) -> list[JsonObject]:
+    query_params: dict[str, str] = {
+        "maxResults": str(limit),
+        "showDeleted": "false",
+        "singleEvents": "false",
+    }
+    if time_min is not None:
+        query_params["timeMin"] = time_min.isoformat()
+    if time_max is not None:
+        query_params["timeMax"] = time_max.isoformat()
+    query_string = urlencode(query_params)
+    request = Request(
+        f"https://www.googleapis.com/calendar/v3/calendars/primary/events?{query_string}",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+        },
+        method="GET",
+    )
+
+    try:
+        with urlopen(request, timeout=CALENDAR_EVENT_FETCH_TIMEOUT_SECONDS) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        raise CalendarEventFetchError("calendar events could not be fetched") from exc
+    except (OSError, URLError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CalendarEventFetchError("calendar events could not be fetched") from exc
+
+    if not isinstance(payload, dict):
+        raise CalendarEventFetchError("calendar events could not be fetched")
+    raw_items = payload.get("items")
+    if not isinstance(raw_items, list):
+        raise CalendarEventFetchError("calendar events could not be fetched")
+
+    items: list[JsonObject] = []
+    for item in raw_items:
+        if isinstance(item, dict):
+            items.append(item)
+    return items
+
+
+def list_calendar_event_records(
+    store: ContinuityStore,
+    secret_manager: CalendarSecretManager,
+    *,
+    user_id: UUID,
+    request: CalendarEventListInput,
+) -> CalendarEventListResponse:
+    del user_id
+
+    if request.time_min is not None and request.time_max is not None and request.time_min > request.time_max:
+        raise CalendarEventListValidationError("calendar event time_min must be less than or equal to time_max")
+
+    account = store.get_calendar_account_optional(request.calendar_account_id)
+    if account is None:
+        raise CalendarAccountNotFoundError(f"calendar account {request.calendar_account_id} was not found")
+
+    bounded_limit = max(1, min(request.limit, MAX_CALENDAR_EVENT_LIST_LIMIT))
+    access_token = resolve_calendar_access_token(
+        store,
+        secret_manager,
+        calendar_account_id=request.calendar_account_id,
+    )
+    raw_items = fetch_calendar_event_list_payload(
+        access_token=access_token,
+        limit=MAX_CALENDAR_EVENT_LIST_LIMIT,
+        time_min=request.time_min,
+        time_max=request.time_max,
+    )
+    records = [
+        record
+        for record in (_serialize_calendar_event_summary(item) for item in raw_items)
+        if record is not None
+    ]
+    items = sorted(records, key=_calendar_event_sort_key)[:bounded_limit]
+    return {
+        "account": serialize_calendar_account_row(account),
+        "items": items,
+        "summary": {
+            "total_count": len(items),
+            "limit": bounded_limit,
+            "order": list(CALENDAR_EVENT_LIST_ORDER),
+            "time_min": None if request.time_min is None else request.time_min.isoformat(),
+            "time_max": None if request.time_max is None else request.time_max.isoformat(),
+        },
+    }
 
 
 def _sanitize_path_segment(value: str) -> str:

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -93,6 +93,8 @@ DEFAULT_SEMANTIC_MEMORY_RETRIEVAL_LIMIT = 5
 MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT = 50
 DEFAULT_ARTIFACT_CHUNK_RETRIEVAL_LIMIT = 5
 MAX_ARTIFACT_CHUNK_RETRIEVAL_LIMIT = 50
+DEFAULT_CALENDAR_EVENT_LIST_LIMIT = 20
+MAX_CALENDAR_EVENT_LIST_LIMIT = 50
 COMPILER_VERSION_V0 = "continuity_v0"
 PROMPT_ASSEMBLY_VERSION_V0 = "prompt_assembly_v0"
 RESPONSE_GENERATION_VERSION_V0 = "response_generation_v0"
@@ -143,6 +145,7 @@ TASK_LIST_ORDER = ["created_at_asc", "id_asc"]
 TASK_WORKSPACE_LIST_ORDER = ["created_at_asc", "id_asc"]
 GMAIL_ACCOUNT_LIST_ORDER = ["created_at_asc", "id_asc"]
 CALENDAR_ACCOUNT_LIST_ORDER = ["created_at_asc", "id_asc"]
+CALENDAR_EVENT_LIST_ORDER = ["start_time_asc", "provider_event_id_asc"]
 TASK_ARTIFACT_LIST_ORDER = ["created_at_asc", "id_asc"]
 TASK_ARTIFACT_CHUNK_LIST_ORDER = ["sequence_no_asc", "id_asc"]
 TASK_ARTIFACT_CHUNK_EMBEDDING_LIST_ORDER = [
@@ -1983,6 +1986,14 @@ class CalendarEventIngestInput:
     provider_event_id: str
 
 
+@dataclass(frozen=True, slots=True)
+class CalendarEventListInput:
+    calendar_account_id: UUID
+    limit: int = DEFAULT_CALENDAR_EVENT_LIST_LIMIT
+    time_min: datetime | None = None
+    time_max: datetime | None = None
+
+
 class CalendarAccountRecord(TypedDict):
     id: str
     provider: str
@@ -2024,6 +2035,30 @@ class CalendarEventIngestionResponse(TypedDict):
     event: CalendarEventIngestionRecord
     artifact: TaskArtifactRecord
     summary: TaskArtifactChunkListSummary
+
+
+class CalendarEventSummaryRecord(TypedDict):
+    provider_event_id: str
+    status: str | None
+    summary: str | None
+    start_time: str | None
+    end_time: str | None
+    html_link: str | None
+    updated_at: str | None
+
+
+class CalendarEventListSummary(TypedDict):
+    total_count: int
+    limit: int
+    order: list[str]
+    time_min: str | None
+    time_max: str | None
+
+
+class CalendarEventListResponse(TypedDict):
+    account: CalendarAccountRecord
+    items: list[CalendarEventSummaryRecord]
+    summary: CalendarEventListSummary
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -25,6 +25,7 @@ from alicebot_api.contracts import (
     ConsentUpsertInput,
     CompileContextSemanticRetrievalInput,
     DEFAULT_ARTIFACT_CHUNK_RETRIEVAL_LIMIT,
+    DEFAULT_CALENDAR_EVENT_LIST_LIMIT,
     DEFAULT_MAX_EVENTS,
     DEFAULT_MAX_ENTITY_EDGES,
     DEFAULT_MAX_ENTITIES,
@@ -34,6 +35,7 @@ from alicebot_api.contracts import (
     DEFAULT_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
     MAX_MEMORY_REVIEW_LIMIT,
     MAX_ARTIFACT_CHUNK_RETRIEVAL_LIMIT,
+    MAX_CALENDAR_EVENT_LIST_LIMIT,
     MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
     ContextCompilerLimits,
     EmbeddingConfigStatus,
@@ -48,6 +50,7 @@ from alicebot_api.contracts import (
     CALENDAR_READONLY_SCOPE,
     GMAIL_READONLY_SCOPE,
     CalendarAccountConnectInput,
+    CalendarEventListInput,
     CalendarEventIngestInput,
     GmailAccountConnectInput,
     GmailMessageIngestInput,
@@ -180,12 +183,14 @@ from alicebot_api.calendar import (
     CalendarCredentialPersistenceError,
     CalendarCredentialValidationError,
     CalendarEventFetchError,
+    CalendarEventListValidationError,
     CalendarEventNotFoundError,
     CalendarEventUnsupportedError,
     create_calendar_account_record,
     get_calendar_account_record,
     ingest_calendar_event_record,
     list_calendar_account_records,
+    list_calendar_event_records,
 )
 from alicebot_api.calendar_secret_manager import build_calendar_secret_manager
 from alicebot_api.gmail_secret_manager import build_gmail_secret_manager
@@ -1750,6 +1755,49 @@ def get_calendar_account(calendar_account_id: UUID, user_id: UUID) -> JSONRespon
             )
     except CalendarAccountNotFoundError as exc:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/calendar-accounts/{calendar_account_id}/events")
+def list_calendar_events(
+    calendar_account_id: UUID,
+    user_id: UUID,
+    limit: int = Query(default=DEFAULT_CALENDAR_EVENT_LIST_LIMIT, ge=1, le=MAX_CALENDAR_EVENT_LIST_LIMIT),
+    time_min: datetime | None = Query(default=None),
+    time_max: datetime | None = Query(default=None),
+) -> JSONResponse:
+    settings = get_settings()
+    secret_manager = build_calendar_secret_manager(settings.calendar_secret_manager_url)
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload = list_calendar_event_records(
+                ContinuityStore(conn),
+                secret_manager,
+                user_id=user_id,
+                request=CalendarEventListInput(
+                    calendar_account_id=calendar_account_id,
+                    limit=limit,
+                    time_min=time_min,
+                    time_max=time_max,
+                ),
+            )
+    except CalendarAccountNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except (
+        CalendarCredentialNotFoundError,
+        CalendarCredentialInvalidError,
+        CalendarCredentialPersistenceError,
+    ) as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    except CalendarEventListValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except CalendarEventFetchError as exc:
+        return JSONResponse(status_code=502, content={"detail": str(exc)})
 
     return JSONResponse(
         status_code=200,

--- a/tests/integration/test_calendar_accounts_api.py
+++ b/tests/integration/test_calendar_accounts_api.py
@@ -273,6 +273,237 @@ def test_calendar_account_endpoints_connect_list_detail_and_isolate(
     }
 
 
+def test_calendar_event_list_endpoint_is_deterministic_and_limit_bounded(
+    migrated_database_urls,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    owner = seed_user(migrated_database_urls["app"], email="owner@example.com")
+    calendar_secret_root = tmp_path / "calendar-secrets"
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            database_url=migrated_database_urls["app"],
+            calendar_secret_manager_url=_build_calendar_secret_manager_url(calendar_secret_root),
+        ),
+    )
+    monkeypatch.setattr(
+        calendar_module,
+        "fetch_calendar_event_list_payload",
+        lambda **_kwargs: [
+            {
+                "id": "evt-c",
+                "summary": "Third",
+                "status": "confirmed",
+                "start": {"dateTime": "2026-03-25T10:00:00+02:00"},
+                "end": {"dateTime": "2026-03-25T10:30:00+02:00"},
+                "htmlLink": "https://calendar.google.com/event?eid=evt-c",
+                "updated": "2026-03-24T09:00:00+00:00",
+            },
+            {
+                "id": "evt-a",
+                "summary": "First",
+                "status": "tentative",
+                "start": {"date": "2026-03-20"},
+                "end": {"date": "2026-03-21"},
+                "updated": "2026-03-19T09:00:00+00:00",
+            },
+            {
+                "id": "evt-b",
+                "summary": "Second",
+                "status": "confirmed",
+                "start": {"dateTime": "2026-03-25T08:30:00+00:00"},
+                "end": {"dateTime": "2026-03-25T09:15:00+00:00"},
+                "updated": "2026-03-24T08:30:00+00:00",
+            },
+        ],
+    )
+
+    _, account_payload = _connect_calendar_account(
+        user_id=owner["user_id"],
+        provider_account_id="acct-owner-001",
+        email_address="owner@gmail.example",
+    )
+    status, payload = invoke_request(
+        "GET",
+        f"/v0/calendar-accounts/{account_payload['account']['id']}/events",
+        query_params={
+            "user_id": str(owner["user_id"]),
+            "limit": "2",
+            "time_min": "2026-03-20T00:00:00+00:00",
+            "time_max": "2026-03-27T00:00:00+00:00",
+        },
+    )
+    tighter_status, tighter_payload = invoke_request(
+        "GET",
+        f"/v0/calendar-accounts/{account_payload['account']['id']}/events",
+        query_params={
+            "user_id": str(owner["user_id"]),
+            "limit": "1",
+        },
+    )
+
+    assert status == 200
+    assert payload == {
+        "account": account_payload["account"],
+        "items": [
+            {
+                "provider_event_id": "evt-a",
+                "status": "tentative",
+                "summary": "First",
+                "start_time": "2026-03-20",
+                "end_time": "2026-03-21",
+                "html_link": None,
+                "updated_at": "2026-03-19T09:00:00+00:00",
+            },
+            {
+                "provider_event_id": "evt-c",
+                "status": "confirmed",
+                "summary": "Third",
+                "start_time": "2026-03-25T10:00:00+02:00",
+                "end_time": "2026-03-25T10:30:00+02:00",
+                "html_link": "https://calendar.google.com/event?eid=evt-c",
+                "updated_at": "2026-03-24T09:00:00+00:00",
+            },
+        ],
+        "summary": {
+            "total_count": 2,
+            "limit": 2,
+            "order": ["start_time_asc", "provider_event_id_asc"],
+            "time_min": "2026-03-20T00:00:00+00:00",
+            "time_max": "2026-03-27T00:00:00+00:00",
+        },
+    }
+    assert tighter_status == 200
+    assert tighter_payload["summary"]["limit"] == 1
+    assert tighter_payload["summary"]["total_count"] == 1
+    assert len(tighter_payload["items"]) == 1
+
+
+def test_calendar_event_list_endpoint_isolates_users_and_handles_missing_accounts(
+    migrated_database_urls,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    owner = seed_user(migrated_database_urls["app"], email="owner@example.com")
+    intruder = seed_user(migrated_database_urls["app"], email="intruder@example.com")
+    calendar_secret_root = tmp_path / "calendar-secrets"
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            database_url=migrated_database_urls["app"],
+            calendar_secret_manager_url=_build_calendar_secret_manager_url(calendar_secret_root),
+        ),
+    )
+    monkeypatch.setattr(
+        calendar_module,
+        "fetch_calendar_event_list_payload",
+        lambda **_kwargs: [],
+    )
+
+    _, account_payload = _connect_calendar_account(
+        user_id=owner["user_id"],
+        provider_account_id="acct-owner-001",
+        email_address="owner@gmail.example",
+    )
+    isolated_status, isolated_payload = invoke_request(
+        "GET",
+        f"/v0/calendar-accounts/{account_payload['account']['id']}/events",
+        query_params={"user_id": str(intruder["user_id"])},
+    )
+    missing_status, missing_payload = invoke_request(
+        "GET",
+        f"/v0/calendar-accounts/{uuid4()}/events",
+        query_params={"user_id": str(owner["user_id"])},
+    )
+
+    assert isolated_status == 404
+    assert isolated_payload == {
+        "detail": f"calendar account {account_payload['account']['id']} was not found"
+    }
+    assert missing_status == 404
+    assert missing_payload["detail"].endswith("was not found")
+
+
+def test_calendar_event_list_endpoint_maps_credential_fetch_and_validation_failures(
+    migrated_database_urls,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    owner = seed_user(migrated_database_urls["app"], email="owner@example.com")
+    calendar_secret_root = tmp_path / "calendar-secrets"
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            database_url=migrated_database_urls["app"],
+            calendar_secret_manager_url=_build_calendar_secret_manager_url(calendar_secret_root),
+        ),
+    )
+
+    _, account_payload = _connect_calendar_account(
+        user_id=owner["user_id"],
+        provider_account_id="acct-owner-001",
+        email_address="owner@gmail.example",
+    )
+    account_id = account_payload["account"]["id"]
+
+    monkeypatch.setattr(
+        calendar_module,
+        "resolve_calendar_access_token",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            calendar_module.CalendarCredentialNotFoundError(
+                f"calendar account {account_id} is missing protected credentials"
+            )
+        ),
+    )
+    credential_status, credential_payload = invoke_request(
+        "GET",
+        f"/v0/calendar-accounts/{account_id}/events",
+        query_params={"user_id": str(owner["user_id"])},
+    )
+    assert credential_status == 409
+    assert credential_payload == {
+        "detail": f"calendar account {account_id} is missing protected credentials"
+    }
+
+    monkeypatch.setattr(
+        calendar_module,
+        "resolve_calendar_access_token",
+        lambda *_args, **_kwargs: "token-for-acct-owner-001",
+    )
+    monkeypatch.setattr(
+        calendar_module,
+        "fetch_calendar_event_list_payload",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            calendar_module.CalendarEventFetchError("calendar events could not be fetched")
+        ),
+    )
+    fetch_status, fetch_payload = invoke_request(
+        "GET",
+        f"/v0/calendar-accounts/{account_id}/events",
+        query_params={"user_id": str(owner["user_id"])},
+    )
+    assert fetch_status == 502
+    assert fetch_payload == {"detail": "calendar events could not be fetched"}
+
+    invalid_window_status, invalid_window_payload = invoke_request(
+        "GET",
+        f"/v0/calendar-accounts/{account_id}/events",
+        query_params={
+            "user_id": str(owner["user_id"]),
+            "time_min": "2026-03-27T00:00:00+00:00",
+            "time_max": "2026-03-20T00:00:00+00:00",
+        },
+    )
+    assert invalid_window_status == 400
+    assert invalid_window_payload == {
+        "detail": "calendar event time_min must be less than or equal to time_max"
+    }
+
+
 def test_calendar_event_ingestion_endpoint_persists_artifact_and_chunks(
     migrated_database_urls,
     monkeypatch,

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -13,6 +13,7 @@ from alicebot_api.calendar import (
     CalendarAccountNotFoundError,
     CalendarCredentialInvalidError,
     CalendarCredentialNotFoundError,
+    CalendarEventListValidationError,
     CalendarEventUnsupportedError,
     build_calendar_event_artifact_relative_path,
     build_calendar_protected_credential_blob,
@@ -21,6 +22,7 @@ from alicebot_api.calendar import (
     get_calendar_account_record,
     ingest_calendar_event_record,
     list_calendar_account_records,
+    list_calendar_event_records,
     resolve_calendar_access_token,
 )
 from alicebot_api.calendar_secret_manager import (
@@ -28,7 +30,11 @@ from alicebot_api.calendar_secret_manager import (
     CalendarSecretManagerError,
 )
 from alicebot_api.contracts import CALENDAR_PROTECTED_CREDENTIAL_KIND, CALENDAR_READONLY_SCOPE
-from alicebot_api.contracts import CalendarAccountConnectInput, CalendarEventIngestInput
+from alicebot_api.contracts import (
+    CalendarAccountConnectInput,
+    CalendarEventIngestInput,
+    CalendarEventListInput,
+)
 from alicebot_api.workspaces import TaskWorkspaceNotFoundError
 
 
@@ -312,6 +318,183 @@ def test_get_calendar_account_record_raises_when_account_is_missing() -> None:
             CalendarStoreStub(),
             user_id=uuid4(),
             calendar_account_id=uuid4(),
+        )
+
+
+def test_list_calendar_event_records_enforces_deterministic_utc_order_and_shape(monkeypatch) -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    user_id = uuid4()
+    account = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=user_id,
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )["account"]
+
+    monkeypatch.setattr(
+        "alicebot_api.calendar.fetch_calendar_event_list_payload",
+        lambda **_kwargs: [
+            {
+                "id": "evt-c",
+                "summary": "Third",
+                "start": {"dateTime": "2026-03-25T10:00:00+02:00"},
+                "end": {"dateTime": "2026-03-25T10:30:00+02:00"},
+                "status": "confirmed",
+                "htmlLink": "https://calendar.google.com/event?eid=evt-c",
+                "updated": "2026-03-24T10:00:00+00:00",
+            },
+            {
+                "id": "evt-a",
+                "summary": "First",
+                "start": {"date": "2026-03-20"},
+                "end": {"date": "2026-03-21"},
+                "status": "tentative",
+                "updated": "2026-03-19T10:00:00+00:00",
+            },
+            {
+                "id": "evt-b",
+                "summary": "Second",
+                "start": {"dateTime": "2026-03-25T08:30:00+00:00"},
+                "end": {"dateTime": "2026-03-25T09:30:00+00:00"},
+                "status": "confirmed",
+                "updated": "2026-03-24T11:00:00+00:00",
+            },
+            {"summary": "Missing id should be skipped"},
+        ],
+    )
+
+    response = list_calendar_event_records(
+        store,
+        secret_manager,
+        user_id=user_id,
+        request=CalendarEventListInput(
+            calendar_account_id=UUID(account["id"]),
+            limit=2,
+            time_min=datetime(2026, 3, 20, 0, 0, tzinfo=UTC),
+            time_max=datetime(2026, 3, 27, 0, 0, tzinfo=UTC),
+        ),
+    )
+
+    assert response["account"] == account
+    assert response["items"] == [
+        {
+            "provider_event_id": "evt-a",
+            "status": "tentative",
+            "summary": "First",
+            "start_time": "2026-03-20",
+            "end_time": "2026-03-21",
+            "html_link": None,
+            "updated_at": "2026-03-19T10:00:00+00:00",
+        },
+        {
+            "provider_event_id": "evt-c",
+            "status": "confirmed",
+            "summary": "Third",
+            "start_time": "2026-03-25T10:00:00+02:00",
+            "end_time": "2026-03-25T10:30:00+02:00",
+            "html_link": "https://calendar.google.com/event?eid=evt-c",
+            "updated_at": "2026-03-24T10:00:00+00:00",
+        },
+    ]
+    assert response["summary"] == {
+        "total_count": 2,
+        "limit": 2,
+        "order": ["start_time_asc", "provider_event_id_asc"],
+        "time_min": "2026-03-20T00:00:00+00:00",
+        "time_max": "2026-03-27T00:00:00+00:00",
+    }
+
+
+def test_list_calendar_event_records_enforces_hard_max_limit(monkeypatch) -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    account = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=uuid4(),
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )["account"]
+    monkeypatch.setattr(
+        "alicebot_api.calendar.fetch_calendar_event_list_payload",
+        lambda **_kwargs: [
+            {
+                "id": f"evt-{index:03d}",
+                "start": {"dateTime": f"2026-03-20T09:{index % 60:02d}:00+00:00"},
+            }
+            for index in range(60)
+        ],
+    )
+
+    response = list_calendar_event_records(
+        store,
+        secret_manager,
+        user_id=uuid4(),
+        request=CalendarEventListInput(
+            calendar_account_id=UUID(account["id"]),
+            limit=999,
+        ),
+    )
+
+    assert response["summary"]["limit"] == 50
+    assert response["summary"]["total_count"] == 50
+    assert len(response["items"]) == 50
+
+
+def test_list_calendar_event_records_raises_for_not_found_account() -> None:
+    with pytest.raises(CalendarAccountNotFoundError, match="was not found"):
+        list_calendar_event_records(
+            CalendarStoreStub(),
+            CalendarSecretManagerStub(),
+            user_id=uuid4(),
+            request=CalendarEventListInput(
+                calendar_account_id=uuid4(),
+                limit=10,
+            ),
+        )
+
+
+def test_list_calendar_event_records_rejects_invalid_time_window() -> None:
+    store = CalendarStoreStub()
+    secret_manager = CalendarSecretManagerStub()
+    account = create_calendar_account_record(
+        store,
+        secret_manager,
+        user_id=uuid4(),
+        request=CalendarAccountConnectInput(
+            provider_account_id="acct-001",
+            email_address="owner@example.com",
+            display_name="Owner",
+            scope=CALENDAR_READONLY_SCOPE,
+            access_token="token-1",
+        ),
+    )["account"]
+
+    with pytest.raises(
+        CalendarEventListValidationError,
+        match="calendar event time_min must be less than or equal to time_max",
+    ):
+        list_calendar_event_records(
+            store,
+            secret_manager,
+            user_id=uuid4(),
+            request=CalendarEventListInput(
+                calendar_account_id=UUID(account["id"]),
+                time_min=datetime(2026, 3, 22, tzinfo=UTC),
+                time_max=datetime(2026, 3, 21, tzinfo=UTC),
+            ),
         )
 
 

--- a/tests/unit/test_calendar_main.py
+++ b/tests/unit/test_calendar_main.py
@@ -14,6 +14,7 @@ from alicebot_api.calendar import (
     CalendarCredentialPersistenceError,
     CalendarCredentialValidationError,
     CalendarEventFetchError,
+    CalendarEventListValidationError,
     CalendarEventNotFoundError,
     CalendarEventUnsupportedError,
 )
@@ -165,6 +166,158 @@ def test_get_calendar_account_endpoint_maps_not_found_to_404(monkeypatch) -> Non
     assert response.status_code == 404
     assert json.loads(response.body) == {
         "detail": f"calendar account {calendar_account_id} was not found"
+    }
+
+
+def test_list_calendar_events_endpoint_returns_payload(monkeypatch) -> None:
+    user_id = uuid4()
+    calendar_account_id = uuid4()
+    settings = _settings()
+
+    @contextmanager
+    def fake_user_connection(*_args, **_kwargs):
+        yield object()
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(
+        main_module,
+        "list_calendar_event_records",
+        lambda *_args, **_kwargs: {
+            "account": {
+                "id": str(calendar_account_id),
+                "provider": "google_calendar",
+                "auth_kind": "oauth_access_token",
+                "provider_account_id": "acct-001",
+                "email_address": "owner@example.com",
+                "display_name": "Owner",
+                "scope": "https://www.googleapis.com/auth/calendar.readonly",
+                "created_at": "2026-03-19T10:00:00+00:00",
+                "updated_at": "2026-03-19T10:00:00+00:00",
+            },
+            "items": [
+                {
+                    "provider_event_id": "evt-001",
+                    "status": "confirmed",
+                    "summary": "Sprint Planning",
+                    "start_time": "2026-03-20T09:00:00+00:00",
+                    "end_time": "2026-03-20T09:30:00+00:00",
+                    "html_link": "https://calendar.google.com/event?eid=evt-001",
+                    "updated_at": "2026-03-19T10:00:00+00:00",
+                }
+            ],
+            "summary": {
+                "total_count": 1,
+                "limit": 20,
+                "order": ["start_time_asc", "provider_event_id_asc"],
+                "time_min": None,
+                "time_max": None,
+            },
+        },
+    )
+
+    response = main_module.list_calendar_events(calendar_account_id, user_id)
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {
+        "account": {
+            "id": str(calendar_account_id),
+            "provider": "google_calendar",
+            "auth_kind": "oauth_access_token",
+            "provider_account_id": "acct-001",
+            "email_address": "owner@example.com",
+            "display_name": "Owner",
+            "scope": "https://www.googleapis.com/auth/calendar.readonly",
+            "created_at": "2026-03-19T10:00:00+00:00",
+            "updated_at": "2026-03-19T10:00:00+00:00",
+        },
+        "items": [
+            {
+                "provider_event_id": "evt-001",
+                "status": "confirmed",
+                "summary": "Sprint Planning",
+                "start_time": "2026-03-20T09:00:00+00:00",
+                "end_time": "2026-03-20T09:30:00+00:00",
+                "html_link": "https://calendar.google.com/event?eid=evt-001",
+                "updated_at": "2026-03-19T10:00:00+00:00",
+            }
+        ],
+        "summary": {
+            "total_count": 1,
+            "limit": 20,
+            "order": ["start_time_asc", "provider_event_id_asc"],
+            "time_min": None,
+            "time_max": None,
+        },
+    }
+
+
+def test_list_calendar_events_endpoint_maps_errors(monkeypatch) -> None:
+    user_id = uuid4()
+    calendar_account_id = uuid4()
+    settings = _settings()
+
+    @contextmanager
+    def fake_user_connection(*_args, **_kwargs):
+        yield object()
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+
+    monkeypatch.setattr(
+        main_module,
+        "list_calendar_event_records",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarAccountNotFoundError(f"calendar account {calendar_account_id} was not found")
+        ),
+    )
+    response = main_module.list_calendar_events(calendar_account_id, user_id)
+    assert response.status_code == 404
+    assert json.loads(response.body) == {
+        "detail": f"calendar account {calendar_account_id} was not found"
+    }
+
+    monkeypatch.setattr(
+        main_module,
+        "list_calendar_event_records",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarCredentialNotFoundError(
+                f"calendar account {calendar_account_id} is missing protected credentials"
+            )
+        ),
+    )
+    response = main_module.list_calendar_events(calendar_account_id, user_id)
+    assert response.status_code == 409
+    assert json.loads(response.body) == {
+        "detail": f"calendar account {calendar_account_id} is missing protected credentials"
+    }
+
+    monkeypatch.setattr(
+        main_module,
+        "list_calendar_event_records",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarEventListValidationError(
+                "calendar event time_min must be less than or equal to time_max"
+            )
+        ),
+    )
+    response = main_module.list_calendar_events(calendar_account_id, user_id)
+    assert response.status_code == 400
+    assert json.loads(response.body) == {
+        "detail": "calendar event time_min must be less than or equal to time_max"
+    }
+
+    monkeypatch.setattr(
+        main_module,
+        "list_calendar_event_records",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CalendarEventFetchError("calendar events could not be fetched")
+        ),
+    )
+    response = main_module.list_calendar_events(calendar_account_id, user_id)
+    assert response.status_code == 502
+    assert json.loads(response.body) == {
+        "detail": "calendar events could not be fetched"
     }
 
 


### PR DESCRIPTION
Backend sprint limited to deterministic, read-only Calendar event discovery for one connected account with bounded filters and ordering. Verification passed: ./.venv/bin/python -m pytest tests/unit and ./.venv/bin/python -m pytest tests/integration.