### PR TITLE
Sprint 7H: MVP RC truth sync and gate canonicalization

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,53 +2,52 @@
 
 ## Sprint Title
 
-Sprint 7G: MVP Extensive Validation Matrix
+Sprint 7H: MVP RC Truth Sync And Gate Canonicalization
 
 ## Sprint Type
 
-qa
+docs
 
 ## Sprint Reason
 
-Sprint 7F proved quantitative readiness gates and passed review. The remaining MVP risk is practical testing confidence: evidence is still split across multiple backend and web commands, which makes “thoroughly test the agent/os” slower and easier to execute inconsistently.
+Sprint 7G delivered a deterministic extensive validation matrix and passed review, but canonical project docs still anchor to Sprint 6X-era state and one runbook command remains machine-specific. This creates avoidable planning and review drift risk right before MVP release-candidate decisions.
 
 ## Sprint Intent
 
-Create one deterministic MVP validation matrix runner (plus tests and runbook) that executes the shipped end-to-end backend and web verification surfaces from a single command and outputs a clear go/no-go result.
+Synchronize canonical docs and runbooks to the accepted Sprint 7G baseline and formalize the MVP validation matrix command as the default go/no-go gate, without changing product or backend behavior.
 
 ## Git Instructions
 
-- Branch Name: `codex/sprint-7g-mvp-extensive-validation-matrix`
+- Branch Name: `codex/sprint-7h-mvp-rc-truth-sync`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR, no stacked PRs unless Control Tower explicitly opens a follow-up sprint
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- MVP-critical seams are shipped and quantitative gates now pass, but practical confidence still depends on running scattered commands manually.
-- We need one reproducible “extensive testing” entrypoint for backend and web behavior together.
-- A deterministic validation matrix reduces release risk without adding product scope.
+- Sprint 7G now gives one reliable extensive-testing entrypoint.
+- Canonical docs still claim Sprint 6X as current state, which no longer matches shipped verification reality.
+- Pre-MVP control reliability now depends more on accurate docs and deterministic operator instructions than on new feature seams.
 
 ## Design Truth
 
-- This is a verification sprint, not a feature sprint.
-- Reuse existing shipped seams and tests; do not widen product, connector, or architecture scope.
-- Keep output explicit and reviewer-friendly with deterministic pass/fail reporting.
+- This is a documentation/control-artifact sprint, not a feature sprint.
+- Make reality explicit: accepted state includes Sprint 7G readiness + validation tooling.
+- Keep instructions portable and machine-independent.
 
 ## Exact Surfaces In Scope
 
-- Validation orchestration over shipped backend + web test surfaces.
-- Single-command extensive testing entrypoint and deterministic summary output.
-- Runbook/report alignment for reproducible reviewer execution.
+- Canonical truth docs and planning docs.
+- MVP validation runbook portability and gate canonicalization.
+- Optional small durable rule updates to prevent recurrence.
 
 ## Exact Files In Scope
 
-- [run_mvp_validation_matrix.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_mvp_validation_matrix.py)
-- [run_mvp_acceptance.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_mvp_acceptance.py)
-- [run_mvp_readiness_gates.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_mvp_readiness_gates.py)
-- [test_mvp_validation_matrix.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_mvp_validation_matrix.py)
-- [package.json](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/package.json)
-- [vitest.config.ts](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/vitest.config.ts)
+- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md)
+- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md)
+- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md)
+- [CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md)
+- [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md)
 - [mvp-validation-matrix.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/mvp-validation-matrix.md)
 - [mvp-readiness-gates.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/mvp-readiness-gates.md)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
@@ -57,69 +56,67 @@ Create one deterministic MVP validation matrix runner (plus tests and runbook) t
 
 ## In Scope
 
-- Add `scripts/run_mvp_validation_matrix.py` that runs a deterministic sequence and reports per-step status plus final `PASS`/`NO_GO`.
-- Sequence must include:
-  - readiness gates (`python3 scripts/run_mvp_readiness_gates.py`)
-  - bounded backend integration matrix covering shipped seams (continuity, responses, approvals/execution, tasks/steps, traces, memory/entities/artifacts, Gmail/Calendar account seams)
-  - bounded web test matrix covering shipped operator shell surfaces (`/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, `/traces`) through existing Vitest suites
-- Add deterministic integration tests for matrix runner behavior (pass/fail propagation, output shape, exit code contract).
-- Add runbook documentation with prerequisites, exact command, expected runtime class, and failure triage flow.
+- Update canonical docs to reflect accepted state through Sprint 7G (no 6X-era “current state” language).
+- Document the MVP default validation command as:
+  - `python3 scripts/run_mvp_validation_matrix.py`
+- Fix runbook portability by removing machine-specific absolute command paths.
+- Align README quick checks and handoff docs with readiness + validation matrix workflow.
+- Optionally add concise RULES guidance to prevent recurrence:
+  - no machine-specific local absolute paths in shared runbooks
+  - canonical docs must be updated when sprint-level operating baseline changes
 
 ## Out of Scope
 
 - No new endpoints, migrations, or schema changes.
 - No connector breadth expansion or write-capable connector behavior.
 - No auth, orchestration, or worker-runtime expansion.
-- No new web routes or UI redesign.
-- No feature behavior changes beyond testability/verification wiring.
+- No new web routes, UI redesign, or test-behavior changes.
+- No new validation runner features beyond documentation alignment.
 
 ## Required Deliverables
 
-- `scripts/run_mvp_validation_matrix.py` committed and runnable.
-- `tests/integration/test_mvp_validation_matrix.py` committed with deterministic runner-contract coverage.
-- `docs/runbooks/mvp-validation-matrix.md` committed and aligned to executable commands.
-- Updated `BUILD_REPORT.md` and `REVIEW_REPORT.md` reflecting Sprint 7G only.
+- Canonical docs updated to Sprint 7G truth baseline.
+- Portable, machine-independent commands in `docs/runbooks/mvp-validation-matrix.md`.
+- Updated sprint reports reflecting Sprint 7H docs/control scope only.
 
 ## Acceptance Criteria
 
-- `python3 scripts/run_mvp_validation_matrix.py` executes the defined matrix and exits `0` only when all steps pass.
-- A single induced step failure causes deterministic non-zero exit and explicit failing-step output.
-- Matrix includes both backend and web verification commands defined in this sprint packet.
-- `python3 scripts/run_mvp_readiness_gates.py` remains part of the matrix prerequisite chain and passes in reviewer environment.
-- Sprint remains within QA/test orchestration and documentation surfaces only.
+- `README.md`, `ROADMAP.md`, `ARCHITECTURE.md`, and `.ai/handoff/CURRENT_STATE.md` no longer claim Sprint 6X as current state.
+- `docs/runbooks/mvp-validation-matrix.md` uses repo-relative or environment-agnostic commands (no `/Users/...` paths).
+- A grep-based portability check passes for shared docs/runbooks:
+  - no `file://`, `vscode://`, or local absolute user-home paths.
+- Sprint remains documentation/rules/report scope only.
 
 ## Implementation Constraints
 
-- Keep matrix commands explicit and stable; avoid hidden autodiscovery.
-- Do not add flaky timing assertions to web/backend suites in this sprint.
-- Prefer reusing existing tests over inventing broad new coverage surfaces.
-- Keep runtime bounded and practical for local reviewer use.
+- Keep edits concise and truth-preserving.
+- Do not introduce new feature claims beyond what repo evidence already supports.
+- Preserve product scope boundaries already documented in `PRODUCT_BRIEF.md`.
 
 ## Suggested Work Breakdown
 
-1. Define the exact backend + web validation command list and output contract.
-2. Implement `scripts/run_mvp_validation_matrix.py` with deterministic sequencing and exit-code behavior.
-3. Add `tests/integration/test_mvp_validation_matrix.py` for pass/fail propagation and output assertions.
-4. Add `docs/runbooks/mvp-validation-matrix.md` with execution and triage flow.
-5. Run matrix command(s), capture evidence, and update sprint reports.
+1. Update canonical baseline statements from 6X-era to accepted 7G-era truth.
+2. Normalize MVP validation runbook commands to portable forms.
+3. Align README/handoff/roadmap language with current validation workflow.
+4. Run portability/consistency checks over touched docs.
+5. Update build/review reports.
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact matrix steps executed (backend + web + readiness prerequisite)
-- exact command(s) and environment assumptions
-- per-step outcome table with duration and exit status
-- induced-failure verification summary
+- exact canonical docs updated
+- portability checks executed and results
+- explicit statement of what remains deferred
 - explicit deferred criteria not covered by this sprint
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint stayed within extensive-validation scope
-- matrix runner output is deterministic and actionable
-- backend and web verification coverage in the matrix matches this packet
+- sprint stayed within docs/control-artifact scope
+- canonical files now match accepted 7G baseline
+- runbook command portability is fixed
 - no hidden product/backend scope entered
 
 ## Exit Condition
 
-This sprint is complete when one documented command provides deterministic, reviewer-ready extensive test evidence across shipped backend and web surfaces with explicit pass/fail output and no product scope expansion.
+This sprint is complete when canonical docs and runbooks are synchronized to the accepted Sprint 7G operating baseline, matrix gate usage is explicit and portable, and review can no longer fail due to baseline-document drift.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -2,9 +2,10 @@
 
 ## Canonical Truth
 
-- The working repo state is current through Sprint 6X.
-- Use [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md) for implemented boundaries, [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md) for forward planning, and [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md) for durable operating rules.
-- The live sprint reports are [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md) and [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md) at repo root; older accepted sprint history belongs in [docs/archive/sprints](/Users/samirusani/Desktop/Codex/AliceBot/docs/archive/sprints), not in this handoff.
+- The working repo state is current through Sprint 7G.
+- The accepted baseline includes deterministic MVP release-candidate validation tooling, with `python3 scripts/run_mvp_validation_matrix.py` as the default go/no-go command.
+- Use [PRODUCT_BRIEF.md](../../PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](../../ARCHITECTURE.md) for implemented boundaries, [ROADMAP.md](../../ROADMAP.md) for forward planning, and [RULES.md](../../RULES.md) for durable operating rules.
+- The live sprint reports are [BUILD_REPORT.md](../../BUILD_REPORT.md) and [REVIEW_REPORT.md](../../REVIEW_REPORT.md) at repo root; older accepted sprint history belongs in [docs/archive/sprints](../../docs/archive/sprints), not in this handoff.
 
 ## Implemented Surfaces
 
@@ -44,6 +45,6 @@
 
 ## Planning Guardrails
 
-- Plan from the implemented Sprint 6X repo state, not from older Sprint 5-era narratives.
+- Plan from the implemented Sprint 7G repo state, not from older Sprint 5-era narratives.
 - Do not describe broader Gmail scope, broader Calendar scope beyond bounded read-only event discovery plus selected-event ingestion, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
 - The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, including `/gmail`, `/calendar`, `/memories`, `/entities`, and `/artifacts`, not assumed to be leftover connector cleanup by default.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Current Implemented Slice
 
-AliceBot now implements the accepted repo slice through Sprint 6X.
+AliceBot now implements the accepted repo slice through Sprint 7G.
 
 - `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and narrow read-only Gmail and Calendar seams with external-secret-backed credentials plus bounded Calendar event discovery and selected-item ingestion into the artifact pipeline.
 - `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
@@ -19,6 +19,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 
 - `docker-compose.yml` starts local Postgres with `pgvector`, Redis, and MinIO.
 - `scripts/dev_up.sh`, `scripts/migrate.sh`, and `scripts/api_dev.sh` provide the local startup path.
+- `scripts/run_mvp_readiness_gates.py` and `scripts/run_mvp_validation_matrix.py` provide deterministic MVP release-candidate gate evidence, with the validation matrix command as the default go/no-go gate.
 - `apps/api` exposes FastAPI endpoints for:
   - continuity and response generation: `/healthz`, `POST /v0/threads`, `GET /v0/threads`, `GET /v0/threads/{thread_id}`, `GET /v0/threads/{thread_id}/sessions`, `GET /v0/threads/{thread_id}/events`, `POST /v0/context/compile`, `POST /v0/responses`
   - memory, embeddings, and graph seams

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,94 +1,75 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Sprint 7G MVP extensive validation matrix: one deterministic command that runs readiness prerequisite + bounded backend seams + bounded web operator-shell suites and returns explicit `PASS`/`NO_GO`.
+Synchronize canonical truth docs and MVP runbooks to the accepted Sprint 7G baseline, make the validation matrix command the explicit default MVP go/no-go gate, and keep all work within docs/control-artifact scope.
 
 ## Completed Work
-- Added `scripts/run_mvp_validation_matrix.py` with deterministic step order:
-  - `readiness_gates` (`python3 scripts/run_mvp_readiness_gates.py`)
-  - `backend_integration_matrix` (bounded seam-focused integration test list)
-  - `web_validation_matrix` (explicit Vitest matrix for `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, `/traces`)
-- Added explicit failing-step signaling and final result contract:
-  - Per-step `PASS`/`FAIL`, command, duration, exit code, coverage
-  - `Failing steps: ...` line on non-pass runs
-  - exit code `0` only when all steps pass
-- Added deterministic induced-failure support:
-  - `--induce-step {readiness_gates|backend_integration_matrix|web_validation_matrix}`
-  - forced exit code `97` on selected step for no-go contract verification
-- Added `tests/integration/test_mvp_validation_matrix.py`:
-  - sequence/coverage contract assertions
-  - exit-code contract assertions
-  - induced failure propagation and output-shape assertions
-- Added web matrix command to `apps/web/package.json`:
-  - `test:mvp:validation-matrix`
-  - explicit bounded suite list (no autodiscovery)
-- Added `docs/runbooks/mvp-validation-matrix.md`:
-  - prerequisites, exact command, runtime class, deterministic negative check, triage flow
-- Updated `docs/runbooks/mvp-readiness-gates.md` to document readiness as matrix prerequisite step.
+- Updated canonical baseline language from Sprint 6X-era to accepted Sprint 7G in:
+  - `README.md`
+  - `ROADMAP.md`
+  - `ARCHITECTURE.md`
+  - `.ai/handoff/CURRENT_STATE.md`
+- Canonicalized MVP gate usage in docs:
+  - documented `python3 scripts/run_mvp_validation_matrix.py` as the default MVP release-candidate go/no-go command
+  - kept readiness gating as prerequisite context
+- Fixed portability issue in `docs/runbooks/mvp-validation-matrix.md`:
+  - replaced machine-specific web test command path with repo-relative command:
+    - from a machine-specific absolute-prefix command
+    - to `npm --prefix apps/web run test:mvp:validation-matrix`
+- Normalized shared canonical links in key docs away from local user-home absolute paths to portable repo-relative links.
+- Added concise durable rules in `RULES.md` to prevent recurrence:
+  - no machine-specific local absolute paths in shared runbooks/canonical docs
+  - canonical truth docs must be updated when sprint-level baseline changes
+- Updated sprint reports (`BUILD_REPORT.md`, `REVIEW_REPORT.md`) for Sprint 7H docs/control scope.
 
 ## Incomplete Work
-- None within Sprint 7G scope.
+- None within Sprint 7H scope.
 
-## Exact Matrix Steps Executed
-1. `readiness_gates`
-2. `backend_integration_matrix`
-3. `web_validation_matrix`
+## Exact Canonical Docs Updated
+- `README.md`
+- `ROADMAP.md`
+- `ARCHITECTURE.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `RULES.md`
+- `docs/runbooks/mvp-validation-matrix.md`
 
-## Exact Commands And Environment Assumptions
-Commands used:
-- `python3 -m pytest -q tests/integration/test_mvp_validation_matrix.py tests/integration/test_mvp_readiness_gates.py`
-- `python3 scripts/run_mvp_validation_matrix.py`
-- `python3 scripts/run_mvp_validation_matrix.py --induce-step backend_integration_matrix`
+## Portability Checks Executed And Results
+1. Sprint-baseline drift check (targeted canonical docs):
+   - Command:
+     - `rg -n "Sprint 6X" README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md`
+   - Result: no matches.
 
-Environment assumptions:
-- Local Postgres reachable on configured admin/app URLs (required by readiness/backend steps).
-- Python dependencies installed in project environment.
-- Web dependencies installed for `apps/web` (`npm --prefix apps/web install`).
+2. Shared-doc portability check (targeted canonical docs + runbooks):
+   - Command:
+     - `rg -n -e 'file://' -e 'vscode://' -e '/[U]sers/' -e '/home/' -e 'C:\\Users\\' README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md RULES.md docs/runbooks/mvp-validation-matrix.md docs/runbooks/mvp-readiness-gates.md`
+   - Result: no matches.
 
-## Per-Step Outcome Table (Latest Normal Matrix Run)
-
-| Step | Status | Duration (s) | Exit Status |
-|---|---|---:|---:|
-| `readiness_gates` | `PASS` | `3.404` | `0` |
-| `backend_integration_matrix` | `PASS` | `27.834` | `0` |
-| `web_validation_matrix` | `PASS` | `2.302` | `0` |
-
-Normal command result:
-- `python3 scripts/run_mvp_validation_matrix.py` -> `MVP validation matrix result: PASS` (process exit `0`)
-
-## Induced-Failure Verification Summary
-- Command: `python3 scripts/run_mvp_validation_matrix.py --induce-step backend_integration_matrix`
-- Result:
-  - `readiness_gates`: `PASS`
-  - `backend_integration_matrix`: `FAIL` (`exit_code=97`, `induced_failure: true`)
-  - `web_validation_matrix`: `PASS`
-  - explicit output: `Failing steps: backend_integration_matrix`
-  - final output: `MVP validation matrix result: NO_GO`
-  - process exit: non-zero (`1`)
-
-## Files Changed
-- `/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_mvp_validation_matrix.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_mvp_validation_matrix.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/apps/web/package.json`
-- `/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/mvp-validation-matrix.md`
-- `/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/mvp-readiness-gates.md`
-- `/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md`
-- `/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md`
-
-## Tests Run
-- `python3 -m pytest -q tests/integration/test_mvp_validation_matrix.py tests/integration/test_mvp_readiness_gates.py` -> `9 passed`
-- `python3 scripts/run_mvp_validation_matrix.py` -> `PASS` (all 3 matrix steps passed)
-- `python3 scripts/run_mvp_validation_matrix.py --induce-step backend_integration_matrix` -> `NO_GO` (single deterministic induced failure surfaced)
-
-## Blockers/Issues
-- Sandboxed localhost DB access fails with `psycopg.OperationalError: ... Operation not permitted`; DB-backed matrix commands required unsandboxed execution for evidence collection.
-- Runner output includes upstream readiness/Alembic logs, which are expected but verbose.
+## Explicit Statement Of What Remains Deferred
+Sprint 7H intentionally does not change product behavior, API/runtime behavior, schema, or test behavior. It only synchronizes canonical docs/rules/runbooks and sprint reports.
 
 ## Explicit Deferred Criteria Not Covered By This Sprint
 - No new endpoints, migrations, or schema changes.
-- No connector capability expansion or write-capability changes.
-- No auth/orchestration/worker-runtime expansion.
-- No new web routes or UI redesign.
+- No connector breadth expansion or write-capable connector behavior.
+- No auth, orchestration, or worker-runtime expansion.
+- No new web routes, UI redesign, or test-behavior changes.
+- No new MVP validation-runner features beyond documentation alignment.
+
+## Files Changed
+- `README.md`
+- `ROADMAP.md`
+- `ARCHITECTURE.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `RULES.md`
+- `docs/runbooks/mvp-validation-matrix.md`
+- `BUILD_REPORT.md`
+- `REVIEW_REPORT.md`
+
+## Tests Run
+- `rg -n "Sprint 6X" README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md`
+- `rg -n -e 'file://' -e 'vscode://' -e '/[U]sers/' -e '/home/' -e 'C:\\Users\\' README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md RULES.md docs/runbooks/mvp-validation-matrix.md docs/runbooks/mvp-readiness-gates.md`
+
+## Blockers/Issues
+- None.
 
 ## Recommended Next Step
-Run `python3 scripts/run_mvp_validation_matrix.py` in reviewer CI on merge gate and use `docs/runbooks/mvp-validation-matrix.md` as the canonical triage flow for any non-pass step.
+Run `python3 scripts/run_mvp_validation_matrix.py` as the standard reviewer/CI MVP release-candidate gate and keep canonical truth docs synchronized in any sprint that changes operating baseline.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 6X: a FastAPI backend plus a bounded Next.js operator shell.
+AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Sprint 7G: a FastAPI backend plus a bounded Next.js operator shell with deterministic MVP readiness and validation matrix gating.
 
 ## Current Implemented Slice
 
@@ -22,20 +22,22 @@ AliceBot is a private, permissioned personal AI operating system. The current re
 Useful checks:
 
 - API health: [http://127.0.0.1:8000/healthz](http://127.0.0.1:8000/healthz)
+- MVP readiness gates: `python3 scripts/run_mvp_readiness_gates.py`
+- MVP default go/no-go validation gate: `python3 scripts/run_mvp_validation_matrix.py`
 - Backend tests: `./.venv/bin/python -m pytest tests/unit tests/integration`
 - Web tests: `pnpm --dir apps/web test`
 - Web shell: `pnpm --dir apps/web dev`
 
 ## Repo Map
 
-- [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md): stable product scope and ship gates
-- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md): implemented technical boundaries
-- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md): forward planning from the current repo state
-- [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md): durable engineering and scope rules
-- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md): compact recovery snapshot
-- [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md): current sprint build report
-- [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md): current sprint review report
-- [docs/archive/sprints](/Users/samirusani/Desktop/Codex/AliceBot/docs/archive/sprints): accepted historical sprint build and review artifacts
+- [PRODUCT_BRIEF.md](PRODUCT_BRIEF.md): stable product scope and ship gates
+- [ARCHITECTURE.md](ARCHITECTURE.md): implemented technical boundaries
+- [ROADMAP.md](ROADMAP.md): forward planning from the current repo state
+- [RULES.md](RULES.md): durable engineering and scope rules
+- [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURRENT_STATE.md): compact recovery snapshot
+- [BUILD_REPORT.md](BUILD_REPORT.md): current sprint build report
+- [REVIEW_REPORT.md](REVIEW_REPORT.md): current sprint review report
+- [docs/archive/sprints](docs/archive/sprints): accepted historical sprint build and review artifacts
 
 ## Environment Notes
 

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,46 +4,36 @@
 PASS
 
 ## criteria met
-- Sprint stayed within Sprint 7G verification scope (QA orchestration, tests, and runbooks only); no product/API/schema/UI expansion detected in changed files.
-- `scripts/run_mvp_validation_matrix.py` is implemented and runs a deterministic three-step sequence in the required order:
-  - `readiness_gates`
-  - `backend_integration_matrix`
-  - `web_validation_matrix`
-- Matrix includes required backend and web verification surfaces from the sprint packet:
-  - backend integration suite list covers continuity, responses, approvals/execution, tasks/steps, traces, memory/entities/artifacts, and Gmail/Calendar account seams
-  - web matrix script covers `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, `/traces` via explicit Vitest suites
-- Exit-code and output contract are met:
-  - per-step status/command/duration/exit code/coverage output
-  - explicit `Failing steps: ...` line on failures
-  - final `MVP validation matrix result: PASS|NO_GO`
-  - process exits `0` only when all steps pass
-- Induced single-step failure behavior is deterministic and correctly reported:
-  - `python3 scripts/run_mvp_validation_matrix.py --induce-step backend_integration_matrix` produced backend step failure (`exit_code=97`), explicit failing-step output, and final non-zero exit.
-- Required test coverage for matrix runner contract exists and passes:
-  - `python3 -m pytest -q tests/integration/test_mvp_validation_matrix.py tests/integration/test_mvp_readiness_gates.py` -> `9 passed`
-- Required runbook deliverable exists and is aligned with execution/triage flow:
-  - `docs/runbooks/mvp-validation-matrix.md`
+- Sprint stayed within Sprint 7H documentation/control-artifact scope; changed files are docs, handoff, rules, and reports only.
+- Canonical baseline files no longer claim Sprint 6X as current state:
+  - `README.md`
+  - `ROADMAP.md`
+  - `ARCHITECTURE.md`
+  - `.ai/handoff/CURRENT_STATE.md`
+- MVP default go/no-go command is explicitly documented as `python3 scripts/run_mvp_validation_matrix.py` in canonical docs/runbooks.
+- `docs/runbooks/mvp-validation-matrix.md` now uses a portable web matrix command (`npm --prefix apps/web run test:mvp:validation-matrix`) and no `/Users/...` absolute path.
+- Portability patterns (`file://`, `vscode://`, local absolute user-home paths) are absent from targeted shared canonical docs/runbooks when checked with a shell-safe grep command.
+- No hidden product/backend/runtime/schema scope expansion was introduced.
 
 ## criteria missed
-- None blocking Sprint 7G acceptance.
+- None of the Sprint 7H acceptance criteria are functionally missed.
 
 ## quality issues
-- Non-blocking: `scripts/run_mvp_validation_matrix.py` resolves Python executable via local `.venv` autodetection, so printed command strings differ by environment. Behavior is correct, but output strictness is environment-sensitive.
-- Non-blocking: matrix output is verbose because readiness/backend subprocess logs (including Alembic migration logs) are streamed inline.
+- None significant for sprint scope.
 
 ## regression risks
-- Low product regression risk: changes are confined to validation orchestration, package script wiring, tests, and runbooks.
-- Moderate environment risk: readiness/backend matrix steps require local Postgres and unsandboxed localhost access; restricted environments can produce false negatives.
+- Low product regression risk because changes are docs/rules/report only.
+- Low process risk after fixing the portability-check command in `BUILD_REPORT.md` to a shell-safe form.
 
 ## docs issues
-- Non-blocking portability issue: `docs/runbooks/mvp-validation-matrix.md` shows the web step command with a machine-specific absolute path (`npm --prefix /Users/.../apps/web ...`). Prefer documenting it as `npm --prefix apps/web run test:mvp:validation-matrix`.
+- None. Portability-check command formatting in `BUILD_REPORT.md` is shell-safe and copy-paste reproducible.
 
 ## should anything be added to RULES.md?
-- Optional: add a documentation rule to avoid machine-specific absolute paths in runbooks unless strictly required.
+- Optional: add one line requiring shell commands in reports/runbooks to be copy-paste runnable in a POSIX shell (especially regex patterns with backslashes).
 
 ## should anything update ARCHITECTURE.md?
-- No. Sprint 7G introduces validation orchestration/reporting only and does not change architecture.
+- No additional architecture updates required for Sprint 7H.
 
 ## recommended next action
-- Approve Sprint 7G as `PASS`.
-- Optionally apply one small follow-up docs cleanup: replace the absolute web command path in `docs/runbooks/mvp-validation-matrix.md` with the repo-relative form.
+1. Accept Sprint 7H.
+2. Keep using the documented shell-safe portability checks for future docs/control sprints.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,20 +2,22 @@
 
 ## Current Position
 
-- The accepted repo state is current through Sprint 6X.
+- The accepted repo state is current through Sprint 7G.
 - The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, narrow read-only Gmail and Calendar seams with selected-item ingestion, bounded read-only Calendar event discovery for one connected account, and the no-tools assistant-response seam.
 - The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
 - `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, keeps bounded thread review visible beside both assistant and governed-request composition, and ships thread-linked governed workflow, ordered task-step timeline review, and bounded explain-why trace embedding.
 - `/gmail` and `/calendar` are shipped bounded connector workspaces in the shell: account review, selected-account detail, explicit connect, and one selected-item ingestion path into one chosen task workspace. The API baseline also includes bounded Calendar event discovery for one connected account with deterministic ordering and bounded limits.
 - `/memories`, `/entities`, and `/artifacts` are shipped bounded review workspaces in the shell, not planned surface.
+- Sprint 7G also established deterministic MVP release-candidate validation tooling; `python3 scripts/run_mvp_validation_matrix.py` is the default MVP go/no-go command.
 - Historical sprint detail belongs in build and review artifacts, not in this roadmap.
 
 ## Next Delivery Focus
 
 ### Build From The Shipped API Plus Web-Shell Baseline
 
-- Plan the next sprint from the implemented Sprint 6X backend-plus-web baseline, not from the older Sprint 6R narrative.
+- Plan the next sprint from the implemented Sprint 7G backend-plus-web baseline, not from older pre-7G narratives.
 - Treat transcript continuity, thread-linked workflow review, task-step timeline review, bounded explain-why embedding in `/chat`, the shipped review workspaces (`/memories`, `/entities`, `/artifacts`), the shipped connector workspaces (`/gmail`, `/calendar`), and bounded Calendar event discovery as baseline, not pending work.
+- Treat the deterministic validation matrix command (`python3 scripts/run_mvp_validation_matrix.py`) as the default MVP release-candidate gate.
 - Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.
 - Reuse the existing continuity, response, approval, task, workspace-artifact, memory, entity, execution, and trace surfaces instead of introducing parallel contracts.
 

--- a/RULES.md
+++ b/RULES.md
@@ -6,6 +6,8 @@
 - Treat `.ai/active/SPRINT_PACKET.md` as an input/control artifact: do not edit it during implementation unless Control Tower explicitly changes the sprint.
 - Never describe planned behavior as already implemented.
 - Keep canonical truth files concise, current, and durable.
+- Shared runbooks and canonical docs must use machine-independent commands and links; do not use local user-home absolute paths.
+- When a sprint changes the operating baseline, update canonical truth docs in the same sprint before handoff.
 - Archive stale planning or history material instead of deleting it when traceability still matters.
 - Do not widen product scope without an explicit roadmap or sprint change.
 

--- a/docs/runbooks/mvp-validation-matrix.md
+++ b/docs/runbooks/mvp-validation-matrix.md
@@ -2,6 +2,7 @@
 
 ## Objective
 Run one deterministic command that executes MVP readiness prerequisites plus bounded backend and web verification matrices, then emits a clear `PASS` or `NO_GO`.
+Use this as the default MVP release-candidate go/no-go gate.
 
 ## Prerequisites
 - Python dependencies installed for backend integration tests (`python3 -m venv .venv` and `./.venv/bin/python -m pip install -e '.[dev]'`).
@@ -19,7 +20,7 @@ The runner executes this deterministic step order:
 2. `backend_integration_matrix`
    - `python3 -m pytest -q tests/integration/test_continuity_api.py tests/integration/test_responses_api.py tests/integration/test_approval_api.py tests/integration/test_proxy_execution_api.py tests/integration/test_tasks_api.py tests/integration/test_traces_api.py tests/integration/test_memory_review_api.py tests/integration/test_entities_api.py tests/integration/test_task_artifacts_api.py tests/integration/test_gmail_accounts_api.py tests/integration/test_calendar_accounts_api.py`
 3. `web_validation_matrix`
-   - `npm --prefix /Users/samirusani/Desktop/Codex/AliceBot/apps/web run test:mvp:validation-matrix`
+   - `npm --prefix apps/web run test:mvp:validation-matrix`
 
 Expected behavior:
 - Prints per-step status with command, duration, exit code, and coverage.


### PR DESCRIPTION
## Summary\n- sync canonical docs to accepted Sprint 7G baseline\n- canonicalize MVP RC go/no-go command as python3 scripts/run_mvp_validation_matrix.py\n- remove machine-specific command paths from shared runbook/docs and update sprint reports\n\n## Verification\n- rg -n "Sprint 6X" README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md\n- rg -n -e 'file://' -e 'vscode://' -e '/[U]sers/' -e '/home/' -e 'C:\\Users\\' README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md RULES.md docs/runbooks/mvp-validation-matrix.md docs/runbooks/mvp-readiness-gates.md\n\nControl Tower decision: MERGE_APPROVED (squash merge).