### PR TITLE
Phase 2 Sprint 3: open-loop backbone

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 2 Sprint 2: Typed Memory Backbone
+Phase 2 Sprint 3: Capture Classification And Open-Loop Backbone
 
 ## Sprint Type
 
@@ -10,37 +10,37 @@ feature
 
 ## Sprint Reason
 
-Phase 2 planning reset is complete and merged. The next required build seam is typed memory infrastructure so continuity-first capture, open loops, resumption, and later multi-agent vertical profiles can reuse one durable substrate.
+Phase 2 Sprint 2 typed memory backbone is merged. The next dependency is a first-class open-loop domain so unresolved commitments can be captured, reviewed, and resolved deterministically instead of inferred ad hoc from raw memory entries.
 
 ## Sprint Intent
 
-Implement typed memory metadata end-to-end (schema, store, contracts/API, compiler serialization, memory UI, tests) without widening into open-loop workflows, resumption generation, or worker orchestration.
+Implement a narrow open-loop backbone (schema, store, contracts/API, compiler inclusion, and `/memories` review adoption) using the shipped typed-memory substrate, without introducing automation or worker orchestration.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase2-sprint2-typed-memory-backbone`
+- Branch Name: `codex/phase2-sprint3-open-loop-backbone`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- Phase 2 now defines continuity-first outcomes; current memory model is too flat.
-- Sprint 2 typed memory backbone is the critical dependency for Sprint 3 capture/open-loop domain.
-- This is the narrowest high-leverage seam that advances Phase 2 without scope creep.
+- Typed memory is now available; unresolved intent still has no dedicated lifecycle seam.
+- Open loops are required before continuity-first resumption can be accurate.
+- This keeps scope narrow while creating a reusable seam for later vertical agents.
 
 ## Design Truth
 
-- Extend existing memory architecture; do not create parallel memory stacks.
-- Keep behavior deterministic, test-backed, and audit-friendly.
-- Preserve current review and explainability guarantees.
+- Reuse current memory and continuity seams; do not create a parallel capture stack.
+- Keep open-loop lifecycle deterministic and auditable.
+- Preserve append-only revision guarantees and per-user isolation.
 
 ## Exact Surfaces In Scope
 
-- memory schema + persistence
-- memory contracts + API behavior
-- compiler context-pack memory serialization
-- `/memories` UI typed metadata adoption
+- open-loop schema + persistence
+- open-loop contracts + API behavior
+- compiler context-pack open-loop serialization
+- `/memories` open-loop review adoption
 - sprint-scoped backend and frontend tests
 
 ## Exact Files In Scope
@@ -63,53 +63,53 @@ Implement typed memory metadata end-to-end (schema, store, contracts/API, compil
 
 ## In Scope
 
-- Add typed memory fields:
-  - `memory_type`
-  - `confidence`
-  - `salience`
-  - `confirmation_status`
-  - `valid_from`
-  - `valid_to`
-  - `last_confirmed_at`
-- Persist/retrieve typed metadata through store + API.
-- Keep revisions append-only and metadata-auditable.
-- Include typed metadata in compiler memory serialization.
-- Render typed metadata in `/memories` list/detail with safe fallbacks.
-- Add/update tests across migration, API, compiler, and UI seams.
+- Add an `open_loops` table with deterministic lifecycle fields:
+  - `id`, `user_id`, `memory_id`, `title`, `status`, `opened_at`, `due_at`, `resolved_at`, `resolution_note`, `created_at`, `updated_at`
+- Add lifecycle domain validation for `status` (`open`, `resolved`, `dismissed`).
+- Add store methods for create/list/detail/update-status with strict user scoping.
+- Add API endpoints:
+  - `GET /v0/open-loops`
+  - `GET /v0/open-loops/{open_loop_id}`
+  - `POST /v0/open-loops`
+  - `POST /v0/open-loops/{open_loop_id}/status`
+- Extend memory admission flow to allow optional open-loop creation when memory candidate includes `open_loop` payload.
+- Include top open loops in compiled context payload with deterministic ordering and bounded limits.
+- Show open-loop summary/list and selected detail in `/memories` with safe live/fixture fallbacks.
+- Add/update tests across migration, store, API, compiler, and UI seams.
 
 ## Out of Scope
 
-- open-loop records/workflows
-- capture classification pipeline
-- resumption brief generation
-- focus dashboard
-- worker activation
+- autonomous follow-up execution or reminders
+- resumption brief synthesis
+- background workers or scheduler integration
 - connector expansion
-- Phase 3 agent runtime/profile implementation
+- multi-agent runtime/profile routing (Phase 3)
+- broad UI redesign outside `/memories`
 
 ## Required Deliverables
 
-- migration-backed typed memory metadata support
-- backend store/contracts/API support for typed memory fields
-- compiler serialization of typed memory metadata
-- `/memories` typed metadata visibility + filtering
+- migration-backed open-loop domain
+- backend store/contracts/API support for open-loop lifecycle
+- compiler serialization for open-loop context slice
+- `/memories` open-loop review surface (summary + detail)
 - updated sprint reports for this sprint only
 
 ## Acceptance Criteria
 
-- typed memory metadata persists and returns from list/detail APIs
-- invalid `memory_type` values are rejected deterministically
-- revision guarantees remain append-only and correct
-- compiled context includes typed memory metadata
-- `/memories` reflects typed metadata without regression
+- open loops persist and return from list/detail APIs with strict per-user isolation
+- invalid open-loop status values are rejected deterministically (`400`)
+- status transitions (`open` -> `resolved`/`dismissed`) persist audit fields correctly
+- memory admission can create an open loop when requested, without regressing existing admissions
+- compiled context includes open loops deterministically when present
+- `/memories` renders open-loop summary and selected details without regression
 - backend + frontend tests pass for touched seams
-- no out-of-scope feature work enters sprint
+- no out-of-scope automation or orchestration work enters sprint
 
 ## Implementation Constraints
 
 - preserve RLS and per-user isolation
-- preserve deterministic ordering in compiler/review outputs
-- keep defaults backward-safe when typed metadata is absent
+- keep deterministic ordering in API and compiler outputs
+- keep backward-safe defaults for memory admission without open-loop payload
 - co-deliver tests with each seam change
 
 ## Control Tower Task Cards
@@ -152,19 +152,19 @@ Responsibilities:
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact typed fields shipped
+- exact open-loop fields and endpoints shipped
 - migration id(s) and API surface deltas
 - exact commands/tests run with outcomes
-- explicit deferred scope (open loops/resumption/workers/Phase 3 runtime)
+- explicit deferred scope (resumption/workers/automation/Phase 3 runtime)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint remained typed-memory-backbone scoped
+- sprint remained open-loop-backbone scoped
 - schema/store/contracts/compiler/UI consistency
 - sufficient tests for all touched seams
 - no hidden scope expansion
 
 ## Exit Condition
 
-This sprint is complete when typed memory metadata is fully wired through persistence, API, compiler, and `/memories` UI with deterministic, test-backed behavior and no open-loop or Phase 3 runtime scope expansion.
+This sprint is complete when open loops are fully wired through persistence, API, compiler, and `/memories` review with deterministic, test-backed behavior and no automation/worker/Phase 3 scope expansion.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,11 +4,11 @@
 
 AliceBot now implements the accepted repo slice through Sprint 7G.
 
-- `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and narrow read-only Gmail and Calendar seams with external-secret-backed credentials plus bounded Calendar event discovery and selected-item ingestion into the artifact pipeline.
+- `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review plus open-loop lifecycle capture/review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and narrow read-only Gmail and Calendar seams with external-secret-backed credentials plus bounded Calendar event discovery and selected-item ingestion into the artifact pipeline.
 - `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
 - `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, renders a selected-thread transcript from immutable continuity events, and keeps supporting session and operational review, thread-linked governed workflow review, ordered task-step timeline review, and bounded explain-why trace review in the right rail.
 - `/gmail` and `/calendar` are shipped bounded connector workspaces over existing backend seams: visible account list review, selected-account detail, explicit account connection, and explicit single-item ingestion into one chosen task workspace, with live/fixture/unavailable states kept explicit.
-- `/artifacts`, `/memories`, and `/entities` are now shipped bounded review workspaces that expose existing artifact, memory, and entity read seams with explicit live/fixture/unavailable modes.
+- `/artifacts`, `/memories`, and `/entities` are now shipped bounded review workspaces that expose existing artifact, memory (including open-loop review), and entity read seams with explicit live/fixture/unavailable modes.
 - `workers` remains scaffold-only. No background runner, automatic multi-step progression, or asynchronous job system is implemented.
 
 The repo is intentionally still narrow. Document ingestion remains local and deterministic. The only live execution handler is the no-external-I/O `proxy.echo` path. Gmail and Calendar remain read-only; Calendar includes bounded event discovery and selected-event ingestion only. Rich parsing, mailbox sync, attachments, broader Calendar capabilities, broader proxying, and runner-style orchestration are still planned later.
@@ -22,7 +22,8 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 - `scripts/run_mvp_readiness_gates.py` and `scripts/run_mvp_validation_matrix.py` provide deterministic MVP release-candidate gate evidence, with the validation matrix command as the default go/no-go gate.
 - `apps/api` exposes FastAPI endpoints for:
   - continuity and response generation: `/healthz`, `POST /v0/threads`, `GET /v0/threads`, `GET /v0/threads/{thread_id}`, `GET /v0/threads/{thread_id}/sessions`, `GET /v0/threads/{thread_id}/events`, `POST /v0/context/compile`, `POST /v0/responses`
-  - memory, embeddings, and graph seams
+  - memory and open-loop seams, including `POST /v0/memories/admit`, `GET /v0/open-loops`, `GET /v0/open-loops/{open_loop_id}`, `POST /v0/open-loops`, and `POST /v0/open-loops/{open_loop_id}/status`
+  - embeddings and graph seams
   - policy, tool, approval, execution-budget, and proxy execution governance
   - task, task-step, task-workspace, task-artifact, artifact-chunk, and trace review reads and mutations
   - narrow Gmail account connect/read plus selected-message ingestion
@@ -35,7 +36,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
   - `/artifacts`: artifact list and selected detail, linked workspace summary, and ordered chunk review
   - `/gmail`: connected-account review, selected-account detail, explicit connect, and selected-message ingestion into one chosen task workspace
   - `/calendar`: connected-account review, selected-account detail, explicit connect, and selected-event ingestion into one chosen task workspace
-  - `/memories`: memory summary and queue posture, selected detail, revision review, and label review
+  - `/memories`: memory summary and queue posture, selected detail, revision review, label review, plus open-loop summary/list/detail review
   - `/entities`: entity list and selected detail with related edge review
   - `/traces`: trace summary, detail, and ordered event review
 - `tests` cover both the backend seams and the web shell. Durable repo evidence includes integration coverage for continuity and responses plus Vitest coverage for `/chat`, thread selection, bounded continuity review, and assistant-response submission.
@@ -58,6 +59,13 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 2. `GET /v0/threads`, `GET /v0/threads/{thread_id}`, `GET /v0/threads/{thread_id}/sessions`, and `GET /v0/threads/{thread_id}/events` expose bounded continuity review over persisted records.
 3. `POST /v0/responses` compiles context deterministically, persists the submitted user message plus the assistant reply as immutable events, and returns linked compile and response trace metadata.
 4. `/chat` consumes those shipped seams directly. Selected-thread identity stays explicit across assistant and governed-request modes, immutable thread events drive the primary transcript surface, and non-conversation continuity stays in bounded supporting review instead of polluting the main conversation record.
+
+### Memory And Open-Loop Review
+
+1. `POST /v0/memories/admit` supports the typed memory admission seam and optional open-loop creation in the same admission request.
+2. Open loops persist as a first-class lifecycle seam with deterministic status transitions (`open`, `resolved`, `dismissed`) and strict user scoping on list/detail/mutation reads.
+3. `POST /v0/context/compile` includes a bounded, deterministically ordered open-loop slice and summary when open loops are present.
+4. `/memories` exposes open-loop review alongside memory review so operators can inspect unresolved commitments and selected lifecycle details in one surface.
 
 ### Governance, Tasks, And Explainability
 

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,90 +1,97 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Phase 2 Sprint 2 typed memory backbone end-to-end (schema, store, contracts/API, compiler serialization, and `/memories` UI) without expanding into open-loop workflows, resumption generation, worker orchestration, or Phase 3 runtime.
+Implement Phase 2 Sprint 3 open-loop backbone end-to-end (schema, store, contracts/API, compiler serialization, and `/memories` review adoption) without adding automation, worker orchestration, resumption synthesis, or Phase 3 runtime behavior.
 
 ## Completed Work
-- Added typed memory metadata fields across persistence, API serialization, and compiler output:
-  - `memory_type`
-  - `confidence`
-  - `salience`
-  - `confirmation_status`
-  - `valid_from`
-  - `valid_to`
-  - `last_confirmed_at`
-- Added deterministic validation for `memory_type` in admission flow (`400` with explicit allowed values).
-- Preserved append-only revision guarantees; metadata changes are now threaded through admission/update paths and remain auditable in candidate payloads when provided.
-- Linked migration lineage to the current Alembic head (`down_revision = 20260319_0030`) so upgrade runs remain single-head and deterministic.
-- Extended memory store SQL read/write paths and typed row contracts to include new metadata fields.
-- Extended `AdmitMemoryRequest`/`MemoryCandidateInput` handling for optional typed metadata plus temporal-range validation.
-- Extended compiler memory serialization to include typed metadata in context-pack memories when present.
-- Added `/memories` web route with:
-  - list/detail split review surface
-  - typed metadata visibility
-  - safe fallbacks for missing metadata
-- Added/updated sprint-scoped tests for migration, store/API behavior, compiler outputs, and web API/page seams.
+- Shipped migration-backed `open_loops` domain with deterministic lifecycle fields:
+  - `id`
+  - `user_id`
+  - `memory_id`
+  - `title`
+  - `status`
+  - `opened_at`
+  - `due_at`
+  - `resolved_at`
+  - `resolution_note`
+  - `created_at`
+  - `updated_at`
+- Added open-loop status validation for `open`, `resolved`, and `dismissed`.
+- Added store methods for open-loop create/list/detail/count/update-status with strict `user_id` scoping.
+- Added API surface:
+  - `GET /v0/open-loops`
+  - `GET /v0/open-loops/{open_loop_id}`
+  - `POST /v0/open-loops`
+  - `POST /v0/open-loops/{open_loop_id}/status`
+- Extended memory admission to accept optional `open_loop` payload and create an open loop during admission without regressing existing admission paths.
+- Extended compiled context payload to include bounded, deterministic open-loop slice and open-loop summary when open loops exist.
+- Updated `/memories` to show open-loop summary/list and selected detail with live + fixture-safe fallback behavior.
+- Added/updated sprint-scoped migration, unit, integration, and web tests for the touched seams.
+- Added explicit test coverage for:
+  - successful `open -> dismissed` transition audit fields
+  - cross-user `404` denial on open-loop detail/status mutation
+- Updated `ARCHITECTURE.md` to document the shipped open-loop domain/API/compiler and `/memories` adoption.
+- Fixed route model typing bug in open-loop status filter (`OpenLoopStatusFilter`) so FastAPI route registration remains valid.
 
 ## Incomplete Work
 - None within sprint scope.
 
 ## Migration IDs And API Surface Deltas
 - Migration added:
-  - `20260323_0030_typed_memory_backbone`
-- Schema delta (`memories`):
-  - Added columns: `memory_type`, `confidence`, `salience`, `confirmation_status`, `valid_from`, `valid_to`, `last_confirmed_at`
-  - Added constraints: memory type domain, confirmation status domain, confidence/salience range checks, temporal range check
-  - Added index: `memories_user_type_updated_idx`
+  - `20260323_0031_open_loop_backbone`
+- Schema delta:
+  - New `open_loops` table and indexes:
+    - `open_loops_user_status_opened_idx`
+    - `open_loops_user_memory_idx`
+  - Enforced status domain + lifecycle consistency checks.
+  - RLS enabled/forced with owner policy.
+  - Granted `SELECT, INSERT, UPDATE` on `open_loops` to `alicebot_app`.
 - API deltas:
-  - `POST /v0/memories/admit`: accepts optional typed metadata fields and rejects invalid `memory_type` deterministically.
-  - `GET /v0/memories`, `GET /v0/memories/{memory_id}`, `GET /v0/memories/review-queue`: now return typed metadata fields when available.
-  - Context compiler memory serialization includes typed metadata fields when present.
+  - New open-loop list/detail/create/status-update endpoints listed above.
+  - `POST /v0/memories/admit` now accepts optional `open_loop` payload and may return created open-loop details.
+  - `POST /v0/context/compile` context pack may include `open_loops` and `open_loop_summary` when candidate open loops exist.
 
 ## Files Changed
-- `apps/api/alembic/versions/20260323_0030_typed_memory_backbone.py`
+- `apps/api/alembic/versions/20260323_0031_open_loop_backbone.py`
 - `apps/api/src/alicebot_api/store.py`
 - `apps/api/src/alicebot_api/contracts.py`
 - `apps/api/src/alicebot_api/memory.py`
 - `apps/api/src/alicebot_api/main.py`
 - `apps/api/src/alicebot_api/compiler.py`
+- `ARCHITECTURE.md`
 - `apps/web/lib/api.ts`
+- `apps/web/lib/api.test.ts`
 - `apps/web/app/memories/page.tsx`
 - `apps/web/app/memories/page.test.tsx`
-- `tests/unit/test_20260323_0030_typed_memory_backbone.py`
+- `tests/unit/test_20260323_0031_open_loop_backbone.py`
 - `tests/unit/test_memory_store.py`
-- `tests/unit/test_entity_store.py`
 - `tests/unit/test_memory.py`
-- `tests/integration/test_memory_admission.py`
-- `tests/integration/test_memory_review_api.py`
-- `tests/integration/test_context_compile.py`
-- `tests/integration/test_migrations.py`
-- `.ai/active/SPRINT_PACKET.md`
+- `tests/unit/test_compiler.py`
+- `tests/unit/test_main.py`
+- `tests/integration/test_open_loops_api.py`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 ## Tests Run
-1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_20260323_0030_typed_memory_backbone.py tests/unit/test_memory_store.py tests/unit/test_entity_store.py tests/unit/test_memory.py tests/unit/test_compiler.py tests/unit/test_main.py`
-- Outcome: `73 passed`
+1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_20260323_0031_open_loop_backbone.py tests/unit/test_memory_store.py tests/unit/test_memory.py tests/unit/test_compiler.py tests/unit/test_main.py`
+- Outcome: `79 passed`
 
-2. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_explicit_preferences.py`
-- Outcome: `8 passed`
+2. `cd apps/web && pnpm test -- lib/api.test.ts app/memories/page.test.tsx`
+- Outcome: `24 passed`
 
-3. `cd apps/web && pnpm test -- lib/api.test.ts app/memories/page.test.tsx`
-- Outcome: `23 passed`
-
-4. `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_memory_admission.py`
-- Outcome (DB-enabled verification): `5 passed`
-
-5. `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_memory_review_api.py tests/integration/test_context_compile.py tests/integration/test_migrations.py`
-- Outcome (DB-enabled verification): `25 passed`
+3. `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_open_loops_api.py tests/integration/test_migrations.py`
+- Outcome: `11 passed`
+- Note: executed with escalated permissions to allow local Postgres connectivity from this environment.
 
 ## Blockers/Issues
-- No blocking issues remain for sprint-scope acceptance.
+- No unresolved blockers.
+- Environment-specific constraint encountered: DB-backed integration tests required running outside sandbox network restrictions.
 
 ## Explicit Deferred Scope
-- Open loops/workflows
-- Resumption brief generation
-- Worker activation/orchestration
-- Phase 3 runtime/profile implementation
+- Resumption brief synthesis
+- Background workers/scheduler automation
+- Autonomous follow-up execution/reminder orchestration
+- Phase 3 multi-agent runtime/profile routing
 
 ## Recommended Next Step
-Proceed with sprint PR review and merge using this sprint-scoped diff and the verified test evidence.
+Proceed to sprint review with this open-loop backbone diff and test evidence, then merge once Control Tower approves scope and acceptance criteria.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,38 +4,39 @@
 PASS
 
 ## criteria met
-- Typed memory metadata is wired through schema/store/contracts/API/compiler/UI for the sprint fields: `memory_type`, `confidence`, `salience`, `confirmation_status`, `valid_from`, `valid_to`, `last_confirmed_at`.
-- Invalid `memory_type` values are rejected deterministically (`400`) in admission flow.
-- Revision behavior remains append-only for add/update/delete memory admissions.
-- Compiled context memory serialization includes typed metadata.
-- `/memories` renders typed metadata with safe fallbacks.
-- No out-of-scope feature work is present in the current sprint diff.
-- Touched backend and frontend tests pass when DB access is available:
-- `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_20260323_0030_typed_memory_backbone.py tests/unit/test_memory_store.py tests/unit/test_entity_store.py tests/unit/test_memory.py tests/unit/test_compiler.py tests/unit/test_main.py` -> `73 passed`
-- `cd apps/web && pnpm test -- lib/api.test.ts app/memories/page.test.tsx` -> `23 passed`
-- `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_memory_admission.py` -> `5 passed`
-- `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_memory_review_api.py tests/integration/test_context_compile.py tests/integration/test_migrations.py` -> `25 passed`
-- DB-backed non-default typed-metadata roundtrip is now explicitly covered through `POST /v0/memories/admit` and asserted in both `GET /v0/memories` and `GET /v0/memories/{memory_id}` integration flows.
+- Sprint remained scoped to open-loop backbone seams (schema/store/contracts/API/compiler/`/memories`) with no worker, automation, or Phase 3 runtime expansion.
+- Migration `20260323_0031` adds `open_loops` lifecycle fields, constraints, indexes, RLS, and app-role grants.
+- Store/contracts/API seams for list/detail/create/status are implemented and user-scoped.
+- Memory admission accepts optional `open_loop` payload and can emit created open-loop data in admit responses.
+- Compiler context pack includes deterministic open-loop ordering and summary when open loops exist.
+- `/memories` renders open-loop summary/list/detail with live/fixture fallback behavior.
+- Added explicit transition and adversarial isolation evidence:
+- Successful `open -> dismissed` transition with audit-field assertions (`resolved_at`, `resolution_note`) is now covered.
+- Cross-user denial coverage now asserts `404` for `GET /v0/open-loops/{id}` and `POST /v0/open-loops/{id}/status`.
+- `ARCHITECTURE.md` now includes the shipped open-loop domain/API/compiler/`/memories` slice.
+- Relevant tests executed and passing in this review:
+- `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_20260323_0031_open_loop_backbone.py tests/unit/test_memory_store.py tests/unit/test_memory.py tests/unit/test_compiler.py tests/unit/test_main.py` -> `79 passed`
+- `cd apps/web && pnpm test -- lib/api.test.ts app/memories/page.test.tsx` -> `24 passed`
+- `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_open_loops_api.py tests/integration/test_migrations.py` -> `11 passed` (run outside sandbox networking for local Postgres access)
 
 ## criteria missed
 - None.
 
 ## quality issues
-- None significant for sprint scope.
+- Open-loop compile limit is currently coupled to `max_memories` (`apps/api/src/alicebot_api/compiler.py`). This is acceptable for sprint scope but should be decoupled in a later sprint.
 
 ## regression risks
-- Low for shipped typed-memory seams based on passing unit/web/integration suites.
-- Low residual risk after explicit non-default typed-metadata roundtrip coverage was added and verified.
+- Low for touched seams based on unit/web/integration coverage.
+- Residual risk remains low for broader non-sprint integrations not re-run in this pass.
 
 ## docs issues
 - None blocking for sprint acceptance.
 
 ## should anything be added to RULES.md?
-- No mandatory update.
-- Optional guardrail: explicitly disallow committing local environment files such as `apps/web/.env.local`.
+- Optional: require lifecycle-domain acceptance tests to include every allowed transition and cross-user list/detail/mutation denial checks.
 
 ## should anything update ARCHITECTURE.md?
-- Yes, a small follow-up update is recommended to record typed metadata fields and validation constraints on `memories`, plus compiler serialization of those fields.
+- Already updated in this sprint to include open-loop seams.
 
 ## recommended next action
-1. Proceed to Control Tower merge approval for Sprint 2 typed-memory backbone.
+1. Proceed to Control Tower merge approval for Sprint 3 open-loop backbone.

--- a/apps/api/alembic/versions/20260323_0031_open_loop_backbone.py
+++ b/apps/api/alembic/versions/20260323_0031_open_loop_backbone.py
@@ -1,0 +1,94 @@
+"""Add open-loop lifecycle table for unresolved commitments."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260323_0031"
+down_revision = "20260323_0030"
+branch_labels = None
+depends_on = None
+
+OPEN_LOOP_STATUSES = (
+    "open",
+    "resolved",
+    "dismissed",
+)
+
+_OPEN_LOOP_STATUSES_SQL = ", ".join(f"'{value}'" for value in OPEN_LOOP_STATUSES)
+
+_RLS_TABLES = ("open_loops",)
+
+_UPGRADE_SCHEMA_STATEMENT = f"""
+        CREATE TABLE open_loops (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          memory_id uuid NULL,
+          title text NOT NULL,
+          status text NOT NULL,
+          opened_at timestamptz NOT NULL DEFAULT now(),
+          due_at timestamptz NULL,
+          resolved_at timestamptz NULL,
+          resolution_note text NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (id, user_id),
+          CONSTRAINT open_loops_memory_fkey
+            FOREIGN KEY (memory_id, user_id)
+            REFERENCES memories(id, user_id)
+            ON DELETE SET NULL,
+          CONSTRAINT open_loops_status_check
+            CHECK (status IN ({_OPEN_LOOP_STATUSES_SQL})),
+          CONSTRAINT open_loops_title_length_check
+            CHECK (char_length(title) <= 280),
+          CONSTRAINT open_loops_resolution_note_length_check
+            CHECK (resolution_note IS NULL OR char_length(resolution_note) <= 2000),
+          CONSTRAINT open_loops_resolved_state_check
+            CHECK (
+              (status = 'open' AND resolved_at IS NULL AND resolution_note IS NULL)
+              OR (status IN ('resolved', 'dismissed') AND resolved_at IS NOT NULL)
+            )
+        );
+
+        CREATE INDEX open_loops_user_status_opened_idx
+          ON open_loops (user_id, status, opened_at DESC, created_at DESC, id DESC);
+        CREATE INDEX open_loops_user_memory_idx
+          ON open_loops (user_id, memory_id, created_at DESC, id DESC);
+        """
+
+_UPGRADE_GRANT_STATEMENTS = (
+    "GRANT SELECT, INSERT, UPDATE ON open_loops TO alicebot_app",
+)
+
+_UPGRADE_POLICY_STATEMENT = """
+        CREATE POLICY open_loops_is_owner ON open_loops
+          USING (user_id = app.current_user_id())
+          WITH CHECK (user_id = app.current_user_id());
+        """
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP TABLE IF EXISTS open_loops",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def _enable_row_level_security() -> None:
+    for table_name in _RLS_TABLES:
+        op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+
+
+def upgrade() -> None:
+    op.execute(_UPGRADE_SCHEMA_STATEMENT)
+    _execute_statements(_UPGRADE_GRANT_STATEMENTS)
+    _enable_row_level_security()
+    op.execute(_UPGRADE_POLICY_STATEMENT)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/compiler.py
+++ b/apps/api/src/alicebot_api/compiler.py
@@ -22,9 +22,12 @@ from alicebot_api.contracts import (
     ContextPackHybridMemorySummary,
     ContextPackMemory,
     ContextPackMemorySummary,
+    ContextPackOpenLoop,
+    ContextPackOpenLoopSummary,
     HybridMemoryDecisionTracePayload,
     HybridArtifactRetrievalDecisionTracePayload,
     MemorySelectionSource,
+    OPEN_LOOP_REVIEW_ORDER,
     SEMANTIC_MEMORY_RETRIEVAL_ORDER,
     TASK_ARTIFACT_CHUNK_RETRIEVAL_ORDER,
     TASK_ARTIFACT_CHUNK_SEMANTIC_RETRIEVAL_ORDER,
@@ -52,6 +55,7 @@ from alicebot_api.store import (
     EntityRow,
     EventRow,
     MemoryRow,
+    OpenLoopRow,
     SemanticMemoryRetrievalRow,
     SessionRow,
     ThreadRow,
@@ -86,6 +90,13 @@ class CompiledTraceRun:
 class CompiledMemorySection:
     items: list[ContextPackMemory]
     summary: ContextPackMemorySummary
+    decisions: list[CompilerDecision]
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledOpenLoopSection:
+    items: list[ContextPackOpenLoop]
+    summary: ContextPackOpenLoopSummary
     decisions: list[CompilerDecision]
 
 
@@ -184,6 +195,29 @@ def _serialize_memory(memory: MemoryRow) -> dict[str, object]:
     }
     payload.update(_serialize_typed_memory_metadata(memory))
     return payload
+
+
+def _open_loop_sort_key(open_loop: OpenLoopRow) -> tuple[str, str, str]:
+    return (
+        open_loop["opened_at"].isoformat(),
+        open_loop["created_at"].isoformat(),
+        str(open_loop["id"]),
+    )
+
+
+def _serialize_open_loop(open_loop: OpenLoopRow) -> ContextPackOpenLoop:
+    return {
+        "id": str(open_loop["id"]),
+        "memory_id": None if open_loop["memory_id"] is None else str(open_loop["memory_id"]),
+        "title": open_loop["title"],
+        "status": open_loop["status"],  # type: ignore[typeddict-item]
+        "opened_at": open_loop["opened_at"].isoformat(),
+        "due_at": isoformat_or_none(open_loop["due_at"]),
+        "resolved_at": isoformat_or_none(open_loop["resolved_at"]),
+        "resolution_note": open_loop["resolution_note"],
+        "created_at": open_loop["created_at"].isoformat(),
+        "updated_at": open_loop["updated_at"].isoformat(),
+    }
 
 
 def _entity_sort_key(entity: EntityRow) -> tuple[str, str]:
@@ -750,6 +784,70 @@ def _compile_memory_section(
     )
 
 
+def _compile_open_loop_section(
+    *,
+    open_loops: list[OpenLoopRow],
+    limits: ContextCompilerLimits,
+) -> CompiledOpenLoopSection:
+    ordered_open_loops = sorted(open_loops, key=_open_loop_sort_key, reverse=True)
+    included_open_loops = (
+        ordered_open_loops[: limits.max_memories] if limits.max_memories > 0 else []
+    )
+    excluded_open_loops = (
+        ordered_open_loops[limits.max_memories :] if limits.max_memories > 0 else ordered_open_loops
+    )
+
+    decisions: list[CompilerDecision] = []
+    for position, open_loop in enumerate(included_open_loops, start=1):
+        decisions.append(
+            CompilerDecision(
+                "included",
+                "open_loop",
+                open_loop["id"],
+                "within_open_loop_limit",
+                position,
+                metadata={
+                    "title": open_loop["title"],
+                    "status": open_loop["status"],
+                    "memory_id": (
+                        None if open_loop["memory_id"] is None else str(open_loop["memory_id"])
+                    ),
+                    "due_at": isoformat_or_none(open_loop["due_at"]),
+                },
+            )
+        )
+
+    for position, open_loop in enumerate(excluded_open_loops, start=1):
+        decisions.append(
+            CompilerDecision(
+                "excluded",
+                "open_loop",
+                open_loop["id"],
+                "open_loop_limit_exceeded",
+                position,
+                metadata={
+                    "title": open_loop["title"],
+                    "status": open_loop["status"],
+                    "memory_id": (
+                        None if open_loop["memory_id"] is None else str(open_loop["memory_id"])
+                    ),
+                    "due_at": isoformat_or_none(open_loop["due_at"]),
+                },
+            )
+        )
+
+    return CompiledOpenLoopSection(
+        items=[_serialize_open_loop(open_loop) for open_loop in included_open_loops],
+        summary={
+            "candidate_count": len(ordered_open_loops),
+            "included_count": len(included_open_loops),
+            "excluded_limit_count": len(excluded_open_loops),
+            "order": list(OPEN_LOOP_REVIEW_ORDER),
+        },
+        decisions=decisions,
+    )
+
+
 def _compile_artifact_chunk_section(
     store: ContinuityStore,
     *,
@@ -1128,7 +1226,9 @@ def compile_continuity_context(
     entities: list[EntityRow],
     entity_edges: list[EntityEdgeRow],
     limits: ContextCompilerLimits,
+    open_loops: list[OpenLoopRow] | None = None,
     memory_section: CompiledMemorySection | None = None,
+    open_loop_section: CompiledOpenLoopSection | None = None,
     artifact_chunk_section: CompiledArtifactChunkSection | None = None,
 ) -> CompilerRunResult:
     latest_session_sequence: dict[UUID, int] = {}
@@ -1222,6 +1322,11 @@ def compile_continuity_context(
         limits=limits,
     )
     decisions.extend(resolved_memory_section.decisions)
+    resolved_open_loop_section = open_loop_section or _compile_open_loop_section(
+        open_loops=[] if open_loops is None else open_loops,
+        limits=limits,
+    )
+    decisions.extend(resolved_open_loop_section.decisions)
     resolved_artifact_chunk_section = artifact_chunk_section or CompiledArtifactChunkSection(
         items=[],
         summary=_empty_artifact_chunk_summary(),
@@ -1358,6 +1463,10 @@ def compile_continuity_context(
                 "included_dual_source_memory_count": resolved_memory_section.summary[
                     "hybrid_retrieval"
                 ]["included_dual_source_count"],
+                "included_open_loop_count": resolved_open_loop_section.summary["included_count"],
+                "excluded_open_loop_limit_count": resolved_open_loop_section.summary[
+                    "excluded_limit_count"
+                ],
                 "artifact_retrieval_requested": resolved_artifact_chunk_section.summary["requested"],
                 "artifact_retrieval_scope_kind": (
                     None
@@ -1405,8 +1514,7 @@ def compile_continuity_context(
         )
     )
 
-    return CompilerRunResult(
-        context_pack={
+    context_pack: CompiledContextPack = {
             "compiler_version": COMPILER_VERSION_V0,
             "scope": {
                 "user_id": str(user["id"]),
@@ -1440,7 +1548,13 @@ def compile_continuity_context(
                 "included_count": len(included_entity_edges),
                 "excluded_limit_count": excluded_entity_edge_limit_count,
             },
-        },
+        }
+    if resolved_open_loop_section.summary["candidate_count"] > 0:
+        context_pack["open_loops"] = list(resolved_open_loop_section.items)
+        context_pack["open_loop_summary"] = resolved_open_loop_section.summary
+
+    return CompilerRunResult(
+        context_pack=context_pack,
         trace_events=trace_events,
     )
 
@@ -1460,11 +1574,16 @@ def compile_and_persist_trace(
     sessions = store.list_thread_sessions(thread_id)
     events = store.list_thread_events(thread_id)
     memories = store.list_context_memories()
+    open_loops = store.list_open_loops(status="open")
     memory_section = _compile_memory_section(
         store,
         memories=memories,
         limits=limits,
         semantic_retrieval=semantic_retrieval,
+    )
+    open_loop_section = _compile_open_loop_section(
+        open_loops=open_loops,
+        limits=limits,
     )
     artifact_chunk_section = _compile_artifact_chunk_section(
         store,
@@ -1481,10 +1600,12 @@ def compile_and_persist_trace(
         sessions=sessions,
         events=events,
         memories=memories,
+        open_loops=open_loops,
         entities=entities,
         entity_edges=entity_edges,
         limits=limits,
         memory_section=memory_section,
+        open_loop_section=open_loop_section,
         artifact_chunk_section=artifact_chunk_section,
     )
     trace = store.create_trace(

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -10,6 +10,8 @@ from alicebot_api.store import JsonObject, JsonValue
 DecisionKind = Literal["included", "excluded"]
 AdmissionAction = Literal["NOOP", "ADD", "UPDATE", "DELETE"]
 MemoryStatus = Literal["active", "deleted"]
+OpenLoopStatus = Literal["open", "resolved", "dismissed"]
+OpenLoopStatusFilter = Literal["open", "resolved", "dismissed", "all"]
 MemoryType = Literal[
     "preference",
     "identity_fact",
@@ -101,6 +103,8 @@ DEFAULT_MAX_ENTITIES = 5
 DEFAULT_MAX_ENTITY_EDGES = 10
 DEFAULT_MEMORY_REVIEW_LIMIT = 20
 MAX_MEMORY_REVIEW_LIMIT = 100
+DEFAULT_OPEN_LOOP_LIMIT = 20
+MAX_OPEN_LOOP_LIMIT = 100
 DEFAULT_SEMANTIC_MEMORY_RETRIEVAL_LIMIT = 5
 MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT = 50
 DEFAULT_ARTIFACT_CHUNK_RETRIEVAL_LIMIT = 5
@@ -127,6 +131,7 @@ MEMORY_REVIEW_LABEL_VALUES = [
     "insufficient_evidence",
 ]
 MEMORY_REVIEW_LABEL_ORDER = ["created_at_asc", "id_asc"]
+OPEN_LOOP_REVIEW_ORDER = ["opened_at_desc", "created_at_desc", "id_desc"]
 MEMORY_TYPES = [
     "preference",
     "identity_fact",
@@ -142,6 +147,11 @@ MEMORY_CONFIRMATION_STATUSES = [
     "unconfirmed",
     "confirmed",
     "contested",
+]
+OPEN_LOOP_STATUSES = [
+    "open",
+    "resolved",
+    "dismissed",
 ]
 DEFAULT_MEMORY_TYPE: MemoryType = "preference"
 DEFAULT_MEMORY_CONFIRMATION_STATUS: MemoryConfirmationStatus = "unconfirmed"
@@ -677,6 +687,26 @@ class ContextPackMemorySummary(TypedDict):
     hybrid_retrieval: ContextPackHybridMemorySummary
 
 
+class ContextPackOpenLoop(TypedDict):
+    id: str
+    memory_id: str | None
+    title: str
+    status: OpenLoopStatus
+    opened_at: str
+    due_at: str | None
+    resolved_at: str | None
+    resolution_note: str | None
+    created_at: str
+    updated_at: str
+
+
+class ContextPackOpenLoopSummary(TypedDict):
+    candidate_count: int
+    included_count: int
+    excluded_limit_count: int
+    order: list[str]
+
+
 class HybridMemoryDecisionTracePayload(TypedDict):
     embedding_config_id: str | None
     memory_key: str
@@ -752,6 +782,8 @@ class CompiledContextPack(TypedDict):
     events: list[ContextPackEvent]
     memories: list[ContextPackMemory]
     memory_summary: ContextPackMemorySummary
+    open_loops: NotRequired[list[ContextPackOpenLoop]]
+    open_loop_summary: NotRequired[ContextPackOpenLoopSummary]
     artifact_chunks: list[ContextPackArtifactChunk]
     artifact_chunk_summary: ContextPackArtifactChunkSummary
     entities: list[ContextPackEntity]
@@ -915,6 +947,19 @@ class GenerateResponseSuccess(TypedDict):
 
 
 @dataclass(frozen=True, slots=True)
+class OpenLoopCandidateInput:
+    title: str
+    due_at: datetime | None = None
+
+    def as_payload(self) -> JsonObject:
+        payload: JsonObject = {
+            "title": self.title,
+        }
+        payload["due_at"] = isoformat_or_none(self.due_at)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
 class MemoryCandidateInput:
     memory_key: str
     value: JsonValue | None
@@ -927,6 +972,7 @@ class MemoryCandidateInput:
     valid_from: datetime | None = None
     valid_to: datetime | None = None
     last_confirmed_at: datetime | None = None
+    open_loop: OpenLoopCandidateInput | None = None
 
     def as_payload(self) -> JsonObject:
         payload: JsonObject = {
@@ -949,6 +995,8 @@ class MemoryCandidateInput:
             payload["valid_to"] = isoformat_or_none(self.valid_to)
         if self.last_confirmed_at is not None:
             payload["last_confirmed_at"] = isoformat_or_none(self.last_confirmed_at)
+        if self.open_loop is not None:
+            payload["open_loop"] = self.open_loop.as_payload()
         return payload
 
 
@@ -960,6 +1008,34 @@ class ExplicitPreferenceExtractionRequestInput:
         return {
             "source_event_id": str(self.source_event_id),
         }
+
+
+@dataclass(frozen=True, slots=True)
+class OpenLoopCreateInput:
+    title: str
+    memory_id: UUID | None = None
+    due_at: datetime | None = None
+
+    def as_payload(self) -> JsonObject:
+        payload: JsonObject = {
+            "title": self.title,
+            "memory_id": None if self.memory_id is None else str(self.memory_id),
+        }
+        payload["due_at"] = isoformat_or_none(self.due_at)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class OpenLoopStatusUpdateInput:
+    status: OpenLoopStatus
+    resolution_note: str | None = None
+
+    def as_payload(self) -> JsonObject:
+        payload: JsonObject = {
+            "status": self.status,
+        }
+        payload["resolution_note"] = self.resolution_note
+        return payload
 
 
 class ExtractedPreferenceCandidateRecord(TypedDict):
@@ -1337,6 +1413,7 @@ class AdmissionDecisionOutput:
     reason: str
     memory: PersistedMemoryRecord | None
     revision: PersistedMemoryRevisionRecord | None
+    open_loop: OpenLoopRecord | None = None
 
 
 class ExplicitPreferenceAdmissionRecord(TypedDict):
@@ -1395,6 +1472,45 @@ class MemoryReviewListResponse(TypedDict):
 
 class MemoryReviewDetailResponse(TypedDict):
     memory: MemoryReviewRecord
+
+
+class OpenLoopRecord(TypedDict):
+    id: str
+    memory_id: str | None
+    title: str
+    status: OpenLoopStatus
+    opened_at: str
+    due_at: str | None
+    resolved_at: str | None
+    resolution_note: str | None
+    created_at: str
+    updated_at: str
+
+
+class OpenLoopListSummary(TypedDict):
+    status: OpenLoopStatusFilter
+    limit: int
+    returned_count: int
+    total_count: int
+    has_more: bool
+    order: list[str]
+
+
+class OpenLoopListResponse(TypedDict):
+    items: list[OpenLoopRecord]
+    summary: OpenLoopListSummary
+
+
+class OpenLoopDetailResponse(TypedDict):
+    open_loop: OpenLoopRecord
+
+
+class OpenLoopCreateResponse(TypedDict):
+    open_loop: OpenLoopRecord
+
+
+class OpenLoopStatusUpdateResponse(TypedDict):
+    open_loop: OpenLoopRecord
 
 
 class MemoryRevisionReviewRecord(TypedDict):

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -31,9 +31,11 @@ from alicebot_api.contracts import (
     DEFAULT_MAX_ENTITIES,
     DEFAULT_MAX_MEMORIES,
     DEFAULT_MEMORY_REVIEW_LIMIT,
+    DEFAULT_OPEN_LOOP_LIMIT,
     DEFAULT_MAX_SESSIONS,
     DEFAULT_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
     MAX_MEMORY_REVIEW_LIMIT,
+    MAX_OPEN_LOOP_LIMIT,
     MAX_ARTIFACT_CHUNK_RETRIEVAL_LIMIT,
     MAX_CALENDAR_EVENT_LIST_LIMIT,
     MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
@@ -55,12 +57,16 @@ from alicebot_api.contracts import (
     GmailAccountConnectInput,
     GmailMessageIngestInput,
     MemoryCandidateInput,
+    OpenLoopCandidateInput,
     MemoryEmbeddingUpsertInput,
     THREAD_EVENT_LIST_ORDER,
     THREAD_LIST_ORDER,
     THREAD_SESSION_LIST_ORDER,
     MemoryReviewLabelValue,
     MemoryReviewStatusFilter,
+    OpenLoopStatusFilter,
+    OpenLoopCreateInput,
+    OpenLoopStatusUpdateInput,
     PolicyCreateInput,
     PolicyEffect,
     PolicyEvaluationRequestInput,
@@ -229,14 +235,20 @@ from alicebot_api.explicit_preferences import (
 from alicebot_api.memory import (
     MemoryAdmissionValidationError,
     MemoryReviewNotFoundError,
+    OpenLoopNotFoundError,
+    OpenLoopValidationError,
     admit_memory_candidate,
+    create_open_loop_record,
     create_memory_review_label_record,
+    get_open_loop_record,
     get_memory_evaluation_summary,
     get_memory_review_record,
+    list_open_loop_records,
     list_memory_review_queue_records,
     list_memory_review_label_records,
     list_memory_review_records,
     list_memory_revision_review_records,
+    update_open_loop_status_record,
 )
 from alicebot_api.policy import (
     PolicyEvaluationValidationError,
@@ -429,6 +441,13 @@ class CreateThreadRequest(BaseModel):
     title: str = Field(min_length=1, max_length=200)
 
 
+class AdmitMemoryOpenLoopRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(min_length=1, max_length=280)
+    due_at: datetime | None = None
+
+
 class AdmitMemoryRequest(BaseModel):
     user_id: UUID
     memory_key: str = Field(min_length=1, max_length=200)
@@ -442,6 +461,7 @@ class AdmitMemoryRequest(BaseModel):
     valid_from: datetime | None = None
     valid_to: datetime | None = None
     last_confirmed_at: datetime | None = None
+    open_loop: AdmitMemoryOpenLoopRequest | None = None
 
     @model_validator(mode="after")
     def validate_temporal_range(self) -> "AdmitMemoryRequest":
@@ -459,6 +479,19 @@ class CreateMemoryReviewLabelRequest(BaseModel):
     user_id: UUID
     label: MemoryReviewLabelValue
     note: str | None = Field(default=None, min_length=1, max_length=280)
+
+
+class CreateOpenLoopRequest(BaseModel):
+    user_id: UUID
+    memory_id: UUID | None = None
+    title: str = Field(min_length=1, max_length=280)
+    due_at: datetime | None = None
+
+
+class UpdateOpenLoopStatusRequest(BaseModel):
+    user_id: UUID
+    status: str = Field(min_length=1, max_length=100)
+    resolution_note: str | None = Field(default=None, min_length=1, max_length=2000)
 
 
 class CreateEntityRequest(BaseModel):
@@ -1134,21 +1167,129 @@ def admit_memory(request: AdmitMemoryRequest) -> JSONResponse:
                     valid_from=request.valid_from,
                     valid_to=request.valid_to,
                     last_confirmed_at=request.last_confirmed_at,
+                    open_loop=(
+                        None
+                        if request.open_loop is None
+                        else OpenLoopCandidateInput(
+                            title=request.open_loop.title,
+                            due_at=request.open_loop.due_at,
+                        )
+                    ),
                 ),
             )
     except MemoryAdmissionValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
+    payload = {
+        "decision": decision.action,
+        "reason": decision.reason,
+        "memory": decision.memory,
+        "revision": decision.revision,
+    }
+    if decision.open_loop is not None:
+        payload["open_loop"] = decision.open_loop
+
     return JSONResponse(
         status_code=200,
-        content=jsonable_encoder(
-            {
-                "decision": decision.action,
-                "reason": decision.reason,
-                "memory": decision.memory,
-                "revision": decision.revision,
-            }
-        ),
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/open-loops")
+def list_open_loops(
+    user_id: UUID,
+    status: OpenLoopStatusFilter = Query(default="open"),
+    limit: int = Query(default=DEFAULT_OPEN_LOOP_LIMIT, ge=1, le=MAX_OPEN_LOOP_LIMIT),
+) -> JSONResponse:
+    settings = get_settings()
+
+    with user_connection(settings.database_url, user_id) as conn:
+        payload = list_open_loop_records(
+            ContinuityStore(conn),
+            user_id=user_id,
+            status=status,
+            limit=limit,
+        )
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/open-loops/{open_loop_id}")
+def get_open_loop(
+    open_loop_id: UUID,
+    user_id: UUID,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload = get_open_loop_record(
+                ContinuityStore(conn),
+                user_id=user_id,
+                open_loop_id=open_loop_id,
+            )
+    except OpenLoopNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.post("/v0/open-loops")
+def create_open_loop(request: CreateOpenLoopRequest) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            payload = create_open_loop_record(
+                ContinuityStore(conn),
+                user_id=request.user_id,
+                open_loop=OpenLoopCreateInput(
+                    memory_id=request.memory_id,
+                    title=request.title,
+                    due_at=request.due_at,
+                ),
+            )
+    except OpenLoopValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=201,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.post("/v0/open-loops/{open_loop_id}/status")
+def update_open_loop_status(
+    open_loop_id: UUID,
+    request: UpdateOpenLoopStatusRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            payload = update_open_loop_status_record(
+                ContinuityStore(conn),
+                user_id=request.user_id,
+                open_loop_id=open_loop_id,
+                request=OpenLoopStatusUpdateInput(
+                    status=request.status,  # type: ignore[arg-type]
+                    resolution_note=request.resolution_note,
+                ),
+            )
+    except OpenLoopValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except OpenLoopNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
     )
 
 

--- a/apps/api/src/alicebot_api/memory.py
+++ b/apps/api/src/alicebot_api/memory.py
@@ -8,7 +8,10 @@ from alicebot_api.contracts import (
     DEFAULT_MEMORY_CONFIRMATION_STATUS,
     DEFAULT_MEMORY_TYPE,
     DEFAULT_MEMORY_REVIEW_LIMIT,
+    DEFAULT_OPEN_LOOP_LIMIT,
     MEMORY_CONFIRMATION_STATUSES,
+    OPEN_LOOP_REVIEW_ORDER,
+    OPEN_LOOP_STATUSES,
     MEMORY_REVIEW_LABEL_ORDER,
     MEMORY_REVIEW_LABEL_VALUES,
     MEMORY_REVIEW_QUEUE_ORDER,
@@ -35,11 +38,28 @@ from alicebot_api.contracts import (
     MemoryReviewListSummary,
     MemoryReviewRecord,
     MemoryReviewStatusFilter,
+    OpenLoopCreateInput,
+    OpenLoopCreateResponse,
+    OpenLoopDetailResponse,
+    OpenLoopListResponse,
+    OpenLoopListSummary,
+    OpenLoopRecord,
+    OpenLoopStatusFilter,
+    OpenLoopStatusUpdateInput,
+    OpenLoopStatusUpdateResponse,
     PersistedMemoryRecord,
     PersistedMemoryRevisionRecord,
     isoformat_or_none,
 )
-from alicebot_api.store import ContinuityStore, JsonObject, LabelCountRow, MemoryReviewLabelRow, MemoryRevisionRow, MemoryRow
+from alicebot_api.store import (
+    ContinuityStore,
+    JsonObject,
+    LabelCountRow,
+    MemoryReviewLabelRow,
+    MemoryRevisionRow,
+    MemoryRow,
+    OpenLoopRow,
+)
 
 
 class MemoryAdmissionValidationError(ValueError):
@@ -48,6 +68,14 @@ class MemoryAdmissionValidationError(ValueError):
 
 class MemoryReviewNotFoundError(LookupError):
     """Raised when a requested memory is not visible inside the current user scope."""
+
+
+class OpenLoopValidationError(ValueError):
+    """Raised when an open-loop request fails explicit lifecycle validation."""
+
+
+class OpenLoopNotFoundError(LookupError):
+    """Raised when a requested open loop is not visible inside the current user scope."""
 
 
 def _serialize_typed_memory_metadata(memory: MemoryRow) -> JsonObject:
@@ -368,6 +396,168 @@ def get_memory_evaluation_summary(
     }
 
 
+def _serialize_open_loop(open_loop: OpenLoopRow) -> OpenLoopRecord:
+    return {
+        "id": str(open_loop["id"]),
+        "memory_id": None if open_loop["memory_id"] is None else str(open_loop["memory_id"]),
+        "title": open_loop["title"],
+        "status": open_loop["status"],
+        "opened_at": open_loop["opened_at"].isoformat(),
+        "due_at": isoformat_or_none(open_loop["due_at"]),
+        "resolved_at": isoformat_or_none(open_loop["resolved_at"]),
+        "resolution_note": open_loop["resolution_note"],
+        "created_at": open_loop["created_at"].isoformat(),
+        "updated_at": open_loop["updated_at"].isoformat(),
+    }
+
+
+def _normalize_open_loop_status_filter(status: OpenLoopStatusFilter) -> str | None:
+    if status == "all":
+        return None
+    return status
+
+
+def _normalize_open_loop_title(
+    title: str,
+    *,
+    error_prefix: str,
+    error_type: type[ValueError],
+) -> str:
+    normalized = title.strip()
+    if not normalized:
+        raise error_type(f"{error_prefix} must be a non-empty string")
+    if len(normalized) > 280:
+        raise error_type(f"{error_prefix} must be 280 characters or fewer")
+    return normalized
+
+
+def _normalize_open_loop_resolution_note(note: str | None) -> str | None:
+    if note is None:
+        return None
+    normalized = note.strip()
+    if not normalized:
+        raise OpenLoopValidationError("resolution_note must be a non-empty string when provided")
+    if len(normalized) > 2000:
+        raise OpenLoopValidationError("resolution_note must be 2000 characters or fewer")
+    return normalized
+
+
+def _validate_open_loop_status(status: str) -> str:
+    if status not in OPEN_LOOP_STATUSES:
+        allowed_values = ", ".join(OPEN_LOOP_STATUSES)
+        raise OpenLoopValidationError(f"status must be one of: {allowed_values}")
+    return status
+
+
+def list_open_loop_records(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    status: OpenLoopStatusFilter = "open",
+    limit: int = DEFAULT_OPEN_LOOP_LIMIT,
+) -> OpenLoopListResponse:
+    del user_id
+
+    normalized_status = _normalize_open_loop_status_filter(status)
+    total_count = store.count_open_loops(status=normalized_status)
+    open_loops = store.list_open_loops(status=normalized_status, limit=limit)
+    items = [_serialize_open_loop(open_loop) for open_loop in open_loops]
+    summary: OpenLoopListSummary = {
+        "status": status,
+        "limit": limit,
+        "returned_count": len(items),
+        "total_count": total_count,
+        "has_more": len(items) < total_count,
+        "order": list(OPEN_LOOP_REVIEW_ORDER),
+    }
+    return {
+        "items": items,
+        "summary": summary,
+    }
+
+
+def get_open_loop_record(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    open_loop_id: UUID,
+) -> OpenLoopDetailResponse:
+    del user_id
+
+    open_loop = store.get_open_loop_optional(open_loop_id)
+    if open_loop is None:
+        raise OpenLoopNotFoundError(f"open loop {open_loop_id} was not found")
+    return {
+        "open_loop": _serialize_open_loop(open_loop),
+    }
+
+
+def create_open_loop_record(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    open_loop: OpenLoopCreateInput,
+) -> OpenLoopCreateResponse:
+    del user_id
+
+    if open_loop.memory_id is not None:
+        memory = store.get_memory_optional(open_loop.memory_id)
+        if memory is None:
+            raise OpenLoopValidationError(
+                "memory_id must reference an existing memory owned by the user"
+            )
+
+    created = store.create_open_loop(
+        memory_id=open_loop.memory_id,
+        title=_normalize_open_loop_title(
+            open_loop.title,
+            error_prefix="title",
+            error_type=OpenLoopValidationError,
+        ),
+        status="open",
+        opened_at=None,
+        due_at=open_loop.due_at,
+        resolved_at=None,
+        resolution_note=None,
+    )
+    return {
+        "open_loop": _serialize_open_loop(created),
+    }
+
+
+def update_open_loop_status_record(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    open_loop_id: UUID,
+    request: OpenLoopStatusUpdateInput,
+) -> OpenLoopStatusUpdateResponse:
+    del user_id
+
+    existing = store.get_open_loop_optional(open_loop_id)
+    if existing is None:
+        raise OpenLoopNotFoundError(f"open loop {open_loop_id} was not found")
+
+    normalized_status = _validate_open_loop_status(request.status)
+    if normalized_status == "open":
+        raise OpenLoopValidationError("status transition must be resolved or dismissed")
+    if existing["status"] != "open":
+        raise OpenLoopValidationError("open loop status can only transition from open")
+
+    updated = store.update_open_loop_status_optional(
+        open_loop_id=open_loop_id,
+        status=normalized_status,
+        resolved_at=None,
+        resolution_note=_normalize_open_loop_resolution_note(request.resolution_note),
+    )
+    if updated is None:
+        raise OpenLoopNotFoundError(f"open loop {open_loop_id} was not found")
+
+    return {
+        "open_loop": _serialize_open_loop(updated),
+    }
+
+
 def _dedupe_source_event_ids(source_event_ids: tuple[UUID, ...]) -> tuple[UUID, ...]:
     deduped: list[UUID] = []
     seen: set[UUID] = set()
@@ -402,6 +592,31 @@ def _validate_source_events(store: ContinuityStore, source_event_ids: tuple[UUID
 
 def _candidate_payload(candidate: MemoryCandidateInput) -> JsonObject:
     return candidate.as_payload()
+
+
+def _create_open_loop_for_memory(
+    store: ContinuityStore,
+    *,
+    candidate: MemoryCandidateInput,
+    memory: MemoryRow,
+) -> OpenLoopRecord | None:
+    if candidate.open_loop is None:
+        return None
+
+    created = store.create_open_loop(
+        memory_id=memory["id"],
+        title=_normalize_open_loop_title(
+            candidate.open_loop.title,
+            error_prefix="open_loop.title",
+            error_type=MemoryAdmissionValidationError,
+        ),
+        status="open",
+        opened_at=None,
+        due_at=candidate.open_loop.due_at,
+        resolved_at=None,
+        resolution_note=None,
+    )
+    return _serialize_open_loop(created)
 
 
 def _validate_memory_type(memory_type: str | None) -> str | None:
@@ -575,6 +790,11 @@ def admit_memory_candidate(
             reason="source_backed_add",
             memory=_serialize_memory(memory),
             revision=_serialize_memory_revision(revision),
+            open_loop=_create_open_loop_for_memory(
+                store,
+                candidate=candidate,
+                memory=memory,
+            ),
         )
 
     metadata_changed = any(
@@ -596,6 +816,11 @@ def admit_memory_candidate(
             reason="memory_unchanged",
             memory=_serialize_memory(existing_memory),
             revision=None,
+            open_loop=_create_open_loop_for_memory(
+                store,
+                candidate=candidate,
+                memory=existing_memory,
+            ),
         )
 
     memory = store.update_memory(
@@ -625,4 +850,9 @@ def admit_memory_candidate(
         reason="source_backed_update",
         memory=_serialize_memory(memory),
         revision=_serialize_memory_revision(revision),
+        open_loop=_create_open_loop_for_memory(
+            store,
+            candidate=candidate,
+            memory=memory,
+        ),
     )

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -124,6 +124,20 @@ class MemoryReviewLabelRow(TypedDict):
     created_at: datetime
 
 
+class OpenLoopRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    memory_id: UUID | None
+    title: str
+    status: str
+    opened_at: datetime
+    due_at: datetime | None
+    resolved_at: datetime | None
+    resolution_note: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
 class EmbeddingConfigRow(TypedDict):
     id: UUID
     user_id: UUID
@@ -984,6 +998,172 @@ LIST_ALL_MEMORY_REVIEW_LABEL_COUNTS_SQL = """
                 FROM memory_review_labels
                 GROUP BY label
                 ORDER BY label ASC
+                """
+
+INSERT_OPEN_LOOP_SQL = """
+                INSERT INTO open_loops (
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  COALESCE(%s, clock_timestamp()),
+                  %s,
+                  %s,
+                  %s,
+                  clock_timestamp(),
+                  clock_timestamp()
+                )
+                RETURNING
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                """
+
+GET_OPEN_LOOP_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                FROM open_loops
+                WHERE id = %s
+                """
+
+LIST_OPEN_LOOPS_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                FROM open_loops
+                ORDER BY opened_at DESC, created_at DESC, id DESC
+                """
+
+LIST_OPEN_LOOPS_BY_STATUS_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                FROM open_loops
+                WHERE status = %s
+                ORDER BY opened_at DESC, created_at DESC, id DESC
+                """
+
+LIST_LIMITED_OPEN_LOOPS_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                FROM open_loops
+                ORDER BY opened_at DESC, created_at DESC, id DESC
+                LIMIT %s
+                """
+
+LIST_LIMITED_OPEN_LOOPS_BY_STATUS_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                FROM open_loops
+                WHERE status = %s
+                ORDER BY opened_at DESC, created_at DESC, id DESC
+                LIMIT %s
+                """
+
+COUNT_OPEN_LOOPS_SQL = """
+                SELECT COUNT(*) AS count
+                FROM open_loops
+                """
+
+COUNT_OPEN_LOOPS_BY_STATUS_SQL = """
+                SELECT COUNT(*) AS count
+                FROM open_loops
+                WHERE status = %s
+                """
+
+UPDATE_OPEN_LOOP_STATUS_SQL = """
+                UPDATE open_loops
+                SET status = %s,
+                    resolved_at = CASE
+                      WHEN %s = 'open' THEN NULL
+                      ELSE COALESCE(%s, clock_timestamp())
+                    END,
+                    resolution_note = CASE
+                      WHEN %s = 'open' THEN NULL
+                      ELSE %s
+                    END,
+                    updated_at = clock_timestamp()
+                WHERE id = %s
+                RETURNING
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
                 """
 
 INSERT_EMBEDDING_CONFIG_SQL = """
@@ -3206,6 +3386,76 @@ class ContinuityStore:
 
     def list_all_memory_review_label_counts(self) -> list[LabelCountRow]:
         return self._fetch_all(LIST_ALL_MEMORY_REVIEW_LABEL_COUNTS_SQL)
+
+    def create_open_loop(
+        self,
+        *,
+        memory_id: UUID | None,
+        title: str,
+        status: str,
+        opened_at: datetime | None,
+        due_at: datetime | None,
+        resolved_at: datetime | None,
+        resolution_note: str | None,
+    ) -> OpenLoopRow:
+        return self._fetch_one(
+            "create_open_loop",
+            INSERT_OPEN_LOOP_SQL,
+            (
+                memory_id,
+                title,
+                status,
+                opened_at,
+                due_at,
+                resolved_at,
+                resolution_note,
+            ),
+        )
+
+    def get_open_loop(self, open_loop_id: UUID) -> OpenLoopRow:
+        return self._fetch_one("get_open_loop", GET_OPEN_LOOP_SQL, (open_loop_id,))
+
+    def get_open_loop_optional(self, open_loop_id: UUID) -> OpenLoopRow | None:
+        return self._fetch_optional_one(GET_OPEN_LOOP_SQL, (open_loop_id,))
+
+    def list_open_loops(
+        self,
+        *,
+        status: str | None = None,
+        limit: int | None = None,
+    ) -> list[OpenLoopRow]:
+        if status is None and limit is None:
+            return self._fetch_all(LIST_OPEN_LOOPS_SQL)
+        if status is None:
+            return self._fetch_all(LIST_LIMITED_OPEN_LOOPS_SQL, (limit,))
+        if limit is None:
+            return self._fetch_all(LIST_OPEN_LOOPS_BY_STATUS_SQL, (status,))
+        return self._fetch_all(LIST_LIMITED_OPEN_LOOPS_BY_STATUS_SQL, (status, limit))
+
+    def count_open_loops(self, *, status: str | None = None) -> int:
+        if status is None:
+            return self._fetch_count(COUNT_OPEN_LOOPS_SQL)
+        return self._fetch_count(COUNT_OPEN_LOOPS_BY_STATUS_SQL, (status,))
+
+    def update_open_loop_status_optional(
+        self,
+        *,
+        open_loop_id: UUID,
+        status: str,
+        resolved_at: datetime | None,
+        resolution_note: str | None,
+    ) -> OpenLoopRow | None:
+        return self._fetch_optional_one(
+            UPDATE_OPEN_LOOP_STATUS_SQL,
+            (
+                status,
+                status,
+                resolved_at,
+                status,
+                resolution_note,
+                open_loop_id,
+            ),
+        )
 
     def create_embedding_config(
         self,

--- a/apps/web/app/memories/page.test.tsx
+++ b/apps/web/app/memories/page.test.tsx
@@ -9,18 +9,22 @@ const {
   getMemoryDetailMock,
   getMemoryEvaluationSummaryMock,
   getMemoryRevisionsMock,
+  getOpenLoopDetailMock,
   hasLiveApiConfigMock,
   listMemoriesMock,
   listMemoryLabelsMock,
+  listOpenLoopsMock,
   listMemoryReviewQueueMock,
 } = vi.hoisted(() => ({
   getApiConfigMock: vi.fn(),
   getMemoryDetailMock: vi.fn(),
   getMemoryEvaluationSummaryMock: vi.fn(),
   getMemoryRevisionsMock: vi.fn(),
+  getOpenLoopDetailMock: vi.fn(),
   hasLiveApiConfigMock: vi.fn(),
   listMemoriesMock: vi.fn(),
   listMemoryLabelsMock: vi.fn(),
+  listOpenLoopsMock: vi.fn(),
   listMemoryReviewQueueMock: vi.fn(),
 }));
 
@@ -56,9 +60,11 @@ vi.mock("../../lib/api", async () => {
     getMemoryDetail: getMemoryDetailMock,
     getMemoryEvaluationSummary: getMemoryEvaluationSummaryMock,
     getMemoryRevisions: getMemoryRevisionsMock,
+    getOpenLoopDetail: getOpenLoopDetailMock,
     hasLiveApiConfig: hasLiveApiConfigMock,
     listMemories: listMemoriesMock,
     listMemoryLabels: listMemoryLabelsMock,
+    listOpenLoops: listOpenLoopsMock,
     listMemoryReviewQueue: listMemoryReviewQueueMock,
   };
 });
@@ -69,9 +75,11 @@ describe("MemoriesPage", () => {
     getMemoryDetailMock.mockReset();
     getMemoryEvaluationSummaryMock.mockReset();
     getMemoryRevisionsMock.mockReset();
+    getOpenLoopDetailMock.mockReset();
     hasLiveApiConfigMock.mockReset();
     listMemoriesMock.mockReset();
     listMemoryLabelsMock.mockReset();
+    listOpenLoopsMock.mockReset();
     listMemoryReviewQueueMock.mockReset();
 
     getApiConfigMock.mockReturnValue({
@@ -163,6 +171,44 @@ describe("MemoriesPage", () => {
         label_value_order: ["correct", "incorrect", "outdated", "insufficient_evidence"],
       },
     });
+    listOpenLoopsMock.mockResolvedValue({
+      items: [
+        {
+          id: "loop-live-1",
+          memory_id: "memory-live-1",
+          title: "Confirm merchant details",
+          status: "open",
+          opened_at: "2026-03-23T09:00:00Z",
+          due_at: "2026-03-25T09:00:00Z",
+          resolved_at: null,
+          resolution_note: null,
+          created_at: "2026-03-23T09:00:00Z",
+          updated_at: "2026-03-23T09:00:00Z",
+        },
+      ],
+      summary: {
+        status: "open",
+        limit: 20,
+        returned_count: 1,
+        total_count: 1,
+        has_more: false,
+        order: ["opened_at_desc", "created_at_desc", "id_desc"],
+      },
+    });
+    getOpenLoopDetailMock.mockResolvedValue({
+      open_loop: {
+        id: "loop-live-1",
+        memory_id: "memory-live-1",
+        title: "Confirm merchant details",
+        status: "open",
+        opened_at: "2026-03-23T09:00:00Z",
+        due_at: "2026-03-25T09:00:00Z",
+        resolved_at: null,
+        resolution_note: null,
+        created_at: "2026-03-23T09:00:00Z",
+        updated_at: "2026-03-23T09:00:00Z",
+      },
+    });
     getMemoryDetailMock.mockResolvedValue({
       memory: {
         id: "memory-live-1",
@@ -246,6 +292,8 @@ describe("MemoriesPage", () => {
     expect(screen.getByText("Live revisions")).toBeInTheDocument();
     expect(screen.getByText("Live labels")).toBeInTheDocument();
     expect(screen.getByText("Typed metadata")).toBeInTheDocument();
+    expect(screen.getByText("Open-loop backbone")).toBeInTheDocument();
+    expect(screen.getByText("Confirm merchant details")).toBeInTheDocument();
     expect(screen.getByText("decision")).toBeInTheDocument();
     expect(screen.getByText("confirmed")).toBeInTheDocument();
     expect(screen.getByText("0.93")).toBeInTheDocument();
@@ -262,6 +310,10 @@ describe("MemoriesPage", () => {
       "memory-live-1",
       "user-1",
     );
+    expect(listOpenLoopsMock).toHaveBeenCalledWith("https://api.example.com", "user-1", {
+      status: "open",
+      limit: 20,
+    });
   });
 
   it("keeps fallback state explicit when live reads partially fail and shows unavailable revision/label panels", async () => {
@@ -296,6 +348,7 @@ describe("MemoriesPage", () => {
     });
     listMemoryReviewQueueMock.mockRejectedValue(new Error("queue down"));
     getMemoryEvaluationSummaryMock.mockRejectedValue(new Error("summary down"));
+    listOpenLoopsMock.mockRejectedValue(new Error("open loops down"));
     getMemoryDetailMock.mockRejectedValue(new Error("detail down"));
     getMemoryRevisionsMock.mockRejectedValue(new Error("revisions down"));
     listMemoryLabelsMock.mockRejectedValue(new Error("labels down"));
@@ -310,6 +363,7 @@ describe("MemoriesPage", () => {
 
     expect(screen.getByText("Summary: summary down")).toBeInTheDocument();
     expect(screen.getByText("Queue: queue down")).toBeInTheDocument();
+    expect(screen.getByText(/open loops down/)).toBeInTheDocument();
     expect(screen.getAllByText("Insufficient evidence").length).toBeGreaterThan(0);
     expect(screen.getByText("Detail read")).toBeInTheDocument();
     expect(screen.getByText("detail down")).toBeInTheDocument();

--- a/apps/web/app/memories/page.tsx
+++ b/apps/web/app/memories/page.tsx
@@ -10,14 +10,18 @@ import type {
   MemoryReviewLabelSummary,
   MemoryReviewRecord,
   MemoryRevisionReviewListSummary,
+  OpenLoopListSummary,
+  OpenLoopRecord,
 } from "../../lib/api";
 import {
   combinePageModes,
+  getOpenLoopDetail,
   getApiConfig,
   getMemoryDetail,
   getMemoryEvaluationSummary,
   getMemoryRevisions,
   hasLiveApiConfig,
+  listOpenLoops,
   listMemories,
   listMemoryLabels,
   listMemoryReviewQueue,
@@ -105,6 +109,55 @@ function formatTypedTimestamp(value: string | null | undefined) {
   return value ?? "Not set";
 }
 
+const openLoopFixtures: OpenLoopRecord[] = [
+  {
+    id: "loop-fixture-1",
+    memory_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2",
+    title: "Confirm magnesium package size before reorder",
+    status: "open",
+    opened_at: "2026-03-20T09:00:00Z",
+    due_at: "2026-03-24T09:00:00Z",
+    resolved_at: null,
+    resolution_note: null,
+    created_at: "2026-03-20T09:00:00Z",
+    updated_at: "2026-03-20T09:00:00Z",
+  },
+  {
+    id: "loop-fixture-2",
+    memory_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1",
+    title: "Verify merchant preference after next approval",
+    status: "open",
+    opened_at: "2026-03-19T09:00:00Z",
+    due_at: null,
+    resolved_at: null,
+    resolution_note: null,
+    created_at: "2026-03-19T09:00:00Z",
+    updated_at: "2026-03-19T09:00:00Z",
+  },
+];
+
+const openLoopSummaryFixture: OpenLoopListSummary = {
+  status: "open",
+  limit: 20,
+  returned_count: openLoopFixtures.length,
+  total_count: openLoopFixtures.length,
+  has_more: false,
+  order: ["opened_at_desc", "created_at_desc", "id_desc"],
+};
+
+function resolveSelectedOpenLoopId(requestedOpenLoopId: string, items: OpenLoopRecord[]) {
+  if (!items.length) {
+    return "";
+  }
+
+  const availableIds = new Set(items.map((item) => item.id));
+  if (requestedOpenLoopId && availableIds.has(requestedOpenLoopId)) {
+    return requestedOpenLoopId;
+  }
+
+  return items[0]?.id ?? "";
+}
+
 export default async function MemoriesPage({
   searchParams,
 }: {
@@ -115,6 +168,7 @@ export default async function MemoriesPage({
     string | string[] | undefined
   >;
   const requestedMemoryId = normalizeParam(params.memory);
+  const requestedOpenLoopId = normalizeParam(params.open_loop);
   const activeFilter = normalizeFilter(params.filter);
   const apiConfig = getApiConfig();
   const liveModeReady = hasLiveApiConfig(apiConfig);
@@ -133,11 +187,17 @@ export default async function MemoriesPage({
   let evaluationSummarySource: ApiSource = "fixture";
   let evaluationSummaryUnavailableReason: string | undefined;
 
+  let openLoops = openLoopFixtures;
+  let openLoopSummary = openLoopSummaryFixture;
+  let openLoopSource: ApiSource = "fixture";
+  let openLoopUnavailableReason: string | undefined;
+
   if (liveModeReady) {
-    const [memoryResult, queueResult, summaryResult] = await Promise.allSettled([
+    const [memoryResult, queueResult, summaryResult, openLoopResult] = await Promise.allSettled([
       listMemories(apiConfig.apiBaseUrl, apiConfig.userId, { status: "active" }),
       listMemoryReviewQueue(apiConfig.apiBaseUrl, apiConfig.userId),
       getMemoryEvaluationSummary(apiConfig.apiBaseUrl, apiConfig.userId),
+      listOpenLoops(apiConfig.apiBaseUrl, apiConfig.userId, { status: "open", limit: 20 }),
     ]);
 
     if (memoryResult.status === "fulfilled") {
@@ -170,6 +230,17 @@ export default async function MemoriesPage({
         summaryResult.reason instanceof Error
           ? summaryResult.reason.message
           : "Memory evaluation summary could not be loaded.";
+    }
+
+    if (openLoopResult.status === "fulfilled") {
+      openLoops = openLoopResult.value.items;
+      openLoopSummary = openLoopResult.value.summary;
+      openLoopSource = "live";
+    } else {
+      openLoopUnavailableReason =
+        openLoopResult.reason instanceof Error
+          ? openLoopResult.reason.message
+          : "Open-loop list could not be loaded.";
     }
   }
 
@@ -206,6 +277,35 @@ export default async function MemoriesPage({
       }
       selectedMemoryUnavailableReason =
         error instanceof Error ? error.message : "Selected memory detail could not be loaded.";
+    }
+  }
+
+  const selectedOpenLoopId = resolveSelectedOpenLoopId(requestedOpenLoopId, openLoops);
+  const selectedOpenLoopFromList = openLoops.find((item) => item.id === selectedOpenLoopId) ?? null;
+  let selectedOpenLoop = selectedOpenLoopFromList;
+  let selectedOpenLoopSource: ApiSource | null = selectedOpenLoop ? openLoopSource : null;
+  let selectedOpenLoopUnavailableReason: string | undefined;
+
+  if (selectedOpenLoopFromList && liveModeReady && openLoopSource === "live") {
+    try {
+      const payload = await getOpenLoopDetail(
+        apiConfig.apiBaseUrl,
+        selectedOpenLoopFromList.id,
+        apiConfig.userId,
+      );
+      selectedOpenLoop = payload.open_loop;
+      selectedOpenLoopSource = "live";
+    } catch (error) {
+      const fixtureOpenLoop = openLoopFixtures.find((item) => item.id === selectedOpenLoopFromList.id);
+      if (fixtureOpenLoop) {
+        selectedOpenLoop = fixtureOpenLoop;
+        selectedOpenLoopSource = "fixture";
+      } else {
+        selectedOpenLoop = null;
+        selectedOpenLoopSource = null;
+      }
+      selectedOpenLoopUnavailableReason =
+        error instanceof Error ? error.message : "Selected open loop could not be loaded.";
     }
   }
 
@@ -271,7 +371,9 @@ export default async function MemoriesPage({
     memoryListSource,
     reviewQueueSource,
     evaluationSummarySource,
+    openLoopSource,
     selectedMemorySource,
+    selectedOpenLoopSource,
     revisionSource === "unavailable" ? null : revisionSource,
     labelSource === "unavailable" ? null : labelSource,
   );
@@ -289,6 +391,7 @@ export default async function MemoriesPage({
               {activeFilter === "queue" ? "Queue filter active" : "Active list filter"}
             </span>
             <span className="subtle-chip">{visibleMemories.length} visible memories</span>
+            <span className="subtle-chip">{openLoops.length} open loops</span>
           </div>
         }
       />
@@ -302,6 +405,85 @@ export default async function MemoriesPage({
         queueUnavailableReason={reviewQueueUnavailableReason}
         activeFilter={activeFilter}
       />
+
+      <div className="section-card">
+        <header className="section-card__header">
+          <div>
+            <p className="section-card__eyebrow">Open-loop backbone</p>
+            <h2 className="section-card__title">Unresolved commitment review</h2>
+          </div>
+          <p className="section-card__description">
+            Review unresolved loops with deterministic ordering and inspect one selected loop in detail.
+          </p>
+        </header>
+
+        <div className="stack">
+          <p className="muted-copy">
+            Source: {openLoopSource === "live" ? "Live list" : "Fixture list"}
+            {openLoopUnavailableReason ? ` · ${openLoopUnavailableReason}` : ""}
+          </p>
+          <p className="muted-copy">
+            {openLoopSummary.returned_count} open loops shown of {openLoopSummary.total_count} total
+          </p>
+          {openLoops.length ? (
+            <ul className="stack">
+              {openLoops.map((openLoop) => {
+                const selected = selectedOpenLoop?.id === openLoop.id;
+                const hrefParts = [
+                  `/memories?open_loop=${encodeURIComponent(openLoop.id)}`,
+                  selectedMemory?.id
+                    ? `memory=${encodeURIComponent(selectedMemory.id)}`
+                    : null,
+                  activeFilter === "queue" ? "filter=queue" : null,
+                ].filter(Boolean);
+                const href = hrefParts.length > 1 ? `${hrefParts[0]}&${hrefParts.slice(1).join("&")}` : hrefParts[0];
+                return (
+                  <li key={openLoop.id}>
+                    <a href={href} aria-current={selected ? "page" : undefined}>
+                      {openLoop.title}
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <p className="muted-copy">No open loops are currently available.</p>
+          )}
+
+          {selectedOpenLoop ? (
+            <dl className="key-value-grid key-value-grid--compact">
+              <div>
+                <dt>Status</dt>
+                <dd>{selectedOpenLoop.status}</dd>
+              </div>
+              <div>
+                <dt>Memory link</dt>
+                <dd className="mono">{selectedOpenLoop.memory_id ?? "Not linked"}</dd>
+              </div>
+              <div>
+                <dt>Opened at</dt>
+                <dd className="mono">{formatTypedTimestamp(selectedOpenLoop.opened_at)}</dd>
+              </div>
+              <div>
+                <dt>Due at</dt>
+                <dd className="mono">{formatTypedTimestamp(selectedOpenLoop.due_at)}</dd>
+              </div>
+              <div>
+                <dt>Resolved at</dt>
+                <dd className="mono">{formatTypedTimestamp(selectedOpenLoop.resolved_at)}</dd>
+              </div>
+              <div>
+                <dt>Resolution note</dt>
+                <dd>{selectedOpenLoop.resolution_note ?? "Not set"}</dd>
+              </div>
+            </dl>
+          ) : (
+            <p className="muted-copy">
+              {selectedOpenLoopUnavailableReason ?? "Select an open loop to inspect its detail fields."}
+            </p>
+          )}
+        </div>
+      </div>
 
       <div className="memory-layout">
         <MemoryList

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -8,8 +8,10 @@ import {
   connectGmailAccount,
   createThread,
   deriveThreadWorkflowState,
+  createOpenLoop,
   getCalendarAccountDetail,
   getGmailAccountDetail,
+  getOpenLoopDetail,
   getTaskArtifactDetail,
   getTaskWorkspaceDetail,
   getEntityDetail,
@@ -28,6 +30,7 @@ import {
   listEntities,
   listEntityEdges,
   listGmailAccounts,
+  listOpenLoops,
   listTaskArtifactChunks,
   listTaskArtifacts,
   listTaskWorkspaces,
@@ -45,6 +48,7 @@ import {
   submitAssistantResponse,
   submitApprovalRequest,
   submitMemoryLabel,
+  updateOpenLoopStatus,
 } from "./api";
 
 describe("api helpers", () => {
@@ -1635,6 +1639,137 @@ describe("api helpers", () => {
         }),
       ],
     ]);
+  });
+
+  it("reads and mutates open-loop endpoints with user-scoped routing", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "loop-1",
+              memory_id: "memory-1",
+              title: "Confirm reorder details",
+              status: "open",
+              opened_at: "2026-03-23T09:00:00Z",
+              due_at: "2026-03-25T09:00:00Z",
+              resolved_at: null,
+              resolution_note: null,
+              created_at: "2026-03-23T09:00:00Z",
+              updated_at: "2026-03-23T09:00:00Z",
+            },
+          ],
+          summary: {
+            status: "open",
+            limit: 5,
+            returned_count: 1,
+            total_count: 1,
+            has_more: false,
+            order: ["opened_at_desc", "created_at_desc", "id_desc"],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          open_loop: {
+            id: "loop-1",
+            memory_id: "memory-1",
+            title: "Confirm reorder details",
+            status: "open",
+            opened_at: "2026-03-23T09:00:00Z",
+            due_at: "2026-03-25T09:00:00Z",
+            resolved_at: null,
+            resolution_note: null,
+            created_at: "2026-03-23T09:00:00Z",
+            updated_at: "2026-03-23T09:00:00Z",
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          open_loop: {
+            id: "loop-2",
+            memory_id: "memory-1",
+            title: "Follow up on confidence",
+            status: "open",
+            opened_at: "2026-03-24T09:00:00Z",
+            due_at: null,
+            resolved_at: null,
+            resolution_note: null,
+            created_at: "2026-03-24T09:00:00Z",
+            updated_at: "2026-03-24T09:00:00Z",
+          },
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          open_loop: {
+            id: "loop-1",
+            memory_id: "memory-1",
+            title: "Confirm reorder details",
+            status: "resolved",
+            opened_at: "2026-03-23T09:00:00Z",
+            due_at: "2026-03-25T09:00:00Z",
+            resolved_at: "2026-03-24T10:00:00Z",
+            resolution_note: "Resolved",
+            created_at: "2026-03-23T09:00:00Z",
+            updated_at: "2026-03-24T10:00:00Z",
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await listOpenLoops("https://api.example.com", "user-1", { status: "open", limit: 5 });
+    await getOpenLoopDetail("https://api.example.com", "loop-1", "user-1");
+    await createOpenLoop("https://api.example.com", {
+      user_id: "user-1",
+      memory_id: "memory-1",
+      title: "Follow up on confidence",
+    });
+    await updateOpenLoopStatus("https://api.example.com", "loop-1", {
+      user_id: "user-1",
+      status: "resolved",
+      resolution_note: "Resolved",
+    });
+
+    expect(fetchMock.mock.calls).toEqual([
+      [
+        "https://api.example.com/v0/open-loops?user_id=user-1&status=open&limit=5",
+        expect.objectContaining({ cache: "no-store" }),
+      ],
+      [
+        "https://api.example.com/v0/open-loops/loop-1?user_id=user-1",
+        expect.objectContaining({ cache: "no-store" }),
+      ],
+      [
+        "https://api.example.com/v0/open-loops",
+        expect.objectContaining({ method: "POST" }),
+      ],
+      [
+        "https://api.example.com/v0/open-loops/loop-1/status",
+        expect.objectContaining({ method: "POST" }),
+      ],
+    ]);
+    expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body))).toEqual({
+      user_id: "user-1",
+      memory_id: "memory-1",
+      title: "Follow up on confidence",
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[3]?.[1]?.body))).toEqual({
+      user_id: "user-1",
+      status: "resolved",
+      resolution_note: "Resolved",
+    });
   });
 
   it("posts explicit memory admissions to the shipped endpoint", async () => {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -248,6 +248,8 @@ export type TraceReviewEventListSummary = {
 
 export type MemoryReviewStatus = "active" | "deleted";
 export type MemoryReviewStatusFilter = MemoryReviewStatus | "all";
+export type OpenLoopStatus = "open" | "resolved" | "dismissed";
+export type OpenLoopStatusFilter = OpenLoopStatus | "all";
 export type MemoryReviewLabelValue =
   | "correct"
   | "incorrect"
@@ -374,6 +376,28 @@ export type MemoryEvaluationSummary = {
   total_label_row_count: number;
   label_row_counts_by_value: MemoryReviewLabelCounts;
   label_value_order: MemoryReviewLabelValue[];
+};
+
+export type OpenLoopRecord = {
+  id: string;
+  memory_id: string | null;
+  title: string;
+  status: OpenLoopStatus;
+  opened_at: string;
+  due_at: string | null;
+  resolved_at: string | null;
+  resolution_note: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type OpenLoopListSummary = {
+  status: OpenLoopStatusFilter;
+  limit: number;
+  returned_count: number;
+  total_count: number;
+  has_more: boolean;
+  order: string[];
 };
 
 export type EntityType = "person" | "merchant" | "product" | "project" | "routine";
@@ -601,6 +625,23 @@ export type MemoryAdmitPayload = {
   value: unknown | null;
   source_event_ids: string[];
   delete_requested?: boolean;
+  open_loop?: {
+    title: string;
+    due_at?: string | null;
+  };
+};
+
+export type OpenLoopCreatePayload = {
+  user_id: string;
+  memory_id?: string | null;
+  title: string;
+  due_at?: string | null;
+};
+
+export type OpenLoopStatusUpdatePayload = {
+  user_id: string;
+  status: OpenLoopStatus;
+  resolution_note?: string | null;
 };
 
 export type ApprovalRequestPayload = {
@@ -676,6 +717,7 @@ export type MemoryAdmissionResponse = {
   reason: string;
   memory: PersistedMemoryRecord | null;
   revision: PersistedMemoryRevisionRecord | null;
+  open_loop?: OpenLoopRecord | null;
 };
 
 export type AssistantResponsePayload = {
@@ -1077,6 +1119,57 @@ export function admitMemory(apiBaseUrl: string, payload: MemoryAdmitPayload) {
     method: "POST",
     body: JSON.stringify(payload),
   });
+}
+
+export function listOpenLoops(
+  apiBaseUrl: string,
+  userId: string,
+  options?: {
+    status?: OpenLoopStatusFilter;
+    limit?: number;
+  },
+) {
+  return requestJson<{ items: OpenLoopRecord[]; summary: OpenLoopListSummary }>(
+    apiBaseUrl,
+    "/v0/open-loops",
+    undefined,
+    {
+      user_id: userId,
+      status: options?.status,
+      limit: options?.limit ? String(options.limit) : undefined,
+    },
+  );
+}
+
+export function getOpenLoopDetail(apiBaseUrl: string, openLoopId: string, userId: string) {
+  return requestJson<{ open_loop: OpenLoopRecord }>(
+    apiBaseUrl,
+    `/v0/open-loops/${openLoopId}`,
+    undefined,
+    { user_id: userId },
+  );
+}
+
+export function createOpenLoop(apiBaseUrl: string, payload: OpenLoopCreatePayload) {
+  return requestJson<{ open_loop: OpenLoopRecord }>(apiBaseUrl, "/v0/open-loops", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function updateOpenLoopStatus(
+  apiBaseUrl: string,
+  openLoopId: string,
+  payload: OpenLoopStatusUpdatePayload,
+) {
+  return requestJson<{ open_loop: OpenLoopRecord }>(
+    apiBaseUrl,
+    `/v0/open-loops/${openLoopId}/status`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
 }
 
 export function listToolExecutions(apiBaseUrl: string, userId: string) {

--- a/tests/integration/test_open_loops_api.py
+++ b/tests/integration/test_open_loops_api.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlencode
+from uuid import UUID, uuid4
+
+import anyio
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+from alicebot_api.contracts import MemoryCandidateInput
+from alicebot_api.db import user_connection
+from alicebot_api.memory import admit_memory_candidate
+from alicebot_api.store import ContinuityStore
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+
+        request_received = True
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def seed_user_with_memory(database_url: str) -> dict[str, object]:
+    user_id = uuid4()
+
+    with user_connection(database_url, user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, "owner@example.com", "Owner")
+        thread = store.create_thread("Open-loop thread")
+        session = store.create_session(thread["id"], status="active")
+        source_event_id = store.append_event(
+            thread["id"],
+            session["id"],
+            "message.user",
+            {"text": "Remember to confirm reorder details."},
+        )["id"]
+        decision = admit_memory_candidate(
+            store,
+            user_id=user_id,
+            candidate=MemoryCandidateInput(
+                memory_key="user.preference.coffee",
+                value={"likes": "oat milk"},
+                source_event_ids=(source_event_id,),
+            ),
+        )
+
+    assert decision.memory is not None
+    return {
+        "user_id": user_id,
+        "thread_id": thread["id"],
+        "source_event_id": source_event_id,
+        "memory_id": UUID(decision.memory["id"]),
+    }
+
+
+def test_open_loop_endpoints_create_list_detail_and_isolation(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    seeded = seed_user_with_memory(migrated_database_urls["app"])
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    create_status, create_payload = invoke_request(
+        "POST",
+        "/v0/open-loops",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "memory_id": str(seeded["memory_id"]),
+            "title": "Confirm order details before submission",
+            "due_at": "2026-03-28T09:00:00+00:00",
+        },
+    )
+
+    assert create_status == 201
+    assert create_payload["open_loop"]["status"] == "open"
+    assert create_payload["open_loop"]["memory_id"] == str(seeded["memory_id"])
+
+    open_loop_id = create_payload["open_loop"]["id"]
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v0/open-loops",
+        query_params={"user_id": str(seeded["user_id"]), "status": "open", "limit": "10"},
+    )
+    detail_status, detail_payload = invoke_request(
+        "GET",
+        f"/v0/open-loops/{open_loop_id}",
+        query_params={"user_id": str(seeded["user_id"])},
+    )
+
+    assert list_status == 200
+    assert [item["id"] for item in list_payload["items"]] == [open_loop_id]
+    assert list_payload["summary"]["order"] == ["opened_at_desc", "created_at_desc", "id_desc"]
+    assert detail_status == 200
+    assert detail_payload["open_loop"]["id"] == open_loop_id
+
+    intruder_id = uuid4()
+    with user_connection(migrated_database_urls["app"], intruder_id) as conn:
+        ContinuityStore(conn).create_user(intruder_id, "intruder@example.com", "Intruder")
+
+    intruder_status, intruder_payload = invoke_request(
+        "GET",
+        "/v0/open-loops",
+        query_params={"user_id": str(intruder_id), "status": "open", "limit": "10"},
+    )
+    assert intruder_status == 200
+    assert intruder_payload["items"] == []
+    assert intruder_payload["summary"]["total_count"] == 0
+
+    intruder_detail_status, intruder_detail_payload = invoke_request(
+        "GET",
+        f"/v0/open-loops/{open_loop_id}",
+        query_params={"user_id": str(intruder_id)},
+    )
+    assert intruder_detail_status == 404
+    assert "was not found" in intruder_detail_payload["detail"]
+
+    intruder_mutation_status, intruder_mutation_payload = invoke_request(
+        "POST",
+        f"/v0/open-loops/{open_loop_id}/status",
+        payload={
+            "user_id": str(intruder_id),
+            "status": "resolved",
+            "resolution_note": "Unauthorized user should not mutate this row.",
+        },
+    )
+    assert intruder_mutation_status == 404
+    assert "was not found" in intruder_mutation_payload["detail"]
+
+
+def test_open_loop_status_endpoint_rejects_invalid_values_and_persists_audit_fields(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    seeded = seed_user_with_memory(migrated_database_urls["app"])
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    create_status, create_payload = invoke_request(
+        "POST",
+        "/v0/open-loops",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "memory_id": str(seeded["memory_id"]),
+            "title": "Confirm order details before submission",
+        },
+    )
+    assert create_status == 201
+    open_loop_id = create_payload["open_loop"]["id"]
+
+    invalid_status, invalid_payload = invoke_request(
+        "POST",
+        f"/v0/open-loops/{open_loop_id}/status",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "status": "pending_review",
+        },
+    )
+    assert invalid_status == 400
+    assert invalid_payload == {"detail": "status must be one of: open, resolved, dismissed"}
+
+    resolve_status, resolve_payload = invoke_request(
+        "POST",
+        f"/v0/open-loops/{open_loop_id}/status",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "status": "resolved",
+            "resolution_note": "Resolved after checking the latest cart.",
+        },
+    )
+    assert resolve_status == 200
+    assert resolve_payload["open_loop"]["status"] == "resolved"
+    assert resolve_payload["open_loop"]["resolved_at"] is not None
+    assert (
+        resolve_payload["open_loop"]["resolution_note"]
+        == "Resolved after checking the latest cart."
+    )
+
+    repeat_status, repeat_payload = invoke_request(
+        "POST",
+        f"/v0/open-loops/{open_loop_id}/status",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "status": "dismissed",
+        },
+    )
+    assert repeat_status == 400
+    assert repeat_payload == {"detail": "open loop status can only transition from open"}
+
+
+def test_open_loop_status_endpoint_supports_open_to_dismissed_with_audit_fields(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    seeded = seed_user_with_memory(migrated_database_urls["app"])
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    create_status, create_payload = invoke_request(
+        "POST",
+        "/v0/open-loops",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "memory_id": str(seeded["memory_id"]),
+            "title": "Dismiss this candidate after confirming no action is needed",
+        },
+    )
+    assert create_status == 201
+    open_loop_id = create_payload["open_loop"]["id"]
+
+    dismiss_status, dismiss_payload = invoke_request(
+        "POST",
+        f"/v0/open-loops/{open_loop_id}/status",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "status": "dismissed",
+            "resolution_note": "No follow-up required after manual verification.",
+        },
+    )
+
+    assert dismiss_status == 200
+    assert dismiss_payload["open_loop"]["status"] == "dismissed"
+    assert dismiss_payload["open_loop"]["resolved_at"] is not None
+    assert (
+        dismiss_payload["open_loop"]["resolution_note"]
+        == "No follow-up required after manual verification."
+    )
+
+
+def test_memory_admission_can_create_open_loop_when_requested(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    seeded = seed_user_with_memory(migrated_database_urls["app"])
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    admit_status, admit_payload = invoke_request(
+        "POST",
+        "/v0/memories/admit",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "memory_key": "user.preference.delivery.window",
+            "value": {"window": "weekday_morning"},
+            "source_event_ids": [str(seeded["source_event_id"])],
+            "open_loop": {
+                "title": "Reconfirm delivery window before next order",
+                "due_at": "2026-03-29T09:00:00+00:00",
+            },
+        },
+    )
+
+    assert admit_status == 200
+    assert admit_payload["decision"] == "ADD"
+    assert admit_payload["open_loop"]["title"] == "Reconfirm delivery window before next order"
+    assert admit_payload["open_loop"]["status"] == "open"
+    assert admit_payload["open_loop"]["memory_id"] == admit_payload["memory"]["id"]
+
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v0/open-loops",
+        query_params={"user_id": str(seeded["user_id"]), "status": "open", "limit": "10"},
+    )
+    assert list_status == 200
+    assert any(
+        item["title"] == "Reconfirm delivery window before next order"
+        for item in list_payload["items"]
+    )
+
+
+def test_context_compile_includes_bounded_open_loop_slice_when_present(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    seeded = seed_user_with_memory(migrated_database_urls["app"])
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    with user_connection(migrated_database_urls["app"], seeded["user_id"]) as conn:
+        store = ContinuityStore(conn)
+        store.create_open_loop(
+            memory_id=seeded["memory_id"],
+            title="Older open loop",
+            status="open",
+            opened_at=datetime(2026, 3, 23, 8, 0, tzinfo=UTC),
+            due_at=None,
+            resolved_at=None,
+            resolution_note=None,
+        )
+        store.create_open_loop(
+            memory_id=seeded["memory_id"],
+            title="Newer open loop",
+            status="open",
+            opened_at=datetime(2026, 3, 23, 9, 0, tzinfo=UTC),
+            due_at=None,
+            resolved_at=None,
+            resolution_note=None,
+        )
+
+    compile_status, compile_payload = invoke_request(
+        "POST",
+        "/v0/context/compile",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "thread_id": str(seeded["thread_id"]),
+            "max_sessions": 3,
+            "max_events": 8,
+            "max_memories": 1,
+            "max_entities": 5,
+            "max_entity_edges": 10,
+        },
+    )
+
+    assert compile_status == 200
+    assert compile_payload["context_pack"]["open_loops"] == [
+        {
+            "id": compile_payload["context_pack"]["open_loops"][0]["id"],
+            "memory_id": str(seeded["memory_id"]),
+            "title": "Newer open loop",
+            "status": "open",
+            "opened_at": "2026-03-23T09:00:00+00:00",
+            "due_at": None,
+            "resolved_at": None,
+            "resolution_note": None,
+            "created_at": compile_payload["context_pack"]["open_loops"][0]["created_at"],
+            "updated_at": compile_payload["context_pack"]["open_loops"][0]["updated_at"],
+        }
+    ]
+    assert compile_payload["context_pack"]["open_loop_summary"] == {
+        "candidate_count": 2,
+        "included_count": 1,
+        "excluded_limit_count": 1,
+        "order": ["opened_at_desc", "created_at_desc", "id_desc"],
+    }

--- a/tests/unit/test_20260323_0031_open_loop_backbone.py
+++ b/tests/unit/test_20260323_0031_open_loop_backbone.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260323_0031_open_loop_backbone"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == [
+        module._UPGRADE_SCHEMA_STATEMENT,
+        *module._UPGRADE_GRANT_STATEMENTS,
+        "ALTER TABLE open_loops ENABLE ROW LEVEL SECURITY",
+        "ALTER TABLE open_loops FORCE ROW LEVEL SECURITY",
+        module._UPGRADE_POLICY_STATEMENT,
+    ]
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_open_loop_status_domain_matches_sprint_contract() -> None:
+    module = load_migration_module()
+
+    assert module.OPEN_LOOP_STATUSES == ("open", "resolved", "dismissed")

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -1369,3 +1369,91 @@ def test_compile_memory_section_orders_limits_and_excludes_deleted() -> None:
         "hybrid_memory_deleted",
     ]
     assert memory_section.decisions[-1].metadata["selected_sources"] == ["symbolic"]
+
+
+def test_compile_continuity_context_includes_open_loops_when_present() -> None:
+    user_id = uuid4()
+    thread_id = uuid4()
+    base_time = datetime(2026, 3, 23, 9, 0, tzinfo=UTC)
+    newer_open_loop_id = uuid4()
+    older_open_loop_id = uuid4()
+
+    compiler_run = compile_continuity_context(
+        user={
+            "id": user_id,
+            "email": "owner@example.com",
+            "display_name": "Owner",
+            "created_at": base_time,
+        },
+        thread={
+            "id": thread_id,
+            "user_id": user_id,
+            "title": "Open-loop context",
+            "created_at": base_time,
+            "updated_at": base_time,
+        },
+        sessions=[],
+        events=[],
+        memories=[],
+        entities=[],
+        entity_edges=[],
+        limits=ContextCompilerLimits(
+            max_sessions=1,
+            max_events=1,
+            max_memories=1,
+            max_entities=1,
+            max_entity_edges=1,
+        ),
+        open_loops=[
+            {
+                "id": older_open_loop_id,
+                "user_id": user_id,
+                "memory_id": None,
+                "title": "Older open loop",
+                "status": "open",
+                "opened_at": base_time,
+                "due_at": None,
+                "resolved_at": None,
+                "resolution_note": None,
+                "created_at": base_time,
+                "updated_at": base_time,
+            },
+            {
+                "id": newer_open_loop_id,
+                "user_id": user_id,
+                "memory_id": None,
+                "title": "Newer open loop",
+                "status": "open",
+                "opened_at": base_time + timedelta(minutes=2),
+                "due_at": None,
+                "resolved_at": None,
+                "resolution_note": None,
+                "created_at": base_time + timedelta(minutes=2),
+                "updated_at": base_time + timedelta(minutes=2),
+            },
+        ],
+    )
+
+    assert compiler_run.context_pack["open_loops"] == [
+        {
+            "id": str(newer_open_loop_id),
+            "memory_id": None,
+            "title": "Newer open loop",
+            "status": "open",
+            "opened_at": (base_time + timedelta(minutes=2)).isoformat(),
+            "due_at": None,
+            "resolved_at": None,
+            "resolution_note": None,
+            "created_at": (base_time + timedelta(minutes=2)).isoformat(),
+            "updated_at": (base_time + timedelta(minutes=2)).isoformat(),
+        }
+    ]
+    assert compiler_run.context_pack["open_loop_summary"] == {
+        "candidate_count": 2,
+        "included_count": 1,
+        "excluded_limit_count": 1,
+        "order": ["opened_at_desc", "created_at_desc", "id_desc"],
+    }
+    reasons = [event.payload["reason"] for event in compiler_run.trace_events if "reason" in event.payload]
+    assert "within_open_loop_limit" in reasons
+    assert "open_loop_limit_exceeded" in reasons

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -19,7 +19,12 @@ from alicebot_api.embedding import (
 )
 from alicebot_api.entity import EntityNotFoundError, EntityValidationError
 from alicebot_api.entity_edge import EntityEdgeValidationError
-from alicebot_api.memory import MemoryAdmissionValidationError, MemoryReviewNotFoundError
+from alicebot_api.memory import (
+    MemoryAdmissionValidationError,
+    MemoryReviewNotFoundError,
+    OpenLoopNotFoundError,
+    OpenLoopValidationError,
+)
 from alicebot_api.response_generation import ResponseFailure
 from alicebot_api.semantic_retrieval import (
     SemanticArtifactChunkRetrievalValidationError,
@@ -102,6 +107,9 @@ def test_healthcheck_route_is_registered() -> None:
     assert "/v0/context/compile" in route_paths
     assert "/v0/responses" in route_paths
     assert "/v0/memories/admit" in route_paths
+    assert "/v0/open-loops" in route_paths
+    assert "/v0/open-loops/{open_loop_id}" in route_paths
+    assert "/v0/open-loops/{open_loop_id}/status" in route_paths
     assert "/v0/consents" in route_paths
     assert "/v0/policies" in route_paths
     assert "/v0/policies/{policy_id}" in route_paths
@@ -1109,6 +1117,71 @@ def test_admit_memory_returns_decision_payload(monkeypatch) -> None:
     assert captured["candidate"].memory_key == "user.preference.coffee"
 
 
+def test_admit_memory_includes_open_loop_payload_when_created(monkeypatch) -> None:
+    user_id = uuid4()
+    settings = Settings(database_url="postgresql://app")
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def fake_user_connection(_database_url: str, _current_user_id):
+        yield object()
+
+    def fake_admit_memory_candidate(_store, *, user_id, candidate):
+        captured["user_id"] = user_id
+        captured["candidate"] = candidate
+        return AdmissionDecisionOutput(
+            action="NOOP",
+            reason="memory_unchanged",
+            memory=None,
+            revision=None,
+            open_loop={
+                "id": "loop-123",
+                "memory_id": "memory-123",
+                "title": "Confirm before reorder",
+                "status": "open",
+                "opened_at": "2026-03-23T10:00:00+00:00",
+                "due_at": "2026-03-25T10:00:00+00:00",
+                "resolved_at": None,
+                "resolution_note": None,
+                "created_at": "2026-03-23T10:00:00+00:00",
+                "updated_at": "2026-03-23T10:00:00+00:00",
+            },
+        )
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(main_module, "admit_memory_candidate", fake_admit_memory_candidate)
+
+    response = main_module.admit_memory(
+        main_module.AdmitMemoryRequest(
+            user_id=user_id,
+            memory_key="user.preference.coffee",
+            value={"likes": "oat milk"},
+            source_event_ids=[uuid4()],
+            open_loop=main_module.AdmitMemoryOpenLoopRequest(
+                title="Confirm before reorder",
+                due_at="2026-03-25T10:00:00+00:00",
+            ),
+        )
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.body)["open_loop"] == {
+        "id": "loop-123",
+        "memory_id": "memory-123",
+        "title": "Confirm before reorder",
+        "status": "open",
+        "opened_at": "2026-03-23T10:00:00+00:00",
+        "due_at": "2026-03-25T10:00:00+00:00",
+        "resolved_at": None,
+        "resolution_note": None,
+        "created_at": "2026-03-23T10:00:00+00:00",
+        "updated_at": "2026-03-23T10:00:00+00:00",
+    }
+    assert captured["candidate"].open_loop is not None
+    assert captured["candidate"].open_loop.title == "Confirm before reorder"
+
+
 def test_admit_memory_returns_bad_request_when_source_validation_fails(monkeypatch) -> None:
     @contextmanager
     def fake_user_connection(_database_url: str, _current_user_id):
@@ -1425,6 +1498,181 @@ def test_list_memories_returns_review_payload(monkeypatch) -> None:
     assert captured["user_id"] == user_id
     assert captured["status"] == "active"
     assert captured["limit"] == 10
+
+
+def test_open_loop_routes_return_payload_and_errors(monkeypatch) -> None:
+    user_id = uuid4()
+    open_loop_id = uuid4()
+    memory_id = uuid4()
+    settings = Settings(database_url="postgresql://app")
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def fake_user_connection(database_url: str, current_user_id):
+        captured["database_url"] = database_url
+        captured["current_user_id"] = current_user_id
+        yield object()
+
+    def fake_list_open_loop_records(store, *, user_id, status, limit):
+        captured["list_store_type"] = type(store).__name__
+        captured["list_user_id"] = user_id
+        captured["list_status"] = status
+        captured["list_limit"] = limit
+        return {
+            "items": [
+                {
+                    "id": str(open_loop_id),
+                    "memory_id": str(memory_id),
+                    "title": "Follow up",
+                    "status": "open",
+                    "opened_at": "2026-03-23T09:00:00+00:00",
+                    "due_at": None,
+                    "resolved_at": None,
+                    "resolution_note": None,
+                    "created_at": "2026-03-23T09:00:00+00:00",
+                    "updated_at": "2026-03-23T09:00:00+00:00",
+                }
+            ],
+            "summary": {
+                "status": "open",
+                "limit": 10,
+                "returned_count": 1,
+                "total_count": 1,
+                "has_more": False,
+                "order": ["opened_at_desc", "created_at_desc", "id_desc"],
+            },
+        }
+
+    def fake_get_open_loop_record(_store, *, user_id, open_loop_id):
+        captured["detail_user_id"] = user_id
+        captured["detail_open_loop_id"] = open_loop_id
+        return {
+            "open_loop": {
+                "id": str(open_loop_id),
+                "memory_id": str(memory_id),
+                "title": "Follow up",
+                "status": "open",
+                "opened_at": "2026-03-23T09:00:00+00:00",
+                "due_at": None,
+                "resolved_at": None,
+                "resolution_note": None,
+                "created_at": "2026-03-23T09:00:00+00:00",
+                "updated_at": "2026-03-23T09:00:00+00:00",
+            }
+        }
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(main_module, "list_open_loop_records", fake_list_open_loop_records)
+    monkeypatch.setattr(main_module, "get_open_loop_record", fake_get_open_loop_record)
+
+    list_response = main_module.list_open_loops(user_id=user_id, status="open", limit=10)
+    detail_response = main_module.get_open_loop(open_loop_id=open_loop_id, user_id=user_id)
+
+    assert list_response.status_code == 200
+    assert json.loads(list_response.body)["summary"]["status"] == "open"
+    assert detail_response.status_code == 200
+    assert json.loads(detail_response.body)["open_loop"]["id"] == str(open_loop_id)
+    assert captured["list_status"] == "open"
+    assert captured["list_limit"] == 10
+    assert captured["detail_open_loop_id"] == open_loop_id
+
+    monkeypatch.setattr(
+        main_module,
+        "get_open_loop_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OpenLoopNotFoundError("open loop hidden")),
+    )
+    not_found_response = main_module.get_open_loop(open_loop_id=open_loop_id, user_id=user_id)
+    assert not_found_response.status_code == 404
+    assert json.loads(not_found_response.body) == {"detail": "open loop hidden"}
+
+
+def test_open_loop_mutation_routes_handle_create_and_status_validation(monkeypatch) -> None:
+    user_id = uuid4()
+    open_loop_id = uuid4()
+    settings = Settings(database_url="postgresql://app")
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def fake_user_connection(database_url: str, current_user_id):
+        captured["database_url"] = database_url
+        captured["current_user_id"] = current_user_id
+        yield object()
+
+    def fake_create_open_loop_record(_store, *, user_id, open_loop):
+        captured["create_user_id"] = user_id
+        captured["create_open_loop"] = open_loop
+        return {
+            "open_loop": {
+                "id": str(open_loop_id),
+                "memory_id": None,
+                "title": open_loop.title,
+                "status": "open",
+                "opened_at": "2026-03-23T09:00:00+00:00",
+                "due_at": None,
+                "resolved_at": None,
+                "resolution_note": None,
+                "created_at": "2026-03-23T09:00:00+00:00",
+                "updated_at": "2026-03-23T09:00:00+00:00",
+            }
+        }
+
+    def fake_update_open_loop_status_record(_store, *, user_id, open_loop_id, request):
+        captured["status_user_id"] = user_id
+        captured["status_open_loop_id"] = open_loop_id
+        captured["status_request"] = request
+        return {
+            "open_loop": {
+                "id": str(open_loop_id),
+                "memory_id": None,
+                "title": "Follow up",
+                "status": "resolved",
+                "opened_at": "2026-03-23T09:00:00+00:00",
+                "due_at": None,
+                "resolved_at": "2026-03-24T09:00:00+00:00",
+                "resolution_note": "Resolved",
+                "created_at": "2026-03-23T09:00:00+00:00",
+                "updated_at": "2026-03-24T09:00:00+00:00",
+            }
+        }
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(main_module, "create_open_loop_record", fake_create_open_loop_record)
+    monkeypatch.setattr(main_module, "update_open_loop_status_record", fake_update_open_loop_status_record)
+
+    create_response = main_module.create_open_loop(
+        main_module.CreateOpenLoopRequest(
+            user_id=user_id,
+            title="Follow up",
+        )
+    )
+    status_response = main_module.update_open_loop_status(
+        open_loop_id=open_loop_id,
+        request=main_module.UpdateOpenLoopStatusRequest(
+            user_id=user_id,
+            status="resolved",
+            resolution_note="Resolved",
+        ),
+    )
+
+    assert create_response.status_code == 201
+    assert json.loads(create_response.body)["open_loop"]["title"] == "Follow up"
+    assert status_response.status_code == 200
+    assert json.loads(status_response.body)["open_loop"]["status"] == "resolved"
+    assert captured["status_request"].status == "resolved"
+
+    monkeypatch.setattr(
+        main_module,
+        "update_open_loop_status_record",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OpenLoopValidationError("status invalid")),
+    )
+    bad_status_response = main_module.update_open_loop_status(
+        open_loop_id=open_loop_id,
+        request=main_module.UpdateOpenLoopStatusRequest(user_id=user_id, status="invalid"),
+    )
+    assert bad_status_response.status_code == 400
+    assert json.loads(bad_status_response.body) == {"detail": "status invalid"}
 
 
 def test_get_memory_returns_not_found_when_memory_is_inaccessible(monkeypatch) -> None:

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -5,18 +5,29 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from alicebot_api.contracts import MemoryCandidateInput
+from alicebot_api.contracts import (
+    MemoryCandidateInput,
+    OpenLoopCandidateInput,
+    OpenLoopCreateInput,
+    OpenLoopStatusUpdateInput,
+)
 from alicebot_api.memory import (
     MemoryAdmissionValidationError,
     MemoryReviewNotFoundError,
+    OpenLoopNotFoundError,
+    OpenLoopValidationError,
     admit_memory_candidate,
+    create_open_loop_record,
     create_memory_review_label_record,
+    get_open_loop_record,
     get_memory_evaluation_summary,
     get_memory_review_record,
+    list_open_loop_records,
     list_memory_review_queue_records,
     list_memory_review_label_records,
     list_memory_review_records,
     list_memory_revision_review_records,
+    update_open_loop_status_record,
 )
 
 
@@ -26,6 +37,7 @@ class MemoryStoreStub:
         self.events: dict[UUID, dict[str, object]] = {}
         self.memory: dict[str, object] | None = None
         self.revisions: list[dict[str, object]] = []
+        self.open_loops: list[dict[str, object]] = []
 
     def list_events_by_ids(self, event_ids: list[UUID]) -> list[dict[str, object]]:
         return [self.events[event_id] for event_id in event_ids if event_id in self.events]
@@ -131,6 +143,33 @@ class MemoryStoreStub:
         }
         self.revisions.append(revision)
         return revision
+
+    def create_open_loop(
+        self,
+        *,
+        memory_id: UUID | None,
+        title: str,
+        status: str,
+        opened_at: datetime | None,
+        due_at: datetime | None,
+        resolved_at: datetime | None,
+        resolution_note: str | None,
+    ) -> dict[str, object]:
+        created = {
+            "id": uuid4(),
+            "user_id": self.memory["user_id"] if self.memory is not None else uuid4(),
+            "memory_id": memory_id,
+            "title": title,
+            "status": status,
+            "opened_at": self.base_time if opened_at is None else opened_at,
+            "due_at": due_at,
+            "resolved_at": resolved_at,
+            "resolution_note": resolution_note,
+            "created_at": self.base_time,
+            "updated_at": self.base_time,
+        }
+        self.open_loops.append(created)
+        return created
 
 
 def seed_event(store: MemoryStoreStub) -> UUID:
@@ -244,6 +283,32 @@ def test_admit_memory_candidate_adds_new_memory_with_first_revision() -> None:
     assert decision.revision["sequence_no"] == 1
     assert decision.revision["action"] == "ADD"
     assert decision.revision["new_value"] == {"likes": "oat milk"}
+
+
+def test_admit_memory_candidate_creates_open_loop_when_requested() -> None:
+    store = MemoryStoreStub()
+    event_id = seed_event(store)
+
+    decision = admit_memory_candidate(
+        store,  # type: ignore[arg-type]
+        user_id=uuid4(),
+        candidate=MemoryCandidateInput(
+            memory_key="user.preference.coffee",
+            value={"likes": "oat milk"},
+            source_event_ids=(event_id,),
+            open_loop=OpenLoopCandidateInput(
+                title="Confirm this preference before next reorder",
+                due_at=datetime(2026, 3, 20, 9, 0, tzinfo=UTC),
+            ),
+        ),
+    )
+
+    assert decision.action == "ADD"
+    assert decision.open_loop is not None
+    assert decision.open_loop["memory_id"] == decision.memory["id"]
+    assert decision.open_loop["title"] == "Confirm this preference before next reorder"
+    assert decision.open_loop["status"] == "open"
+    assert decision.open_loop["due_at"] == "2026-03-20T09:00:00+00:00"
 
 
 def test_admit_memory_candidate_updates_existing_memory_and_appends_revision() -> None:
@@ -416,6 +481,201 @@ class MemoryReviewStoreStub:
             memories,
             key=lambda memory: (memory["updated_at"], memory["created_at"], memory["id"]),
             reverse=True,
+        )
+
+
+class OpenLoopStoreStub:
+    def __init__(self) -> None:
+        self.base_time = datetime(2026, 3, 23, 12, 0, tzinfo=UTC)
+        self.memories: dict[UUID, dict[str, object]] = {}
+        self.open_loops: dict[UUID, dict[str, object]] = {}
+
+    def get_memory_optional(self, memory_id: UUID) -> dict[str, object] | None:
+        return self.memories.get(memory_id)
+
+    def count_open_loops(self, *, status: str | None = None) -> int:
+        if status is None:
+            return len(self.open_loops)
+        return len([item for item in self.open_loops.values() if item["status"] == status])
+
+    def list_open_loops(self, *, status: str | None = None, limit: int | None = None) -> list[dict[str, object]]:
+        items = list(self.open_loops.values())
+        if status is not None:
+            items = [item for item in items if item["status"] == status]
+        ordered = sorted(
+            items,
+            key=lambda item: (item["opened_at"], item["created_at"], item["id"]),
+            reverse=True,
+        )
+        if limit is None:
+            return ordered
+        return ordered[:limit]
+
+    def create_open_loop(
+        self,
+        *,
+        memory_id: UUID | None,
+        title: str,
+        status: str,
+        opened_at: datetime | None,
+        due_at: datetime | None,
+        resolved_at: datetime | None,
+        resolution_note: str | None,
+    ) -> dict[str, object]:
+        open_loop_id = uuid4()
+        loop = {
+            "id": open_loop_id,
+            "user_id": uuid4(),
+            "memory_id": memory_id,
+            "title": title,
+            "status": status,
+            "opened_at": self.base_time if opened_at is None else opened_at,
+            "due_at": due_at,
+            "resolved_at": resolved_at,
+            "resolution_note": resolution_note,
+            "created_at": self.base_time,
+            "updated_at": self.base_time,
+        }
+        self.open_loops[open_loop_id] = loop
+        return loop
+
+    def get_open_loop_optional(self, open_loop_id: UUID) -> dict[str, object] | None:
+        return self.open_loops.get(open_loop_id)
+
+    def update_open_loop_status_optional(
+        self,
+        *,
+        open_loop_id: UUID,
+        status: str,
+        resolved_at: datetime | None,
+        resolution_note: str | None,
+    ) -> dict[str, object] | None:
+        existing = self.open_loops.get(open_loop_id)
+        if existing is None:
+            return None
+        updated = {
+            **existing,
+            "status": status,
+            "resolved_at": self.base_time + timedelta(minutes=5) if resolved_at is None else resolved_at,
+            "resolution_note": resolution_note,
+            "updated_at": self.base_time + timedelta(minutes=5),
+        }
+        self.open_loops[open_loop_id] = updated
+        return updated
+
+
+def test_open_loop_records_support_create_list_get_and_status_transition() -> None:
+    store = OpenLoopStoreStub()
+    memory_id = uuid4()
+    store.memories[memory_id] = {"id": memory_id}
+
+    created = create_open_loop_record(
+        store,  # type: ignore[arg-type]
+        user_id=uuid4(),
+        open_loop=OpenLoopCreateInput(
+            memory_id=memory_id,
+            title="Follow up with merchant confirmation",
+            due_at=datetime(2026, 3, 27, 10, 0, tzinfo=UTC),
+        ),
+    )
+    open_loop_id = UUID(created["open_loop"]["id"])
+
+    listed = list_open_loop_records(
+        store,  # type: ignore[arg-type]
+        user_id=uuid4(),
+        status="open",
+        limit=10,
+    )
+    detail = get_open_loop_record(
+        store,  # type: ignore[arg-type]
+        user_id=uuid4(),
+        open_loop_id=open_loop_id,
+    )
+    updated = update_open_loop_status_record(
+        store,  # type: ignore[arg-type]
+        user_id=uuid4(),
+        open_loop_id=open_loop_id,
+        request=OpenLoopStatusUpdateInput(
+            status="resolved",
+            resolution_note="Resolved in latest review pass.",
+        ),
+    )
+
+    assert created["open_loop"]["status"] == "open"
+    assert listed["summary"] == {
+        "status": "open",
+        "limit": 10,
+        "returned_count": 1,
+        "total_count": 1,
+        "has_more": False,
+        "order": ["opened_at_desc", "created_at_desc", "id_desc"],
+    }
+    assert detail["open_loop"]["id"] == str(open_loop_id)
+    assert updated["open_loop"]["status"] == "resolved"
+    assert updated["open_loop"]["resolution_note"] == "Resolved in latest review pass."
+    assert updated["open_loop"]["resolved_at"] is not None
+
+
+def test_open_loop_records_support_dismissed_transition_with_audit_fields() -> None:
+    store = OpenLoopStoreStub()
+    memory_id = uuid4()
+    store.memories[memory_id] = {"id": memory_id}
+
+    created = create_open_loop_record(
+        store,  # type: ignore[arg-type]
+        user_id=uuid4(),
+        open_loop=OpenLoopCreateInput(
+            memory_id=memory_id,
+            title="Dismiss after confirming no further action is needed",
+            due_at=None,
+        ),
+    )
+
+    dismissed = update_open_loop_status_record(
+        store,  # type: ignore[arg-type]
+        user_id=uuid4(),
+        open_loop_id=UUID(created["open_loop"]["id"]),
+        request=OpenLoopStatusUpdateInput(
+            status="dismissed",
+            resolution_note="No action required after review.",
+        ),
+    )
+
+    assert dismissed["open_loop"]["status"] == "dismissed"
+    assert dismissed["open_loop"]["resolved_at"] is not None
+    assert dismissed["open_loop"]["resolution_note"] == "No action required after review."
+
+
+def test_open_loop_status_update_rejects_invalid_status_and_missing_records() -> None:
+    store = OpenLoopStoreStub()
+    loop_id = uuid4()
+    store.open_loops[loop_id] = {
+        "id": loop_id,
+        "user_id": uuid4(),
+        "memory_id": None,
+        "title": "Investigate",
+        "status": "open",
+        "opened_at": store.base_time,
+        "due_at": None,
+        "resolved_at": None,
+        "resolution_note": None,
+        "created_at": store.base_time,
+        "updated_at": store.base_time,
+    }
+
+    with pytest.raises(OpenLoopValidationError, match="status must be one of"):
+        update_open_loop_status_record(
+            store,  # type: ignore[arg-type]
+            user_id=uuid4(),
+            open_loop_id=loop_id,
+            request=OpenLoopStatusUpdateInput(status="invalid"),  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(OpenLoopNotFoundError, match="was not found"):
+        get_open_loop_record(
+            store,  # type: ignore[arg-type]
+            user_id=uuid4(),
+            open_loop_id=uuid4(),
         )
 
 

--- a/tests/unit/test_memory_store.py
+++ b/tests/unit/test_memory_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
@@ -417,3 +418,260 @@ def test_memory_review_label_methods_use_append_only_queries_and_deterministic_o
             (memory_id,),
         ),
     ]
+
+
+def test_open_loop_methods_use_expected_queries_and_lifecycle_serialization() -> None:
+    memory_id = uuid4()
+    open_loop_id = uuid4()
+    opened_at = datetime(2026, 3, 23, 11, 0, tzinfo=UTC)
+    due_at = datetime(2026, 3, 25, 9, 0, tzinfo=UTC)
+    resolved_at = datetime(2026, 3, 24, 9, 0, tzinfo=UTC)
+    cursor = RecordingCursor(
+        fetchone_results=[
+            {
+                "id": open_loop_id,
+                "user_id": uuid4(),
+                "memory_id": memory_id,
+                "title": "Confirm magnesium reorder",
+                "status": "open",
+                "opened_at": opened_at,
+                "due_at": due_at,
+                "resolved_at": None,
+                "resolution_note": None,
+                "created_at": opened_at,
+                "updated_at": opened_at,
+            },
+            {
+                "id": open_loop_id,
+                "user_id": uuid4(),
+                "memory_id": memory_id,
+                "title": "Confirm magnesium reorder",
+                "status": "open",
+                "opened_at": opened_at,
+                "due_at": due_at,
+                "resolved_at": None,
+                "resolution_note": None,
+                "created_at": opened_at,
+                "updated_at": opened_at,
+            },
+            {"count": 1},
+            {"count": 1},
+            {
+                "id": open_loop_id,
+                "user_id": uuid4(),
+                "memory_id": memory_id,
+                "title": "Confirm magnesium reorder",
+                "status": "resolved",
+                "opened_at": opened_at,
+                "due_at": due_at,
+                "resolved_at": resolved_at,
+                "resolution_note": "Resolved after order confirmation.",
+                "created_at": opened_at,
+                "updated_at": resolved_at,
+            },
+        ],
+        fetchall_results=[
+            [
+                {
+                    "id": open_loop_id,
+                    "memory_id": memory_id,
+                    "status": "open",
+                    "opened_at": opened_at,
+                }
+            ],
+            [
+                {
+                    "id": open_loop_id,
+                    "memory_id": memory_id,
+                    "status": "open",
+                    "opened_at": opened_at,
+                }
+            ],
+        ],
+    )
+    store = ContinuityStore(RecordingConnection(cursor))
+
+    created = store.create_open_loop(
+        memory_id=memory_id,
+        title="Confirm magnesium reorder",
+        status="open",
+        opened_at=None,
+        due_at=due_at,
+        resolved_at=None,
+        resolution_note=None,
+    )
+    detail = store.get_open_loop_optional(open_loop_id)
+    listed_all = store.list_open_loops(limit=5)
+    listed_open = store.list_open_loops(status="open", limit=3)
+    count_all = store.count_open_loops()
+    count_open = store.count_open_loops(status="open")
+    updated = store.update_open_loop_status_optional(
+        open_loop_id=open_loop_id,
+        status="resolved",
+        resolved_at=None,
+        resolution_note="Resolved after order confirmation.",
+    )
+
+    assert created["id"] == open_loop_id
+    assert detail is not None
+    assert detail["status"] == "open"
+    assert listed_all[0]["id"] == open_loop_id
+    assert listed_open[0]["status"] == "open"
+    assert count_all == 1
+    assert count_open == 1
+    assert updated is not None
+    assert updated["status"] == "resolved"
+    assert updated["resolved_at"] == resolved_at
+
+    assert cursor.executed[0] == (
+        """
+                INSERT INTO open_loops (
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  COALESCE(%s, clock_timestamp()),
+                  %s,
+                  %s,
+                  %s,
+                  clock_timestamp(),
+                  clock_timestamp()
+                )
+                RETURNING
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                """,
+        (memory_id, "Confirm magnesium reorder", "open", None, due_at, None, None),
+    )
+    assert cursor.executed[1] == (
+        """
+                SELECT
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                FROM open_loops
+                WHERE id = %s
+                """,
+        (open_loop_id,),
+    )
+    assert cursor.executed[2] == (
+        """
+                SELECT
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                FROM open_loops
+                ORDER BY opened_at DESC, created_at DESC, id DESC
+                LIMIT %s
+                """,
+        (5,),
+    )
+    assert cursor.executed[3] == (
+        """
+                SELECT
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                FROM open_loops
+                WHERE status = %s
+                ORDER BY opened_at DESC, created_at DESC, id DESC
+                LIMIT %s
+                """,
+        ("open", 3),
+    )
+    assert cursor.executed[4] == (
+        """
+                SELECT COUNT(*) AS count
+                FROM open_loops
+                """,
+        None,
+    )
+    assert cursor.executed[5] == (
+        """
+                SELECT COUNT(*) AS count
+                FROM open_loops
+                WHERE status = %s
+                """,
+        ("open",),
+    )
+    assert cursor.executed[6] == (
+        """
+                UPDATE open_loops
+                SET status = %s,
+                    resolved_at = CASE
+                      WHEN %s = 'open' THEN NULL
+                      ELSE COALESCE(%s, clock_timestamp())
+                    END,
+                    resolution_note = CASE
+                      WHEN %s = 'open' THEN NULL
+                      ELSE %s
+                    END,
+                    updated_at = clock_timestamp()
+                WHERE id = %s
+                RETURNING
+                  id,
+                  user_id,
+                  memory_id,
+                  title,
+                  status,
+                  opened_at,
+                  due_at,
+                  resolved_at,
+                  resolution_note,
+                  created_at,
+                  updated_at
+                """,
+        (
+            "resolved",
+            "resolved",
+            None,
+            "resolved",
+            "Resolved after order confirmation.",
+            open_loop_id,
+        ),
+    )


### PR DESCRIPTION
## Sprint
Phase 2 Sprint 3: Capture Classification And Open-Loop Backbone

## What This PR Ships
This sprint introduces a first-class open-loop backbone over the typed-memory substrate. It wires open-loop lifecycle support through schema, store, API/contracts, compiler context serialization, and `/memories` review UI.

### Implemented Surface
- New migration `20260323_0031_open_loop_backbone` with `open_loops` table, lifecycle checks, indexes, RLS, and app-role grants.
- Store layer support for open-loop create/list/detail/count/status update with strict per-user scoping.
- Contracts and API endpoints:
  - `GET /v0/open-loops`
  - `GET /v0/open-loops/{open_loop_id}`
  - `POST /v0/open-loops`
  - `POST /v0/open-loops/{open_loop_id}/status`
- Memory admission now accepts optional `open_loop` payload and can create/open-loop metadata during admit flow.
- Compiler context pack now includes deterministic, bounded open-loop data and summary when present.
- `/memories` now renders open-loop summary/list/detail with safe live-vs-fixture fallback behavior.
- Sprint reports updated for this sprint (`BUILD_REPORT.md`, `REVIEW_REPORT.md`, active sprint packet).

## Scope Guardrails Confirmed
- Stayed inside Sprint 3 open-loop backbone seams.
- No automation, worker orchestration, resumption synthesis, or Phase 3 runtime/profile work was introduced.
- No hidden backend/runtime scope expansion outside sprint intent.

## Verification Evidence
Executed in this workspace for this branch:

1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_20260323_0031_open_loop_backbone.py tests/unit/test_memory_store.py tests/unit/test_memory.py tests/unit/test_compiler.py tests/unit/test_main.py`
- Result: `79 passed`

2. `cd apps/web && pnpm test -- lib/api.test.ts app/memories/page.test.tsx`
- Result: `24 passed`

3. `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_open_loops_api.py tests/integration/test_migrations.py`
- Result: `11 passed`
- Note: integration tests require local Postgres access; run completed successfully outside sandbox networking restrictions.

## Review State
- `REVIEW_REPORT.md` verdict: `PASS`
- Acceptance criteria missed: `None`
- Reported quality note is non-blocking: current open-loop compile limit is coupled to `max_memories` and can be decoupled later.

## Merge Readiness
Requesting Control Tower merge approval for squash merge once review is accepted.
