### PR TITLE
Phase 2 Sprint 5: explicit commitment capture

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 2 Sprint 4: Deterministic Resumption Briefs
+Phase 2 Sprint 5: Explicit Commitment Capture
 
 ## Sprint Type
 
@@ -10,46 +10,47 @@ feature
 
 ## Sprint Reason
 
-Phase 2 Sprint 3 open-loop backbone is merged. The next continuity-first seam is deterministic resumption support so operators can re-enter a thread with a compact, auditable brief instead of manually reconstructing context from raw events, memories, and open loops.
+Phase 2 Sprint 4 deterministic resumption briefs are merged. The next missing continuity seam is explicit commitment capture so user-stated follow-ups can become governed open-loop records without manual data entry.
 
 ## Sprint Intent
 
-Implement a bounded resumption-brief read seam (contracts, API, compiler-backed assembly, and `/chat` display adoption) without introducing automation, autonomous follow-up behavior, or worker orchestration.
+Implement a bounded explicit-commitment extraction seam that reads one `message.user` event and creates a deterministic open-loop record (plus linked memory evidence) through existing governed admission pathways, without automation or worker orchestration.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase2-sprint4-resumption-briefs`
+- Branch Name: `codex/phase2-sprint5-explicit-commitment-capture`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- Typed memories and open loops are now shipped and stable.
-- `/chat` still requires manual reconstruction to resume a thread efficiently.
-- A deterministic brief seam is required before any future automation or vertical-agent specialization.
+- Typed memory, open-loop lifecycle, and resumption brief seams are now shipped.
+- Commitment capture is still manual and creates operator friction.
+- A deterministic extraction seam is required before safe future reminder/orchestration work.
 
 ## Design Truth
 
-- Reuse existing continuity, memory, and open-loop seams; do not create a parallel context pipeline.
-- Build brief generation as deterministic assembly from durable records, not free-form model synthesis.
-- Preserve per-user isolation and existing append-only audit guarantees.
+- Reuse existing continuity events, memory admission, and open-loop seams; do not add parallel storage.
+- Keep extraction pattern-driven and deterministic; no model-based interpretation.
+- Preserve per-user isolation, append-only memory revision guarantees, and auditable source linkage.
 
 ## Exact Surfaces In Scope
 
-- resumption-brief contracts + API behavior
-- compiler-backed deterministic brief assembly
-- `/chat` brief visibility for selected thread
+- commitment extraction contracts + API behavior
+- deterministic pattern extraction and admission orchestration
+- `/memories` review parity (captured open-loop + linked memory evidence visible through existing surfaces)
 - sprint-scoped backend and frontend tests
 
 ## Exact Files In Scope
 
+- [explicit_commitments.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/explicit_commitments.py)
 - [contracts.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/contracts.py)
 - [main.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/main.py)
-- [compiler.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/compiler.py)
+- [memory.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/memory.py)
+- [store.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/store.py)
 - [api.ts](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/lib/api.ts)
-- [page.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/app/chat/page.tsx)
-- [thread-summary.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-summary.tsx)
+- [page.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/app/memories/page.tsx)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
 - [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
@@ -60,50 +61,56 @@ Implement a bounded resumption-brief read seam (contracts, API, compiler-backed 
 
 ## In Scope
 
-- Add resumption-brief contracts (request/response schema) with explicit, typed fields.
+- Add typed contracts for explicit commitment extraction request/response.
 - Add API endpoint:
-  - `GET /v0/threads/{thread_id}/resumption-brief`
-- Assemble brief deterministically from existing durable seams:
-  - selected thread metadata
-  - latest conversation events
-  - active open loops
-  - bounded memory highlights
-  - latest workflow/task-step posture when present
-- Include deterministic ordering and bounded limits for each brief section.
-- Expose brief in `/chat` selected-thread summary panel with live/fixture/unavailable behavior parity.
-- Add/update tests across API, compiler/assembly logic, and `/chat` UI seams.
+  - `POST /v0/open-loops/extract-explicit-commitments`
+- Endpoint input:
+  - `user_id` (required)
+  - `source_event_id` (required; must reference a user-owned `message.user` event)
+- Deterministically extract commitment candidates from explicit patterns (for example: `remind me to ...`, `i need to ...`, `don't let me forget to ...`, `remember to ...`), with bounded normalization and clause rejection rules.
+- Persist extracted commitments through existing governed seams:
+  - admit/update a linked memory evidence record
+  - create an open-loop record linked to that memory when no active open loop already exists for the same memory
+- Return deterministic extraction summary including:
+  - candidate count
+  - admitted-memory decisions
+  - open-loop create/noop outcomes
+  - source event identity/kind
+- Add/update `/memories` API wiring/tests if needed so newly captured commitment loops and linked memory evidence remain visible with existing live/fixture/unavailable behavior.
+- Add/update tests across extraction logic, endpoint behavior, user isolation, and deterministic idempotence-on-repeat for the same source event.
 
 ## Out of Scope
 
-- new database tables or migration work
 - autonomous follow-up execution or reminders
 - background workers or scheduler integration
 - connector expansion
 - multi-agent runtime/profile routing (Phase 3)
-- broad UI redesign outside `/chat`
+- free-form model-based extraction or classification
+- broad UI redesign outside `/memories`
 
 ## Required Deliverables
 
-- backend contracts/API for deterministic resumption brief read
-- compiler or dedicated assembly helper for deterministic brief construction
-- `/chat` resumption-brief display for selected thread
+- backend contracts/API for explicit commitment extraction
+- deterministic extraction module with tests
+- governed admission + open-loop creation orchestration with duplicate-open-loop guard for repeated source events
 - updated sprint reports for this sprint only
 
 ## Acceptance Criteria
 
-- endpoint returns deterministic brief payload for a selected thread with strict per-user isolation
-- missing/cross-user thread behavior is deterministic (`404`)
-- brief sections use bounded limits and stable ordering
-- brief reflects active open loops and recent continuity evidence when present
-- `/chat` renders brief content with live/fixture/unavailable states and no regression to existing chat workflow surfaces
+- endpoint returns deterministic extraction payload with strict per-user isolation
+- invalid/missing/non-user-message `source_event_id` returns deterministic `400`
+- cross-user or missing event access is rejected deterministically without side effects
+- supported explicit commitment statements produce candidate(s), memory admission(s), and open-loop outcome(s)
+- repeated extraction for the same source event does not create duplicate active open loops for the same derived commitment memory
+- `/memories` existing review surfaces continue to show resulting open-loop and memory evidence without regression
 - backend + frontend tests pass for touched seams
 - no out-of-scope automation, worker, or Phase 3 routing work enters sprint
 
 ## Implementation Constraints
 
 - preserve RLS and per-user isolation
-- keep deterministic ordering in API and compiler outputs
-- keep brief generation model-free and source-attributed to durable seams
+- keep extraction deterministic and pattern-based (no model calls)
+- keep memory/open-loop evidence source-attributed to the original event
 - co-deliver tests with each seam change
 
 ## Control Tower Task Cards
@@ -115,43 +122,44 @@ Write scope:
 - `apps/api/src/alicebot_api/main.py`
 - API/integration tests
 
-### Task 2: Deterministic Brief Assembly
+### Task 2: Extraction + Admission Orchestration
 Owner: backend operative B  
 Write scope:
-- `apps/api/src/alicebot_api/compiler.py`
-- compiler tests
+- `apps/api/src/alicebot_api/explicit_commitments.py`
+- `apps/api/src/alicebot_api/memory.py`
+- `apps/api/src/alicebot_api/store.py`
+- unit tests
 
-### Task 3: Chat UI Adoption
+### Task 3: Web Surface Compatibility
 Owner: frontend operative  
 Write scope:
 - `apps/web/lib/api.ts`
-- `apps/web/app/chat/page.tsx`
-- `apps/web/components/thread-summary.tsx`
-- related chat components/tests
+- `apps/web/app/memories/page.tsx`
+- related memory components/tests
 
 ### Task 4: Integration Review
 Owner: control tower  
 Responsibilities:
-- verify contracts/API/assembly/UI coherence
+- verify contracts/API/extraction/admission/UI coherence
 - verify strict sprint scope
 - verify acceptance + evidence completeness
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact resumption-brief fields and endpoint shipped
-- API surface deltas and deterministic ordering rules
+- exact extraction patterns, endpoint, and payload fields shipped
+- API surface deltas and dedupe/no-side-effect rules
 - exact commands/tests run with outcomes
 - explicit deferred scope (automation/workers/Phase 3 runtime orchestration)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint remained deterministic-resumption-brief scoped
-- contracts/API/assembly/UI consistency
+- sprint remained explicit-commitment-capture scoped
+- contracts/API/extraction/admission/UI consistency
 - sufficient tests for all touched seams
 - no hidden scope expansion
 
 ## Exit Condition
 
-This sprint is complete when deterministic resumption briefs are exposed through a user-scoped API seam and surfaced in `/chat` selected-thread review with test-backed behavior and no automation/worker/Phase 3 scope expansion.
+This sprint is complete when explicit commitment extraction is available through a user-scoped deterministic API seam, persists through governed memory/open-loop pathways with repeat-call duplicate protection, and passes sprint-scoped tests without automation/worker/Phase 3 scope expansion.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,58 +1,61 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Phase 2 Sprint 4 deterministic resumption briefs (typed contracts, user-scoped API, compiler-backed deterministic assembly, and `/chat` selected-thread display adoption) without adding automation, worker orchestration, or Phase 3 runtime/profile routing.
+Implement Phase 2 Sprint 5 explicit commitment capture as a deterministic, user-scoped seam that reads one `message.user` event and persists commitment memory evidence plus an open loop through existing governed admission pathways, without automation, workers, or Phase 3 routing.
 
 ## Completed Work
-- Shipped typed resumption-brief contracts and bounds in `apps/api/src/alicebot_api/contracts.py`.
-- Shipped `GET /v0/threads/{thread_id}/resumption-brief` in `apps/api/src/alicebot_api/main.py`.
-- Added bounded query inputs:
-  - `user_id` (required)
-  - `max_events` (default `8`, max `50`)
-  - `max_open_loops` (default `5`, max `20`)
-  - `max_memories` (default `5`, max `20`)
-- Added compiler-backed deterministic brief assembly in `apps/api/src/alicebot_api/compiler.py` via `compile_resumption_brief(...)`.
-- Brief assembly is sourced from existing durable seams only:
-  - selected thread metadata
-  - latest conversation events (`message.user`, `message.assistant`)
-  - active open loops (`status="open"`)
-  - active memory highlights
-  - latest task + latest task-step posture for the selected thread when present
-- Added `/chat` adoption:
-  - `apps/web/lib/api.ts`: typed client + `getThreadResumptionBrief(...)`
-  - `apps/web/app/chat/page.tsx`: live/fixture/unavailable brief loading
-  - `apps/web/components/thread-summary.tsx`: brief section rendering in selected-thread panel
-- Added/updated sprint-scoped backend/frontend tests for contracts/API/assembly/UI seams.
+- Added explicit commitment contracts in `apps/api/src/alicebot_api/contracts.py`:
+  - `ExplicitCommitmentPattern`
+  - `ExplicitCommitmentExtractionRequestInput`
+  - candidate/admission/open-loop outcome/summary/response typed records.
+- Added deterministic extractor/orchestrator module `apps/api/src/alicebot_api/explicit_commitments.py`.
+- Added API endpoint in `apps/api/src/alicebot_api/main.py`:
+  - `POST /v0/open-loops/extract-explicit-commitments`
+  - input: `user_id` (required), `source_event_id` (required)
+  - deterministic `400` for invalid/missing/non-user/cross-user source event.
+- Added web API typing/client support in `apps/web/lib/api.ts`:
+  - `extractExplicitCommitments(...)`
+  - explicit commitment response types.
+- Added sprint-scoped tests:
+  - `tests/unit/test_explicit_commitments.py`
+  - `tests/integration/test_explicit_commitments_api.py`
+  - `tests/unit/test_main.py` route + endpoint handler coverage
+  - `apps/web/lib/api.test.ts` request wiring coverage
+- Verified `/memories` review parity via integration checks against existing `/v0/memories` and `/v0/open-loops` surfaces and frontend memories page tests.
 
-## Exact Resumption-Brief Fields Shipped
-- Top-level `brief` payload:
-  - `assembly_version`
-  - `thread`
-  - `conversation`
-    - `items`
-    - `summary`: `limit`, `returned_count`, `total_count`, `order`, `kinds`
-  - `open_loops`
-    - `items`
-    - `summary`: `limit`, `returned_count`, `total_count`, `order`
-  - `memory_highlights`
-    - `items`
-    - `summary`: `limit`, `returned_count`, `total_count`, `order`
-  - `workflow` (`null` when absent)
-    - `task`
-    - `latest_task_step`
-    - `summary`: `present`, `task_order`, `task_step_order`
-  - `sources`
+## Exact Extraction Patterns, Endpoint, And Payload Fields Shipped
+- Endpoint shipped:
+  - `POST /v0/open-loops/extract-explicit-commitments`
+- Deterministic explicit patterns:
+  - `remind me to ...`
+  - `i need to ...`
+  - `don't let me forget to ...` (also supports `dont`)
+  - `remember to ...`
+- Bounded normalization and clause rejection rules:
+  - whitespace normalization
+  - trailing punctuation trim (`.`, `!`, `?`)
+  - bounded token/character limits
+  - deterministic token-shape validation
+  - clause-style tail rejection via deterministic prefix/token guards.
+- Response fields shipped:
+  - `candidates[]`:
+    - `memory_key`, `value`, `source_event_ids`, `delete_requested`, `pattern`, `commitment_text`, `open_loop_title`
+  - `admissions[]`:
+    - memory admission `decision`, `reason`, `memory`, `revision`
+    - open-loop outcome `open_loop.decision`, `open_loop.reason`, `open_loop.open_loop`
+  - `summary`:
+    - `source_event_id`, `source_event_kind`, `candidate_count`, `admission_count`, `persisted_change_count`, `noop_count`, `open_loop_created_count`, `open_loop_noop_count`
 
-## API Surface Deltas And Deterministic Ordering Rules
-- New endpoint:
-  - `GET /v0/threads/{thread_id}/resumption-brief`
-- Deterministic not-found behavior:
-  - missing thread and cross-user thread both return `404` with thread-specific detail.
-- Deterministic ordering and bounded windows:
-  - conversation candidates ordered by `sequence_no_asc`, then bounded to latest window (`max_events`).
-  - open loops ordered by `opened_at_desc`, `created_at_desc`, `id_desc`, then bounded by `max_open_loops`.
-  - memory highlights ordered by `updated_at_asc`, `created_at_asc`, `id_asc`, then bounded to latest window (`max_memories`).
-  - workflow posture uses latest task by `created_at_asc`, `id_asc` and latest task-step by `sequence_no_asc`, `created_at_asc`, `id_asc`.
+## API Surface Deltas And Dedupe/No-Side-Effect Rules
+- New backend surface:
+  - `POST /v0/open-loops/extract-explicit-commitments`
+- New web client surface:
+  - `extractExplicitCommitments(apiBaseUrl, { user_id, source_event_id })`
+- Dedupe rule implemented:
+  - after memory admission, create open loop only when no active (`status="open"`) open loop already exists for the derived memory.
+  - repeat extraction for same source event yields open-loop outcome `NOOP_ACTIVE_EXISTS` and does not create duplicate active loops.
+- No-side-effect rule implemented:
+  - if `source_event_id` is missing, cross-user, or not `message.user`, endpoint returns deterministic `400` and performs no memory/open-loop writes.
 
 ## Incomplete Work
 - None within sprint scope.
@@ -60,40 +63,36 @@ Implement Phase 2 Sprint 4 deterministic resumption briefs (typed contracts, use
 ## Files Changed
 - `apps/api/src/alicebot_api/contracts.py`
 - `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/compiler.py`
-- `apps/web/lib/api.ts`
-- `apps/web/app/chat/page.tsx`
-- `apps/web/components/thread-summary.tsx`
-- `tests/unit/test_compiler.py`
+- `apps/api/src/alicebot_api/explicit_commitments.py`
+- `tests/unit/test_explicit_commitments.py`
+- `tests/integration/test_explicit_commitments_api.py`
 - `tests/unit/test_main.py`
-- `tests/integration/test_continuity_api.py`
+- `apps/web/lib/api.ts`
 - `apps/web/lib/api.test.ts`
-- `apps/web/components/thread-summary.test.tsx`
-- `apps/web/app/chat/page.test.tsx`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 ## Tests Run
-1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_compiler.py tests/unit/test_main.py`
-- Outcome: `53 passed`
+1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_explicit_commitments.py tests/unit/test_main.py`
+- Outcome: `54 passed`
 
-2. `cd apps/web && pnpm test -- app/chat/page.test.tsx components/thread-summary.test.tsx lib/api.test.ts`
-- Outcome: `28 passed`
+2. `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_explicit_commitments_api.py`
+- Initial sandbox run: failed due local Postgres access restriction.
+- Escalated run outcome: `3 passed`
 
-3. `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_continuity_api.py`
-- Outcome: `3 passed`
-- Note: executed with escalated permissions to allow local Postgres access from this environment.
+3. `cd apps/web && pnpm test -- lib/api.test.ts app/memories/page.test.tsx`
+- Outcome: `26 passed`
 
 ## Blockers/Issues
-- No unresolved blockers.
-- Environment constraint: DB-backed integration tests require execution outside default sandbox network restrictions.
+- No unresolved functional blockers.
+- Environment constraint: DB-backed integration tests require local Postgres access outside default sandbox network restrictions.
 
 ## Explicit Deferred Scope
-- autonomous follow-up behavior/reminders
-- background worker or scheduler integration
-- automation orchestration
+- autonomous reminders/follow-up execution
+- background workers/scheduler orchestration
+- connector expansion
 - Phase 3 multi-agent runtime/profile routing
-- database migrations/new tables outside sprint scope
+- model-based/free-form extraction
 
 ## Recommended Next Step
-Proceed to Control Tower integration review for Sprint 4, focusing on deterministic brief payload coherence across contracts/API/compiler/UI and merge after reviewer `PASS` + explicit merge approval.
+Submit for Control Tower integration review focusing on endpoint contract stability, deterministic open-loop dedupe behavior, and cross-user no-side-effect guarantees before squash merge.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,45 +4,48 @@
 PASS
 
 ## criteria met
-- Sprint stayed within the Sprint 4 scope: contracts/API/compiler/UI for deterministic resumption briefs only.
-- Shipped endpoint and contract seam are coherent and typed:
-  - `GET /v0/threads/{thread_id}/resumption-brief`
-  - payload includes `assembly_version`, `thread`, `conversation`, `open_loops`, `memory_highlights`, `workflow`, `sources`
-- Per-user isolation and deterministic not-found behavior are implemented:
-  - thread lookup is user-scoped
-  - cross-user and missing thread requests return deterministic `404`
-- Deterministic ordering and bounded sections are explicit in implementation and reflected in summaries:
-  - conversation order: `sequence_no_asc` with bounded latest window
-  - open-loop order: `opened_at_desc`, `created_at_desc`, `id_desc`
-  - memory order: `updated_at_asc`, `created_at_asc`, `id_asc` with bounded latest window
-  - workflow posture selection uses stable task/task-step ordering
-- `/chat` selected-thread panel now supports resumption brief live/fixture/unavailable states without removing existing chat workflow surfaces.
-- Verified tests:
-  - `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_compiler.py tests/unit/test_main.py` -> `53 passed`
-  - `cd apps/web && pnpm test -- app/chat/page.test.tsx components/thread-summary.test.tsx lib/api.test.ts` -> `28 passed`
-  - `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_continuity_api.py` -> `3 passed` (required elevated local DB access in this environment)
+- Sprint stayed within explicit-commitment-capture scope (no automation/workers/Phase 3 routing changes).
+- Contracts and API seam are shipped and coherent:
+  - `POST /v0/open-loops/extract-explicit-commitments`
+  - request requires `user_id` and `source_event_id`
+  - response returns deterministic `candidates`, `admissions` (including open-loop outcomes), and `summary`.
+- Deterministic pattern extraction is implemented (no model calls) in `apps/api/src/alicebot_api/explicit_commitments.py` for:
+  - `remind me to ...`
+  - `i need to ...`
+  - `don't let me forget to ...`
+  - `remember to ...`
+- Invalid source event semantics are enforced with deterministic `400` for non-user/cross-user/missing event IDs.
+- Persistence uses governed seams:
+  - memory writes go through `admit_memory_candidate(...)`
+  - open loops are linked to admitted memory.
+- Duplicate active open loops are prevented on repeat extraction (`NOOP_ACTIVE_EXISTS`).
+- `/memories` parity is preserved through existing review surfaces (`/v0/memories`, `/v0/open-loops`).
+- Sprint-scoped tests for touched seams pass:
+  - `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_explicit_commitments.py tests/unit/test_main.py` -> `54 passed`
+  - `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_explicit_commitments_api.py` -> `3 passed`
+  - `cd apps/web && pnpm test -- lib/api.test.ts app/memories/page.test.tsx` -> `26 passed`
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking quality issues found in sprint scope.
-- Minor non-blocking note: fixture-mode brief intentionally leaves open-loops and memory-highlights empty; this is acceptable for state-parity UI validation in this sprint.
+- No blocking implementation quality issues found.
+- Minor non-blocking note: active-open-loop dedupe currently scans `list_open_loops(status="open")` in user scope; acceptable for current bounded usage.
 
 ## regression risks
-- Low for touched seams due unit + integration + web test coverage on new surfaces.
-- Residual risk remains on unrelated app surfaces not exercised in this sprint review run.
+- Low on touched seams due unit + integration + frontend coverage.
+- Residual risk remains on unrelated surfaces not rerun in this review.
 
 ## docs issues
-- No blocking documentation gaps for sprint acceptance.
-- `BUILD_REPORT.md` includes required endpoint, fields, ordering rules, tests, and deferred scope.
+- No blocking docs issues for sprint acceptance.
+- `BUILD_REPORT.md` includes required endpoint, extraction patterns, payload fields, dedupe/no-side-effect behavior, tests, and deferred scope.
 
 ## should anything be added to RULES.md?
-- Optional improvement: add a rule that every new continuity-read endpoint must ship explicit ordering constants plus test assertions for ordering and bounds.
+- No required rule additions for this sprint.
 
 ## should anything update ARCHITECTURE.md?
-- Optional improvement: add a short “Resumption Brief Read Seam” subsection documenting source seams (`threads/events/open_loops/memories/tasks/task_steps`) and deterministic assembly constraints.
+- Optional follow-up only: add a short subsection documenting the explicit commitment extraction seam and dedupe behavior for future reminder/orchestration phases.
 
 ## recommended next action
-1. Mark Sprint 4 as reviewer `PASS` and move to Control Tower merge gate.
-2. Optionally capture the non-blocking RULES/ARCHITECTURE clarifications in a follow-up docs-only PR.
+- Mark sprint as reviewer `PASS` and move to Control Tower merge gate.
+- Optional follow-up hardening: add one integration assertion for a random/nonexistent `source_event_id` no-side-effect behavior.

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -93,6 +93,17 @@ ExplicitPreferencePattern = Literal[
     "remember_that_i_dont_like",
     "remember_that_i_prefer",
 ]
+ExplicitCommitmentPattern = Literal[
+    "remind_me_to",
+    "i_need_to",
+    "dont_let_me_forget_to",
+    "remember_to",
+]
+ExplicitCommitmentOpenLoopDecision = Literal[
+    "CREATED",
+    "NOOP_ACTIVE_EXISTS",
+    "NOOP_MEMORY_NOT_PERSISTED",
+]
 MemorySelectionSource = Literal["symbolic", "semantic"]
 ArtifactSelectionSource = Literal["lexical", "semantic"]
 
@@ -1029,6 +1040,16 @@ class ExplicitPreferenceExtractionRequestInput:
 
 
 @dataclass(frozen=True, slots=True)
+class ExplicitCommitmentExtractionRequestInput:
+    source_event_id: UUID
+
+    def as_payload(self) -> JsonObject:
+        return {
+            "source_event_id": str(self.source_event_id),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class OpenLoopCreateInput:
     title: str
     memory_id: UUID | None = None
@@ -1063,6 +1084,16 @@ class ExtractedPreferenceCandidateRecord(TypedDict):
     delete_requested: bool
     pattern: ExplicitPreferencePattern
     subject_text: str
+
+
+class ExtractedCommitmentCandidateRecord(TypedDict):
+    memory_key: str
+    value: JsonValue
+    source_event_ids: list[str]
+    delete_requested: bool
+    pattern: ExplicitCommitmentPattern
+    commitment_text: str
+    open_loop_title: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -1454,6 +1485,37 @@ class ExplicitPreferenceExtractionResponse(TypedDict):
     candidates: list[ExtractedPreferenceCandidateRecord]
     admissions: list[ExplicitPreferenceAdmissionRecord]
     summary: ExplicitPreferenceExtractionSummary
+
+
+class ExplicitCommitmentOpenLoopOutcome(TypedDict):
+    decision: ExplicitCommitmentOpenLoopDecision
+    reason: str
+    open_loop: OpenLoopRecord | None
+
+
+class ExplicitCommitmentAdmissionRecord(TypedDict):
+    decision: AdmissionAction
+    reason: str
+    memory: PersistedMemoryRecord | None
+    revision: PersistedMemoryRevisionRecord | None
+    open_loop: ExplicitCommitmentOpenLoopOutcome
+
+
+class ExplicitCommitmentExtractionSummary(TypedDict):
+    source_event_id: str
+    source_event_kind: str
+    candidate_count: int
+    admission_count: int
+    persisted_change_count: int
+    noop_count: int
+    open_loop_created_count: int
+    open_loop_noop_count: int
+
+
+class ExplicitCommitmentExtractionResponse(TypedDict):
+    candidates: list[ExtractedCommitmentCandidateRecord]
+    admissions: list[ExplicitCommitmentAdmissionRecord]
+    summary: ExplicitCommitmentExtractionSummary
 
 
 class MemoryReviewRecord(TypedDict):

--- a/apps/api/src/alicebot_api/explicit_commitments.py
+++ b/apps/api/src/alicebot_api/explicit_commitments.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Sequence
+from uuid import UUID
+
+from alicebot_api.contracts import (
+    AdmissionDecisionOutput,
+    ExplicitCommitmentAdmissionRecord,
+    ExplicitCommitmentExtractionRequestInput,
+    ExplicitCommitmentExtractionResponse,
+    ExplicitCommitmentExtractionSummary,
+    ExplicitCommitmentOpenLoopOutcome,
+    ExplicitCommitmentPattern,
+    ExtractedCommitmentCandidateRecord,
+    MemoryCandidateInput,
+    OpenLoopRecord,
+)
+from alicebot_api.memory import admit_memory_candidate
+from alicebot_api.store import ContinuityStore, EventRow, OpenLoopRow
+
+_DIRECT_PATTERNS: tuple[tuple[ExplicitCommitmentPattern, re.Pattern[str]], ...] = (
+    ("remind_me_to", re.compile(r"^remind me to (?P<commitment>.+)$", re.IGNORECASE)),
+    ("i_need_to", re.compile(r"^i need to (?P<commitment>.+)$", re.IGNORECASE)),
+    (
+        "dont_let_me_forget_to",
+        re.compile(r"^don'?t let me forget to (?P<commitment>.+)$", re.IGNORECASE),
+    ),
+    ("remember_to", re.compile(r"^remember to (?P<commitment>.+)$", re.IGNORECASE)),
+)
+_TRAILING_PUNCTUATION = ".!?"
+_MEMORY_KEY_PREFIX = "user.commitment."
+_MAX_MEMORY_KEY_LENGTH = 200
+_MEMORY_KEY_HASH_LENGTH = 12
+_MAX_COMMITMENT_TOKENS = 20
+_MAX_COMMITMENT_CHARACTERS = 180
+_ALLOWED_COMMITMENT_TOKEN = re.compile(r"^[a-z0-9][a-z0-9+#&./+'-]*$", re.IGNORECASE)
+_DISALLOWED_COMMITMENT_PREFIX_TOKENS = {
+    "that",
+    "if",
+    "when",
+    "because",
+    "whether",
+}
+
+
+class ExplicitCommitmentExtractionValidationError(ValueError):
+    """Raised when an explicit-commitment extraction request is invalid."""
+
+
+def _normalize_whitespace(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _normalize_commitment_text(commitment_text: str) -> str:
+    normalized = _normalize_whitespace(commitment_text)
+    normalized = normalized.rstrip(_TRAILING_PUNCTUATION).strip()
+    return normalized
+
+
+def _canonicalize_commitment_for_key(commitment_text: str) -> str:
+    return commitment_text.casefold()
+
+
+def _commitment_has_supported_shape(commitment_text: str) -> bool:
+    if len(commitment_text) > _MAX_COMMITMENT_CHARACTERS:
+        return False
+
+    tokens = commitment_text.split(" ")
+    if not tokens or len(tokens) > _MAX_COMMITMENT_TOKENS:
+        return False
+
+    if tokens[0].casefold() in _DISALLOWED_COMMITMENT_PREFIX_TOKENS:
+        return False
+
+    return all(_ALLOWED_COMMITMENT_TOKEN.fullmatch(token) is not None for token in tokens)
+
+
+def _slugify_commitment(commitment_text: str, *, max_length: int) -> str:
+    slug = commitment_text.casefold()
+    slug = slug.replace("'", "")
+    slug = re.sub(r"[^a-z0-9]+", "_", slug)
+    slug = slug.strip("_")
+    if len(slug) > max_length:
+        slug = slug[:max_length].rstrip("_")
+    return slug
+
+
+def _build_memory_key(commitment_text: str) -> str:
+    canonical_commitment = _canonicalize_commitment_for_key(commitment_text)
+    digest = hashlib.sha256(canonical_commitment.encode("utf-8")).hexdigest()[:_MEMORY_KEY_HASH_LENGTH]
+    max_slug_length = _MAX_MEMORY_KEY_LENGTH - len(_MEMORY_KEY_PREFIX) - len("__") - len(digest)
+    slug = _slugify_commitment(canonical_commitment, max_length=max_slug_length)
+    if not slug:
+        return f"{_MEMORY_KEY_PREFIX}{digest}"
+    return f"{_MEMORY_KEY_PREFIX}{slug}__{digest}"
+
+
+def _build_open_loop_title(commitment_text: str) -> str:
+    return f"Remember to {commitment_text}"
+
+
+def _build_candidate(
+    *,
+    source_event_id: UUID,
+    pattern: ExplicitCommitmentPattern,
+    commitment_text: str,
+) -> ExtractedCommitmentCandidateRecord | None:
+    normalized_commitment = _normalize_commitment_text(commitment_text)
+    if not normalized_commitment:
+        return None
+
+    if not _commitment_has_supported_shape(normalized_commitment):
+        return None
+
+    return {
+        "memory_key": _build_memory_key(normalized_commitment),
+        "value": {
+            "kind": "explicit_commitment",
+            "text": normalized_commitment,
+        },
+        "source_event_ids": [str(source_event_id)],
+        "delete_requested": False,
+        "pattern": pattern,
+        "commitment_text": normalized_commitment,
+        "open_loop_title": _build_open_loop_title(normalized_commitment),
+    }
+
+
+def extract_explicit_commitment_candidates(
+    *,
+    source_event_id: UUID,
+    text: str,
+) -> list[ExtractedCommitmentCandidateRecord]:
+    normalized_text = _normalize_whitespace(text)
+    if not normalized_text:
+        return []
+
+    for pattern_name, pattern in _DIRECT_PATTERNS:
+        match = pattern.fullmatch(normalized_text)
+        if match is None:
+            continue
+        candidate = _build_candidate(
+            source_event_id=source_event_id,
+            pattern=pattern_name,
+            commitment_text=match.group("commitment"),
+        )
+        return [] if candidate is None else [candidate]
+
+    return []
+
+
+def _get_single_source_event(store: ContinuityStore, source_event_id: UUID) -> EventRow:
+    events = store.list_events_by_ids([source_event_id])
+    if not events:
+        raise ExplicitCommitmentExtractionValidationError(
+            "source_event_id must reference an existing message.user event owned by the user"
+        )
+    return events[0]
+
+
+def _extract_text_payload(event: EventRow) -> str:
+    if event["kind"] != "message.user":
+        raise ExplicitCommitmentExtractionValidationError(
+            "source_event_id must reference an existing message.user event owned by the user"
+        )
+
+    payload_text = event["payload"].get("text")
+    if not isinstance(payload_text, str):
+        raise ExplicitCommitmentExtractionValidationError(
+            "source_event_id must reference a message.user event with string payload.text"
+        )
+
+    return payload_text
+
+
+def _serialize_open_loop(open_loop: OpenLoopRow) -> OpenLoopRecord:
+    return {
+        "id": str(open_loop["id"]),
+        "memory_id": None if open_loop["memory_id"] is None else str(open_loop["memory_id"]),
+        "title": open_loop["title"],
+        "status": open_loop["status"],
+        "opened_at": open_loop["opened_at"].isoformat(),
+        "due_at": None if open_loop["due_at"] is None else open_loop["due_at"].isoformat(),
+        "resolved_at": (
+            None if open_loop["resolved_at"] is None else open_loop["resolved_at"].isoformat()
+        ),
+        "resolution_note": open_loop["resolution_note"],
+        "created_at": open_loop["created_at"].isoformat(),
+        "updated_at": open_loop["updated_at"].isoformat(),
+    }
+
+
+def _find_active_open_loop_for_memory(store: ContinuityStore, memory_id: UUID) -> OpenLoopRow | None:
+    for open_loop in store.list_open_loops(status="open"):
+        if open_loop["memory_id"] == memory_id:
+            return open_loop
+    return None
+
+
+def _extract_memory_id(decision: AdmissionDecisionOutput) -> UUID | None:
+    if decision.memory is None:
+        return None
+    return UUID(decision.memory["id"])
+
+
+def _resolve_open_loop_outcome(
+    store: ContinuityStore,
+    *,
+    memory_id: UUID | None,
+    open_loop_title: str,
+) -> ExplicitCommitmentOpenLoopOutcome:
+    if memory_id is None:
+        return {
+            "decision": "NOOP_MEMORY_NOT_PERSISTED",
+            "reason": "memory_not_persisted",
+            "open_loop": None,
+        }
+
+    existing = _find_active_open_loop_for_memory(store, memory_id)
+    if existing is not None:
+        return {
+            "decision": "NOOP_ACTIVE_EXISTS",
+            "reason": "active_open_loop_exists_for_memory",
+            "open_loop": _serialize_open_loop(existing),
+        }
+
+    created = store.create_open_loop(
+        memory_id=memory_id,
+        title=open_loop_title,
+        status="open",
+        opened_at=None,
+        due_at=None,
+        resolved_at=None,
+        resolution_note=None,
+    )
+    return {
+        "decision": "CREATED",
+        "reason": "created_open_loop_for_memory",
+        "open_loop": _serialize_open_loop(created),
+    }
+
+
+def _serialize_admission(
+    decision: AdmissionDecisionOutput,
+    open_loop_outcome: ExplicitCommitmentOpenLoopOutcome,
+) -> ExplicitCommitmentAdmissionRecord:
+    return {
+        "decision": decision.action,
+        "reason": decision.reason,
+        "memory": decision.memory,
+        "revision": decision.revision,
+        "open_loop": open_loop_outcome,
+    }
+
+
+def _build_summary(
+    *,
+    source_event_id: UUID,
+    source_event_kind: str,
+    admissions: Sequence[ExplicitCommitmentAdmissionRecord],
+    candidates: Sequence[ExtractedCommitmentCandidateRecord],
+) -> ExplicitCommitmentExtractionSummary:
+    noop_count = sum(1 for admission in admissions if admission["decision"] == "NOOP")
+    open_loop_created_count = sum(
+        1
+        for admission in admissions
+        if admission["open_loop"]["decision"] == "CREATED"
+    )
+    return {
+        "source_event_id": str(source_event_id),
+        "source_event_kind": source_event_kind,
+        "candidate_count": len(candidates),
+        "admission_count": len(admissions),
+        "persisted_change_count": len(admissions) - noop_count,
+        "noop_count": noop_count,
+        "open_loop_created_count": open_loop_created_count,
+        "open_loop_noop_count": len(admissions) - open_loop_created_count,
+    }
+
+
+def extract_and_admit_explicit_commitments(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: ExplicitCommitmentExtractionRequestInput,
+) -> ExplicitCommitmentExtractionResponse:
+    source_event = _get_single_source_event(store, request.source_event_id)
+    payload_text = _extract_text_payload(source_event)
+    candidates = extract_explicit_commitment_candidates(
+        source_event_id=request.source_event_id,
+        text=payload_text,
+    )
+
+    admissions: list[ExplicitCommitmentAdmissionRecord] = []
+    for candidate in candidates:
+        decision = admit_memory_candidate(
+            store,
+            user_id=user_id,
+            candidate=MemoryCandidateInput(
+                memory_key=candidate["memory_key"],
+                value=candidate["value"],
+                source_event_ids=(request.source_event_id,),
+                delete_requested=candidate["delete_requested"],
+                memory_type="commitment",
+            ),
+        )
+        open_loop_outcome = _resolve_open_loop_outcome(
+            store,
+            memory_id=_extract_memory_id(decision),
+            open_loop_title=candidate["open_loop_title"],
+        )
+        admissions.append(_serialize_admission(decision, open_loop_outcome))
+
+    return {
+        "candidates": list(candidates),
+        "admissions": admissions,
+        "summary": _build_summary(
+            source_event_id=request.source_event_id,
+            source_event_kind=source_event["kind"],
+            admissions=admissions,
+            candidates=candidates,
+        ),
+    }

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -54,6 +54,7 @@ from alicebot_api.contracts import (
     EntityEdgeCreateInput,
     EntityCreateInput,
     EntityType,
+    ExplicitCommitmentExtractionRequestInput,
     ExplicitPreferenceExtractionRequestInput,
     CALENDAR_READONLY_SCOPE,
     GMAIL_READONLY_SCOPE,
@@ -239,6 +240,10 @@ from alicebot_api.entity_edge import (
 from alicebot_api.explicit_preferences import (
     ExplicitPreferenceExtractionValidationError,
     extract_and_admit_explicit_preferences,
+)
+from alicebot_api.explicit_commitments import (
+    ExplicitCommitmentExtractionValidationError,
+    extract_and_admit_explicit_commitments,
 )
 from alicebot_api.memory import (
     MemoryAdmissionValidationError,
@@ -479,6 +484,11 @@ class AdmitMemoryRequest(BaseModel):
 
 
 class ExtractExplicitPreferencesRequest(BaseModel):
+    user_id: UUID
+    source_event_id: UUID
+
+
+class ExtractExplicitCommitmentsRequest(BaseModel):
     user_id: UUID
     source_event_id: UUID
 
@@ -2665,6 +2675,30 @@ def extract_explicit_preferences(request: ExtractExplicitPreferencesRequest) -> 
                 ),
             )
     except ExplicitPreferenceExtractionValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except MemoryAdmissionValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.post("/v0/open-loops/extract-explicit-commitments")
+def extract_explicit_commitments(request: ExtractExplicitCommitmentsRequest) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            payload = extract_and_admit_explicit_commitments(
+                ContinuityStore(conn),
+                user_id=request.user_id,
+                request=ExplicitCommitmentExtractionRequestInput(
+                    source_event_id=request.source_event_id,
+                ),
+            )
+    except ExplicitCommitmentExtractionValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
     except MemoryAdmissionValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -48,6 +48,7 @@ import {
   shouldExpectThreadExecutionReview,
   submitAssistantResponse,
   submitApprovalRequest,
+  extractExplicitCommitments,
   submitMemoryLabel,
   updateOpenLoopStatus,
 } from "./api";
@@ -1906,6 +1907,93 @@ describe("api helpers", () => {
       },
       source_event_ids: ["event-2", "event-1"],
       delete_requested: false,
+    });
+  });
+
+  it("posts explicit commitment extraction requests to the shipped endpoint", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              memory_key: "user.commitment.submit_tax_forms",
+              value: {
+                kind: "explicit_commitment",
+                text: "submit tax forms",
+              },
+              source_event_ids: ["event-1"],
+              delete_requested: false,
+              pattern: "remind_me_to",
+              commitment_text: "submit tax forms",
+              open_loop_title: "Remember to submit tax forms",
+            },
+          ],
+          admissions: [
+            {
+              decision: "ADD",
+              reason: "source_backed_add",
+              memory: {
+                id: "memory-1",
+                user_id: "user-1",
+                memory_key: "user.commitment.submit_tax_forms",
+                value: {
+                  kind: "explicit_commitment",
+                  text: "submit tax forms",
+                },
+                status: "active",
+                source_event_ids: ["event-1"],
+                created_at: "2026-03-23T09:00:00Z",
+                updated_at: "2026-03-23T09:00:00Z",
+                deleted_at: null,
+              },
+              revision: null,
+              open_loop: {
+                decision: "CREATED",
+                reason: "created_open_loop_for_memory",
+                open_loop: {
+                  id: "loop-1",
+                  memory_id: "memory-1",
+                  title: "Remember to submit tax forms",
+                  status: "open",
+                  opened_at: "2026-03-23T09:00:00Z",
+                  due_at: null,
+                  resolved_at: null,
+                  resolution_note: null,
+                  created_at: "2026-03-23T09:00:00Z",
+                  updated_at: "2026-03-23T09:00:00Z",
+                },
+              },
+            },
+          ],
+          summary: {
+            source_event_id: "event-1",
+            source_event_kind: "message.user",
+            candidate_count: 1,
+            admission_count: 1,
+            persisted_change_count: 1,
+            noop_count: 0,
+            open_loop_created_count: 1,
+            open_loop_noop_count: 0,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await extractExplicitCommitments("https://api.example.com", {
+      user_id: "user-1",
+      source_event_id: "event-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v0/open-loops/extract-explicit-commitments",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      user_id: "user-1",
+      source_event_id: "event-1",
     });
   });
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -679,6 +679,59 @@ export type MemoryAdmitPayload = {
   };
 };
 
+export type ExplicitCommitmentPattern =
+  | "remind_me_to"
+  | "i_need_to"
+  | "dont_let_me_forget_to"
+  | "remember_to";
+
+export type ExplicitCommitmentOpenLoopDecision =
+  | "CREATED"
+  | "NOOP_ACTIVE_EXISTS"
+  | "NOOP_MEMORY_NOT_PERSISTED";
+
+export type ExtractExplicitCommitmentsPayload = {
+  user_id: string;
+  source_event_id: string;
+};
+
+export type ExtractedCommitmentCandidateRecord = {
+  memory_key: string;
+  value: unknown;
+  source_event_ids: string[];
+  delete_requested: boolean;
+  pattern: ExplicitCommitmentPattern;
+  commitment_text: string;
+  open_loop_title: string;
+};
+
+export type ExplicitCommitmentAdmissionRecord = {
+  decision: "NOOP" | "ADD" | "UPDATE" | "DELETE";
+  reason: string;
+  memory: PersistedMemoryRecord | null;
+  revision: PersistedMemoryRevisionRecord | null;
+  open_loop: {
+    decision: ExplicitCommitmentOpenLoopDecision;
+    reason: string;
+    open_loop: OpenLoopRecord | null;
+  };
+};
+
+export type ExplicitCommitmentExtractionResponse = {
+  candidates: ExtractedCommitmentCandidateRecord[];
+  admissions: ExplicitCommitmentAdmissionRecord[];
+  summary: {
+    source_event_id: string;
+    source_event_kind: string;
+    candidate_count: number;
+    admission_count: number;
+    persisted_change_count: number;
+    noop_count: number;
+    open_loop_created_count: number;
+    open_loop_noop_count: number;
+  };
+};
+
 export type OpenLoopCreatePayload = {
   user_id: string;
   memory_id?: string | null;
@@ -1195,6 +1248,20 @@ export function admitMemory(apiBaseUrl: string, payload: MemoryAdmitPayload) {
     method: "POST",
     body: JSON.stringify(payload),
   });
+}
+
+export function extractExplicitCommitments(
+  apiBaseUrl: string,
+  payload: ExtractExplicitCommitmentsPayload,
+) {
+  return requestJson<ExplicitCommitmentExtractionResponse>(
+    apiBaseUrl,
+    "/v0/open-loops/extract-explicit-commitments",
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
 }
 
 export function listOpenLoops(

--- a/tests/integration/test_explicit_commitments_api.py
+++ b/tests/integration/test_explicit_commitments_api.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import urlencode
+from uuid import UUID, uuid4
+
+import anyio
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+from alicebot_api.db import user_connection
+from alicebot_api.explicit_commitments import _build_memory_key
+from alicebot_api.store import ContinuityStore
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+
+        request_received = True
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def seed_explicit_commitment_events(database_url: str) -> dict[str, UUID]:
+    user_id = uuid4()
+
+    with user_connection(database_url, user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, "owner@example.com", "Owner")
+        thread = store.create_thread("Explicit commitment extraction")
+        session = store.create_session(thread["id"], status="active")
+        commitment_event = store.append_event(
+            thread["id"],
+            session["id"],
+            "message.user",
+            {"text": "Remind me to submit tax forms."},
+        )["id"]
+        unsupported_event = store.append_event(
+            thread["id"],
+            session["id"],
+            "message.user",
+            {"text": "I had coffee yesterday."},
+        )["id"]
+        clause_event = store.append_event(
+            thread["id"],
+            session["id"],
+            "message.user",
+            {"text": "Remember to if we can reschedule."},
+        )["id"]
+        assistant_event = store.append_event(
+            thread["id"],
+            session["id"],
+            "message.assistant",
+            {"text": "Remind me to submit tax forms."},
+        )["id"]
+
+    return {
+        "user_id": user_id,
+        "commitment_event_id": commitment_event,
+        "unsupported_event_id": unsupported_event,
+        "clause_event_id": clause_event,
+        "assistant_event_id": assistant_event,
+    }
+
+
+def test_extract_explicit_commitments_endpoint_persists_memory_open_loop_and_remains_idempotent_on_repeat(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    seeded = seed_explicit_commitment_events(migrated_database_urls["app"])
+    memory_key = _build_memory_key("submit tax forms")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    first_status, first_payload = invoke_request(
+        "POST",
+        "/v0/open-loops/extract-explicit-commitments",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "source_event_id": str(seeded["commitment_event_id"]),
+        },
+    )
+    repeat_status, repeat_payload = invoke_request(
+        "POST",
+        "/v0/open-loops/extract-explicit-commitments",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "source_event_id": str(seeded["commitment_event_id"]),
+        },
+    )
+
+    assert first_status == 200
+    assert first_payload["candidates"] == [
+        {
+            "memory_key": memory_key,
+            "value": {
+                "kind": "explicit_commitment",
+                "text": "submit tax forms",
+            },
+            "source_event_ids": [str(seeded["commitment_event_id"])],
+            "delete_requested": False,
+            "pattern": "remind_me_to",
+            "commitment_text": "submit tax forms",
+            "open_loop_title": "Remember to submit tax forms",
+        }
+    ]
+    assert first_payload["admissions"][0]["decision"] == "ADD"
+    assert first_payload["admissions"][0]["open_loop"]["decision"] == "CREATED"
+    assert first_payload["summary"] == {
+        "source_event_id": str(seeded["commitment_event_id"]),
+        "source_event_kind": "message.user",
+        "candidate_count": 1,
+        "admission_count": 1,
+        "persisted_change_count": 1,
+        "noop_count": 0,
+        "open_loop_created_count": 1,
+        "open_loop_noop_count": 0,
+    }
+
+    assert repeat_status == 200
+    assert repeat_payload["admissions"][0]["decision"] == "NOOP"
+    assert repeat_payload["admissions"][0]["open_loop"]["decision"] == "NOOP_ACTIVE_EXISTS"
+    assert repeat_payload["summary"] == {
+        "source_event_id": str(seeded["commitment_event_id"]),
+        "source_event_kind": "message.user",
+        "candidate_count": 1,
+        "admission_count": 1,
+        "persisted_change_count": 0,
+        "noop_count": 1,
+        "open_loop_created_count": 0,
+        "open_loop_noop_count": 1,
+    }
+
+    memories_status, memories_payload = invoke_request(
+        "GET",
+        "/v0/memories",
+        query_params={
+            "user_id": str(seeded["user_id"]),
+            "status": "active",
+            "limit": "20",
+        },
+    )
+    open_loops_status, open_loops_payload = invoke_request(
+        "GET",
+        "/v0/open-loops",
+        query_params={
+            "user_id": str(seeded["user_id"]),
+            "status": "open",
+            "limit": "20",
+        },
+    )
+
+    assert memories_status == 200
+    assert open_loops_status == 200
+    assert [item["memory_key"] for item in memories_payload["items"]] == [memory_key]
+    assert len(open_loops_payload["items"]) == 1
+    assert open_loops_payload["items"][0]["memory_id"] == memories_payload["items"][0]["id"]
+
+    with user_connection(migrated_database_urls["app"], seeded["user_id"]) as conn:
+        store = ContinuityStore(conn)
+        memories = store.list_memories()
+        open_loops = store.list_open_loops(status="open")
+
+    assert [memory["memory_key"] for memory in memories] == [memory_key]
+    assert len(open_loops) == 1
+
+
+def test_extract_explicit_commitments_endpoint_returns_no_candidates_for_unsupported_or_clause_text(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    seeded = seed_explicit_commitment_events(migrated_database_urls["app"])
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    unsupported_status, unsupported_payload = invoke_request(
+        "POST",
+        "/v0/open-loops/extract-explicit-commitments",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "source_event_id": str(seeded["unsupported_event_id"]),
+        },
+    )
+    clause_status, clause_payload = invoke_request(
+        "POST",
+        "/v0/open-loops/extract-explicit-commitments",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "source_event_id": str(seeded["clause_event_id"]),
+        },
+    )
+
+    assert unsupported_status == 200
+    assert unsupported_payload == {
+        "candidates": [],
+        "admissions": [],
+        "summary": {
+            "source_event_id": str(seeded["unsupported_event_id"]),
+            "source_event_kind": "message.user",
+            "candidate_count": 0,
+            "admission_count": 0,
+            "persisted_change_count": 0,
+            "noop_count": 0,
+            "open_loop_created_count": 0,
+            "open_loop_noop_count": 0,
+        },
+    }
+    assert clause_status == 200
+    assert clause_payload == {
+        "candidates": [],
+        "admissions": [],
+        "summary": {
+            "source_event_id": str(seeded["clause_event_id"]),
+            "source_event_kind": "message.user",
+            "candidate_count": 0,
+            "admission_count": 0,
+            "persisted_change_count": 0,
+            "noop_count": 0,
+            "open_loop_created_count": 0,
+            "open_loop_noop_count": 0,
+        },
+    }
+
+
+def test_extract_explicit_commitments_endpoint_rejects_invalid_source_event_and_user_scope(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    seeded = seed_explicit_commitment_events(migrated_database_urls["app"])
+    intruder_id = uuid4()
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    with user_connection(migrated_database_urls["app"], intruder_id) as conn:
+        ContinuityStore(conn).create_user(intruder_id, "intruder@example.com", "Intruder")
+
+    assistant_status, assistant_payload = invoke_request(
+        "POST",
+        "/v0/open-loops/extract-explicit-commitments",
+        payload={
+            "user_id": str(seeded["user_id"]),
+            "source_event_id": str(seeded["assistant_event_id"]),
+        },
+    )
+    intruder_status, intruder_payload = invoke_request(
+        "POST",
+        "/v0/open-loops/extract-explicit-commitments",
+        payload={
+            "user_id": str(intruder_id),
+            "source_event_id": str(seeded["commitment_event_id"]),
+        },
+    )
+
+    assert assistant_status == 400
+    assert assistant_payload == {
+        "detail": "source_event_id must reference an existing message.user event owned by the user"
+    }
+    assert intruder_status == 400
+    assert intruder_payload == {
+        "detail": "source_event_id must reference an existing message.user event owned by the user"
+    }
+
+    with user_connection(migrated_database_urls["app"], intruder_id) as conn:
+        store = ContinuityStore(conn)
+        assert store.list_memories() == []
+        assert store.list_open_loops(status="open") == []

--- a/tests/unit/test_explicit_commitments.py
+++ b/tests/unit/test_explicit_commitments.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from alicebot_api.contracts import AdmissionDecisionOutput, ExplicitCommitmentExtractionRequestInput
+from alicebot_api.explicit_commitments import (
+    ExplicitCommitmentExtractionValidationError,
+    _build_memory_key,
+    extract_and_admit_explicit_commitments,
+    extract_explicit_commitment_candidates,
+)
+
+
+class ExplicitCommitmentStoreStub:
+    def __init__(self) -> None:
+        self.base_time = datetime(2026, 3, 23, 9, 0, tzinfo=UTC)
+        self.events: dict[UUID, dict[str, object]] = {}
+        self.open_loops: dict[UUID, dict[str, object]] = {}
+        self.create_open_loop_calls = 0
+
+    def list_events_by_ids(self, event_ids: list[UUID]) -> list[dict[str, object]]:
+        return [self.events[event_id] for event_id in event_ids if event_id in self.events]
+
+    def list_open_loops(self, *, status: str | None = None, limit: int | None = None) -> list[dict[str, object]]:
+        items = list(self.open_loops.values())
+        if status is not None:
+            items = [item for item in items if item["status"] == status]
+        if limit is not None:
+            items = items[:limit]
+        return items
+
+    def create_open_loop(
+        self,
+        *,
+        memory_id: UUID | None,
+        title: str,
+        status: str,
+        opened_at: datetime | None,
+        due_at: datetime | None,
+        resolved_at: datetime | None,
+        resolution_note: str | None,
+    ) -> dict[str, object]:
+        del opened_at, due_at, resolved_at
+
+        self.create_open_loop_calls += 1
+        open_loop_id = uuid4()
+        created = {
+            "id": open_loop_id,
+            "memory_id": memory_id,
+            "title": title,
+            "status": status,
+            "opened_at": self.base_time,
+            "due_at": None,
+            "resolved_at": None,
+            "resolution_note": resolution_note,
+            "created_at": self.base_time,
+            "updated_at": self.base_time,
+        }
+        self.open_loops[open_loop_id] = created
+        return created
+
+
+def seed_event(
+    store: ExplicitCommitmentStoreStub,
+    *,
+    kind: str = "message.user",
+    text: str = "Remind me to submit tax forms.",
+) -> UUID:
+    event_id = uuid4()
+    store.events[event_id] = {
+        "id": event_id,
+        "sequence_no": 1,
+        "kind": kind,
+        "payload": {"text": text},
+        "created_at": store.base_time,
+    }
+    return event_id
+
+
+def test_extract_explicit_commitment_candidates_returns_supported_candidate_shape() -> None:
+    event_id = UUID("11111111-1111-1111-1111-111111111111")
+    memory_key = _build_memory_key("submit tax forms")
+
+    payload = extract_explicit_commitment_candidates(
+        source_event_id=event_id,
+        text="Remind me to submit tax forms.",
+    )
+
+    assert payload == [
+        {
+            "memory_key": memory_key,
+            "value": {
+                "kind": "explicit_commitment",
+                "text": "submit tax forms",
+            },
+            "source_event_ids": [str(event_id)],
+            "delete_requested": False,
+            "pattern": "remind_me_to",
+            "commitment_text": "submit tax forms",
+            "open_loop_title": "Remember to submit tax forms",
+        }
+    ]
+
+
+def test_extract_explicit_commitment_candidates_supports_dont_let_me_forget_pattern() -> None:
+    event_id = UUID("22222222-2222-2222-2222-222222222222")
+
+    payload = extract_explicit_commitment_candidates(
+        source_event_id=event_id,
+        text="Don't let me forget to call the clinic!",
+    )
+
+    assert payload[0]["pattern"] == "dont_let_me_forget_to"
+    assert payload[0]["commitment_text"] == "call the clinic"
+
+
+def test_extract_explicit_commitment_candidates_returns_empty_for_unsupported_text() -> None:
+    assert extract_explicit_commitment_candidates(
+        source_event_id=uuid4(),
+        text="I had coffee yesterday.",
+    ) == []
+
+
+def test_extract_explicit_commitment_candidates_rejects_clause_style_text() -> None:
+    assert extract_explicit_commitment_candidates(
+        source_event_id=uuid4(),
+        text="Remember to if we can reschedule.",
+    ) == []
+
+
+def test_build_memory_key_is_case_insensitive_for_the_same_commitment() -> None:
+    assert _build_memory_key("Submit Tax Forms") == _build_memory_key("submit tax forms")
+
+
+def test_extract_and_admit_explicit_commitments_rejects_invalid_source_event() -> None:
+    store = ExplicitCommitmentStoreStub()
+    event_id = seed_event(store, kind="message.assistant", text="Remind me to submit tax forms.")
+
+    with pytest.raises(
+        ExplicitCommitmentExtractionValidationError,
+        match="source_event_id must reference an existing message.user event owned by the user",
+    ):
+        extract_and_admit_explicit_commitments(
+            store,  # type: ignore[arg-type]
+            user_id=uuid4(),
+            request=ExplicitCommitmentExtractionRequestInput(source_event_id=event_id),
+        )
+
+
+def test_extract_and_admit_explicit_commitments_routes_candidate_through_memory_admission_and_creates_open_loop(
+    monkeypatch,
+) -> None:
+    store = ExplicitCommitmentStoreStub()
+    user_id = uuid4()
+    event_id = seed_event(store, text="I need to submit tax forms.")
+    memory_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    memory_key = _build_memory_key("submit tax forms")
+    captured: dict[str, object] = {}
+
+    def fake_admit_memory_candidate(store_arg, *, user_id, candidate):
+        captured["store"] = store_arg
+        captured["user_id"] = user_id
+        captured["candidate"] = candidate
+        return AdmissionDecisionOutput(
+            action="ADD",
+            reason="source_backed_add",
+            memory={
+                "id": str(memory_id),
+                "user_id": str(user_id),
+                "memory_key": candidate.memory_key,
+                "value": candidate.value,
+                "status": "active",
+                "source_event_ids": [str(event_id)],
+                "memory_type": "commitment",
+                "created_at": "2026-03-23T09:00:00+00:00",
+                "updated_at": "2026-03-23T09:00:00+00:00",
+                "deleted_at": None,
+            },
+            revision={
+                "id": "revision-123",
+                "user_id": str(user_id),
+                "memory_id": str(memory_id),
+                "sequence_no": 1,
+                "action": "ADD",
+                "memory_key": candidate.memory_key,
+                "previous_value": None,
+                "new_value": candidate.value,
+                "source_event_ids": [str(event_id)],
+                "candidate": candidate.as_payload(),
+                "created_at": "2026-03-23T09:00:00+00:00",
+            },
+        )
+
+    monkeypatch.setattr(
+        "alicebot_api.explicit_commitments.admit_memory_candidate",
+        fake_admit_memory_candidate,
+    )
+
+    payload = extract_and_admit_explicit_commitments(
+        store,  # type: ignore[arg-type]
+        user_id=user_id,
+        request=ExplicitCommitmentExtractionRequestInput(source_event_id=event_id),
+    )
+
+    assert captured["store"] is store
+    assert captured["user_id"] == user_id
+    assert captured["candidate"].memory_key == memory_key
+    assert captured["candidate"].memory_type == "commitment"
+    assert payload["admissions"][0]["open_loop"]["decision"] == "CREATED"
+    assert payload["admissions"][0]["open_loop"]["open_loop"]["memory_id"] == str(memory_id)
+    assert payload["summary"] == {
+        "source_event_id": str(event_id),
+        "source_event_kind": "message.user",
+        "candidate_count": 1,
+        "admission_count": 1,
+        "persisted_change_count": 1,
+        "noop_count": 0,
+        "open_loop_created_count": 1,
+        "open_loop_noop_count": 0,
+    }
+    assert store.create_open_loop_calls == 1
+
+
+def test_extract_and_admit_explicit_commitments_keeps_existing_active_open_loop_without_duplicate(
+    monkeypatch,
+) -> None:
+    store = ExplicitCommitmentStoreStub()
+    user_id = uuid4()
+    event_id = seed_event(store, text="Remember to submit tax forms.")
+    memory_id = UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    existing_open_loop_id = UUID("cccccccc-cccc-4ccc-8ccc-cccccccccccc")
+
+    store.open_loops[existing_open_loop_id] = {
+        "id": existing_open_loop_id,
+        "memory_id": memory_id,
+        "title": "Remember to submit tax forms",
+        "status": "open",
+        "opened_at": store.base_time,
+        "due_at": None,
+        "resolved_at": None,
+        "resolution_note": None,
+        "created_at": store.base_time,
+        "updated_at": store.base_time,
+    }
+
+    def fake_admit_memory_candidate(_store_arg, *, user_id, candidate):
+        return AdmissionDecisionOutput(
+            action="NOOP",
+            reason="memory_unchanged",
+            memory={
+                "id": str(memory_id),
+                "user_id": str(user_id),
+                "memory_key": candidate.memory_key,
+                "value": candidate.value,
+                "status": "active",
+                "source_event_ids": [str(event_id)],
+                "memory_type": "commitment",
+                "created_at": "2026-03-23T09:00:00+00:00",
+                "updated_at": "2026-03-23T09:00:00+00:00",
+                "deleted_at": None,
+            },
+            revision=None,
+        )
+
+    monkeypatch.setattr(
+        "alicebot_api.explicit_commitments.admit_memory_candidate",
+        fake_admit_memory_candidate,
+    )
+
+    payload = extract_and_admit_explicit_commitments(
+        store,  # type: ignore[arg-type]
+        user_id=user_id,
+        request=ExplicitCommitmentExtractionRequestInput(source_event_id=event_id),
+    )
+
+    assert payload["admissions"][0]["open_loop"]["decision"] == "NOOP_ACTIVE_EXISTS"
+    assert payload["admissions"][0]["open_loop"]["open_loop"]["id"] == str(existing_open_loop_id)
+    assert store.create_open_loop_calls == 0

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -115,6 +115,7 @@ def test_healthcheck_route_is_registered() -> None:
     assert "/v0/policies/{policy_id}" in route_paths
     assert "/v0/policies/evaluate" in route_paths
     assert "/v0/memories/extract-explicit-preferences" in route_paths
+    assert "/v0/open-loops/extract-explicit-commitments" in route_paths
     assert "/v0/memories" in route_paths
     assert "/v0/memories/review-queue" in route_paths
     assert "/v0/memories/evaluation-summary" in route_paths
@@ -1415,6 +1416,175 @@ def test_extract_explicit_preferences_returns_bad_request_when_source_event_is_i
 
     response = main_module.extract_explicit_preferences(
         main_module.ExtractExplicitPreferencesRequest(
+            user_id=uuid4(),
+            source_event_id=uuid4(),
+        )
+    )
+
+    assert response.status_code == 400
+    assert json.loads(response.body) == {
+        "detail": "source_event_id must reference an existing message.user event owned by the user",
+    }
+
+
+def test_extract_explicit_commitments_returns_payload(monkeypatch) -> None:
+    user_id = uuid4()
+    source_event_id = uuid4()
+    settings = Settings(database_url="postgresql://app")
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def fake_user_connection(database_url: str, current_user_id):
+        captured["database_url"] = database_url
+        captured["current_user_id"] = current_user_id
+        yield object()
+
+    def fake_extract_and_admit_explicit_commitments(store, *, user_id, request):
+        captured["store_type"] = type(store).__name__
+        captured["user_id"] = user_id
+        captured["request"] = request
+        return {
+            "candidates": [
+                {
+                    "memory_key": "user.commitment.submit_tax_forms",
+                    "value": {
+                        "kind": "explicit_commitment",
+                        "text": "submit tax forms",
+                    },
+                    "source_event_ids": [str(source_event_id)],
+                    "delete_requested": False,
+                    "pattern": "remind_me_to",
+                    "commitment_text": "submit tax forms",
+                    "open_loop_title": "Remember to submit tax forms",
+                }
+            ],
+            "admissions": [
+                {
+                    "decision": "ADD",
+                    "reason": "source_backed_add",
+                    "memory": {
+                        "id": "memory-123",
+                        "user_id": str(user_id),
+                        "memory_key": "user.commitment.submit_tax_forms",
+                        "value": {
+                            "kind": "explicit_commitment",
+                            "text": "submit tax forms",
+                        },
+                        "status": "active",
+                        "source_event_ids": [str(source_event_id)],
+                        "memory_type": "commitment",
+                        "created_at": "2026-03-23T09:00:00+00:00",
+                        "updated_at": "2026-03-23T09:00:00+00:00",
+                        "deleted_at": None,
+                    },
+                    "revision": {
+                        "id": "revision-123",
+                        "user_id": str(user_id),
+                        "memory_id": "memory-123",
+                        "sequence_no": 1,
+                        "action": "ADD",
+                        "memory_key": "user.commitment.submit_tax_forms",
+                        "previous_value": None,
+                        "new_value": {
+                            "kind": "explicit_commitment",
+                            "text": "submit tax forms",
+                        },
+                        "source_event_ids": [str(source_event_id)],
+                        "candidate": {
+                            "memory_key": "user.commitment.submit_tax_forms",
+                            "value": {
+                                "kind": "explicit_commitment",
+                                "text": "submit tax forms",
+                            },
+                            "source_event_ids": [str(source_event_id)],
+                            "delete_requested": False,
+                            "memory_type": "commitment",
+                        },
+                        "created_at": "2026-03-23T09:00:00+00:00",
+                    },
+                    "open_loop": {
+                        "decision": "CREATED",
+                        "reason": "created_open_loop_for_memory",
+                        "open_loop": {
+                            "id": "loop-123",
+                            "memory_id": "memory-123",
+                            "title": "Remember to submit tax forms",
+                            "status": "open",
+                            "opened_at": "2026-03-23T09:00:00+00:00",
+                            "due_at": None,
+                            "resolved_at": None,
+                            "resolution_note": None,
+                            "created_at": "2026-03-23T09:00:00+00:00",
+                            "updated_at": "2026-03-23T09:00:00+00:00",
+                        },
+                    },
+                }
+            ],
+            "summary": {
+                "source_event_id": str(source_event_id),
+                "source_event_kind": "message.user",
+                "candidate_count": 1,
+                "admission_count": 1,
+                "persisted_change_count": 1,
+                "noop_count": 0,
+                "open_loop_created_count": 1,
+                "open_loop_noop_count": 0,
+            },
+        }
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(
+        main_module,
+        "extract_and_admit_explicit_commitments",
+        fake_extract_and_admit_explicit_commitments,
+    )
+
+    response = main_module.extract_explicit_commitments(
+        main_module.ExtractExplicitCommitmentsRequest(
+            user_id=user_id,
+            source_event_id=source_event_id,
+        )
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.body)["summary"] == {
+        "source_event_id": str(source_event_id),
+        "source_event_kind": "message.user",
+        "candidate_count": 1,
+        "admission_count": 1,
+        "persisted_change_count": 1,
+        "noop_count": 0,
+        "open_loop_created_count": 1,
+        "open_loop_noop_count": 0,
+    }
+    assert captured["database_url"] == "postgresql://app"
+    assert captured["current_user_id"] == user_id
+    assert captured["user_id"] == user_id
+    assert captured["request"].source_event_id == source_event_id
+
+
+def test_extract_explicit_commitments_returns_bad_request_when_source_event_is_invalid(
+    monkeypatch,
+) -> None:
+    @contextmanager
+    def fake_user_connection(_database_url: str, _current_user_id):
+        yield object()
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: Settings(database_url="postgresql://app"))
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(
+        main_module,
+        "extract_and_admit_explicit_commitments",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            main_module.ExplicitCommitmentExtractionValidationError(
+                "source_event_id must reference an existing message.user event owned by the user"
+            )
+        ),
+    )
+
+    response = main_module.extract_explicit_commitments(
+        main_module.ExtractExplicitCommitmentsRequest(
             user_id=uuid4(),
             source_event_id=uuid4(),
         )


### PR DESCRIPTION
## Sprint
Phase 2 Sprint 5: Explicit Commitment Capture

## Summary
This sprint adds a deterministic explicit-commitment extraction seam that reads one `message.user` event and persists commitment evidence through existing governed memory/open-loop pathways. The implementation is user-scoped, pattern-based (no model calls), and repeat-safe.

## What Shipped
- New extractor/orchestrator module:
  - `apps/api/src/alicebot_api/explicit_commitments.py`
- Contract additions in `apps/api/src/alicebot_api/contracts.py`:
  - extraction request/response records
  - candidate/admission/outcome/summary typed structures
- New endpoint in `apps/api/src/alicebot_api/main.py`:
  - `POST /v0/open-loops/extract-explicit-commitments`
  - required input: `user_id`, `source_event_id`
- Web API updates in `apps/web/lib/api.ts`:
  - `extractExplicitCommitments(...)`
  - typed response models
- Sprint-scoped tests added/updated:
  - `tests/unit/test_explicit_commitments.py`
  - `tests/integration/test_explicit_commitments_api.py`
  - `tests/unit/test_main.py`
  - `apps/web/lib/api.test.ts`
- Sprint control artifacts updated:
  - `.ai/active/SPRINT_PACKET.md`
  - `BUILD_REPORT.md`
  - `REVIEW_REPORT.md`

## Deterministic Extraction Behavior
Supported explicit patterns:
- `remind me to ...`
- `i need to ...`
- `don't let me forget to ...` (also `dont`)
- `remember to ...`

Deterministic normalization/rejection:
- whitespace normalization
- trailing punctuation trim (`.`, `!`, `?`)
- bounded token/character constraints
- deterministic token-shape checks
- clause-tail rejection guards

## Persistence And Dedupe Guarantees
- Source event must be a user-owned `message.user` event.
- Invalid/missing/non-user/cross-user source event requests return deterministic `400` with no side effects.
- Candidate admissions flow through governed memory admission seams.
- Open loops are linked to admitted memory.
- Repeat extraction for the same source event does not create duplicate active loops for the same memory:
  - dedupe outcome is `NOOP_ACTIVE_EXISTS`.

## Scope Integrity
- Stayed within Sprint 5 scope: contracts/API/extraction/orchestration/web API/test/report surfaces.
- No automation, worker orchestration, connector expansion, or Phase 3 routing work introduced.
- No model-based/free-form extraction introduced.

## Verification Evidence
Executed on this branch:

1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_explicit_commitments.py tests/unit/test_main.py`
- Result: `54 passed`

2. `PYTHONPATH=$PWD .venv/bin/pytest tests/integration/test_explicit_commitments_api.py`
- Result: `3 passed`
- Note: integration run requires local Postgres access outside default sandbox networking.

3. `cd apps/web && pnpm test -- lib/api.test.ts app/memories/page.test.tsx`
- Result: `26 passed`

## Review Status
- `REVIEW_REPORT.md` verdict: `PASS`
- Acceptance criteria missed: `None`
- Non-blocking note only: open-loop dedupe currently scans open-loop list in user scope; acceptable for current bounded sprint usage.

## Request
Ready for Control Tower merge gate. Recommended merge mode: squash merge after explicit merge approval.
