### PR TITLE
Phase 2 Sprint 4: deterministic resumption briefs

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 2 Sprint 3: Capture Classification And Open-Loop Backbone
+Phase 2 Sprint 4: Deterministic Resumption Briefs
 
 ## Sprint Type
 
@@ -10,161 +10,148 @@ feature
 
 ## Sprint Reason
 
-Phase 2 Sprint 2 typed memory backbone is merged. The next dependency is a first-class open-loop domain so unresolved commitments can be captured, reviewed, and resolved deterministically instead of inferred ad hoc from raw memory entries.
+Phase 2 Sprint 3 open-loop backbone is merged. The next continuity-first seam is deterministic resumption support so operators can re-enter a thread with a compact, auditable brief instead of manually reconstructing context from raw events, memories, and open loops.
 
 ## Sprint Intent
 
-Implement a narrow open-loop backbone (schema, store, contracts/API, compiler inclusion, and `/memories` review adoption) using the shipped typed-memory substrate, without introducing automation or worker orchestration.
+Implement a bounded resumption-brief read seam (contracts, API, compiler-backed assembly, and `/chat` display adoption) without introducing automation, autonomous follow-up behavior, or worker orchestration.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase2-sprint3-open-loop-backbone`
+- Branch Name: `codex/phase2-sprint4-resumption-briefs`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- Typed memory is now available; unresolved intent still has no dedicated lifecycle seam.
-- Open loops are required before continuity-first resumption can be accurate.
-- This keeps scope narrow while creating a reusable seam for later vertical agents.
+- Typed memories and open loops are now shipped and stable.
+- `/chat` still requires manual reconstruction to resume a thread efficiently.
+- A deterministic brief seam is required before any future automation or vertical-agent specialization.
 
 ## Design Truth
 
-- Reuse current memory and continuity seams; do not create a parallel capture stack.
-- Keep open-loop lifecycle deterministic and auditable.
-- Preserve append-only revision guarantees and per-user isolation.
+- Reuse existing continuity, memory, and open-loop seams; do not create a parallel context pipeline.
+- Build brief generation as deterministic assembly from durable records, not free-form model synthesis.
+- Preserve per-user isolation and existing append-only audit guarantees.
 
 ## Exact Surfaces In Scope
 
-- open-loop schema + persistence
-- open-loop contracts + API behavior
-- compiler context-pack open-loop serialization
-- `/memories` open-loop review adoption
+- resumption-brief contracts + API behavior
+- compiler-backed deterministic brief assembly
+- `/chat` brief visibility for selected thread
 - sprint-scoped backend and frontend tests
 
 ## Exact Files In Scope
 
-- [store.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/store.py)
 - [contracts.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/contracts.py)
-- [memory.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/memory.py)
 - [main.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/main.py)
 - [compiler.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/compiler.py)
 - [api.ts](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/lib/api.ts)
-- [page.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/app/memories/page.tsx)
+- [page.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/app/chat/page.tsx)
+- [thread-summary.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-summary.tsx)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
 - [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
-- relevant migration + tests under:
-  - `apps/api/alembic/versions/`
+- relevant tests under:
   - `tests/unit/`
   - `tests/integration/`
   - `apps/web/**/*.test.tsx`
 
 ## In Scope
 
-- Add an `open_loops` table with deterministic lifecycle fields:
-  - `id`, `user_id`, `memory_id`, `title`, `status`, `opened_at`, `due_at`, `resolved_at`, `resolution_note`, `created_at`, `updated_at`
-- Add lifecycle domain validation for `status` (`open`, `resolved`, `dismissed`).
-- Add store methods for create/list/detail/update-status with strict user scoping.
-- Add API endpoints:
-  - `GET /v0/open-loops`
-  - `GET /v0/open-loops/{open_loop_id}`
-  - `POST /v0/open-loops`
-  - `POST /v0/open-loops/{open_loop_id}/status`
-- Extend memory admission flow to allow optional open-loop creation when memory candidate includes `open_loop` payload.
-- Include top open loops in compiled context payload with deterministic ordering and bounded limits.
-- Show open-loop summary/list and selected detail in `/memories` with safe live/fixture fallbacks.
-- Add/update tests across migration, store, API, compiler, and UI seams.
+- Add resumption-brief contracts (request/response schema) with explicit, typed fields.
+- Add API endpoint:
+  - `GET /v0/threads/{thread_id}/resumption-brief`
+- Assemble brief deterministically from existing durable seams:
+  - selected thread metadata
+  - latest conversation events
+  - active open loops
+  - bounded memory highlights
+  - latest workflow/task-step posture when present
+- Include deterministic ordering and bounded limits for each brief section.
+- Expose brief in `/chat` selected-thread summary panel with live/fixture/unavailable behavior parity.
+- Add/update tests across API, compiler/assembly logic, and `/chat` UI seams.
 
 ## Out of Scope
 
+- new database tables or migration work
 - autonomous follow-up execution or reminders
-- resumption brief synthesis
 - background workers or scheduler integration
 - connector expansion
 - multi-agent runtime/profile routing (Phase 3)
-- broad UI redesign outside `/memories`
+- broad UI redesign outside `/chat`
 
 ## Required Deliverables
 
-- migration-backed open-loop domain
-- backend store/contracts/API support for open-loop lifecycle
-- compiler serialization for open-loop context slice
-- `/memories` open-loop review surface (summary + detail)
+- backend contracts/API for deterministic resumption brief read
+- compiler or dedicated assembly helper for deterministic brief construction
+- `/chat` resumption-brief display for selected thread
 - updated sprint reports for this sprint only
 
 ## Acceptance Criteria
 
-- open loops persist and return from list/detail APIs with strict per-user isolation
-- invalid open-loop status values are rejected deterministically (`400`)
-- status transitions (`open` -> `resolved`/`dismissed`) persist audit fields correctly
-- memory admission can create an open loop when requested, without regressing existing admissions
-- compiled context includes open loops deterministically when present
-- `/memories` renders open-loop summary and selected details without regression
+- endpoint returns deterministic brief payload for a selected thread with strict per-user isolation
+- missing/cross-user thread behavior is deterministic (`404`)
+- brief sections use bounded limits and stable ordering
+- brief reflects active open loops and recent continuity evidence when present
+- `/chat` renders brief content with live/fixture/unavailable states and no regression to existing chat workflow surfaces
 - backend + frontend tests pass for touched seams
-- no out-of-scope automation or orchestration work enters sprint
+- no out-of-scope automation, worker, or Phase 3 routing work enters sprint
 
 ## Implementation Constraints
 
 - preserve RLS and per-user isolation
 - keep deterministic ordering in API and compiler outputs
-- keep backward-safe defaults for memory admission without open-loop payload
+- keep brief generation model-free and source-attributed to durable seams
 - co-deliver tests with each seam change
 
 ## Control Tower Task Cards
 
-### Task 1: Schema + Store
+### Task 1: Contracts + API
 Owner: backend operative A  
 Write scope:
-- migration file(s)
-- `apps/api/src/alicebot_api/store.py`
-- store/migration tests
-
-### Task 2: Contracts + API
-Owner: backend operative B  
-Write scope:
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/memory.py`
 - `apps/api/src/alicebot_api/main.py`
 - API/integration tests
 
-### Task 3: Compiler Integration
-Owner: backend operative C  
+### Task 2: Deterministic Brief Assembly
+Owner: backend operative B  
 Write scope:
 - `apps/api/src/alicebot_api/compiler.py`
 - compiler tests
 
-### Task 4: Memory UI Adoption
+### Task 3: Chat UI Adoption
 Owner: frontend operative  
 Write scope:
 - `apps/web/lib/api.ts`
-- `apps/web/app/memories/page.tsx`
-- related memory components/tests
+- `apps/web/app/chat/page.tsx`
+- `apps/web/components/thread-summary.tsx`
+- related chat components/tests
 
-### Task 5: Integration Review
+### Task 4: Integration Review
 Owner: control tower  
 Responsibilities:
-- verify schema/store/contracts/compiler/UI coherence
+- verify contracts/API/assembly/UI coherence
 - verify strict sprint scope
 - verify acceptance + evidence completeness
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact open-loop fields and endpoints shipped
-- migration id(s) and API surface deltas
+- exact resumption-brief fields and endpoint shipped
+- API surface deltas and deterministic ordering rules
 - exact commands/tests run with outcomes
-- explicit deferred scope (resumption/workers/automation/Phase 3 runtime)
+- explicit deferred scope (automation/workers/Phase 3 runtime orchestration)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint remained open-loop-backbone scoped
-- schema/store/contracts/compiler/UI consistency
+- sprint remained deterministic-resumption-brief scoped
+- contracts/API/assembly/UI consistency
 - sufficient tests for all touched seams
 - no hidden scope expansion
 
 ## Exit Condition
 
-This sprint is complete when open loops are fully wired through persistence, API, compiler, and `/memories` review with deterministic, test-backed behavior and no automation/worker/Phase 3 scope expansion.
+This sprint is complete when deterministic resumption briefs are exposed through a user-scoped API seam and surfaced in `/chat` selected-thread review with test-backed behavior and no automation/worker/Phase 3 scope expansion.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,97 +1,99 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Phase 2 Sprint 3 open-loop backbone end-to-end (schema, store, contracts/API, compiler serialization, and `/memories` review adoption) without adding automation, worker orchestration, resumption synthesis, or Phase 3 runtime behavior.
+Implement Phase 2 Sprint 4 deterministic resumption briefs (typed contracts, user-scoped API, compiler-backed deterministic assembly, and `/chat` selected-thread display adoption) without adding automation, worker orchestration, or Phase 3 runtime/profile routing.
 
 ## Completed Work
-- Shipped migration-backed `open_loops` domain with deterministic lifecycle fields:
-  - `id`
-  - `user_id`
-  - `memory_id`
-  - `title`
-  - `status`
-  - `opened_at`
-  - `due_at`
-  - `resolved_at`
-  - `resolution_note`
-  - `created_at`
-  - `updated_at`
-- Added open-loop status validation for `open`, `resolved`, and `dismissed`.
-- Added store methods for open-loop create/list/detail/count/update-status with strict `user_id` scoping.
-- Added API surface:
-  - `GET /v0/open-loops`
-  - `GET /v0/open-loops/{open_loop_id}`
-  - `POST /v0/open-loops`
-  - `POST /v0/open-loops/{open_loop_id}/status`
-- Extended memory admission to accept optional `open_loop` payload and create an open loop during admission without regressing existing admission paths.
-- Extended compiled context payload to include bounded, deterministic open-loop slice and open-loop summary when open loops exist.
-- Updated `/memories` to show open-loop summary/list and selected detail with live + fixture-safe fallback behavior.
-- Added/updated sprint-scoped migration, unit, integration, and web tests for the touched seams.
-- Added explicit test coverage for:
-  - successful `open -> dismissed` transition audit fields
-  - cross-user `404` denial on open-loop detail/status mutation
-- Updated `ARCHITECTURE.md` to document the shipped open-loop domain/API/compiler and `/memories` adoption.
-- Fixed route model typing bug in open-loop status filter (`OpenLoopStatusFilter`) so FastAPI route registration remains valid.
+- Shipped typed resumption-brief contracts and bounds in `apps/api/src/alicebot_api/contracts.py`.
+- Shipped `GET /v0/threads/{thread_id}/resumption-brief` in `apps/api/src/alicebot_api/main.py`.
+- Added bounded query inputs:
+  - `user_id` (required)
+  - `max_events` (default `8`, max `50`)
+  - `max_open_loops` (default `5`, max `20`)
+  - `max_memories` (default `5`, max `20`)
+- Added compiler-backed deterministic brief assembly in `apps/api/src/alicebot_api/compiler.py` via `compile_resumption_brief(...)`.
+- Brief assembly is sourced from existing durable seams only:
+  - selected thread metadata
+  - latest conversation events (`message.user`, `message.assistant`)
+  - active open loops (`status="open"`)
+  - active memory highlights
+  - latest task + latest task-step posture for the selected thread when present
+- Added `/chat` adoption:
+  - `apps/web/lib/api.ts`: typed client + `getThreadResumptionBrief(...)`
+  - `apps/web/app/chat/page.tsx`: live/fixture/unavailable brief loading
+  - `apps/web/components/thread-summary.tsx`: brief section rendering in selected-thread panel
+- Added/updated sprint-scoped backend/frontend tests for contracts/API/assembly/UI seams.
+
+## Exact Resumption-Brief Fields Shipped
+- Top-level `brief` payload:
+  - `assembly_version`
+  - `thread`
+  - `conversation`
+    - `items`
+    - `summary`: `limit`, `returned_count`, `total_count`, `order`, `kinds`
+  - `open_loops`
+    - `items`
+    - `summary`: `limit`, `returned_count`, `total_count`, `order`
+  - `memory_highlights`
+    - `items`
+    - `summary`: `limit`, `returned_count`, `total_count`, `order`
+  - `workflow` (`null` when absent)
+    - `task`
+    - `latest_task_step`
+    - `summary`: `present`, `task_order`, `task_step_order`
+  - `sources`
+
+## API Surface Deltas And Deterministic Ordering Rules
+- New endpoint:
+  - `GET /v0/threads/{thread_id}/resumption-brief`
+- Deterministic not-found behavior:
+  - missing thread and cross-user thread both return `404` with thread-specific detail.
+- Deterministic ordering and bounded windows:
+  - conversation candidates ordered by `sequence_no_asc`, then bounded to latest window (`max_events`).
+  - open loops ordered by `opened_at_desc`, `created_at_desc`, `id_desc`, then bounded by `max_open_loops`.
+  - memory highlights ordered by `updated_at_asc`, `created_at_asc`, `id_asc`, then bounded to latest window (`max_memories`).
+  - workflow posture uses latest task by `created_at_asc`, `id_asc` and latest task-step by `sequence_no_asc`, `created_at_asc`, `id_asc`.
 
 ## Incomplete Work
 - None within sprint scope.
 
-## Migration IDs And API Surface Deltas
-- Migration added:
-  - `20260323_0031_open_loop_backbone`
-- Schema delta:
-  - New `open_loops` table and indexes:
-    - `open_loops_user_status_opened_idx`
-    - `open_loops_user_memory_idx`
-  - Enforced status domain + lifecycle consistency checks.
-  - RLS enabled/forced with owner policy.
-  - Granted `SELECT, INSERT, UPDATE` on `open_loops` to `alicebot_app`.
-- API deltas:
-  - New open-loop list/detail/create/status-update endpoints listed above.
-  - `POST /v0/memories/admit` now accepts optional `open_loop` payload and may return created open-loop details.
-  - `POST /v0/context/compile` context pack may include `open_loops` and `open_loop_summary` when candidate open loops exist.
-
 ## Files Changed
-- `apps/api/alembic/versions/20260323_0031_open_loop_backbone.py`
-- `apps/api/src/alicebot_api/store.py`
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/memory.py`
 - `apps/api/src/alicebot_api/main.py`
 - `apps/api/src/alicebot_api/compiler.py`
-- `ARCHITECTURE.md`
 - `apps/web/lib/api.ts`
-- `apps/web/lib/api.test.ts`
-- `apps/web/app/memories/page.tsx`
-- `apps/web/app/memories/page.test.tsx`
-- `tests/unit/test_20260323_0031_open_loop_backbone.py`
-- `tests/unit/test_memory_store.py`
-- `tests/unit/test_memory.py`
+- `apps/web/app/chat/page.tsx`
+- `apps/web/components/thread-summary.tsx`
 - `tests/unit/test_compiler.py`
 - `tests/unit/test_main.py`
-- `tests/integration/test_open_loops_api.py`
+- `tests/integration/test_continuity_api.py`
+- `apps/web/lib/api.test.ts`
+- `apps/web/components/thread-summary.test.tsx`
+- `apps/web/app/chat/page.test.tsx`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 ## Tests Run
-1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_20260323_0031_open_loop_backbone.py tests/unit/test_memory_store.py tests/unit/test_memory.py tests/unit/test_compiler.py tests/unit/test_main.py`
-- Outcome: `79 passed`
+1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_compiler.py tests/unit/test_main.py`
+- Outcome: `53 passed`
 
-2. `cd apps/web && pnpm test -- lib/api.test.ts app/memories/page.test.tsx`
-- Outcome: `24 passed`
+2. `cd apps/web && pnpm test -- app/chat/page.test.tsx components/thread-summary.test.tsx lib/api.test.ts`
+- Outcome: `28 passed`
 
-3. `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_open_loops_api.py tests/integration/test_migrations.py`
-- Outcome: `11 passed`
-- Note: executed with escalated permissions to allow local Postgres connectivity from this environment.
+3. `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_continuity_api.py`
+- Outcome: `3 passed`
+- Note: executed with escalated permissions to allow local Postgres access from this environment.
 
 ## Blockers/Issues
 - No unresolved blockers.
-- Environment-specific constraint encountered: DB-backed integration tests required running outside sandbox network restrictions.
+- Environment constraint: DB-backed integration tests require execution outside default sandbox network restrictions.
 
 ## Explicit Deferred Scope
-- Resumption brief synthesis
-- Background workers/scheduler automation
-- Autonomous follow-up execution/reminder orchestration
+- autonomous follow-up behavior/reminders
+- background worker or scheduler integration
+- automation orchestration
 - Phase 3 multi-agent runtime/profile routing
+- database migrations/new tables outside sprint scope
 
 ## Recommended Next Step
-Proceed to sprint review with this open-loop backbone diff and test evidence, then merge once Control Tower approves scope and acceptance criteria.
+Proceed to Control Tower integration review for Sprint 4, focusing on deterministic brief payload coherence across contracts/API/compiler/UI and merge after reviewer `PASS` + explicit merge approval.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,39 +4,45 @@
 PASS
 
 ## criteria met
-- Sprint remained scoped to open-loop backbone seams (schema/store/contracts/API/compiler/`/memories`) with no worker, automation, or Phase 3 runtime expansion.
-- Migration `20260323_0031` adds `open_loops` lifecycle fields, constraints, indexes, RLS, and app-role grants.
-- Store/contracts/API seams for list/detail/create/status are implemented and user-scoped.
-- Memory admission accepts optional `open_loop` payload and can emit created open-loop data in admit responses.
-- Compiler context pack includes deterministic open-loop ordering and summary when open loops exist.
-- `/memories` renders open-loop summary/list/detail with live/fixture fallback behavior.
-- Added explicit transition and adversarial isolation evidence:
-- Successful `open -> dismissed` transition with audit-field assertions (`resolved_at`, `resolution_note`) is now covered.
-- Cross-user denial coverage now asserts `404` for `GET /v0/open-loops/{id}` and `POST /v0/open-loops/{id}/status`.
-- `ARCHITECTURE.md` now includes the shipped open-loop domain/API/compiler/`/memories` slice.
-- Relevant tests executed and passing in this review:
-- `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_20260323_0031_open_loop_backbone.py tests/unit/test_memory_store.py tests/unit/test_memory.py tests/unit/test_compiler.py tests/unit/test_main.py` -> `79 passed`
-- `cd apps/web && pnpm test -- lib/api.test.ts app/memories/page.test.tsx` -> `24 passed`
-- `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_open_loops_api.py tests/integration/test_migrations.py` -> `11 passed` (run outside sandbox networking for local Postgres access)
+- Sprint stayed within the Sprint 4 scope: contracts/API/compiler/UI for deterministic resumption briefs only.
+- Shipped endpoint and contract seam are coherent and typed:
+  - `GET /v0/threads/{thread_id}/resumption-brief`
+  - payload includes `assembly_version`, `thread`, `conversation`, `open_loops`, `memory_highlights`, `workflow`, `sources`
+- Per-user isolation and deterministic not-found behavior are implemented:
+  - thread lookup is user-scoped
+  - cross-user and missing thread requests return deterministic `404`
+- Deterministic ordering and bounded sections are explicit in implementation and reflected in summaries:
+  - conversation order: `sequence_no_asc` with bounded latest window
+  - open-loop order: `opened_at_desc`, `created_at_desc`, `id_desc`
+  - memory order: `updated_at_asc`, `created_at_asc`, `id_asc` with bounded latest window
+  - workflow posture selection uses stable task/task-step ordering
+- `/chat` selected-thread panel now supports resumption brief live/fixture/unavailable states without removing existing chat workflow surfaces.
+- Verified tests:
+  - `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_compiler.py tests/unit/test_main.py` -> `53 passed`
+  - `cd apps/web && pnpm test -- app/chat/page.test.tsx components/thread-summary.test.tsx lib/api.test.ts` -> `28 passed`
+  - `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_continuity_api.py` -> `3 passed` (required elevated local DB access in this environment)
 
 ## criteria missed
 - None.
 
 ## quality issues
-- Open-loop compile limit is currently coupled to `max_memories` (`apps/api/src/alicebot_api/compiler.py`). This is acceptable for sprint scope but should be decoupled in a later sprint.
+- No blocking quality issues found in sprint scope.
+- Minor non-blocking note: fixture-mode brief intentionally leaves open-loops and memory-highlights empty; this is acceptable for state-parity UI validation in this sprint.
 
 ## regression risks
-- Low for touched seams based on unit/web/integration coverage.
-- Residual risk remains low for broader non-sprint integrations not re-run in this pass.
+- Low for touched seams due unit + integration + web test coverage on new surfaces.
+- Residual risk remains on unrelated app surfaces not exercised in this sprint review run.
 
 ## docs issues
-- None blocking for sprint acceptance.
+- No blocking documentation gaps for sprint acceptance.
+- `BUILD_REPORT.md` includes required endpoint, fields, ordering rules, tests, and deferred scope.
 
 ## should anything be added to RULES.md?
-- Optional: require lifecycle-domain acceptance tests to include every allowed transition and cross-user list/detail/mutation denial checks.
+- Optional improvement: add a rule that every new continuity-read endpoint must ship explicit ordering constants plus test assertions for ordering and bounds.
 
 ## should anything update ARCHITECTURE.md?
-- Already updated in this sprint to include open-loop seams.
+- Optional improvement: add a short “Resumption Brief Read Seam” subsection documenting source seams (`threads/events/open_loops/memories/tasks/task_steps`) and deterministic assembly constraints.
 
 ## recommended next action
-1. Proceed to Control Tower merge approval for Sprint 3 open-loop backbone.
+1. Mark Sprint 4 as reviewer `PASS` and move to Control Tower merge gate.
+2. Optionally capture the non-blocking RULES/ARCHITECTURE clarifications in a follow-up docs-only PR.

--- a/apps/api/src/alicebot_api/compiler.py
+++ b/apps/api/src/alicebot_api/compiler.py
@@ -5,6 +5,9 @@ from uuid import UUID
 
 from alicebot_api.contracts import (
     COMPILER_VERSION_V0,
+    DEFAULT_RESUMPTION_BRIEF_EVENT_LIMIT,
+    DEFAULT_RESUMPTION_BRIEF_MEMORY_LIMIT,
+    DEFAULT_RESUMPTION_BRIEF_OPEN_LOOP_LIMIT,
     ArtifactSelectionSource,
     CompileContextArtifactScopedSemanticArtifactRetrievalInput,
     CompilerDecision,
@@ -28,7 +31,19 @@ from alicebot_api.contracts import (
     HybridArtifactRetrievalDecisionTracePayload,
     MemorySelectionSource,
     OPEN_LOOP_REVIEW_ORDER,
+    RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0,
+    RESUMPTION_BRIEF_CONVERSATION_EVENT_KINDS,
+    RESUMPTION_BRIEF_CONVERSATION_ORDER,
+    RESUMPTION_BRIEF_MEMORY_ORDER,
+    ResumptionBriefConversationSection,
+    ResumptionBriefMemoryHighlightSection,
+    ResumptionBriefRecord,
+    ResumptionBriefSectionSummary,
+    ResumptionBriefWorkflowPosture,
+    ResumptionBriefWorkflowSummary,
     SEMANTIC_MEMORY_RETRIEVAL_ORDER,
+    TASK_LIST_ORDER,
+    TASK_STEP_LIST_ORDER,
     TASK_ARTIFACT_CHUNK_RETRIEVAL_ORDER,
     TASK_ARTIFACT_CHUNK_SEMANTIC_RETRIEVAL_ORDER,
     SemanticMemoryRetrievalRequestInput,
@@ -58,10 +73,12 @@ from alicebot_api.store import (
     OpenLoopRow,
     SemanticMemoryRetrievalRow,
     SessionRow,
+    TaskRow,
+    TaskStepRow,
     ThreadRow,
     UserRow,
 )
-from alicebot_api.tasks import TaskNotFoundError
+from alicebot_api.tasks import TaskNotFoundError, serialize_task_row, serialize_task_step_row
 
 SUMMARY_TRACE_EVENT_KIND = "context.summary"
 _UNBOUNDED_SEMANTIC_RETRIEVAL_LIMIT = 2_147_483_647
@@ -1214,6 +1231,143 @@ def _compile_artifact_chunk_section(
         },
         decisions=decisions,
     )
+
+
+def _task_sort_key(task: TaskRow) -> tuple[str, str]:
+    return (task["created_at"].isoformat(), str(task["id"]))
+
+
+def _task_step_sort_key(task_step: TaskStepRow) -> tuple[int, str, str]:
+    return (
+        task_step["sequence_no"],
+        task_step["created_at"].isoformat(),
+        str(task_step["id"]),
+    )
+
+
+def _build_resumption_section_summary(
+    *,
+    limit: int,
+    returned_count: int,
+    total_count: int,
+    order: list[str],
+) -> ResumptionBriefSectionSummary:
+    return {
+        "limit": limit,
+        "returned_count": returned_count,
+        "total_count": total_count,
+        "order": order,
+    }
+
+
+def _build_resumption_workflow_posture(
+    *,
+    store: ContinuityStore,
+    thread_id: UUID,
+) -> ResumptionBriefWorkflowPosture | None:
+    ordered_tasks = sorted(
+        [task for task in store.list_tasks() if task["thread_id"] == thread_id],
+        key=_task_sort_key,
+    )
+    latest_task = ordered_tasks[-1] if ordered_tasks else None
+    if latest_task is None:
+        return None
+
+    ordered_task_steps = sorted(
+        store.list_task_steps_for_task(latest_task["id"]),
+        key=_task_step_sort_key,
+    )
+    latest_task_step = ordered_task_steps[-1] if ordered_task_steps else None
+    summary: ResumptionBriefWorkflowSummary = {
+        "present": True,
+        "task_order": list(TASK_LIST_ORDER),
+        "task_step_order": list(TASK_STEP_LIST_ORDER),
+    }
+    return {
+        "task": serialize_task_row(latest_task),
+        "latest_task_step": None if latest_task_step is None else serialize_task_step_row(latest_task_step),
+        "summary": summary,
+    }
+
+
+def compile_resumption_brief(
+    store: ContinuityStore,
+    *,
+    thread: ThreadRow,
+    event_limit: int = DEFAULT_RESUMPTION_BRIEF_EVENT_LIMIT,
+    open_loop_limit: int = DEFAULT_RESUMPTION_BRIEF_OPEN_LOOP_LIMIT,
+    memory_limit: int = DEFAULT_RESUMPTION_BRIEF_MEMORY_LIMIT,
+) -> ResumptionBriefRecord:
+    bounded_event_limit = max(0, event_limit)
+    bounded_open_loop_limit = max(0, open_loop_limit)
+    bounded_memory_limit = max(0, memory_limit)
+
+    conversation_kinds = frozenset(RESUMPTION_BRIEF_CONVERSATION_EVENT_KINDS)
+    ordered_conversation_events = [
+        event for event in store.list_thread_events(thread["id"]) if event["kind"] in conversation_kinds
+    ]
+    included_events = (
+        ordered_conversation_events[-bounded_event_limit:] if bounded_event_limit > 0 else []
+    )
+    conversation_section: ResumptionBriefConversationSection = {
+        "items": [_serialize_event(event) for event in included_events],
+        "summary": {
+            **_build_resumption_section_summary(
+                limit=bounded_event_limit,
+                returned_count=len(included_events),
+                total_count=len(ordered_conversation_events),
+                order=list(RESUMPTION_BRIEF_CONVERSATION_ORDER),
+            ),
+            "kinds": list(RESUMPTION_BRIEF_CONVERSATION_EVENT_KINDS),
+        },
+    }
+
+    ordered_open_loops = store.list_open_loops(status="open")
+    included_open_loops = (
+        ordered_open_loops[:bounded_open_loop_limit] if bounded_open_loop_limit > 0 else []
+    )
+    open_loop_section = {
+        "items": [_serialize_open_loop(open_loop) for open_loop in included_open_loops],
+        "summary": _build_resumption_section_summary(
+            limit=bounded_open_loop_limit,
+            returned_count=len(included_open_loops),
+            total_count=len(ordered_open_loops),
+            order=list(OPEN_LOOP_REVIEW_ORDER),
+        ),
+    }
+
+    ordered_memories = sorted(
+        [memory for memory in store.list_context_memories() if memory["status"] == "active"],
+        key=_memory_sort_key,
+    )
+    included_memories = ordered_memories[-bounded_memory_limit:] if bounded_memory_limit > 0 else []
+    memory_highlight_section: ResumptionBriefMemoryHighlightSection = {
+        "items": [_serialize_memory(memory) for memory in included_memories],
+        "summary": _build_resumption_section_summary(
+            limit=bounded_memory_limit,
+            returned_count=len(included_memories),
+            total_count=len(ordered_memories),
+            order=list(RESUMPTION_BRIEF_MEMORY_ORDER),
+        ),
+    }
+
+    workflow_posture = _build_resumption_workflow_posture(
+        store=store,
+        thread_id=thread["id"],
+    )
+    sources = ["threads", "events", "open_loops", "memories"]
+    if workflow_posture is not None:
+        sources.extend(["tasks", "task_steps"])
+
+    return {
+        "assembly_version": RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0,
+        "thread": _serialize_thread(thread),
+        "conversation": conversation_section,
+        "open_loops": open_loop_section,
+        "memory_highlights": memory_highlight_section,
+        "workflow": workflow_posture,
+        "sources": sources,
+    }
 
 
 def compile_continuity_context(

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -105,6 +105,12 @@ DEFAULT_MEMORY_REVIEW_LIMIT = 20
 MAX_MEMORY_REVIEW_LIMIT = 100
 DEFAULT_OPEN_LOOP_LIMIT = 20
 MAX_OPEN_LOOP_LIMIT = 100
+DEFAULT_RESUMPTION_BRIEF_EVENT_LIMIT = 8
+MAX_RESUMPTION_BRIEF_EVENT_LIMIT = 50
+DEFAULT_RESUMPTION_BRIEF_OPEN_LOOP_LIMIT = 5
+MAX_RESUMPTION_BRIEF_OPEN_LOOP_LIMIT = 20
+DEFAULT_RESUMPTION_BRIEF_MEMORY_LIMIT = 5
+MAX_RESUMPTION_BRIEF_MEMORY_LIMIT = 20
 DEFAULT_SEMANTIC_MEMORY_RETRIEVAL_LIMIT = 5
 MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT = 50
 DEFAULT_ARTIFACT_CHUNK_RETRIEVAL_LIMIT = 5
@@ -121,6 +127,10 @@ TRACE_REVIEW_EVENT_LIST_ORDER = ["sequence_no_asc", "id_asc"]
 THREAD_LIST_ORDER = ["created_at_desc", "id_desc"]
 THREAD_SESSION_LIST_ORDER = ["started_at_asc", "created_at_asc", "id_asc"]
 THREAD_EVENT_LIST_ORDER = ["sequence_no_asc"]
+RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0 = "resumption_brief_v0"
+RESUMPTION_BRIEF_CONVERSATION_EVENT_KINDS = ["message.user", "message.assistant"]
+RESUMPTION_BRIEF_CONVERSATION_ORDER = ["sequence_no_asc"]
+RESUMPTION_BRIEF_MEMORY_ORDER = ["updated_at_asc", "created_at_asc", "id_asc"]
 MEMORY_REVIEW_ORDER = ["updated_at_desc", "created_at_desc", "id_desc"]
 MEMORY_REVIEW_QUEUE_ORDER = ["updated_at_desc", "created_at_desc", "id_desc"]
 MEMORY_REVISION_REVIEW_ORDER = ["sequence_no_asc"]
@@ -436,6 +446,14 @@ class ThreadEventListSummary(TypedDict):
 class ThreadEventListResponse(TypedDict):
     items: list[ThreadEventRecord]
     summary: ThreadEventListSummary
+
+
+@dataclass(frozen=True, slots=True)
+class ResumptionBriefRequestInput:
+    thread_id: UUID
+    max_events: int = DEFAULT_RESUMPTION_BRIEF_EVENT_LIMIT
+    max_open_loops: int = DEFAULT_RESUMPTION_BRIEF_OPEN_LOOP_LIMIT
+    max_memories: int = DEFAULT_RESUMPTION_BRIEF_MEMORY_LIMIT
 
 
 class TraceReviewSummaryRecord(TypedDict):
@@ -2597,6 +2615,58 @@ class TaskStepTransitionResponse(TypedDict):
     task_step: TaskStepRecord
     sequencing: TaskStepSequencingSummary
     trace: TaskStepMutationTraceSummary
+
+
+class ResumptionBriefSectionSummary(TypedDict):
+    limit: int
+    returned_count: int
+    total_count: int
+    order: list[str]
+
+
+class ResumptionBriefConversationSummary(ResumptionBriefSectionSummary):
+    kinds: list[str]
+
+
+class ResumptionBriefConversationSection(TypedDict):
+    items: list[ThreadEventRecord]
+    summary: ResumptionBriefConversationSummary
+
+
+class ResumptionBriefOpenLoopSection(TypedDict):
+    items: list[OpenLoopRecord]
+    summary: ResumptionBriefSectionSummary
+
+
+class ResumptionBriefMemoryHighlightSection(TypedDict):
+    items: list[ContextPackMemory]
+    summary: ResumptionBriefSectionSummary
+
+
+class ResumptionBriefWorkflowSummary(TypedDict):
+    present: bool
+    task_order: list[str]
+    task_step_order: list[str]
+
+
+class ResumptionBriefWorkflowPosture(TypedDict):
+    task: TaskRecord
+    latest_task_step: TaskStepRecord | None
+    summary: ResumptionBriefWorkflowSummary
+
+
+class ResumptionBriefRecord(TypedDict):
+    assembly_version: str
+    thread: ThreadRecord
+    conversation: ResumptionBriefConversationSection
+    open_loops: ResumptionBriefOpenLoopSection
+    memory_highlights: ResumptionBriefMemoryHighlightSection
+    workflow: ResumptionBriefWorkflowPosture | None
+    sources: list[str]
+
+
+class ResumptionBriefResponse(TypedDict):
+    brief: ResumptionBriefRecord
 
 
 class TaskLifecycleStateTracePayload(TypedDict):

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from fastapi.responses import JSONResponse
 from urllib.parse import urlsplit, urlunsplit
 
-from alicebot_api.compiler import compile_and_persist_trace
+from alicebot_api.compiler import compile_and_persist_trace, compile_resumption_brief
 from alicebot_api.config import Settings, get_settings
 from alicebot_api.contracts import (
     ApprovalApproveInput,
@@ -32,10 +32,16 @@ from alicebot_api.contracts import (
     DEFAULT_MAX_MEMORIES,
     DEFAULT_MEMORY_REVIEW_LIMIT,
     DEFAULT_OPEN_LOOP_LIMIT,
+    DEFAULT_RESUMPTION_BRIEF_EVENT_LIMIT,
+    DEFAULT_RESUMPTION_BRIEF_MEMORY_LIMIT,
+    DEFAULT_RESUMPTION_BRIEF_OPEN_LOOP_LIMIT,
     DEFAULT_MAX_SESSIONS,
     DEFAULT_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
     MAX_MEMORY_REVIEW_LIMIT,
     MAX_OPEN_LOOP_LIMIT,
+    MAX_RESUMPTION_BRIEF_EVENT_LIMIT,
+    MAX_RESUMPTION_BRIEF_MEMORY_LIMIT,
+    MAX_RESUMPTION_BRIEF_OPEN_LOOP_LIMIT,
     MAX_ARTIFACT_CHUNK_RETRIEVAL_LIMIT,
     MAX_CALENDAR_EVENT_LIST_LIMIT,
     MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
@@ -100,6 +106,8 @@ from alicebot_api.contracts import (
     ThreadListResponse,
     ThreadListSummary,
     ThreadRecord,
+    ResumptionBriefRequestInput,
+    ResumptionBriefResponse,
     ThreadSessionListResponse,
     ThreadSessionListSummary,
     ThreadSessionRecord,
@@ -1084,6 +1092,54 @@ def list_thread_events(thread_id: UUID, user_id: UUID) -> JSONResponse:
         "items": items,
         "summary": summary,
     }
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/threads/{thread_id}/resumption-brief")
+def get_thread_resumption_brief(
+    thread_id: UUID,
+    user_id: UUID,
+    max_events: Annotated[
+        int,
+        Query(ge=0, le=MAX_RESUMPTION_BRIEF_EVENT_LIMIT),
+    ] = DEFAULT_RESUMPTION_BRIEF_EVENT_LIMIT,
+    max_open_loops: Annotated[
+        int,
+        Query(
+            ge=0,
+            le=MAX_RESUMPTION_BRIEF_OPEN_LOOP_LIMIT,
+        ),
+    ] = DEFAULT_RESUMPTION_BRIEF_OPEN_LOOP_LIMIT,
+    max_memories: Annotated[
+        int,
+        Query(ge=0, le=MAX_RESUMPTION_BRIEF_MEMORY_LIMIT),
+    ] = DEFAULT_RESUMPTION_BRIEF_MEMORY_LIMIT,
+) -> JSONResponse:
+    settings = get_settings()
+    request = ResumptionBriefRequestInput(
+        thread_id=thread_id,
+        max_events=max_events,
+        max_open_loops=max_open_loops,
+        max_memories=max_memories,
+    )
+
+    with user_connection(settings.database_url, user_id) as conn:
+        store = ContinuityStore(conn)
+        thread = store.get_thread_optional(thread_id)
+        if thread is None:
+            return JSONResponse(status_code=404, content={"detail": f"thread {thread_id} was not found"})
+        brief = compile_resumption_brief(
+            store,
+            thread=thread,
+            event_limit=request.max_events,
+            open_loop_limit=request.max_open_loops,
+            memory_limit=request.max_memories,
+        )
+
+    payload: ResumptionBriefResponse = {"brief": brief}
     return JSONResponse(
         status_code=200,
         content=jsonable_encoder(payload),

--- a/apps/web/app/chat/page.test.tsx
+++ b/apps/web/app/chat/page.test.tsx
@@ -6,6 +6,7 @@ import ChatPage from "./page";
 
 const {
   getApiConfigMock,
+  getThreadResumptionBriefMock,
   getThreadDetailMock,
   getThreadEventsMock,
   getThreadSessionsMock,
@@ -13,6 +14,7 @@ const {
   listThreadsMock,
 } = vi.hoisted(() => ({
   getApiConfigMock: vi.fn(),
+  getThreadResumptionBriefMock: vi.fn(),
   getThreadDetailMock: vi.fn(),
   getThreadEventsMock: vi.fn(),
   getThreadSessionsMock: vi.fn(),
@@ -50,6 +52,7 @@ vi.mock("../../lib/api", async () => {
   return {
     ...actual,
     getApiConfig: getApiConfigMock,
+    getThreadResumptionBrief: getThreadResumptionBriefMock,
     getThreadDetail: getThreadDetailMock,
     getThreadEvents: getThreadEventsMock,
     getThreadSessions: getThreadSessionsMock,
@@ -58,9 +61,54 @@ vi.mock("../../lib/api", async () => {
   };
 });
 
+function buildResumptionBriefFixture() {
+  return {
+    brief: {
+      assembly_version: "resumption_brief_v0",
+      thread: {
+        id: "thread-1",
+        title: "Gamma thread",
+        created_at: "2026-03-17T10:00:00Z",
+        updated_at: "2026-03-17T10:00:00Z",
+      },
+      conversation: {
+        items: [],
+        summary: {
+          limit: 8,
+          returned_count: 0,
+          total_count: 0,
+          order: ["sequence_no_asc"],
+          kinds: ["message.user", "message.assistant"],
+        },
+      },
+      open_loops: {
+        items: [],
+        summary: {
+          limit: 5,
+          returned_count: 0,
+          total_count: 0,
+          order: ["opened_at_desc", "created_at_desc", "id_desc"],
+        },
+      },
+      memory_highlights: {
+        items: [],
+        summary: {
+          limit: 5,
+          returned_count: 0,
+          total_count: 0,
+          order: ["updated_at_asc", "created_at_asc", "id_asc"],
+        },
+      },
+      workflow: null,
+      sources: ["threads", "events", "open_loops", "memories"],
+    },
+  };
+}
+
 describe("ChatPage", () => {
   beforeEach(() => {
     getApiConfigMock.mockReset();
+    getThreadResumptionBriefMock.mockReset();
     getThreadDetailMock.mockReset();
     getThreadEventsMock.mockReset();
     getThreadSessionsMock.mockReset();
@@ -107,6 +155,7 @@ describe("ChatPage", () => {
       items: [],
       summary: { thread_id: "thread-1", total_count: 0, order: [] },
     });
+    getThreadResumptionBriefMock.mockResolvedValue(buildResumptionBriefFixture());
 
     render(await ChatPage({ searchParams: Promise.resolve({}) }));
 
@@ -152,6 +201,7 @@ describe("ChatPage", () => {
       items: [],
       summary: { thread_id: "thread-1", total_count: 0, order: [] },
     });
+    getThreadResumptionBriefMock.mockResolvedValue(buildResumptionBriefFixture());
 
     render(
       await ChatPage({
@@ -195,10 +245,55 @@ describe("ChatPage", () => {
       items: [],
       summary: { thread_id: "thread-1", total_count: 0, order: [] },
     });
+    getThreadResumptionBriefMock.mockRejectedValue(new Error("brief failed"));
 
     render(await ChatPage({ searchParams: Promise.resolve({}) }));
 
     expect(screen.getByText("Continuity unavailable")).toBeInTheDocument();
     expect(screen.getByText("Summary unavailable")).toBeInTheDocument();
+  });
+
+  it("shows resumption brief unavailable state when brief read fails but continuity is live", async () => {
+    getApiConfigMock.mockReturnValue({
+      apiBaseUrl: "https://api.example.com",
+      userId: "user-1",
+      defaultThreadId: "thread-1",
+      defaultToolId: "tool-1",
+    });
+    hasLiveApiConfigMock.mockReturnValue(true);
+    listThreadsMock.mockResolvedValue({
+      items: [
+        {
+          id: "thread-1",
+          title: "Gamma thread",
+          created_at: "2026-03-17T10:00:00Z",
+          updated_at: "2026-03-17T10:00:00Z",
+        },
+      ],
+      summary: { total_count: 1, order: ["created_at_desc", "id_desc"] },
+    });
+    getThreadDetailMock.mockResolvedValue({
+      thread: {
+        id: "thread-1",
+        title: "Gamma thread",
+        created_at: "2026-03-17T10:00:00Z",
+        updated_at: "2026-03-17T10:00:00Z",
+      },
+    });
+    getThreadSessionsMock.mockResolvedValue({
+      items: [],
+      summary: { thread_id: "thread-1", total_count: 0, order: [] },
+    });
+    getThreadEventsMock.mockResolvedValue({
+      items: [],
+      summary: { thread_id: "thread-1", total_count: 0, order: [] },
+    });
+    getThreadResumptionBriefMock.mockRejectedValue(new Error("resumption brief failed"));
+
+    render(await ChatPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText("Live continuity enabled")).toBeInTheDocument();
+    expect(screen.getByText("Resumption brief unavailable")).toBeInTheDocument();
+    expect(screen.getByText("resumption brief failed")).toBeInTheDocument();
   });
 });

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -12,6 +12,7 @@ import { ThreadSummary } from "../../components/thread-summary";
 import type {
   ApiSource,
   ApprovalItem,
+  ResumptionBrief,
   TaskItem,
   TaskStepItem,
   TaskStepListSummary,
@@ -26,6 +27,7 @@ import {
   getTaskSteps,
   getThreadDetail,
   getThreadEvents,
+  getThreadResumptionBrief,
   getThreadSessions,
   hasLiveApiConfig,
   listApprovals,
@@ -81,6 +83,14 @@ type WorkflowViewModel = {
   taskStepSummary: TaskStepListSummary | null;
   taskStepSource: WorkflowSource | null;
   taskStepUnavailableReason?: string;
+};
+
+type ResumptionBriefSource = ApiSource | "unavailable" | null;
+
+type ResumptionBriefViewModel = {
+  brief: ResumptionBrief | null;
+  source: ResumptionBriefSource;
+  unavailableReason?: string;
 };
 
 function normalizeMode(value: string | string[] | undefined): ChatMode {
@@ -318,6 +328,109 @@ async function loadLiveWorkflow(
   };
 }
 
+function buildFixtureResumptionBrief(
+  continuity: ContinuityViewModel,
+  workflow: WorkflowViewModel,
+): ResumptionBrief {
+  const conversationItems = continuity.events
+    .filter((event) => event.kind === "message.user" || event.kind === "message.assistant")
+    .slice(-8);
+  const latestTaskStep = workflow.taskSteps[workflow.taskSteps.length - 1] ?? null;
+
+  return {
+    assembly_version: "resumption_brief_v0",
+    thread: continuity.selectedThread as NonNullable<ContinuityViewModel["selectedThread"]>,
+    conversation: {
+      items: conversationItems,
+      summary: {
+        limit: 8,
+        returned_count: conversationItems.length,
+        total_count: continuity.events.filter(
+          (event) => event.kind === "message.user" || event.kind === "message.assistant",
+        ).length,
+        order: ["sequence_no_asc"],
+        kinds: ["message.user", "message.assistant"],
+      },
+    },
+    open_loops: {
+      items: [],
+      summary: {
+        limit: 5,
+        returned_count: 0,
+        total_count: 0,
+        order: ["opened_at_desc", "created_at_desc", "id_desc"],
+      },
+    },
+    memory_highlights: {
+      items: [],
+      summary: {
+        limit: 5,
+        returned_count: 0,
+        total_count: 0,
+        order: ["updated_at_asc", "created_at_asc", "id_asc"],
+      },
+    },
+    workflow: workflow.task
+      ? {
+          task: workflow.task,
+          latest_task_step: latestTaskStep,
+          summary: {
+            present: true,
+            task_order: ["created_at_asc", "id_asc"],
+            task_step_order: ["sequence_no_asc", "created_at_asc", "id_asc"],
+          },
+        }
+      : null,
+    sources: workflow.task
+      ? ["threads", "events", "open_loops", "memories", "tasks", "task_steps"]
+      : ["threads", "events", "open_loops", "memories"],
+  };
+}
+
+async function loadFixtureResumptionBrief(
+  continuity: ContinuityViewModel,
+  workflow: WorkflowViewModel,
+): Promise<ResumptionBriefViewModel> {
+  if (!continuity.selectedThread) {
+    return {
+      brief: null,
+      source: "fixture",
+    };
+  }
+
+  return {
+    brief: buildFixtureResumptionBrief(continuity, workflow),
+    source: "fixture",
+  };
+}
+
+async function loadLiveResumptionBrief(
+  apiBaseUrl: string,
+  userId: string,
+  selectedThreadId: string,
+): Promise<ResumptionBriefViewModel> {
+  if (!selectedThreadId) {
+    return {
+      brief: null,
+      source: "live",
+    };
+  }
+
+  try {
+    const payload = await getThreadResumptionBrief(apiBaseUrl, selectedThreadId, userId);
+    return {
+      brief: payload.brief,
+      source: "live",
+    };
+  } catch (error) {
+    return {
+      brief: null,
+      source: "unavailable",
+      unavailableReason: error instanceof Error ? error.message : "Resumption brief could not be loaded.",
+    };
+  }
+}
+
 async function loadFixtureContinuity(
   requestedThreadId: string,
   defaultThreadId: string,
@@ -424,6 +537,13 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
   const workflow = liveModeReady
     ? await loadLiveWorkflow(apiConfig.apiBaseUrl, apiConfig.userId, continuity.selectedThreadId)
     : await loadFixtureWorkflow(continuity.selectedThreadId);
+  const resumptionBrief = liveModeReady
+    ? await loadLiveResumptionBrief(
+        apiConfig.apiBaseUrl,
+        apiConfig.userId,
+        continuity.selectedThreadId,
+      )
+    : await loadFixtureResumptionBrief(continuity, workflow);
   const traceTargets = buildThreadTraceTargets(continuity.selectedThreadId, workflow, liveModeReady);
   const traceHrefPrefix = buildChatTraceHrefPrefix(mode, continuity.selectedThreadId);
   const threadTracePanel = await ThreadTracePanel({
@@ -528,6 +648,9 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
             events={continuity.events}
             source={continuity.continuitySource}
             unavailableReason={continuity.unavailableReason}
+            resumptionBrief={resumptionBrief.brief}
+            resumptionSource={resumptionBrief.source}
+            resumptionUnavailableReason={resumptionBrief.unavailableReason}
           />
 
           <ThreadList

--- a/apps/web/components/thread-summary.test.tsx
+++ b/apps/web/components/thread-summary.test.tsx
@@ -63,4 +63,121 @@ describe("ThreadSummary", () => {
     expect(screen.getByText("No thread selected")).toBeInTheDocument();
     expect(screen.getByText("Select a thread")).toBeInTheDocument();
   });
+
+  it("renders deterministic resumption brief sections when available", () => {
+    render(
+      <ThreadSummary
+        thread={{
+          id: "thread-1",
+          title: "Gamma thread",
+          created_at: "2026-03-17T10:00:00Z",
+          updated_at: "2026-03-17T10:05:00Z",
+        }}
+        sessions={[]}
+        events={[]}
+        source="live"
+        resumptionSource="live"
+        resumptionBrief={{
+          assembly_version: "resumption_brief_v0",
+          thread: {
+            id: "thread-1",
+            title: "Gamma thread",
+            created_at: "2026-03-17T10:00:00Z",
+            updated_at: "2026-03-17T10:05:00Z",
+          },
+          conversation: {
+            items: [
+              {
+                id: "event-1",
+                thread_id: "thread-1",
+                session_id: "session-1",
+                sequence_no: 1,
+                kind: "message.user",
+                payload: { text: "Hello" },
+                created_at: "2026-03-17T10:01:00Z",
+              },
+            ],
+            summary: {
+              limit: 8,
+              returned_count: 1,
+              total_count: 1,
+              order: ["sequence_no_asc"],
+              kinds: ["message.user", "message.assistant"],
+            },
+          },
+          open_loops: {
+            items: [
+              {
+                id: "loop-1",
+                memory_id: null,
+                title: "Follow up on dosage",
+                status: "open",
+                opened_at: "2026-03-17T10:02:00Z",
+                due_at: null,
+                resolved_at: null,
+                resolution_note: null,
+                created_at: "2026-03-17T10:02:00Z",
+                updated_at: "2026-03-17T10:02:00Z",
+              },
+            ],
+            summary: {
+              limit: 5,
+              returned_count: 1,
+              total_count: 1,
+              order: ["opened_at_desc", "created_at_desc", "id_desc"],
+            },
+          },
+          memory_highlights: {
+            items: [
+              {
+                id: "memory-1",
+                memory_key: "user.preference.dose_time",
+                value: { value: "morning" },
+                status: "active",
+                source_event_ids: ["event-1"],
+                memory_type: "preference",
+                confirmation_status: "confirmed",
+                created_at: "2026-03-17T10:00:00Z",
+                updated_at: "2026-03-17T10:03:00Z",
+              },
+            ],
+            summary: {
+              limit: 5,
+              returned_count: 1,
+              total_count: 1,
+              order: ["updated_at_asc", "created_at_asc", "id_asc"],
+            },
+          },
+          workflow: null,
+          sources: ["threads", "events", "open_loops", "memories"],
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/Live deterministic brief/i)).toBeInTheDocument();
+    expect(screen.getByText("Latest conversation evidence")).toBeInTheDocument();
+    expect(screen.getByText("Follow up on dosage")).toBeInTheDocument();
+    expect(screen.getByText("user.preference.dose_time")).toBeInTheDocument();
+  });
+
+  it("shows explicit resumption brief unavailable state", () => {
+    render(
+      <ThreadSummary
+        thread={{
+          id: "thread-1",
+          title: "Gamma thread",
+          created_at: "2026-03-17T10:00:00Z",
+          updated_at: "2026-03-17T10:05:00Z",
+        }}
+        sessions={[]}
+        events={[]}
+        source="live"
+        resumptionSource="unavailable"
+        resumptionUnavailableReason="resumption brief down"
+      />,
+    );
+
+    expect(screen.getByText("Resumption brief unavailable")).toBeInTheDocument();
+    expect(screen.getByText("resumption brief down")).toBeInTheDocument();
+  });
 });

--- a/apps/web/components/thread-summary.tsx
+++ b/apps/web/components/thread-summary.tsx
@@ -1,4 +1,4 @@
-import type { ThreadEventItem, ThreadItem, ThreadSessionItem } from "../lib/api";
+import type { ResumptionBrief, ThreadEventItem, ThreadItem, ThreadSessionItem } from "../lib/api";
 import { EmptyState } from "./empty-state";
 import { SectionCard } from "./section-card";
 import { StatusBadge } from "./status-badge";
@@ -9,6 +9,9 @@ type ThreadSummaryProps = {
   events: ThreadEventItem[];
   source: "live" | "fixture" | "unavailable";
   unavailableReason?: string;
+  resumptionBrief?: ResumptionBrief | null;
+  resumptionSource?: "live" | "fixture" | "unavailable" | null;
+  resumptionUnavailableReason?: string;
 };
 
 function formatDate(value: string) {
@@ -32,12 +35,23 @@ function isConversationEvent(event: ThreadEventItem) {
   return event.kind === "message.user" || event.kind === "message.assistant";
 }
 
+function summarizeEvent(event: ThreadEventItem) {
+  const payload = event.payload;
+  if (payload && typeof payload === "object" && "text" in payload && typeof payload.text === "string") {
+    return payload.text;
+  }
+  return event.kind;
+}
+
 export function ThreadSummary({
   thread,
   sessions,
   events,
   source,
   unavailableReason,
+  resumptionBrief = null,
+  resumptionSource = null,
+  resumptionUnavailableReason,
 }: ThreadSummaryProps) {
   if (source === "unavailable") {
     return (
@@ -120,6 +134,99 @@ export function ThreadSummary({
           events are attached to this thread.
         </p>
       </div>
+
+      {resumptionSource === "unavailable" ? (
+        <div className="detail-group">
+          <span className="history-entry__label">Resumption brief</span>
+          <EmptyState
+            title="Resumption brief unavailable"
+            description={
+              resumptionUnavailableReason ??
+              "The deterministic resumption brief could not be loaded for this thread."
+            }
+          />
+        </div>
+      ) : resumptionBrief ? (
+        <div className="detail-group">
+          <span className="history-entry__label">Resumption brief</span>
+          <p>
+            {resumptionSource === "live"
+              ? "Live deterministic brief"
+              : "Fixture deterministic brief"}{" "}
+            from durable continuity seams.
+          </p>
+          <dl className="key-value-grid key-value-grid--compact">
+            <div>
+              <dt>Conversation evidence</dt>
+              <dd>
+                {resumptionBrief.conversation.summary.returned_count}/
+                {resumptionBrief.conversation.summary.total_count}
+              </dd>
+            </div>
+            <div>
+              <dt>Active open loops</dt>
+              <dd>
+                {resumptionBrief.open_loops.summary.returned_count}/
+                {resumptionBrief.open_loops.summary.total_count}
+              </dd>
+            </div>
+            <div>
+              <dt>Memory highlights</dt>
+              <dd>
+                {resumptionBrief.memory_highlights.summary.returned_count}/
+                {resumptionBrief.memory_highlights.summary.total_count}
+              </dd>
+            </div>
+            <div>
+              <dt>Workflow posture</dt>
+              <dd>{resumptionBrief.workflow ? "Present" : "Not linked"}</dd>
+            </div>
+          </dl>
+
+          {resumptionBrief.conversation.items.length > 0 ? (
+            <div className="detail-group detail-group--muted">
+              <span className="history-entry__label">Latest conversation evidence</span>
+              <ul className="timeline-list">
+                {resumptionBrief.conversation.items.map((item) => (
+                  <li key={item.id} className="timeline-item">
+                    <p className="mono">#{item.sequence_no} {item.kind}</p>
+                    <p>{summarizeEvent(item)}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <p className="muted-copy">No conversation evidence is currently available.</p>
+          )}
+
+          {resumptionBrief.open_loops.items.length > 0 ? (
+            <div className="detail-group detail-group--muted">
+              <span className="history-entry__label">Active open loops</span>
+              <ul className="timeline-list">
+                {resumptionBrief.open_loops.items.map((item) => (
+                  <li key={item.id} className="timeline-item">
+                    <p className="mono">{item.title}</p>
+                    <p>Status: {item.status}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {resumptionBrief.memory_highlights.items.length > 0 ? (
+            <div className="detail-group detail-group--muted">
+              <span className="history-entry__label">Memory highlights</span>
+              <ul className="timeline-list">
+                {resumptionBrief.memory_highlights.items.map((item) => (
+                  <li key={item.id} className="timeline-item">
+                    <p className="mono">{item.memory_key}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="detail-group">
         <span className="history-entry__label">Thread ID</span>

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -21,6 +21,7 @@ import {
   getTaskSteps,
   getThreadDetail,
   getThreadEvents,
+  getThreadResumptionBrief,
   getThreadSessions,
   executeApproval,
   ingestCalendarEvent,
@@ -772,6 +773,69 @@ describe("api helpers", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.example.com/v0/tasks/task-1/steps?user_id=user-1",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+      }),
+    );
+  });
+
+  it("reads resumption briefs from the shipped thread endpoint with bounded query params", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          brief: {
+            assembly_version: "resumption_brief_v0",
+            thread: {
+              id: "thread-1",
+              title: "Gamma thread",
+              created_at: "2026-03-17T10:00:00Z",
+              updated_at: "2026-03-17T10:05:00Z",
+            },
+            conversation: {
+              items: [],
+              summary: {
+                limit: 1,
+                returned_count: 0,
+                total_count: 0,
+                order: ["sequence_no_asc"],
+                kinds: ["message.user", "message.assistant"],
+              },
+            },
+            open_loops: {
+              items: [],
+              summary: {
+                limit: 1,
+                returned_count: 0,
+                total_count: 0,
+                order: ["opened_at_desc", "created_at_desc", "id_desc"],
+              },
+            },
+            memory_highlights: {
+              items: [],
+              summary: {
+                limit: 1,
+                returned_count: 0,
+                total_count: 0,
+                order: ["updated_at_asc", "created_at_asc", "id_asc"],
+              },
+            },
+            workflow: null,
+            sources: ["threads", "events", "open_loops", "memories"],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await getThreadResumptionBrief("https://api.example.com", "thread-1", "user-1", {
+      maxEvents: 1,
+      maxOpenLoops: 1,
+      maxMemories: 1,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v0/threads/thread-1/resumption-brief?user_id=user-1&max_events=1&max_open_loops=1&max_memories=1",
       expect.objectContaining({
         cache: "no-store",
         headers: expect.objectContaining({ "Content-Type": "application/json" }),

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -56,6 +56,54 @@ export type ThreadEventListSummary = {
   order: string[];
 };
 
+export type ResumptionBriefSectionSummary = {
+  limit: number;
+  returned_count: number;
+  total_count: number;
+  order: string[];
+};
+
+export type ResumptionBriefConversationSummary = ResumptionBriefSectionSummary & {
+  kinds: string[];
+};
+
+export type ResumptionBriefConversationSection = {
+  items: ThreadEventItem[];
+  summary: ResumptionBriefConversationSummary;
+};
+
+export type ResumptionBriefOpenLoopSection = {
+  items: OpenLoopRecord[];
+  summary: ResumptionBriefSectionSummary;
+};
+
+export type ResumptionBriefMemoryHighlightSection = {
+  items: MemoryReviewRecord[];
+  summary: ResumptionBriefSectionSummary;
+};
+
+export type ResumptionBriefWorkflowSummary = {
+  present: boolean;
+  task_order: string[];
+  task_step_order: string[];
+};
+
+export type ResumptionBriefWorkflowPosture = {
+  task: TaskItem;
+  latest_task_step: TaskStepItem | null;
+  summary: ResumptionBriefWorkflowSummary;
+};
+
+export type ResumptionBrief = {
+  assembly_version: string;
+  thread: ThreadItem;
+  conversation: ResumptionBriefConversationSection;
+  open_loops: ResumptionBriefOpenLoopSection;
+  memory_highlights: ResumptionBriefMemoryHighlightSection;
+  workflow: ResumptionBriefWorkflowPosture | null;
+  sources: string[];
+};
+
 export type ToolRoutingReason = {
   code: string;
   source: string;
@@ -1047,6 +1095,34 @@ export function getThreadEvents(apiBaseUrl: string, threadId: string, userId: st
     `/v0/threads/${threadId}/events`,
     undefined,
     { user_id: userId },
+  );
+}
+
+export function getThreadResumptionBrief(
+  apiBaseUrl: string,
+  threadId: string,
+  userId: string,
+  options?: {
+    maxEvents?: number;
+    maxOpenLoops?: number;
+    maxMemories?: number;
+  },
+) {
+  return requestJson<{ brief: ResumptionBrief }>(
+    apiBaseUrl,
+    `/v0/threads/${threadId}/resumption-brief`,
+    undefined,
+    {
+      user_id: userId,
+      max_events:
+        typeof options?.maxEvents === "number" ? String(Math.max(0, options.maxEvents)) : undefined,
+      max_open_loops:
+        typeof options?.maxOpenLoops === "number"
+          ? String(Math.max(0, options.maxOpenLoops))
+          : undefined,
+      max_memories:
+        typeof options?.maxMemories === "number" ? String(Math.max(0, options.maxMemories)) : undefined,
+    },
   );
 }
 

--- a/tests/integration/test_continuity_api.py
+++ b/tests/integration/test_continuity_api.py
@@ -348,6 +348,236 @@ def test_thread_continuity_endpoints_create_list_detail_sessions_and_events(
     }
 
 
+def test_thread_resumption_brief_endpoint_returns_bounded_sections_and_workflow_posture(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    seeded = seed_user_with_continuity(migrated_database_urls["app"], email="owner@example.com")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    with user_connection(migrated_database_urls["app"], seeded["user_id"]) as conn:
+        store = ContinuityStore(conn)
+        store.create_memory(
+            memory_key="user.preference.tea",
+            value={"likes": "green"},
+            status="active",
+            source_event_ids=[],
+            memory_type="preference",
+        )
+        store.create_memory(
+            memory_key="user.preference.coffee",
+            value={"likes": "oat milk"},
+            status="active",
+            source_event_ids=[],
+            memory_type="preference",
+        )
+        store.create_memory(
+            memory_key="user.preference.deleted",
+            value={"likes": "espresso"},
+            status="deleted",
+            source_event_ids=[],
+            memory_type="preference",
+        )
+        store.create_open_loop(
+            memory_id=None,
+            title="Older open loop",
+            status="open",
+            opened_at=datetime(2026, 3, 18, 9, 0, tzinfo=UTC),
+            due_at=None,
+            resolved_at=None,
+            resolution_note=None,
+        )
+        store.create_open_loop(
+            memory_id=None,
+            title="Latest open loop",
+            status="open",
+            opened_at=datetime(2026, 3, 18, 10, 0, tzinfo=UTC),
+            due_at=None,
+            resolved_at=None,
+            resolution_note=None,
+        )
+        store.create_open_loop(
+            memory_id=None,
+            title="Resolved open loop",
+            status="resolved",
+            opened_at=datetime(2026, 3, 18, 11, 0, tzinfo=UTC),
+            due_at=None,
+            resolved_at=datetime(2026, 3, 18, 11, 5, tzinfo=UTC),
+            resolution_note="resolved",
+        )
+        tool = store.create_tool(
+            tool_key="proxy.echo",
+            name="Proxy Echo",
+            description="Deterministic proxy handler.",
+            version="1.0.0",
+            metadata_version="tool_metadata_v0",
+            active=True,
+            tags=["proxy"],
+            action_hints=["tool.run"],
+            scope_hints=["workspace"],
+            domain_hints=[],
+            risk_hints=[],
+            metadata={"transport": "proxy"},
+        )
+        task = store.create_task(
+            thread_id=seeded["second_thread"]["id"],
+            tool_id=tool["id"],
+            status="approved",
+            request={
+                "thread_id": str(seeded["second_thread"]["id"]),
+                "tool_id": str(tool["id"]),
+                "action": "tool.run",
+                "scope": "workspace",
+                "domain_hint": None,
+                "risk_hint": None,
+                "attributes": {"mode": "resumption"},
+            },
+            tool={
+                "id": str(tool["id"]),
+                "tool_key": "proxy.echo",
+                "name": "Proxy Echo",
+                "description": "Deterministic proxy handler.",
+                "version": "1.0.0",
+                "metadata_version": "tool_metadata_v0",
+                "active": True,
+                "tags": ["proxy"],
+                "action_hints": ["tool.run"],
+                "scope_hints": ["workspace"],
+                "domain_hints": [],
+                "risk_hints": [],
+                "metadata": {"transport": "proxy"},
+                "created_at": tool["created_at"].isoformat(),
+            },
+            latest_approval_id=None,
+            latest_execution_id=None,
+        )
+        first_step_trace = store.create_trace(
+            user_id=seeded["user_id"],
+            thread_id=seeded["second_thread"]["id"],
+            kind="task.step.sequence",
+            compiler_version="task_step_sequence_v0",
+            status="completed",
+            limits={"max_steps": 1},
+        )
+        second_step_trace = store.create_trace(
+            user_id=seeded["user_id"],
+            thread_id=seeded["second_thread"]["id"],
+            kind="task.step.transition",
+            compiler_version="task_step_transition_v0",
+            status="completed",
+            limits={"max_steps": 1},
+        )
+        store.create_task_step(
+            task_id=task["id"],
+            sequence_no=1,
+            kind="governed_request",
+            status="approved",
+            request={
+                "thread_id": str(seeded["second_thread"]["id"]),
+                "tool_id": str(tool["id"]),
+                "action": "tool.run",
+                "scope": "workspace",
+                "domain_hint": None,
+                "risk_hint": None,
+                "attributes": {"step": 1},
+            },
+            outcome={
+                "routing_decision": "ready",
+                "approval_id": None,
+                "approval_status": None,
+                "execution_id": None,
+                "execution_status": None,
+                "blocked_reason": None,
+            },
+            trace_id=first_step_trace["id"],
+            trace_kind="task.step.sequence",
+        )
+        latest_step = store.create_task_step(
+            task_id=task["id"],
+            sequence_no=2,
+            kind="governed_request",
+            status="executed",
+            request={
+                "thread_id": str(seeded["second_thread"]["id"]),
+                "tool_id": str(tool["id"]),
+                "action": "tool.run",
+                "scope": "workspace",
+                "domain_hint": None,
+                "risk_hint": None,
+                "attributes": {"step": 2},
+            },
+            outcome={
+                "routing_decision": "ready",
+                "approval_id": None,
+                "approval_status": None,
+                "execution_id": "execution-1",
+                "execution_status": "completed",
+                "blocked_reason": None,
+            },
+            trace_id=second_step_trace["id"],
+            trace_kind="task.step.transition",
+        )
+
+    status, payload = invoke_request(
+        "GET",
+        f"/v0/threads/{seeded['second_thread']['id']}/resumption-brief",
+        query_params={
+            "user_id": str(seeded["user_id"]),
+            "max_events": "1",
+            "max_open_loops": "1",
+            "max_memories": "1",
+        },
+    )
+
+    assert status == 200
+    assert payload["brief"]["assembly_version"] == "resumption_brief_v0"
+    assert payload["brief"]["thread"]["id"] == str(seeded["second_thread"]["id"])
+    assert payload["brief"]["conversation"]["summary"] == {
+        "limit": 1,
+        "returned_count": 1,
+        "total_count": 2,
+        "order": ["sequence_no_asc"],
+        "kinds": ["message.user", "message.assistant"],
+    }
+    assert [item["sequence_no"] for item in payload["brief"]["conversation"]["items"]] == [2]
+    assert payload["brief"]["open_loops"]["summary"] == {
+        "limit": 1,
+        "returned_count": 1,
+        "total_count": 2,
+        "order": ["opened_at_desc", "created_at_desc", "id_desc"],
+    }
+    assert [item["title"] for item in payload["brief"]["open_loops"]["items"]] == ["Latest open loop"]
+    assert payload["brief"]["memory_highlights"]["summary"] == {
+        "limit": 1,
+        "returned_count": 1,
+        "total_count": 2,
+        "order": ["updated_at_asc", "created_at_asc", "id_asc"],
+    }
+    assert [item["memory_key"] for item in payload["brief"]["memory_highlights"]["items"]] == [
+        "user.preference.coffee"
+    ]
+    assert payload["brief"]["workflow"]["task"]["id"] == str(task["id"])
+    assert payload["brief"]["workflow"]["latest_task_step"]["id"] == str(latest_step["id"])
+    assert payload["brief"]["workflow"]["latest_task_step"]["sequence_no"] == 2
+    assert payload["brief"]["workflow"]["summary"] == {
+        "present": True,
+        "task_order": ["created_at_asc", "id_asc"],
+        "task_step_order": ["sequence_no_asc", "created_at_asc", "id_asc"],
+    }
+    assert payload["brief"]["sources"] == [
+        "threads",
+        "events",
+        "open_loops",
+        "memories",
+        "tasks",
+        "task_steps",
+    ]
+
+
 def test_thread_continuity_endpoints_enforce_user_isolation_and_not_found(
     migrated_database_urls,
     monkeypatch,
@@ -380,6 +610,17 @@ def test_thread_continuity_endpoints_enforce_user_isolation_and_not_found(
         f"/v0/threads/{owner['second_thread']['id']}/events",
         query_params={"user_id": str(intruder_id)},
     )
+    brief_status, brief_payload = invoke_request(
+        "GET",
+        f"/v0/threads/{owner['second_thread']['id']}/resumption-brief",
+        query_params={"user_id": str(intruder_id)},
+    )
+    missing_thread_id = uuid4()
+    missing_brief_status, missing_brief_payload = invoke_request(
+        "GET",
+        f"/v0/threads/{missing_thread_id}/resumption-brief",
+        query_params={"user_id": str(owner['user_id'])},
+    )
 
     assert list_status == 200
     assert list_payload == {
@@ -395,3 +636,7 @@ def test_thread_continuity_endpoints_enforce_user_isolation_and_not_found(
     assert sessions_payload == {"detail": f"thread {owner['second_thread']['id']} was not found"}
     assert events_status == 404
     assert events_payload == {"detail": f"thread {owner['second_thread']['id']} was not found"}
+    assert brief_status == 404
+    assert brief_payload == {"detail": f"thread {owner['second_thread']['id']} was not found"}
+    assert missing_brief_status == 404
+    assert missing_brief_payload == {"detail": f"thread {missing_thread_id} was not found"}

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -7,6 +7,7 @@ from alicebot_api.compiler import (
     SUMMARY_TRACE_EVENT_KIND,
     _compile_artifact_chunk_section,
     _compile_memory_section,
+    compile_resumption_brief,
     compile_continuity_context,
 )
 from alicebot_api.contracts import (
@@ -1457,3 +1458,371 @@ def test_compile_continuity_context_includes_open_loops_when_present() -> None:
     reasons = [event.payload["reason"] for event in compiler_run.trace_events if "reason" in event.payload]
     assert "within_open_loop_limit" in reasons
     assert "open_loop_limit_exceeded" in reasons
+
+
+class ResumptionBriefStoreStub:
+    def __init__(self) -> None:
+        self.base_time = datetime(2026, 3, 23, 10, 0, tzinfo=UTC)
+        self.thread_id = uuid4()
+        self.other_thread_id = uuid4()
+        self.latest_task_id = uuid4()
+        self.latest_step_trace_id = uuid4()
+
+    def list_thread_events(self, thread_id):
+        if thread_id != self.thread_id:
+            return []
+        return [
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "thread_id": self.thread_id,
+                "session_id": uuid4(),
+                "sequence_no": 1,
+                "kind": "message.user",
+                "payload": {"text": "first"},
+                "created_at": self.base_time,
+            },
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "thread_id": self.thread_id,
+                "session_id": uuid4(),
+                "sequence_no": 2,
+                "kind": "approval.request",
+                "payload": {"approval_id": "approval-1"},
+                "created_at": self.base_time + timedelta(minutes=1),
+            },
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "thread_id": self.thread_id,
+                "session_id": uuid4(),
+                "sequence_no": 3,
+                "kind": "message.assistant",
+                "payload": {"text": "second"},
+                "created_at": self.base_time + timedelta(minutes=2),
+            },
+        ]
+
+    def list_open_loops(self, *, status=None, limit=None):
+        assert status == "open"
+        assert limit is None
+        return [
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "memory_id": None,
+                "title": "Latest open loop",
+                "status": "open",
+                "opened_at": self.base_time + timedelta(minutes=3),
+                "due_at": None,
+                "resolved_at": None,
+                "resolution_note": None,
+                "created_at": self.base_time + timedelta(minutes=3),
+                "updated_at": self.base_time + timedelta(minutes=3),
+            },
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "memory_id": None,
+                "title": "Older open loop",
+                "status": "open",
+                "opened_at": self.base_time + timedelta(minutes=1),
+                "due_at": None,
+                "resolved_at": None,
+                "resolution_note": None,
+                "created_at": self.base_time + timedelta(minutes=1),
+                "updated_at": self.base_time + timedelta(minutes=1),
+            },
+        ]
+
+    def list_context_memories(self):
+        return [
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "memory_key": "user.preference.older",
+                "value": {"likes": "tea"},
+                "status": "active",
+                "source_event_ids": [],
+                "memory_type": "preference",
+                "confidence": None,
+                "salience": None,
+                "confirmation_status": "unconfirmed",
+                "valid_from": None,
+                "valid_to": None,
+                "last_confirmed_at": None,
+                "created_at": self.base_time,
+                "updated_at": self.base_time,
+                "deleted_at": None,
+            },
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "memory_key": "user.preference.deleted",
+                "value": {"likes": "espresso"},
+                "status": "deleted",
+                "source_event_ids": [],
+                "memory_type": "preference",
+                "confidence": None,
+                "salience": None,
+                "confirmation_status": "unconfirmed",
+                "valid_from": None,
+                "valid_to": None,
+                "last_confirmed_at": None,
+                "created_at": self.base_time + timedelta(minutes=1),
+                "updated_at": self.base_time + timedelta(minutes=1),
+                "deleted_at": self.base_time + timedelta(minutes=1),
+            },
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "memory_key": "user.preference.latest",
+                "value": {"likes": "oat milk"},
+                "status": "active",
+                "source_event_ids": [],
+                "memory_type": "preference",
+                "confidence": None,
+                "salience": None,
+                "confirmation_status": "unconfirmed",
+                "valid_from": None,
+                "valid_to": None,
+                "last_confirmed_at": None,
+                "created_at": self.base_time + timedelta(minutes=2),
+                "updated_at": self.base_time + timedelta(minutes=2),
+                "deleted_at": None,
+            },
+        ]
+
+    def list_tasks(self):
+        return [
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "thread_id": self.other_thread_id,
+                "tool_id": uuid4(),
+                "status": "approved",
+                "request": {
+                    "thread_id": str(self.other_thread_id),
+                    "tool_id": "tool-1",
+                    "action": "tool.run",
+                    "scope": "workspace",
+                    "domain_hint": None,
+                    "risk_hint": None,
+                    "attributes": {},
+                },
+                "tool": {
+                    "id": "tool-1",
+                    "tool_key": "proxy.echo",
+                    "name": "Proxy Echo",
+                    "description": "Deterministic proxy handler.",
+                    "version": "1.0.0",
+                    "metadata_version": "tool_metadata_v0",
+                    "active": True,
+                    "tags": [],
+                    "action_hints": [],
+                    "scope_hints": [],
+                    "domain_hints": [],
+                    "risk_hints": [],
+                    "metadata": {},
+                    "created_at": self.base_time.isoformat(),
+                },
+                "latest_approval_id": None,
+                "latest_execution_id": None,
+                "created_at": self.base_time,
+                "updated_at": self.base_time,
+            },
+            {
+                "id": self.latest_task_id,
+                "user_id": uuid4(),
+                "thread_id": self.thread_id,
+                "tool_id": uuid4(),
+                "status": "approved",
+                "request": {
+                    "thread_id": str(self.thread_id),
+                    "tool_id": "tool-2",
+                    "action": "tool.run",
+                    "scope": "workspace",
+                    "domain_hint": None,
+                    "risk_hint": None,
+                    "attributes": {"task": "current"},
+                },
+                "tool": {
+                    "id": "tool-2",
+                    "tool_key": "proxy.echo",
+                    "name": "Proxy Echo",
+                    "description": "Deterministic proxy handler.",
+                    "version": "1.0.0",
+                    "metadata_version": "tool_metadata_v0",
+                    "active": True,
+                    "tags": [],
+                    "action_hints": [],
+                    "scope_hints": [],
+                    "domain_hints": [],
+                    "risk_hints": [],
+                    "metadata": {},
+                    "created_at": self.base_time.isoformat(),
+                },
+                "latest_approval_id": None,
+                "latest_execution_id": None,
+                "created_at": self.base_time + timedelta(minutes=2),
+                "updated_at": self.base_time + timedelta(minutes=2),
+            },
+        ]
+
+    def list_task_steps_for_task(self, task_id):
+        if task_id != self.latest_task_id:
+            return []
+        return [
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "task_id": self.latest_task_id,
+                "sequence_no": 1,
+                "parent_step_id": None,
+                "source_approval_id": None,
+                "source_execution_id": None,
+                "kind": "governed_request",
+                "status": "approved",
+                "request": {
+                    "thread_id": str(self.thread_id),
+                    "tool_id": "tool-2",
+                    "action": "tool.run",
+                    "scope": "workspace",
+                    "domain_hint": None,
+                    "risk_hint": None,
+                    "attributes": {"task": "current"},
+                },
+                "outcome": {
+                    "routing_decision": "ready",
+                    "approval_id": None,
+                    "approval_status": None,
+                    "execution_id": None,
+                    "execution_status": None,
+                    "blocked_reason": None,
+                },
+                "trace_id": uuid4(),
+                "trace_kind": "task.step.sequence",
+                "created_at": self.base_time + timedelta(minutes=2),
+                "updated_at": self.base_time + timedelta(minutes=2),
+            },
+            {
+                "id": uuid4(),
+                "user_id": uuid4(),
+                "task_id": self.latest_task_id,
+                "sequence_no": 2,
+                "parent_step_id": None,
+                "source_approval_id": None,
+                "source_execution_id": None,
+                "kind": "governed_request",
+                "status": "executed",
+                "request": {
+                    "thread_id": str(self.thread_id),
+                    "tool_id": "tool-2",
+                    "action": "tool.run",
+                    "scope": "workspace",
+                    "domain_hint": None,
+                    "risk_hint": None,
+                    "attributes": {"task": "current"},
+                },
+                "outcome": {
+                    "routing_decision": "ready",
+                    "approval_id": None,
+                    "approval_status": None,
+                    "execution_id": "execution-1",
+                    "execution_status": "completed",
+                    "blocked_reason": None,
+                },
+                "trace_id": self.latest_step_trace_id,
+                "trace_kind": "task.step.transition",
+                "created_at": self.base_time + timedelta(minutes=3),
+                "updated_at": self.base_time + timedelta(minutes=3),
+            },
+        ]
+
+
+def test_compile_resumption_brief_builds_deterministic_bounded_sections() -> None:
+    store = ResumptionBriefStoreStub()
+    thread = {
+        "id": store.thread_id,
+        "user_id": uuid4(),
+        "title": "Resumption thread",
+        "created_at": store.base_time,
+        "updated_at": store.base_time + timedelta(minutes=3),
+    }
+
+    brief = compile_resumption_brief(
+        store,
+        thread=thread,
+        event_limit=1,
+        open_loop_limit=1,
+        memory_limit=1,
+    )
+
+    assert brief["assembly_version"] == "resumption_brief_v0"
+    assert brief["conversation"]["summary"] == {
+        "limit": 1,
+        "returned_count": 1,
+        "total_count": 2,
+        "order": ["sequence_no_asc"],
+        "kinds": ["message.user", "message.assistant"],
+    }
+    assert [event["sequence_no"] for event in brief["conversation"]["items"]] == [3]
+    assert brief["open_loops"]["summary"] == {
+        "limit": 1,
+        "returned_count": 1,
+        "total_count": 2,
+        "order": ["opened_at_desc", "created_at_desc", "id_desc"],
+    }
+    assert [item["title"] for item in brief["open_loops"]["items"]] == ["Latest open loop"]
+    assert brief["memory_highlights"]["summary"] == {
+        "limit": 1,
+        "returned_count": 1,
+        "total_count": 2,
+        "order": ["updated_at_asc", "created_at_asc", "id_asc"],
+    }
+    assert [item["memory_key"] for item in brief["memory_highlights"]["items"]] == [
+        "user.preference.latest"
+    ]
+    assert brief["workflow"] is not None
+    assert brief["workflow"]["task"]["id"] == str(store.latest_task_id)
+    assert brief["workflow"]["latest_task_step"] is not None
+    assert brief["workflow"]["latest_task_step"]["sequence_no"] == 2
+    assert brief["workflow"]["latest_task_step"]["trace"]["trace_id"] == str(
+        store.latest_step_trace_id
+    )
+    assert brief["workflow"]["summary"] == {
+        "present": True,
+        "task_order": ["created_at_asc", "id_asc"],
+        "task_step_order": ["sequence_no_asc", "created_at_asc", "id_asc"],
+    }
+    assert brief["sources"] == ["threads", "events", "open_loops", "memories", "tasks", "task_steps"]
+
+
+def test_compile_resumption_brief_supports_zero_limits_and_missing_workflow() -> None:
+    store = ResumptionBriefStoreStub()
+    store.list_tasks = lambda: []  # type: ignore[method-assign]
+    thread = {
+        "id": store.thread_id,
+        "user_id": uuid4(),
+        "title": "Resumption thread",
+        "created_at": store.base_time,
+        "updated_at": store.base_time + timedelta(minutes=3),
+    }
+
+    brief = compile_resumption_brief(
+        store,
+        thread=thread,
+        event_limit=0,
+        open_loop_limit=0,
+        memory_limit=0,
+    )
+
+    assert brief["conversation"]["items"] == []
+    assert brief["open_loops"]["items"] == []
+    assert brief["memory_highlights"]["items"] == []
+    assert brief["conversation"]["summary"]["limit"] == 0
+    assert brief["open_loops"]["summary"]["limit"] == 0
+    assert brief["memory_highlights"]["summary"]["limit"] == 0
+    assert brief["workflow"] is None
+    assert brief["sources"] == ["threads", "events", "open_loops", "memories"]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -143,6 +143,7 @@ def test_healthcheck_route_is_registered() -> None:
     assert "/v0/tasks/{task_id}" in route_paths
     assert "/v0/tasks/{task_id}/workspace" in route_paths
     assert "/v0/tasks/{task_id}/steps" in route_paths
+    assert "/v0/threads/{thread_id}/resumption-brief" in route_paths
     assert "/v0/task-workspaces" in route_paths
     assert "/v0/task-workspaces/{task_workspace_id}" in route_paths
     assert "/v0/task-workspaces/{task_workspace_id}/artifacts" in route_paths


### PR DESCRIPTION
## Sprint
Phase 2 Sprint 4: Deterministic Resumption Briefs

## Summary
This sprint adds a deterministic, user-scoped resumption-brief read seam and surfaces it in `/chat` for selected threads. The brief is assembled from existing durable seams only and remains bounded, ordered, and auditable.

## What Shipped
- Typed resumption-brief contracts in `apps/api/src/alicebot_api/contracts.py`.
- New endpoint: `GET /v0/threads/{thread_id}/resumption-brief`.
- Deterministic brief assembly in `apps/api/src/alicebot_api/compiler.py` via `compile_resumption_brief(...)`.
- `/chat` UI adoption:
  - `apps/web/lib/api.ts`: typed client + `getThreadResumptionBrief(...)`
  - `apps/web/app/chat/page.tsx`: selected-thread brief loading (live/fixture/unavailable parity)
  - `apps/web/components/thread-summary.tsx`: brief rendering
- Sprint-scoped report updates in `BUILD_REPORT.md` and `REVIEW_REPORT.md`.

## Deterministic Brief Composition
Brief sections are assembled from durable stored seams:
- selected thread metadata
- latest conversation events
- active open loops
- bounded memory highlights
- latest task and latest task-step posture when present

Ordering and limits are explicit:
- conversation: `sequence_no_asc`, bounded by `max_events`
- open loops: `opened_at_desc`, `created_at_desc`, `id_desc`, bounded by `max_open_loops`
- memory highlights: `updated_at_asc`, `created_at_asc`, `id_asc`, bounded by `max_memories`
- workflow posture: stable latest task/task-step ordering

## Scope And Safety
- Stayed within Sprint 4 surfaces: contracts/API/compiler/UI + sprint tests/docs.
- No automation, worker orchestration, migration/table expansion, or Phase 3 runtime/profile routing added.
- Thread access remains user-scoped; missing/cross-user thread responses are deterministic `404`.

## Verification
Executed on this branch:

1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_compiler.py tests/unit/test_main.py`
- Result: `53 passed`

2. `cd apps/web && pnpm test -- app/chat/page.test.tsx components/thread-summary.test.tsx lib/api.test.ts`
- Result: `28 passed`

3. `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_continuity_api.py`
- Result: `3 passed`
- Note: integration run required local Postgres access outside default sandbox networking.

## Review Status
- `REVIEW_REPORT.md` verdict: `PASS`
- Acceptance criteria missed: `None`
- Non-blocking note: fixture-mode brief intentionally leaves open-loops/memory-highlights empty for state-parity UI validation.

## Request
Ready for Control Tower merge gate. Recommended merge mode remains squash after explicit merge approval.
