### PR TITLE
Sprint 7I: memory quality ship-margin hardening

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,121 +2,122 @@
 
 ## Sprint Title
 
-Sprint 7H: MVP RC Truth Sync And Gate Canonicalization
+Sprint 7I: Memory Quality Ship-Margin Hardening
 
 ## Sprint Type
 
-docs
+qa
 
 ## Sprint Reason
 
-Sprint 7G delivered a deterministic extensive validation matrix and passed review, but canonical project docs still anchor to Sprint 6X-era state and one runbook command remains machine-specific. This creates avoidable planning and review drift risk right before MVP release-candidate decisions.
+Sprint 7H aligned canonical docs and gate usage. The remaining MVP release risk is memory-quality confidence margin: current readiness evidence sits at the floor (`precision=0.800000`, sample `10`), while the product brief requires memory extraction precision to exceed 80% at ship.
 
 ## Sprint Intent
 
-Synchronize canonical docs and runbooks to the accepted Sprint 7G baseline and formalize the MVP validation matrix command as the default go/no-go gate, without changing product or backend behavior.
+Tighten memory-quality readiness gating from minimum-threshold posture to ship-margin posture, with deterministic evidence and no product-scope expansion.
 
 ## Git Instructions
 
-- Branch Name: `codex/sprint-7h-mvp-rc-truth-sync`
+- Branch Name: `codex/sprint-7i-memory-quality-ship-margin`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR, no stacked PRs unless Control Tower explicitly opens a follow-up sprint
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- Sprint 7G now gives one reliable extensive-testing entrypoint.
-- Canonical docs still claim Sprint 6X as current state, which no longer matches shipped verification reality.
-- Pre-MVP control reliability now depends more on accurate docs and deterministic operator instructions than on new feature seams.
+- MVP validation matrix now runs end-to-end and passes.
+- Memory quality is currently just at the pass floor rather than above it.
+- We need stronger deterministic evidence before calling MVP truly ship-ready.
 
 ## Design Truth
 
-- This is a documentation/control-artifact sprint, not a feature sprint.
-- Make reality explicit: accepted state includes Sprint 7G readiness + validation tooling.
-- Keep instructions portable and machine-independent.
+- This is a QA/readiness sprint, not a feature sprint.
+- Keep scope on gate math, deterministic seed/evidence, and runbook/report alignment.
+- Do not widen connectors, auth, orchestration, or UI feature scope.
 
 ## Exact Surfaces In Scope
 
-- Canonical truth docs and planning docs.
-- MVP validation runbook portability and gate canonicalization.
-- Optional small durable rule updates to prevent recurrence.
+- Memory-quality gate thresholds and posture logic in readiness tooling.
+- Deterministic readiness seed profile used by gate probes.
+- Readiness/validation runbooks and sprint reports.
 
 ## Exact Files In Scope
 
-- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md)
-- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md)
-- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md)
-- [CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md)
-- [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md)
-- [mvp-validation-matrix.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/mvp-validation-matrix.md)
+- [run_mvp_readiness_gates.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_mvp_readiness_gates.py)
+- [run_mvp_validation_matrix.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_mvp_validation_matrix.py)
+- [test_mvp_readiness_gates.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_mvp_readiness_gates.py)
+- [test_mvp_validation_matrix.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_mvp_validation_matrix.py)
+- [memory-quality-gate.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/memory-quality-gate.md)
 - [mvp-readiness-gates.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/mvp-readiness-gates.md)
+- [mvp-validation-matrix.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/mvp-validation-matrix.md)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
 - [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
 
 ## In Scope
 
-- Update canonical docs to reflect accepted state through Sprint 7G (no 6X-era “current state” language).
-- Document the MVP default validation command as:
-  - `python3 scripts/run_mvp_validation_matrix.py`
-- Fix runbook portability by removing machine-specific absolute command paths.
-- Align README quick checks and handoff docs with readiness + validation matrix workflow.
-- Optionally add concise RULES guidance to prevent recurrence:
-  - no machine-specific local absolute paths in shared runbooks
-  - canonical docs must be updated when sprint-level operating baseline changes
+- Update memory gate criterion to ship-margin semantics:
+  - `precision > 0.80` (strictly greater, not equal)
+  - `adjudicated_sample >= 20`
+- Update deterministic readiness seed profile so normal gate run can pass only with new margin.
+- Update readiness gate tests to cover boundary behavior explicitly:
+  - `precision == 0.80` must not pass
+  - insufficient sample remains `BLOCKED`
+- Ensure validation matrix behavior stays deterministic with the updated readiness gate.
+- Align runbooks with the stricter memory-quality semantics and interpretation.
 
 ## Out of Scope
 
 - No new endpoints, migrations, or schema changes.
 - No connector breadth expansion or write-capable connector behavior.
 - No auth, orchestration, or worker-runtime expansion.
-- No new web routes, UI redesign, or test-behavior changes.
-- No new validation runner features beyond documentation alignment.
+- No UI feature scope changes.
+- No new product behavior beyond readiness evidence hardening.
 
 ## Required Deliverables
 
-- Canonical docs updated to Sprint 7G truth baseline.
-- Portable, machine-independent commands in `docs/runbooks/mvp-validation-matrix.md`.
-- Updated sprint reports reflecting Sprint 7H docs/control scope only.
+- Updated readiness gate implementation and tests with strict memory-margin criteria.
+- Updated runbooks reflecting strict threshold and larger minimum sample.
+- Updated `BUILD_REPORT.md` and `REVIEW_REPORT.md` for Sprint 7I only.
 
 ## Acceptance Criteria
 
-- `README.md`, `ROADMAP.md`, `ARCHITECTURE.md`, and `.ai/handoff/CURRENT_STATE.md` no longer claim Sprint 6X as current state.
-- `docs/runbooks/mvp-validation-matrix.md` uses repo-relative or environment-agnostic commands (no `/Users/...` paths).
-- A grep-based portability check passes for shared docs/runbooks:
-  - no `file://`, `vscode://`, or local absolute user-home paths.
-- Sprint remains documentation/rules/report scope only.
+- `python3 scripts/run_mvp_readiness_gates.py` returns `PASS` only when `precision > 0.80` and `adjudicated_sample >= 20`.
+- A boundary case with `precision == 0.80` is verified as non-pass (`FAIL` or `NO_GO` path).
+- `python3 scripts/run_mvp_validation_matrix.py` remains deterministic with explicit `PASS/NO_GO`.
+- Sprint remains within QA/readiness + docs/report scope only.
 
 ## Implementation Constraints
 
-- Keep edits concise and truth-preserving.
-- Do not introduce new feature claims beyond what repo evidence already supports.
-- Preserve product scope boundaries already documented in `PRODUCT_BRIEF.md`.
+- Keep threshold/math changes explicit, deterministic, and test-backed.
+- Do not weaken existing gate semantics for latency/cache/acceptance.
+- Keep changes narrow to listed files.
 
 ## Suggested Work Breakdown
 
-1. Update canonical baseline statements from 6X-era to accepted 7G-era truth.
-2. Normalize MVP validation runbook commands to portable forms.
-3. Align README/handoff/roadmap language with current validation workflow.
-4. Run portability/consistency checks over touched docs.
-5. Update build/review reports.
+1. Update memory gate constants and posture logic in `scripts/run_mvp_readiness_gates.py`.
+2. Update deterministic seed profile to satisfy strict ship-margin target on normal run.
+3. Add/adjust integration tests for new boundary and sample semantics.
+4. Validate readiness runner and matrix runner behavior with normal + induced-failure runs.
+5. Update runbooks and sprint reports.
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact canonical docs updated
-- portability checks executed and results
-- explicit statement of what remains deferred
+- exact updated threshold semantics (`>0.80`, sample `>=20`)
+- exact commands run and pass/fail outcomes
+- boundary-test evidence for `precision == 0.80`
+- induced-failure evidence remains deterministic
 - explicit deferred criteria not covered by this sprint
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint stayed within docs/control-artifact scope
-- canonical files now match accepted 7G baseline
-- runbook command portability is fixed
+- sprint stayed within readiness-hardening scope
+- gate math matches Product Brief ship semantics
+- deterministic behavior remains intact in readiness + matrix runners
 - no hidden product/backend scope entered
 
 ## Exit Condition
 
-This sprint is complete when canonical docs and runbooks are synchronized to the accepted Sprint 7G operating baseline, matrix gate usage is explicit and portable, and review can no longer fail due to baseline-document drift.
+This sprint is complete when memory-quality gating has ship-margin strictness (`precision > 0.80`, sample `>=20`) with deterministic evidence and unchanged product scope.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,75 +1,78 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Synchronize canonical truth docs and MVP runbooks to the accepted Sprint 7G baseline, make the validation matrix command the explicit default MVP go/no-go gate, and keep all work within docs/control-artifact scope.
+Harden MVP memory-quality readiness from floor-threshold posture to ship-margin posture by enforcing strict gate semantics (`precision > 0.80`, `adjudicated_sample >= 20`) with deterministic evidence and no product-scope expansion.
 
 ## Completed Work
-- Updated canonical baseline language from Sprint 6X-era to accepted Sprint 7G in:
-  - `README.md`
-  - `ROADMAP.md`
-  - `ARCHITECTURE.md`
-  - `.ai/handoff/CURRENT_STATE.md`
-- Canonicalized MVP gate usage in docs:
-  - documented `python3 scripts/run_mvp_validation_matrix.py` as the default MVP release-candidate go/no-go command
-  - kept readiness gating as prerequisite context
-- Fixed portability issue in `docs/runbooks/mvp-validation-matrix.md`:
-  - replaced machine-specific web test command path with repo-relative command:
-    - from a machine-specific absolute-prefix command
-    - to `npm --prefix apps/web run test:mvp:validation-matrix`
-- Normalized shared canonical links in key docs away from local user-home absolute paths to portable repo-relative links.
-- Added concise durable rules in `RULES.md` to prevent recurrence:
-  - no machine-specific local absolute paths in shared runbooks/canonical docs
-  - canonical truth docs must be updated when sprint-level baseline changes
-- Updated sprint reports (`BUILD_REPORT.md`, `REVIEW_REPORT.md`) for Sprint 7H docs/control scope.
+- Updated memory-quality gate semantics in `scripts/run_mvp_readiness_gates.py`:
+  - precision pass criterion changed from `>= 0.80` to strict `> 0.80`
+  - minimum adjudicated sample changed from `>= 10` to `>= 20`
+  - threshold text in gate output updated accordingly
+- Updated deterministic readiness seed profile in `scripts/run_mvp_readiness_gates.py`:
+  - normal (`on_track`) profile now seeds `correct=17`, `incorrect=3` (`precision=0.85`, sample `20`)
+  - induced boundary profile (`memory_needs_review`) seeds `correct=16`, `incorrect=4` (`precision=0.80`, sample `20`)
+  - insufficient profile remains below required sample (`correct=9`, `incorrect=1`, sample `10`)
+- Updated readiness integration tests in `tests/integration/test_mvp_readiness_gates.py`:
+  - aligned posture test data to new sample threshold
+  - added explicit boundary test proving `precision == 0.80` returns `FAIL`
+  - added explicit insufficient-sample test proving sample `< 20` returns `BLOCKED` even with perfect precision
+- Updated runbooks for strict memory ship-margin semantics:
+  - `docs/runbooks/memory-quality-gate.md`
+  - `docs/runbooks/mvp-readiness-gates.md`
+  - `docs/runbooks/mvp-validation-matrix.md`
+- Updated sprint reports (`BUILD_REPORT.md`, `REVIEW_REPORT.md`) for Sprint 7I scope.
 
 ## Incomplete Work
-- None within Sprint 7H scope.
-
-## Exact Canonical Docs Updated
-- `README.md`
-- `ROADMAP.md`
-- `ARCHITECTURE.md`
-- `.ai/handoff/CURRENT_STATE.md`
-- `RULES.md`
-- `docs/runbooks/mvp-validation-matrix.md`
-
-## Portability Checks Executed And Results
-1. Sprint-baseline drift check (targeted canonical docs):
-   - Command:
-     - `rg -n "Sprint 6X" README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md`
-   - Result: no matches.
-
-2. Shared-doc portability check (targeted canonical docs + runbooks):
-   - Command:
-     - `rg -n -e 'file://' -e 'vscode://' -e '/[U]sers/' -e '/home/' -e 'C:\\Users\\' README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md RULES.md docs/runbooks/mvp-validation-matrix.md docs/runbooks/mvp-readiness-gates.md`
-   - Result: no matches.
-
-## Explicit Statement Of What Remains Deferred
-Sprint 7H intentionally does not change product behavior, API/runtime behavior, schema, or test behavior. It only synchronizes canonical docs/rules/runbooks and sprint reports.
-
-## Explicit Deferred Criteria Not Covered By This Sprint
-- No new endpoints, migrations, or schema changes.
-- No connector breadth expansion or write-capable connector behavior.
-- No auth, orchestration, or worker-runtime expansion.
-- No new web routes, UI redesign, or test-behavior changes.
-- No new MVP validation-runner features beyond documentation alignment.
+- None within Sprint 7I scope.
 
 ## Files Changed
-- `README.md`
-- `ROADMAP.md`
-- `ARCHITECTURE.md`
-- `.ai/handoff/CURRENT_STATE.md`
-- `RULES.md`
+- `scripts/run_mvp_readiness_gates.py`
+- `tests/integration/test_mvp_readiness_gates.py`
+- `docs/runbooks/memory-quality-gate.md`
+- `docs/runbooks/mvp-readiness-gates.md`
 - `docs/runbooks/mvp-validation-matrix.md`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 ## Tests Run
-- `rg -n "Sprint 6X" README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md`
-- `rg -n -e 'file://' -e 'vscode://' -e '/[U]sers/' -e '/home/' -e 'C:\\Users\\' README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md RULES.md docs/runbooks/mvp-validation-matrix.md docs/runbooks/mvp-readiness-gates.md`
+1. `python3 -m pytest -q tests/integration/test_mvp_readiness_gates.py`
+- Outcome: `8 passed`
+
+2. `python3 -m pytest -q tests/integration/test_mvp_validation_matrix.py`
+- Outcome: `3 passed`
+
+3. `python3 scripts/run_mvp_readiness_gates.py`
+- Outcome: `PASS`
+- Memory gate evidence: `precision=0.850000; adjudicated_sample=20; ... posture=on_track`
+- Memory threshold shown by runner: `precision > 0.80 and adjudicated_sample >= 20`
+
+4. `python3 scripts/run_mvp_readiness_gates.py --induce-gate memory_needs_review`
+- Outcome: `NO_GO` (exit code 1)
+- Boundary evidence: memory gate `FAIL` with `precision=0.800000; adjudicated_sample=20; posture=needs_review`
+- Confirms `precision == 0.80` is non-pass under strict ship-margin semantics
+
+5. `python3 scripts/run_mvp_validation_matrix.py`
+- Outcome: `PASS`
+- Step results: readiness `PASS`, backend integration matrix `PASS`, web validation matrix `PASS`
+- Final line: `MVP validation matrix result: PASS`
+
+6. `python3 scripts/run_mvp_validation_matrix.py --induce-step backend_integration_matrix`
+- Outcome: `NO_GO` (exit code 1)
+- Deterministic induced-failure evidence:
+  - induced step exited with `97`
+  - output included `Failing steps: backend_integration_matrix`
+  - final line: `MVP validation matrix result: NO_GO`
 
 ## Blockers/Issues
-- None.
+- No implementation blockers.
+- Note: local Postgres-backed commands required elevated execution in this environment due sandbox restrictions on `localhost:5432`.
+
+## Explicit Deferred Criteria Not Covered By This Sprint
+- No new endpoints, migrations, or schema changes.
+- No connector breadth expansion or write-capable connector behavior.
+- No auth, orchestration, or worker-runtime expansion.
+- No UI feature scope changes.
+- No new product behavior beyond readiness evidence hardening.
 
 ## Recommended Next Step
-Run `python3 scripts/run_mvp_validation_matrix.py` as the standard reviewer/CI MVP release-candidate gate and keep canonical truth docs synchronized in any sprint that changes operating baseline.
+Run `python3 scripts/run_mvp_validation_matrix.py` as the release-candidate gate in CI/reviewer flow and require memory gate evidence to remain above ship margin (`precision > 0.80`, sample `>= 20`).

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,36 +4,38 @@
 PASS
 
 ## criteria met
-- Sprint stayed within Sprint 7H documentation/control-artifact scope; changed files are docs, handoff, rules, and reports only.
-- Canonical baseline files no longer claim Sprint 6X as current state:
-  - `README.md`
-  - `ROADMAP.md`
-  - `ARCHITECTURE.md`
-  - `.ai/handoff/CURRENT_STATE.md`
-- MVP default go/no-go command is explicitly documented as `python3 scripts/run_mvp_validation_matrix.py` in canonical docs/runbooks.
-- `docs/runbooks/mvp-validation-matrix.md` now uses a portable web matrix command (`npm --prefix apps/web run test:mvp:validation-matrix`) and no `/Users/...` absolute path.
-- Portability patterns (`file://`, `vscode://`, local absolute user-home paths) are absent from targeted shared canonical docs/runbooks when checked with a shell-safe grep command.
-- No hidden product/backend/runtime/schema scope expansion was introduced.
+- Acceptance criteria met for strict memory gate semantics in `scripts/run_mvp_readiness_gates.py`:
+  - `precision > 0.80` (strictly greater)
+  - `adjudicated_sample >= 20`
+- Boundary behavior is explicitly enforced and tested:
+  - `precision == 0.80` evaluates to `FAIL`/`NO_GO` (`memory_needs_review` induced path and integration test coverage).
+  - Sample below minimum remains `BLOCKED` even with perfect precision.
+- Deterministic validation matrix behavior remains intact:
+  - `python3 scripts/run_mvp_validation_matrix.py` returns `PASS`.
+  - `python3 scripts/run_mvp_validation_matrix.py --induce-step backend_integration_matrix` returns `NO_GO` with explicit failing step and deterministic induced exit behavior.
+- Scope discipline maintained:
+  - Code and doc changes remained in Sprint 7I readiness-hardening surfaces.
+  - No connector/auth/orchestration/UI/backend feature expansion detected.
 
 ## criteria missed
-- None of the Sprint 7H acceptance criteria are functionally missed.
+- None.
 
 ## quality issues
-- None significant for sprint scope.
+- No implementation-quality issues found in sprint-scoped changes.
 
 ## regression risks
-- Low product regression risk because changes are docs/rules/report only.
-- Low process risk after fixing the portability-check command in `BUILD_REPORT.md` to a shell-safe form.
+- Low functional risk.
+- Expected operational tightening: memory gate now intentionally rejects the former floor case (`precision == 0.80`) and requires larger adjudicated sample (`>= 20`).
 
 ## docs issues
-- None. Portability-check command formatting in `BUILD_REPORT.md` is shell-safe and copy-paste reproducible.
+- None. Runbooks are aligned with the strict threshold semantics and boundary interpretation.
 
 ## should anything be added to RULES.md?
-- Optional: add one line requiring shell commands in reports/runbooks to be copy-paste runnable in a POSIX shell (especially regex patterns with backslashes).
+- No.
 
 ## should anything update ARCHITECTURE.md?
-- No additional architecture updates required for Sprint 7H.
+- No.
 
 ## recommended next action
-1. Accept Sprint 7H.
-2. Keep using the documented shell-safe portability checks for future docs/control sprints.
+1. Accept Sprint 7I.
+2. Keep `python3 scripts/run_mvp_validation_matrix.py` as the release-candidate gate in CI/reviewer flow.

--- a/docs/runbooks/memory-quality-gate.md
+++ b/docs/runbooks/memory-quality-gate.md
@@ -15,20 +15,20 @@ Use `/memories` to read a deterministic ship-gate signal for memory quality befo
 ## Gate Math
 - `precision = correct / (correct + incorrect)` (undefined when denominator is `0`)
 - `adjudicated_sample = correct + incorrect`
-- `remaining_to_minimum_sample = max(0, 10 - adjudicated_sample)`
-- Precision target: `>= 0.80`
-- Minimum adjudicated sample: `>= 10`
+- `remaining_to_minimum_sample = max(0, 20 - adjudicated_sample)`
+- Precision target: `> 0.80` (strictly greater)
+- Minimum adjudicated sample: `>= 20`
 
 ## Gate States
-- `on_track`: precision `>= 0.80` and adjudicated sample `>= 10`
-- `needs_review`: precision `< 0.80` and adjudicated sample `>= 10`
-- `insufficient_evidence`: adjudicated sample `< 10`
+- `on_track`: precision `> 0.80` and adjudicated sample `>= 20`
+- `needs_review`: precision `<= 0.80` and adjudicated sample `>= 20`
+- `insufficient_evidence`: adjudicated sample `< 20`
 - `unavailable data`: evaluation summary not available for computation
 
 ## Posture Readouts
 - Sample posture:
-  - enough sample when adjudicated sample `>= 10`
-  - insufficient sample when adjudicated sample `< 10`
+  - enough sample when adjudicated sample `>= 20`
+  - insufficient sample when adjudicated sample `< 20`
 - Queue posture:
   - queue clear when `unlabeled_memory_count = 0`
   - backlog present when `unlabeled_memory_count > 0`
@@ -69,3 +69,5 @@ Use `/memories` to read a deterministic ship-gate signal for memory quality befo
   - `on_track` -> gate `PASS`
   - `needs_review` -> gate `FAIL`
   - `insufficient_evidence` or unavailable data -> gate `BLOCKED`
+- Boundary behavior:
+  - `precision == 0.80` is `needs_review` and does not pass.

--- a/docs/runbooks/mvp-readiness-gates.md
+++ b/docs/runbooks/mvp-readiness-gates.md
@@ -20,7 +20,7 @@ Expected behavior:
   - `acceptance_suite` (runs `python3 scripts/run_mvp_acceptance.py`)
   - `latency_p95` (`p95_seconds < 5.0`)
   - `cache_reuse` (`cache_reuse_ratio >= 0.70` when cached-token telemetry is present)
-  - `memory_quality` (`precision >= 0.80` and `adjudicated_sample >= 10`)
+  - `memory_quality` (`precision > 0.80` and `adjudicated_sample >= 20`)
 - Prints explicit `PASS`, `FAIL`, or `BLOCKED` per gate with measured values and thresholds.
 - Returns exit code `0` only when every gate is `PASS`.
 - Returns non-zero on any `FAIL` or `BLOCKED` gate.
@@ -45,7 +45,7 @@ Expected behavior:
   - `precision = correct / (correct + incorrect)` when denominator > 0.
   - `adjudicated_sample = correct + incorrect`.
   - `PASS` when precision and sample thresholds are met.
-  - `FAIL` when adjudicated sample is sufficient but precision is below target.
+  - `FAIL` when adjudicated sample is sufficient but precision is at-or-below target (`<= 0.80`).
   - `BLOCKED` when adjudicated sample is below minimum or summary data is unavailable/invalid.
 
 ## Optional Deterministic Negative Checks

--- a/docs/runbooks/mvp-validation-matrix.md
+++ b/docs/runbooks/mvp-validation-matrix.md
@@ -17,6 +17,7 @@ python3 scripts/run_mvp_validation_matrix.py
 The runner executes this deterministic step order:
 1. `readiness_gates`
    - `python3 scripts/run_mvp_readiness_gates.py`
+   - includes strict memory-quality ship margin (`precision > 0.80`, `adjudicated_sample >= 20`)
 2. `backend_integration_matrix`
    - `python3 -m pytest -q tests/integration/test_continuity_api.py tests/integration/test_responses_api.py tests/integration/test_approval_api.py tests/integration/test_proxy_execution_api.py tests/integration/test_tasks_api.py tests/integration/test_traces_api.py tests/integration/test_memory_review_api.py tests/integration/test_entities_api.py tests/integration/test_task_artifacts_api.py tests/integration/test_gmail_accounts_api.py tests/integration/test_calendar_accounts_api.py`
 3. `web_validation_matrix`

--- a/scripts/run_mvp_readiness_gates.py
+++ b/scripts/run_mvp_readiness_gates.py
@@ -48,7 +48,7 @@ MEMORY_GATE_NAME = "memory_quality"
 LATENCY_P95_THRESHOLD_SECONDS = 5.0
 CACHE_REUSE_THRESHOLD = 0.70
 MEMORY_PRECISION_THRESHOLD = 0.80
-MEMORY_MIN_ADJUDICATED_SAMPLE = 10
+MEMORY_MIN_ADJUDICATED_SAMPLE = 20
 PROBE_CALL_COUNT = 8
 
 GateStatus = Literal["PASS", "FAIL", "BLOCKED"]
@@ -189,17 +189,17 @@ def _seed_memory_quality_sample(
     profile: MemoryProfile,
 ) -> None:
     if profile == "on_track":
-        correct_count = 8
-        incorrect_count = 2
-        total_count = 10
+        correct_count = 17
+        incorrect_count = 3
+        total_count = 20
     elif profile == "needs_review":
-        correct_count = 6
+        correct_count = 16
         incorrect_count = 4
-        total_count = 10
+        total_count = 20
     else:
-        correct_count = 5
+        correct_count = 9
         incorrect_count = 1
-        total_count = 6
+        total_count = 10
 
     with user_connection(database_url, user_id) as conn:
         store = ContinuityStore(conn)
@@ -346,7 +346,7 @@ def _evaluate_memory_quality_gate(summary: dict[str, Any]) -> GateResult:
             status="BLOCKED",
             measured="precision=unavailable; adjudicated_sample=unavailable",
             threshold=(
-                f"precision >= {MEMORY_PRECISION_THRESHOLD:.2f} and "
+                f"precision > {MEMORY_PRECISION_THRESHOLD:.2f} and "
                 f"adjudicated_sample >= {MEMORY_MIN_ADJUDICATED_SAMPLE}"
             ),
             detail="evaluation summary payload was missing label counts",
@@ -361,7 +361,7 @@ def _evaluate_memory_quality_gate(summary: dict[str, Any]) -> GateResult:
             status="BLOCKED",
             measured="precision=unavailable; adjudicated_sample=unavailable",
             threshold=(
-                f"precision >= {MEMORY_PRECISION_THRESHOLD:.2f} and "
+                f"precision > {MEMORY_PRECISION_THRESHOLD:.2f} and "
                 f"adjudicated_sample >= {MEMORY_MIN_ADJUDICATED_SAMPLE}"
             ),
             detail="evaluation summary payload had invalid value types",
@@ -373,7 +373,7 @@ def _evaluate_memory_quality_gate(summary: dict[str, Any]) -> GateResult:
     if adjudicated_sample < MEMORY_MIN_ADJUDICATED_SAMPLE:
         status: GateStatus = "BLOCKED"
         posture = "insufficient_evidence"
-    elif precision is not None and precision >= MEMORY_PRECISION_THRESHOLD:
+    elif precision is not None and precision > MEMORY_PRECISION_THRESHOLD:
         status = "PASS"
         posture = "on_track"
     else:
@@ -389,7 +389,7 @@ def _evaluate_memory_quality_gate(summary: dict[str, Any]) -> GateResult:
             f"unlabeled_memory_count={unlabeled}; posture={posture}"
         ),
         threshold=(
-            f"precision >= {MEMORY_PRECISION_THRESHOLD:.2f} and "
+            f"precision > {MEMORY_PRECISION_THRESHOLD:.2f} and "
             f"adjudicated_sample >= {MEMORY_MIN_ADJUDICATED_SAMPLE}"
         ),
         detail=f"correct={correct}; incorrect={incorrect}",
@@ -601,7 +601,7 @@ def run_readiness_gates(*, induce_gate: InducedScenario | None = None) -> list[G
                     status="BLOCKED",
                     measured="precision=unavailable; adjudicated_sample=unavailable",
                     threshold=(
-                        f"precision >= {MEMORY_PRECISION_THRESHOLD:.2f} and "
+                        f"precision > {MEMORY_PRECISION_THRESHOLD:.2f} and "
                         f"adjudicated_sample >= {MEMORY_MIN_ADJUDICATED_SAMPLE}"
                     ),
                     detail=blocked_detail,

--- a/tests/integration/test_mvp_readiness_gates.py
+++ b/tests/integration/test_mvp_readiness_gates.py
@@ -60,19 +60,19 @@ def test_cache_reuse_gate_enforces_threshold_math() -> None:
 def test_memory_quality_gate_posture_alignment() -> None:
     pass_gate = readiness_gates._evaluate_memory_quality_gate(
         {
-            "label_row_counts_by_value": {"correct": 8, "incorrect": 2},
+            "label_row_counts_by_value": {"correct": 17, "incorrect": 3},
             "unlabeled_memory_count": 0,
         }
     )
     fail_gate = readiness_gates._evaluate_memory_quality_gate(
         {
-            "label_row_counts_by_value": {"correct": 6, "incorrect": 4},
+            "label_row_counts_by_value": {"correct": 15, "incorrect": 5},
             "unlabeled_memory_count": 0,
         }
     )
     blocked_gate = readiness_gates._evaluate_memory_quality_gate(
         {
-            "label_row_counts_by_value": {"correct": 5, "incorrect": 1},
+            "label_row_counts_by_value": {"correct": 9, "incorrect": 1},
             "unlabeled_memory_count": 0,
         }
     )
@@ -82,6 +82,33 @@ def test_memory_quality_gate_posture_alignment() -> None:
     assert fail_gate.status == "FAIL"
     assert "posture=needs_review" in fail_gate.measured
     assert blocked_gate.status == "BLOCKED"
+    assert "posture=insufficient_evidence" in blocked_gate.measured
+    assert pass_gate.threshold == "precision > 0.80 and adjudicated_sample >= 20"
+
+
+def test_memory_quality_gate_rejects_precision_boundary_at_point_80() -> None:
+    boundary_gate = readiness_gates._evaluate_memory_quality_gate(
+        {
+            "label_row_counts_by_value": {"correct": 16, "incorrect": 4},
+            "unlabeled_memory_count": 0,
+        }
+    )
+
+    assert boundary_gate.status == "FAIL"
+    assert "precision=0.800000" in boundary_gate.measured
+    assert "posture=needs_review" in boundary_gate.measured
+
+
+def test_memory_quality_gate_blocks_when_sample_is_below_20_even_with_perfect_precision() -> None:
+    blocked_gate = readiness_gates._evaluate_memory_quality_gate(
+        {
+            "label_row_counts_by_value": {"correct": 19, "incorrect": 0},
+            "unlabeled_memory_count": 0,
+        }
+    )
+
+    assert blocked_gate.status == "BLOCKED"
+    assert "adjudicated_sample=19" in blocked_gate.measured
     assert "posture=insufficient_evidence" in blocked_gate.measured
 
 


### PR DESCRIPTION
## Context
Sprint 7I addresses the remaining MVP release risk around memory-quality confidence margin.  
Before this sprint, readiness evidence could pass at the floor (`precision = 0.80`, sample `10`). The product brief requires memory extraction precision to exceed 80% at ship.

## Goal
Harden readiness gate semantics so memory quality passes only when it is above the floor with a larger evidence sample, while keeping scope strictly in QA/readiness and docs/report surfaces.

## What Changed
1. Memory gate semantics were tightened in `scripts/run_mvp_readiness_gates.py`:
- `precision >= 0.80` -> `precision > 0.80`
- `adjudicated_sample >= 10` -> `adjudicated_sample >= 20`

2. Deterministic readiness seed profiles were aligned to the stricter thresholds:
- Pass profile (`on_track`): `correct=17`, `incorrect=3` (`precision=0.85`, sample `20`)
- Boundary profile (`memory_needs_review`): `correct=16`, `incorrect=4` (`precision=0.80`, sample `20`)
- Insufficient profile: sample remains below threshold (`10`)

3. Integration coverage was updated in `tests/integration/test_mvp_readiness_gates.py`:
- Explicit boundary test confirming `precision == 0.80` is a non-pass (`FAIL`)
- Explicit insufficient-sample test confirming sample `< 20` is `BLOCKED`
- Existing posture tests aligned to new minimum sample requirement

4. Runbooks were updated to match implemented semantics:
- `docs/runbooks/memory-quality-gate.md`
- `docs/runbooks/mvp-readiness-gates.md`
- `docs/runbooks/mvp-validation-matrix.md`

5. Sprint control artifacts were updated for Sprint 7I:
- `BUILD_REPORT.md`
- `REVIEW_REPORT.md`

## Verification
Executed and documented:
- `python3 -m pytest -q tests/integration/test_mvp_readiness_gates.py` -> `8 passed`
- `python3 -m pytest -q tests/integration/test_mvp_validation_matrix.py` -> `3 passed`
- `python3 scripts/run_mvp_readiness_gates.py` -> `PASS`
- `python3 scripts/run_mvp_readiness_gates.py --induce-gate memory_needs_review` -> `NO_GO` (boundary case at `0.80`)
- `python3 scripts/run_mvp_validation_matrix.py` -> `PASS`
- `python3 scripts/run_mvp_validation_matrix.py --induce-step backend_integration_matrix` -> deterministic `NO_GO` with failing step surfaced

## Scope Guardrails
This sprint intentionally did **not** expand product/runtime scope:
- No new endpoints, migrations, or schema changes
- No connector breadth/write expansion
- No auth/orchestration/worker runtime changes
- No UI feature expansion

## Outcome
Memory-quality readiness is now ship-margin aligned (`precision > 0.80`, sample `>= 20`) with deterministic boundary evidence and no scope drift.

Control Tower decision: `MERGE_APPROVED` (squash merge).
