### PR TITLE
Sprint 6Y: Project truth sync after calendar event discovery

### DIFF
--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -2,17 +2,17 @@
 
 ## Canonical Truth
 
-- The working repo state is current through Sprint 6V.
+- The working repo state is current through Sprint 6X.
 - Use [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md) for implemented boundaries, [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md) for forward planning, and [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md) for durable operating rules.
 - The live sprint reports are [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md) and [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md) at repo root; older accepted sprint history belongs in [docs/archive/sprints](/Users/samirusani/Desktop/Codex/AliceBot/docs/archive/sprints), not in this handoff.
 
 ## Implemented Surfaces
 
-- `apps/api` is the core shipped product surface. It implements continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact chunk retrieval and embeddings, traces, and narrow read-only Gmail and Calendar seams with selected-item ingestion.
+- `apps/api` is the core shipped product surface. It implements continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact chunk retrieval and embeddings, traces, and narrow read-only Gmail and Calendar seams with selected-item ingestion plus bounded Calendar event discovery.
 - `apps/web` is also a shipped surface now. The operator shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live reads when API config is present and explicit fixture fallback when it is not.
 - `/chat` now ships assistant-response mode, governed-request mode, visible thread selection, compact thread creation, selected-thread transcript continuity, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, and bounded supporting continuity review over thread sessions and events.
 - `/gmail` ships a bounded Gmail operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-message ingestion into one selected task workspace.
-- `/calendar` ships a bounded Calendar operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-event ingestion into one selected task workspace.
+- `/calendar` ships a bounded Calendar operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-event ingestion into one selected task workspace. The shipped API baseline now also includes bounded read-only event discovery for one selected account (`GET /v0/calendar-accounts/{calendar_account_id}/events`) with deterministic ordering metadata and bounded limits.
 - `/memories` ships a bounded memory review workspace: active/queue list posture, selected memory detail, revision review, and memory-label review/submit seams with explicit live/fixture/unavailable states.
 - `/entities` ships a bounded entity review workspace: list, selected entity detail, and related edge review with explicit live/fixture/unavailable states.
 - `/artifacts` ships a bounded artifact review workspace: list, selected artifact detail, linked task-workspace summary, and ordered chunk evidence with explicit live/fixture/unavailable states.
@@ -25,7 +25,7 @@
 - Explain-why in `/chat` is selected-thread scoped and bounded: it reuses shipped trace list/detail/event reads, shows linked trace shortcuts from transcript/workflow/timeline context, and keeps full trace workspace in `/traces`.
 - Governed actions still route through policy, allowlist, approval, and approved-only proxy execution; `proxy.echo` is still the only live execution handler.
 - Task workspaces and artifacts remain rooted local boundaries. Ingestion remains narrow to plain text, markdown, narrow PDF text, narrow DOCX text from `word/document.xml`, and narrow RFC822 extraction.
-- Gmail and Calendar remain read-only and selected-item-only connector surfaces. Secret material stays behind dedicated secret-manager seams, the Gmail `legacy_db_v0` transition path still exists for older credential rows, and the shipped web workspaces stay bounded to account review, explicit connect, and one-item ingestion into one selected task workspace.
+- Gmail and Calendar remain read-only connector surfaces. Calendar now includes bounded event discovery for one selected account plus selected-event ingestion. Secret material stays behind dedicated secret-manager seams, the Gmail `legacy_db_v0` transition path still exists for older credential rows, and the shipped web workspaces stay bounded to account review, explicit connect, and one-item ingestion into one selected task workspace.
 
 ## Active Risks
 
@@ -36,7 +36,7 @@
 ## Repo Evidence To Trust
 
 - Backend continuity and response seams: `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`
-- Backend Gmail and Calendar seams: `tests/integration/test_gmail_accounts_api.py`, `tests/integration/test_calendar_accounts_api.py`, `tests/unit/test_gmail.py`, `tests/unit/test_calendar.py`, `tests/unit/test_20260316_0026_gmail_accounts.py`, `tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py`
+- Backend Gmail and Calendar seams: `tests/integration/test_gmail_accounts_api.py`, `tests/integration/test_calendar_accounts_api.py`, `tests/unit/test_gmail.py`, `tests/unit/test_calendar.py`, `tests/unit/test_calendar_main.py`, `tests/unit/test_20260316_0026_gmail_accounts.py`, `tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py`
 - Web `/chat` continuity + workflow/timeline/explainability adoption: `apps/web/app/chat/page.tsx`, `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`, `apps/web/components/thread-event-list.tsx`, `apps/web/components/response-composer.tsx`, `apps/web/components/thread-workflow-panel.tsx`, `apps/web/components/task-step-list.tsx`, `apps/web/components/response-history.tsx`, `apps/web/components/thread-trace-panel.tsx`, and matching component tests.
 - Web review workspaces added through the accepted Sprint 6P/6Q/6R sequence: `apps/web/app/memories/page.tsx`, `apps/web/app/memories/page.test.tsx`, `apps/web/app/entities/page.tsx`, `apps/web/app/entities/page.test.tsx`, `apps/web/app/artifacts/page.tsx`, `apps/web/app/artifacts/page.test.tsx`.
 - Web Gmail and Calendar workspaces: `apps/web/app/gmail/page.tsx`, `apps/web/app/calendar/page.tsx`, `apps/web/lib/api.ts`, `apps/web/lib/api.test.ts`, `apps/web/components/gmail-account-list.test.tsx`, `apps/web/components/calendar-account-list.test.tsx`, `apps/web/components/calendar-event-ingest-form.test.tsx`
@@ -44,6 +44,6 @@
 
 ## Planning Guardrails
 
-- Plan from the implemented Sprint 6V repo state, not from older Sprint 5-era narratives.
-- Do not describe broader Gmail scope, broader Calendar scope, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
+- Plan from the implemented Sprint 6X repo state, not from older Sprint 5-era narratives.
+- Do not describe broader Gmail scope, broader Calendar scope beyond bounded read-only event discovery plus selected-event ingestion, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
 - The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, including `/gmail`, `/calendar`, `/memories`, `/entities`, and `/artifacts`, not assumed to be leftover connector cleanup by default.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,16 +2,16 @@
 
 ## Current Implemented Slice
 
-AliceBot now implements the accepted repo slice through Sprint 6V.
+AliceBot now implements the accepted repo slice through Sprint 6X.
 
-- `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and narrow read-only Gmail and Calendar seams with external-secret-backed credentials plus selected-item ingestion into the artifact pipeline.
+- `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and narrow read-only Gmail and Calendar seams with external-secret-backed credentials plus bounded Calendar event discovery and selected-item ingestion into the artifact pipeline.
 - `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
 - `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, renders a selected-thread transcript from immutable continuity events, and keeps supporting session and operational review, thread-linked governed workflow review, ordered task-step timeline review, and bounded explain-why trace review in the right rail.
 - `/gmail` and `/calendar` are shipped bounded connector workspaces over existing backend seams: visible account list review, selected-account detail, explicit account connection, and explicit single-item ingestion into one chosen task workspace, with live/fixture/unavailable states kept explicit.
 - `/artifacts`, `/memories`, and `/entities` are now shipped bounded review workspaces that expose existing artifact, memory, and entity read seams with explicit live/fixture/unavailable modes.
 - `workers` remains scaffold-only. No background runner, automatic multi-step progression, or asynchronous job system is implemented.
 
-The repo is intentionally still narrow. Document ingestion remains local and deterministic. The only live execution handler is the no-external-I/O `proxy.echo` path. Gmail and Calendar remain read-only and selected-item-only. Rich parsing, mailbox sync, attachments, broader Calendar capabilities, broader proxying, and runner-style orchestration are still planned later.
+The repo is intentionally still narrow. Document ingestion remains local and deterministic. The only live execution handler is the no-external-I/O `proxy.echo` path. Gmail and Calendar remain read-only; Calendar includes bounded event discovery and selected-event ingestion only. Rich parsing, mailbox sync, attachments, broader Calendar capabilities, broader proxying, and runner-style orchestration are still planned later.
 
 ## Implemented Now
 
@@ -25,7 +25,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
   - policy, tool, approval, execution-budget, and proxy execution governance
   - task, task-step, task-workspace, task-artifact, artifact-chunk, and trace review reads and mutations
   - narrow Gmail account connect/read plus selected-message ingestion
-  - narrow Calendar account connect/read plus selected-event ingestion
+  - narrow Calendar account connect/read, bounded event discovery, plus selected-event ingestion
 - `apps/web` exposes the current operator shell:
   - `/`: bounded home view over the shipped shell surfaces
   - `/chat`: assistant mode, governed request mode, thread selection, thread creation, transcript-first continuity review, thread-linked governed workflow and task-step timeline review, bounded explain-why embedding, and bounded supporting operational review
@@ -71,7 +71,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 2. Artifact ingestion supports the narrow current set only: plain text, markdown, narrow local PDF text extraction, narrow DOCX text extraction from `word/document.xml`, and narrow RFC822 email extraction.
 3. Artifact retrieval works over persisted chunk rows and persisted chunk embeddings, including deterministic lexical retrieval, direct semantic retrieval, and the current lexical-first hybrid compile merge.
 4. Gmail remains narrow: one read-only account seam, secret-free account reads, external-secret-backed primary credentials, refresh-token renewal and rotation handling, and one selected-message ingestion path that lands in the existing RFC822 artifact workflow.
-5. Calendar remains narrow: one read-only account seam, secret-free account reads, external-secret-backed credentials, and one selected-event ingestion path that lands in the existing text artifact/chunk workflow.
+5. Calendar remains narrow: one read-only account seam, secret-free account reads, external-secret-backed credentials, bounded event discovery (`GET /v0/calendar-accounts/{calendar_account_id}/events`) with deterministic ordering and bounded limits, and one selected-event ingestion path that lands in the existing text artifact/chunk workflow.
 
 ## Testing Coverage Implemented Now
 
@@ -88,7 +88,7 @@ The following remain planned later and must not be described as implemented:
 - runner-style orchestration and automatic multi-step progression
 - auth beyond the current database user-context model
 - richer document parsing, OCR, image extraction, or layout reconstruction
-- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and broader Calendar capabilities such as event listing/search, recurrence expansion, sync, and write actions
+- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and broader Calendar capabilities such as recurrence expansion, sync, and write actions
 - broader proxy execution breadth or real-world side effects beyond `proxy.echo`
 - retrieval reranking or weighted fusion beyond the current lexical-first hybrid compile merge
 

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,125 +1,74 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Sprint 6X: a deterministic, user-scoped, read-only Calendar event discovery API for one connected account at `GET /v0/calendar-accounts/{calendar_account_id}/events`, with bounded filters, stable ordering metadata, and no expansion into sync/recurrence/write/UI scope.
+Synchronize canonical project truth artifacts to the accepted implemented repo baseline through Sprint 6X, including shipped bounded read-only Calendar event discovery, without changing runtime behavior or product scope.
 
 ## Completed Work
-- Added Calendar event discovery contracts in `apps/api/src/alicebot_api/contracts.py`:
-  - Constants:
-    - `DEFAULT_CALENDAR_EVENT_LIST_LIMIT = 20`
-    - `MAX_CALENDAR_EVENT_LIST_LIMIT = 50`
-    - `CALENDAR_EVENT_LIST_ORDER = ["start_time_asc", "provider_event_id_asc"]`
-  - Request input contract:
-    - `CalendarEventListInput(calendar_account_id, limit, time_min, time_max)`
-  - Response contracts:
-    - `CalendarEventSummaryRecord`
-    - `CalendarEventListSummary`
-    - `CalendarEventListResponse`
-- Implemented read-only event discovery service logic in `apps/api/src/alicebot_api/calendar.py`:
-  - `fetch_calendar_event_list_payload(...)` using existing credential/secret seams.
-  - `list_calendar_event_records(...)` for one account with user-scoped visibility.
-  - `CalendarEventListValidationError` for invalid time windows.
-  - Deterministic normalization and sorting of events.
-- Added endpoint in `apps/api/src/alicebot_api/main.py`:
-  - `GET /v0/calendar-accounts/{calendar_account_id}/events`
-  - Query params: `user_id`, `limit`, `time_min`, `time_max`
-  - Deterministic error mapping:
-    - 404: missing/non-visible account
-    - 409: credential missing/invalid/persistence issues
-    - 400: invalid query window (`time_min > time_max`)
-    - 502: upstream provider fetch failures
-- Added/updated tests:
-  - `tests/unit/test_calendar.py`
-  - `tests/unit/test_calendar_main.py`
-  - `tests/integration/test_calendar_accounts_api.py`
-
-## Ordering And Limit Rule
-- Ordering rule in response summary: `order = ["start_time_asc", "provider_event_id_asc"]`.
-- Deterministic sort key applied server-side after provider fetch:
-  1. `start_time` normalized to UTC datetime ascending (all-day `date` values normalize to midnight UTC)
-  2. `provider_event_id` ascending
-- Limit behavior:
-  - Default `limit=20`
-  - Hard max `limit=50`
-  - Response summary always returns applied `limit`.
-
-## Example Calendar Event List Response
-```json
-{
-  "account": {
-    "id": "2f90c8ea-6f04-4d7f-9e5e-b8e7cbfd4b3e",
-    "provider": "google_calendar",
-    "auth_kind": "oauth_access_token",
-    "provider_account_id": "acct-owner-001",
-    "email_address": "owner@gmail.example",
-    "display_name": "Owner",
-    "scope": "https://www.googleapis.com/auth/calendar.readonly",
-    "created_at": "2026-03-19T11:02:10.100000+00:00",
-    "updated_at": "2026-03-19T11:02:10.100000+00:00"
-  },
-  "items": [
-    {
-      "provider_event_id": "evt-a",
-      "status": "tentative",
-      "summary": "First",
-      "start_time": "2026-03-20",
-      "end_time": "2026-03-21",
-      "html_link": null,
-      "updated_at": "2026-03-19T09:00:00+00:00"
-    },
-    {
-      "provider_event_id": "evt-b",
-      "status": "confirmed",
-      "summary": "Second",
-      "start_time": "2026-03-25T09:00:00+00:00",
-      "end_time": "2026-03-25T09:45:00+00:00",
-      "html_link": null,
-      "updated_at": "2026-03-24T08:30:00+00:00"
-    }
-  ],
-  "summary": {
-    "total_count": 2,
-    "limit": 2,
-    "order": ["start_time_asc", "provider_event_id_asc"],
-    "time_min": "2026-03-20T00:00:00+00:00",
-    "time_max": "2026-03-27T00:00:00+00:00"
-  }
-}
-```
+- Updated `ROADMAP.md`:
+  - Advanced current-position baseline from Sprint 6V to Sprint 6X.
+  - Added shipped bounded Calendar event discovery to backend baseline wording.
+  - Updated next-delivery framing to plan from Sprint 6X baseline.
+  - Corrected deferred Calendar wording so event listing/search is no longer described as entirely deferred.
+- Updated `.ai/handoff/CURRENT_STATE.md`:
+  - Advanced canonical truth statement from Sprint 6V to Sprint 6X.
+  - Updated implemented surfaces/boundaries to include bounded read-only Calendar event discovery.
+  - Updated planning guardrails to Sprint 6X baseline and explicit Calendar boundary.
+  - Added `tests/unit/test_calendar_main.py` to backend Calendar seam evidence.
+- Updated `ARCHITECTURE.md`:
+  - Advanced accepted implemented slice from Sprint 6V to Sprint 6X.
+  - Added bounded Calendar event discovery to the implemented API slice, runtime endpoint summary, and core Calendar flow.
+  - Corrected deferred list so it now defers broader Calendar capabilities (recurrence/sync/write), not event listing/search wholesale.
+- Updated `README.md` (needed for sprint-state freshness):
+  - Advanced top-level accepted slice from Sprint 6V to Sprint 6X.
+  - Updated API baseline wording to include bounded Calendar event discovery.
 
 ## Incomplete Work
-- None within Sprint 6X scope.
+- None within Sprint 6Y scope.
 
 ## Files Changed
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/calendar.py`
-- `apps/api/src/alicebot_api/main.py`
-- `tests/unit/test_calendar.py`
-- `tests/unit/test_calendar_main.py`
-- `tests/integration/test_calendar_accounts_api.py`
+- `ROADMAP.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `ARCHITECTURE.md`
+- `README.md`
 - `BUILD_REPORT.md`
 
+## Accepted Repo Evidence Used
+- Calendar event discovery implementation and boundaries:
+  - `apps/api/src/alicebot_api/main.py` (`GET /v0/calendar-accounts/{calendar_account_id}/events`)
+  - `apps/api/src/alicebot_api/calendar.py` (`list_calendar_event_records`, bounded limits, deterministic sort/order metadata, time-window validation)
+- Calendar event discovery tests:
+  - `tests/integration/test_calendar_accounts_api.py` (deterministic ordering, limit bounds, user isolation, error mapping)
+  - `tests/unit/test_calendar.py` (service-level sorting, hard max limit, validation behavior)
+  - `tests/unit/test_calendar_main.py` (endpoint payload and error mapping)
+- Existing shipped Calendar workspace baseline (bounded account review/connect/selected-event ingestion):
+  - `apps/web/app/calendar/page.tsx`
+  - `apps/web/components/calendar-event-ingest-form.tsx`
+
+## Stale Claims Corrected
+- "Accepted/working repo state is current through Sprint 6V" corrected to Sprint 6X in canonical truth docs.
+- "Calendar event listing/search is entirely deferred" corrected to reflect shipped bounded read-only event discovery for one connected account.
+- Planning language now anchors on Sprint 6X shipped API + web-shell baseline.
+
 ## Tests Run
-- `./.venv/bin/python -m pytest tests/unit/test_calendar.py tests/unit/test_calendar_main.py tests/integration/test_calendar_accounts_api.py` -> PASS (`30 passed`)
-- `./.venv/bin/python -m pytest tests/unit` -> PASS (`484 passed`)
-- `./.venv/bin/python -m pytest tests/integration` -> PASS (`153 passed`)
+- No runtime code changed in this sprint; no test run was required for documentation-only synchronization.
 
 ## Blockers / Issues
-- No implementation blockers.
-- Integration tests required DB access outside sandbox to reach local Postgres (`localhost:5432`), then passed with escalated execution.
-- Existing unrelated pre-existing modifications remained untouched in:
-  - `.ai/active/SPRINT_PACKET.md`
-  - `REVIEW_REPORT.md`
+- No blockers.
 
-## Intentionally Deferred After This Sprint
-- UI changes.
-- Event ingestion behavior changes.
-- Recurring event expansion.
-- Background sync/backfill.
-- Write-capable calendar actions.
-- Gmail scope expansion.
-- Auth redesign.
-- Runner orchestration.
+## Scope Confirmation
+- No runtime code changes.
+- No schema changes.
+- No API contract changes.
+- No UI behavior changes.
+- No Gmail/Calendar scope expansion beyond documenting already shipped seams.
+
+## Intentionally Deferred After This Truth Sync
+- Calendar recurrence expansion, sync/backfill, and write-capable Calendar actions.
+- Gmail search/sync/attachments/write actions.
+- Runner-style orchestration and automatic multi-step progression.
+- Auth expansion beyond current database user-context model.
+- Richer document parsing/OCR/layout reconstruction.
+- Broader execution side effects beyond `proxy.echo`.
 
 ## Recommended Next Step
-Proceed to reviewer validation focused on deterministic event discovery behavior (ordering/limits/isolation/error mapping), then merge if review is PASS.
+Proceed with review pass focused on truth alignment (Sprint 6X baseline and Calendar boundary wording), then start the next feature sprint from this synchronized documentation baseline.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6V: a FastAPI backend plus a bounded Next.js operator shell.
+AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6X: a FastAPI backend plus a bounded Next.js operator shell.
 
 ## Current Implemented Slice
 
-- `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and narrow read-only Gmail and Calendar seams with selected-item ingestion.
+- `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, governed memory and retrieval, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and narrow read-only Gmail and Calendar seams with bounded event discovery plus selected-item ingestion.
 - `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
 - `/chat` supports both assistant and governed-request modes, selected-thread continuity, compact thread creation, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, and bounded supporting continuity review.
 - `/gmail` and `/calendar` are shipped bounded connector workspaces for account review, selected-account detail, explicit account connection, and explicit single-item ingestion into one selected task workspace.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,11 +2,11 @@
 
 ## Current Position
 
-- The accepted repo state is current through Sprint 6V.
-- The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, narrow read-only Gmail and Calendar seams with selected-item ingestion, and the no-tools assistant-response seam.
+- The accepted repo state is current through Sprint 6X.
+- The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, narrow read-only Gmail and Calendar seams with selected-item ingestion, bounded read-only Calendar event discovery for one connected account, and the no-tools assistant-response seam.
 - The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
 - `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, keeps bounded thread review visible beside both assistant and governed-request composition, and ships thread-linked governed workflow, ordered task-step timeline review, and bounded explain-why trace embedding.
-- `/gmail` and `/calendar` are shipped bounded connector workspaces in the shell: account review, selected-account detail, explicit connect, and one selected-item ingestion path into one chosen task workspace.
+- `/gmail` and `/calendar` are shipped bounded connector workspaces in the shell: account review, selected-account detail, explicit connect, and one selected-item ingestion path into one chosen task workspace. The API baseline also includes bounded Calendar event discovery for one connected account with deterministic ordering and bounded limits.
 - `/memories`, `/entities`, and `/artifacts` are shipped bounded review workspaces in the shell, not planned surface.
 - Historical sprint detail belongs in build and review artifacts, not in this roadmap.
 
@@ -14,8 +14,8 @@
 
 ### Build From The Shipped API Plus Web-Shell Baseline
 
-- Plan the next sprint from the implemented Sprint 6V backend-plus-web baseline, not from the older Sprint 6R narrative.
-- Treat transcript continuity, thread-linked workflow review, task-step timeline review, bounded explain-why embedding in `/chat`, the shipped review workspaces (`/memories`, `/entities`, `/artifacts`), and the shipped connector workspaces (`/gmail`, `/calendar`) as baseline, not pending work.
+- Plan the next sprint from the implemented Sprint 6X backend-plus-web baseline, not from the older Sprint 6R narrative.
+- Treat transcript continuity, thread-linked workflow review, task-step timeline review, bounded explain-why embedding in `/chat`, the shipped review workspaces (`/memories`, `/entities`, `/artifacts`), the shipped connector workspaces (`/gmail`, `/calendar`), and bounded Calendar event discovery as baseline, not pending work.
 - Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.
 - Reuse the existing continuity, response, approval, task, workspace-artifact, memory, entity, execution, and trace surfaces instead of introducing parallel contracts.
 
@@ -34,7 +34,7 @@
 
 ## Deferred Until Explicitly Opened
 
-- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and broader Calendar capabilities such as event listing/search, recurrence expansion, sync, and write actions
+- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and broader Calendar capabilities such as recurrence expansion, sync, and write actions
 - runner-style orchestration and automatic multi-step progression
 - richer document parsing, OCR, and layout-aware ingestion
 - broader tool execution breadth beyond the current governed `proxy.echo` seam


### PR DESCRIPTION
Documentation-only sprint. Canonical truth files synchronized to implemented repo state through Sprint 6X with Calendar discovery documented as shipped and broader Calendar capabilities deferred.