### PR TITLE
Phase 2 Sprint 9: gate wrapper parity

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 2 Sprint 8: Closeout Gate And Truth Sync
+Phase 2 Sprint 9: Phase-2 Gate Wrapper Parity
 
 ## Sprint Type
 
@@ -10,144 +10,127 @@ hardening
 
 ## Sprint Reason
 
-Phase 2 Sprint 7 is merged and validation is green, but canonical docs and runbook entrypoints still describe older Sprint 7G-era state. Planning drift is now the primary delivery risk.
+Phase 2 gate entrypoint scripts now exist and are used, but wrapper behavior (arg passthrough and exit-code passthrough) is only manually verified. The remaining risk is silent drift between wrapper behavior and underlying MVP runners.
 
 ## Sprint Intent
 
-Synchronize canonical project truth to the merged Phase 2 Sprint 7 state and add explicit Phase 2 gate entrypoints, without changing product runtime behavior.
+Add deterministic automated tests for Phase 2 wrapper parity and tighten wrapper robustness without changing gate semantics.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase2-sprint8-closeout-gate-truth-sync`
+- Branch Name: `codex/phase2-sprint9-gate-wrapper-parity`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- Repo behavior and tests indicate Phase 2 maturity, but reader-facing truth artifacts are stale.
-- Control decisions now depend more on docs/runbooks than on new feature seams.
-- This is the narrowest, highest-leverage closeout seam before Phase 2 completion call.
+- Phase 2 validation now runs through wrapper scripts in control flow.
+- Current checks prove executability, but not full passthrough guarantees.
+- This is the narrowest remaining seam before declaring Phase 2 gate tooling stable.
 
 ## Design Truth
 
-- Do not change shipped feature contracts in this sprint.
-- Keep Phase 2 gate entrypoints deterministic and shell-compatible.
-- Canonical docs must reflect merged repo truth through Sprint 7.
+- Preserve existing gate semantics and target-script mappings.
+- Keep wrappers deterministic, non-interactive, and shell-compatible.
+- Validate behavior via automated tests, not manual inspection only.
 
 ## Exact Surfaces In Scope
 
-- canonical docs truth sync
-- Phase 2 gate script entrypoints
-- sprint-scoped script/docs verification
+- phase2 gate wrapper scripts
+- wrapper parity unit tests
+- sprint-scoped script/test verification
 
 ## Exact Files In Scope
 
-- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md)
-- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md)
-- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md)
-- [CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md)
-- [run_mvp_acceptance.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_mvp_acceptance.py)
-- [run_mvp_readiness_gates.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_mvp_readiness_gates.py)
-- [run_mvp_validation_matrix.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_mvp_validation_matrix.py)
 - [run_phase2_acceptance.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_phase2_acceptance.py)
 - [run_phase2_readiness_gates.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_phase2_readiness_gates.py)
 - [run_phase2_validation_matrix.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_phase2_validation_matrix.py)
+- [test_phase2_gate_wrappers.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_phase2_gate_wrappers.py)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
 - [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
 - relevant verification under:
-  - `python3 -m py_compile scripts/run_phase2_acceptance.py scripts/run_phase2_readiness_gates.py scripts/run_phase2_validation_matrix.py`
+  - `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_phase2_gate_wrappers.py`
 
 ## In Scope
 
-- Update canonical docs to reflect merged state through Phase 2 Sprint 7:
-  - typed memory + open-loop seams
-  - resumption brief seam
-  - unified explicit-signal capture + `/chat` manual capture controls
-  - current validation/gate commands
-- Add Phase 2 gate entrypoint scripts:
-  - `scripts/run_phase2_acceptance.py`
-  - `scripts/run_phase2_readiness_gates.py`
-  - `scripts/run_phase2_validation_matrix.py`
-- Keep Phase 2 scripts deterministic and compatible:
-  - either thin wrappers to MVP runners or aliased implementations with identical semantics
-- Ensure README and handoff docs point to canonical gate commands and current control artifacts.
-- Update roadmap “Current Position” baseline from Sprint 7G-era wording to current merged phase state.
-- Record explicit deferred scope boundaries for what is still not shipped.
+- Add automated tests that assert for each phase2 wrapper:
+  - forwards all CLI args unchanged to target MVP script
+  - executes with repo-root cwd
+  - returns subprocess exit code unchanged
+  - keeps expected target script mapping
+- Add deterministic fallback-path coverage:
+  - venv python selected when present
+  - `sys.executable` selected when venv missing
+- Optional small wrapper hardening if needed for testability:
+  - extract shared wrapper-run helper, preserving existing behavior
+  - avoid changing user-facing CLI surface
 
 ## Out of Scope
 
-- any backend/API behavior change
-- UI/UX feature changes
-- new migrations/schema changes
+- any product/runtime API change
+- docs truth-sync edits outside direct wrapper references
+- UI changes
 - workers/automation/orchestration implementation
 - Phase 3 runtime/profile routing implementation
 
 ## Required Deliverables
 
-- canonical docs synchronized to merged Phase 2 state
-- Phase 2 gate script entrypoints present and parseable
-- clear command guidance for operators/builders in README + handoff docs
+- wrapper parity test suite committed and passing
+- phase2 wrappers verified to preserve arg/exit-code passthrough semantics
 - updated sprint reports for this sprint only
 
 ## Acceptance Criteria
 
-- canonical docs no longer claim Sprint 7G as current state
-- README/ROADMAP/ARCHITECTURE/CURRENT_STATE are mutually consistent about shipped seams
-- `scripts/run_phase2_acceptance.py`, `scripts/run_phase2_readiness_gates.py`, `scripts/run_phase2_validation_matrix.py` exist and compile
-- phase2 validation entrypoint command is documented and executable
-- no product/runtime behavior changes are introduced
+- tests cover all three wrappers and pass
+- tests assert deterministic arg passthrough behavior
+- tests assert deterministic exit-code passthrough behavior
+- tests assert wrapper target-script mapping and Python executable resolution behavior
+- no gate semantics changed versus current alias behavior
 - no out-of-scope implementation work enters sprint
 
 ## Implementation Constraints
 
 - keep script behavior deterministic and non-interactive
-- use machine-independent paths/commands in docs
-- avoid deleting historical artifacts needed for traceability
+- use machine-independent assertions in tests
+- do not introduce external dependencies for tests
 - co-deliver verification commands with outcomes in reports
 
 ## Control Tower Task Cards
 
-### Task 1: Canonical Docs Sync
-Owner: documentation operative  
-Write scope:
-- `README.md`
-- `ROADMAP.md`
-- `ARCHITECTURE.md`
-- `.ai/handoff/CURRENT_STATE.md`
-
-### Task 2: Phase 2 Gate Entrypoints
+### Task 1: Wrapper Test Coverage
 Owner: tooling operative  
 Write scope:
 - `scripts/run_phase2_acceptance.py`
 - `scripts/run_phase2_readiness_gates.py`
 - `scripts/run_phase2_validation_matrix.py`
+- `tests/unit/test_phase2_gate_wrappers.py`
 
-### Task 3: Integration Review
+### Task 2: Integration Review
 Owner: control tower  
 Responsibilities:
-- verify docs/runbook truth coherence
-- verify phase2 entrypoint script integrity
+- verify wrapper parity evidence completeness
+- verify no behavior drift in gate aliases
 - verify strict sprint scope
 - verify acceptance + evidence completeness
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact docs/files updated and previous stale claims removed
-- exact phase2 entrypoint scripts added/updated
+- exact wrapper/test files changed
+- exact parity guarantees asserted by tests
 - exact verification commands run with outcomes
 - explicit deferred scope (automation/workers/Phase 3 runtime orchestration)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint remained closeout-truth-sync scoped
-- docs/script consistency across canonical surfaces
-- verification evidence is sufficient for script/docs-only sprint
+- sprint remained wrapper-parity scoped
+- wrapper/test consistency and completeness
+- verification evidence is sufficient for script-hardening sprint
 - no hidden scope expansion
 
 ## Exit Condition
 
-This sprint is complete when canonical docs and gate entrypoints accurately represent merged Phase 2 state, verification evidence is recorded, and no product/runtime behavior changed.
+This sprint is complete when automated tests prove Phase 2 gate wrappers preserve arg/exit-code passthrough semantics for all three wrappers, with no product/runtime behavior change.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,58 +1,37 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Synchronize canonical project truth to the merged Phase 2 Sprint 7 state and add deterministic Phase 2 gate entrypoints without changing product runtime behavior.
+Add deterministic automated parity coverage for Phase 2 gate wrappers so arg passthrough, exit-code passthrough, target mappings, and Python executable resolution are verified without changing gate semantics.
 
 ## Completed Work
-- Removed stale canonical claims that the repo is only current through Sprint 7G.
-- Updated canonical docs (`README.md`, `ROADMAP.md`, `ARCHITECTURE.md`, `.ai/handoff/CURRENT_STATE.md`) to align on the merged Phase 2 Sprint 7 baseline.
-- Synced canonical seam descriptions across docs for:
-  - typed memory + open-loop seams
-  - deterministic resumption brief seam (`GET /v0/threads/{thread_id}/resumption-brief`)
-  - unified explicit-signal capture seam and `/chat` manual capture controls
-  - canonical Phase 2 gate commands
-- Added deterministic Phase 2 gate entrypoint scripts as thin wrappers with identical semantics to existing MVP runners:
-  - `scripts/run_phase2_acceptance.py`
-  - `scripts/run_phase2_readiness_gates.py`
-  - `scripts/run_phase2_validation_matrix.py`
-- Updated canonical gate guidance so Phase 2 validation is documented as the default go/no-go entrypoint.
-- Updated sprint reports for this sprint closeout (`BUILD_REPORT.md`, `REVIEW_REPORT.md`).
+- Added `tests/unit/test_phase2_gate_wrappers.py` with deterministic, parameterized coverage for all three Phase 2 wrappers.
+- Added assertions that each wrapper forwards CLI args unchanged and in order to its mapped MVP target script.
+- Added assertions that each wrapper executes subprocesses with repo-root `cwd`.
+- Added assertions that each wrapper returns subprocess exit codes unchanged.
+- Added assertions that target-script mappings are stable for:
+  - `run_phase2_acceptance.py -> run_mvp_acceptance.py`
+  - `run_phase2_readiness_gates.py -> run_mvp_readiness_gates.py`
+  - `run_phase2_validation_matrix.py -> run_mvp_validation_matrix.py`
+- Added deterministic fallback-path assertions for executable resolution:
+  - prefer `.venv/bin/python` when present
+  - fall back to `sys.executable` when `.venv/bin/python` is absent
 
 ## Incomplete Work
 - None within sprint scope.
 
 ## Files Changed
-- `.ai/active/SPRINT_PACKET.md`
-- `README.md`
-- `ROADMAP.md`
-- `ARCHITECTURE.md`
-- `.ai/handoff/CURRENT_STATE.md`
-- `scripts/run_phase2_acceptance.py`
-- `scripts/run_phase2_readiness_gates.py`
-- `scripts/run_phase2_validation_matrix.py`
+- `tests/unit/test_phase2_gate_wrappers.py`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 ## Tests Run
-1. `rg -n "Sprint 7G" README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md`
-- Outcome: no matches (exit code `1`), confirming stale Sprint 7G current-state claims were removed from canonical docs.
-
-2. `python3 -m py_compile scripts/run_phase2_acceptance.py scripts/run_phase2_readiness_gates.py scripts/run_phase2_validation_matrix.py`
-- Outcome: pass (exit code `0`), all three Phase 2 entrypoint scripts parse and compile.
-
-3. `python3 scripts/run_phase2_acceptance.py --help`
-- Outcome: pass (exit code `0`), wrapper executes and forwards to deterministic acceptance runner.
-
-4. `python3 scripts/run_phase2_readiness_gates.py --help`
-- Outcome: pass (exit code `0`), wrapper executes and forwards to deterministic readiness gates runner.
-
-5. `python3 scripts/run_phase2_validation_matrix.py --help`
-- Outcome: pass (exit code `0`), wrapper executes and forwards to deterministic validation matrix runner.
+1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_phase2_gate_wrappers.py`
+- Outcome: pass (`12 passed`, exit code `0`).
 
 ## Blockers/Issues
-- No implementation blockers.
-- Full gate execution (`run_phase2_validation_matrix.py` end-to-end) was not run in this sprint pass to avoid out-of-scope heavy runtime execution; entrypoint parseability and executability were verified.
-- Explicit deferred scope boundaries (not shipped in this sprint): workers/automation/orchestration implementation, Phase 3 runtime/profile routing, and backend/API/UI contract changes outside docs + gate-entrypoint closeout.
+- No blockers encountered.
+- No wrapper semantic changes were required; existing wrappers already satisfied sprint behavior and were validated by the new tests.
+- Explicit deferred scope (not implemented in this sprint): automation/workers implementation and Phase 3 runtime/profile orchestration.
 
 ## Recommended Next Step
-Proceed with Control Tower integration review for docs/script coherence and scope compliance, then open the sprint PR from `codex/phase2-sprint8-closeout-gate-truth-sync`.
+Proceed to Control Tower integration review for sprint-scope confirmation and parity-evidence validation, then open/advance the sprint PR.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,23 +4,24 @@
 PASS
 
 ## criteria met
-- Sprint remained closeout-truth-sync scoped: canonical docs, sprint artifacts, and three new Phase 2 gate entrypoint scripts.
-- Canonical docs no longer claim Sprint 7G as current state (`rg -n "Sprint 7G" README.md ROADMAP.md ARCHITECTURE.md .ai/handoff/CURRENT_STATE.md` returned no matches).
-- `README.md`, `ROADMAP.md`, `ARCHITECTURE.md`, and `.ai/handoff/CURRENT_STATE.md` are mutually aligned on shipped seams (typed memory + open loops, resumption brief, manual explicit-signal capture controls, and Phase 2 gate commands).
-- `scripts/run_phase2_acceptance.py`, `scripts/run_phase2_readiness_gates.py`, and `scripts/run_phase2_validation_matrix.py` exist and parse (`python3 -m py_compile ...` passed).
-- Phase 2 validation entrypoint is documented and executable (`python3 scripts/run_phase2_validation_matrix.py --help` passed; same for acceptance/readiness wrappers).
-- No product runtime behavior changes were introduced; wrappers delegate to existing MVP scripts.
-- No out-of-scope work (workers/orchestration/Phase 3 runtime changes/backend contract changes) was introduced.
+- Sprint remained wrapper-parity scoped; no product/runtime API, UI, orchestration, or Phase 3 scope expansion detected.
+- Automated parity tests were added for all three wrappers in `tests/unit/test_phase2_gate_wrappers.py`.
+- Tests assert deterministic CLI arg passthrough to mapped MVP targets.
+- Tests assert subprocess exit-code passthrough behavior.
+- Tests assert repo-root `cwd` usage for wrapper subprocess execution.
+- Tests assert stable wrapper-to-target mappings for all three wrappers.
+- Tests assert executable resolution behavior: prefer `.venv/bin/python`, fallback to `sys.executable`.
+- Verification evidence is reproducible and valid: `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_phase2_gate_wrappers.py` passed (`12 passed`, exit code `0`).
+- No gate semantics changes were introduced in wrapper scripts during this sprint.
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking quality issues in sprint scope.
-- Non-blocking: wrapper behavior is verified via compile/`--help` checks, but there is no direct automated assertion for argument/exit-code passthrough semantics.
+- No blocking quality issues found within sprint scope.
 
 ## regression risks
-- Low. Main residual risk is future doc drift or alias-wrapper drift if MVP script names/locations change without updating wrappers.
+- Low. Main residual risk is future wrapper/target drift if MVP script names or locations change; current parity tests should catch this quickly.
 
 ## docs issues
 - None blocking.
@@ -29,8 +30,8 @@ PASS
 - No.
 
 ## should anything update ARCHITECTURE.md?
-- No further update required for this sprint.
+- No.
 
 ## recommended next action
-1. Proceed to Control Tower closeout and open the sprint PR.
-2. Optional follow-up: add a tiny automated test that validates Phase 2 wrapper arg passthrough and return-code passthrough.
+1. Proceed with Control Tower integration review and squash-merge approval flow.
+2. Ensure the new test file is included in the sprint commit/PR diff before merge.

--- a/tests/unit/test_phase2_gate_wrappers.py
+++ b/tests/unit/test_phase2_gate_wrappers.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+WRAPPER_CASES = (
+    ("run_phase2_acceptance.py", "run_mvp_acceptance.py"),
+    ("run_phase2_readiness_gates.py", "run_mvp_readiness_gates.py"),
+    ("run_phase2_validation_matrix.py", "run_mvp_validation_matrix.py"),
+)
+
+
+def _load_wrapper_module(script_name: str) -> ModuleType:
+    script_path = REPO_ROOT / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"test_{script_name.replace('.', '_')}", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(("wrapper_script", "target_script"), WRAPPER_CASES)
+def test_wrapper_target_mapping_is_stable(wrapper_script: str, target_script: str) -> None:
+    module = _load_wrapper_module(wrapper_script)
+
+    assert module.TARGET_SCRIPT == module.ROOT_DIR / "scripts" / target_script
+
+
+@pytest.mark.parametrize(("wrapper_script", "target_script"), WRAPPER_CASES)
+def test_wrapper_main_forwards_args_and_exit_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, wrapper_script: str, target_script: str
+) -> None:
+    module = _load_wrapper_module(wrapper_script)
+    fake_root = tmp_path / "repo"
+    fake_root.mkdir()
+    fake_target = fake_root / "scripts" / target_script
+    fake_python = str(fake_root / ".venv" / "bin" / "python")
+    forwarded_args = ["--dry-run", "--limit=3", "value with spaces", "--flag=true"]
+    call: dict[str, object] = {}
+
+    def fake_run(command, cwd, check):  # noqa: ANN001
+        call["command"] = command
+        call["cwd"] = cwd
+        call["check"] = check
+        return SimpleNamespace(returncode=23)
+
+    monkeypatch.setattr(module, "ROOT_DIR", fake_root)
+    monkeypatch.setattr(module, "TARGET_SCRIPT", fake_target)
+    monkeypatch.setattr(module, "_resolve_python_executable", lambda: fake_python)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        [str(REPO_ROOT / "scripts" / wrapper_script), *forwarded_args],
+    )
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    assert module.main() == 23
+    assert call == {
+        "command": [fake_python, str(fake_target), *forwarded_args],
+        "cwd": fake_root,
+        "check": False,
+    }
+
+
+@pytest.mark.parametrize(("wrapper_script", "_target_script"), WRAPPER_CASES)
+def test_resolve_python_executable_prefers_repo_venv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, wrapper_script: str, _target_script: str
+) -> None:
+    module = _load_wrapper_module(wrapper_script)
+    fake_root = tmp_path / "repo"
+    venv_python = fake_root / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("#!/usr/bin/env python3\n")
+
+    monkeypatch.setattr(module, "ROOT_DIR", fake_root)
+    monkeypatch.setattr(module.sys, "executable", "/usr/bin/system-python")
+
+    assert module._resolve_python_executable() == str(venv_python)
+
+
+@pytest.mark.parametrize(("wrapper_script", "_target_script"), WRAPPER_CASES)
+def test_resolve_python_executable_falls_back_to_sys_executable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, wrapper_script: str, _target_script: str
+) -> None:
+    module = _load_wrapper_module(wrapper_script)
+    fake_root = tmp_path / "repo"
+    fake_root.mkdir()
+    fallback_python = "/usr/local/bin/fallback-python"
+
+    monkeypatch.setattr(module, "ROOT_DIR", fake_root)
+    monkeypatch.setattr(module.sys, "executable", fallback_python)
+
+    assert module._resolve_python_executable() == fallback_python


### PR DESCRIPTION
## Sprint
Phase 2 Sprint 9: Phase-2 Gate Wrapper Parity

## Summary
This sprint hardens Phase 2 gate tooling by adding deterministic automated parity tests for all three Phase 2 wrapper scripts. The goal is to prevent silent drift between wrapper behavior and underlying MVP runners without changing gate semantics.

## What Shipped
- Added parity test suite:
  - `tests/unit/test_phase2_gate_wrappers.py`
- Updated sprint control artifacts:
  - `.ai/active/SPRINT_PACKET.md`
  - `BUILD_REPORT.md`
  - `REVIEW_REPORT.md`

## Parity Guarantees Now Test-Backed
For each wrapper:
- `scripts/run_phase2_acceptance.py`
- `scripts/run_phase2_readiness_gates.py`
- `scripts/run_phase2_validation_matrix.py`

The tests assert:
- CLI args are forwarded unchanged and in-order to the mapped MVP target script.
- Wrapper subprocess is run with repo-root `cwd`.
- Wrapper return code matches subprocess return code exactly.
- Wrapper-to-target mapping remains stable:
  - `run_phase2_acceptance.py -> run_mvp_acceptance.py`
  - `run_phase2_readiness_gates.py -> run_mvp_readiness_gates.py`
  - `run_phase2_validation_matrix.py -> run_mvp_validation_matrix.py`
- Python executable resolution remains deterministic:
  - prefer `.venv/bin/python` when present
  - fallback to `sys.executable` when `.venv/bin/python` is absent

## Scope Integrity
- Stayed within Sprint 9 hardening scope: wrapper parity tests + sprint artifacts.
- No product/runtime API changes.
- No UI changes.
- No worker/orchestration/Phase 3 implementation changes.
- No wrapper semantic changes were introduced; behavior is validated, not altered.

## Verification Evidence
Executed on this branch:

1. `PYTHONPATH=$PWD .venv/bin/pytest tests/unit/test_phase2_gate_wrappers.py`
- Result: `12 passed` (exit code `0`)

## Review Status
- `REVIEW_REPORT.md` verdict: `PASS`
- Acceptance criteria missed: `None`
- No blocking quality issues identified in sprint scope.

## Merge Request
Ready for Control Tower merge gate under squash-merge policy after explicit approval.
