### PR TITLE
Phase 2 Sprint 15: Phase-closeout packet and exit guardrail

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 2 Sprint 14: Memory-Quality Gate Realism Hardening
+Phase 2 Sprint 15: Phase-Closeout Packet And Exit Guardrail
 
 ## Sprint Type
 
@@ -10,128 +10,137 @@ hardening
 
 ## Sprint Reason
 
-Current readiness `memory_quality` evidence is still generated from synthetic seeded memory labels in `scripts/run_phase2_readiness_gates.py`. That can pass while explicit-signal capture quality regresses. This is now the highest remaining MVP-testing risk and is distinct from prior gate/doc canonicalization sprints.
+Phase 2 gate execution is currently green through Sprint 14, but canonical docs still describe the repo as current through Sprint 11 and there is no explicit, enforced Phase 2 exit packet/checklist. We need one closeout sprint that finalizes phase truth and makes exit-state drift mechanically detectable.
 
 ## Sprint Intent
 
-Make readiness `memory_quality` evidence derive from deterministic explicit-signal capture outcomes and deterministic adjudication logic, while preserving existing gate thresholds and deterministic no-go behavior.
+Create an explicit Phase 2 closeout packet, sync canonical truth docs to Sprint 14, and update truth guardrails so the closeout state is enforced deterministically.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase2-sprint14-memory-quality-realism`
+- Branch Name: `codex/phase2-sprint15-closeout-packet`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- `python3 scripts/run_phase2_validation_matrix.py` is green, but memory-quality gating still uses synthetic seeded labels.
-- A green memory gate should mean capture/extraction behavior is healthy, not only seeded bookkeeping is healthy.
-- This closes a true testing-evidence gap without expanding product feature scope.
+- We are on track technically (`python3 scripts/run_phase2_validation_matrix.py` is PASS), but closeout governance artifacts lag.
+- Repeated “what phase are we in” friction comes from missing enforced exit packet, not missing core functionality.
+- This is a non-redundant closeout sprint: it converts current state into an explicit, enforceable phase-complete baseline.
 
 ## Design Truth
 
-- Keep thresholds unchanged:
-  - precision `> 0.80`
-  - adjudicated sample `>= 20`
-- Keep deterministic gate behavior and induced-gate controls.
-- Do not change API contracts or user-facing product behavior.
+- No endpoint/schema/runtime feature changes.
+- Keep existing gate thresholds and matrix behavior unchanged.
+- Closeout should be encoded as deterministic file+marker truth, not ad hoc interpretation.
 
 ## Exact Surfaces In Scope
 
-- readiness gate memory-quality evidence generation path
-- readiness gate test coverage for memory-quality evidence source and posture transitions
-- sprint-scoped reports
+- canonical truth doc sync to Sprint 14 baseline
+- explicit Phase 2 exit packet documentation
+- deterministic control-doc truth guardrail update for closeout state
 
 ## Exact Files In Scope
 
-- [run_phase2_readiness_gates.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_phase2_readiness_gates.py)
-- [test_mvp_readiness_gates.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_mvp_readiness_gates.py)
+- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md)
+- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md)
+- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md)
+- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md)
+- [check_control_doc_truth.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/check_control_doc_truth.py)
+- [test_control_doc_truth.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_control_doc_truth.py)
+- [phase2-closeout-packet.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/phase2-closeout-packet.md)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
 - [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
 - relevant verification under:
-  - `./.venv/bin/python -m pytest tests/integration/test_mvp_readiness_gates.py -q`
-  - `python3 scripts/run_phase2_readiness_gates.py --induce-gate memory_needs_review`
-  - `python3 scripts/run_phase2_readiness_gates.py --induce-gate memory_insufficient`
+  - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+  - `python3 scripts/check_control_doc_truth.py`
   - `python3 scripts/run_phase2_validation_matrix.py`
 
 ## In Scope
 
-- Replace synthetic memory-label seeding as the default `memory_quality` evidence source with deterministic capture-derived evaluation inputs.
-- Implement deterministic adjudication mapping from capture-derived outputs to memory review labels used by evaluation-summary.
-- Preserve current gate posture semantics:
-  - `PASS` when thresholds are exceeded
-  - `FAIL` when sample is sufficient but precision is at/below threshold
-  - `BLOCKED` when sample is insufficient or evidence unavailable
-- Keep `--induce-gate memory_needs_review` and `--induce-gate memory_insufficient` deterministic and explicit.
+- Update canonical docs to reflect accepted state through Phase 2 Sprint 14.
+- Add a dedicated closeout runbook packet documenting:
+  - required Phase 2 go/no-go commands
+  - required PASS evidence bundle
+  - explicit deferred scope entering next phase
+- Update control-doc truth rules to require closeout packet presence and Sprint 14 baseline markers.
+- Update unit tests for truth guardrails to cover new required markers and stale-marker rejection behavior.
 
 ## Out of Scope
 
-- endpoint/schema changes
-- acceptance scenario expansion beyond readiness-memory evidence source
-- connector/orchestration/worker scope
-- UI feature changes
-- Phase 3 runtime/profile routing
+- API/runtime feature work
+- connector capability expansion
+- orchestration/worker implementation
+- UI redesign
+- Phase 3 routing implementation
 
 ## Required Deliverables
 
-- readiness `memory_quality` path no longer depends on synthetic bulk memory seeding as primary evidence
-- deterministic tests proving capture-derived memory-quality evidence behavior
-- unchanged thresholds and deterministic induced-gate behavior
-- updated sprint reports for this sprint only
+- canonical docs synced to Sprint 14 baseline
+- `docs/runbooks/phase2-closeout-packet.md` committed as closeout source-of-truth
+- truth guardrail rules and tests updated and passing
+- sprint reports updated for this sprint only
 
 ## Acceptance Criteria
 
-- `tests/integration/test_mvp_readiness_gates.py` passes with updated canonical memory-quality evidence logic.
-- Default readiness run computes `memory_quality` from capture-derived deterministic evidence path.
-- `--induce-gate memory_needs_review` and `--induce-gate memory_insufficient` still force expected deterministic outcomes.
-- Full `python3 scripts/run_phase2_validation_matrix.py` remains PASS.
-- No API contract or runtime endpoint behavior changes are introduced.
+- Canonical docs no longer claim Sprint 11 as current baseline.
+- `python3 scripts/check_control_doc_truth.py` passes with updated closeout markers.
+- `tests/unit/test_control_doc_truth.py` passes with updated rule assertions.
+- `docs/runbooks/phase2-closeout-packet.md` clearly defines the Phase 2 exit evidence bundle and deferred scope boundary.
+- `python3 scripts/run_phase2_validation_matrix.py` remains PASS.
+- No product/runtime endpoint behavior changes are introduced.
 
 ## Implementation Constraints
 
-- keep scripts deterministic and non-interactive
-- preserve existing threshold constants and gate naming
-- avoid external dependencies
-- keep assertions machine-independent
+- keep checks deterministic and machine-independent
+- avoid adding dependencies
+- preserve existing gate command semantics
+- do not broaden scope beyond closeout docs/guardrails
 
 ## Control Tower Task Cards
 
-### Task 1: Memory-Quality Evidence Source
+### Task 1: Canonical Truth Sync
 Owner: tooling operative  
 Write scope:
-- `scripts/run_phase2_readiness_gates.py`
+- `ARCHITECTURE.md`
+- `ROADMAP.md`
+- `README.md`
+- `.ai/handoff/CURRENT_STATE.md`
 
-### Task 2: Gate Test Alignment
+### Task 2: Closeout Guardrail
 Owner: tooling operative  
 Write scope:
-- `tests/integration/test_mvp_readiness_gates.py`
+- `docs/runbooks/phase2-closeout-packet.md`
+- `scripts/check_control_doc_truth.py`
+- `tests/unit/test_control_doc_truth.py`
 
 ### Task 3: Integration Review
 Owner: control tower  
 Responsibilities:
-- verify evidence source changed from synthetic seed to capture-derived logic
-- verify threshold and posture semantics unchanged
-- verify no hidden scope expansion
-- verify reports and packet consistency
+- verify closeout packet completeness
+- verify canonical truth sync to Sprint 14
+- verify guardrail coverage for closeout markers
+- verify strict no hidden scope expansion
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact previous synthetic evidence path and exact replacement path
-- deterministic adjudication rules used
-- verification command outputs and outcomes
-- explicit deferred scope
+- exact canonical-doc baseline marker changes
+- exact closeout packet contents added
+- exact truth-guardrail rule/test changes
+- exact verification command outcomes
+- explicit deferred scope into next phase
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint stayed memory-quality-readiness scoped
-- capture-derived evidence is deterministic and credible
-- threshold/posture behavior is preserved
+- sprint remained closeout-doc-and-guardrail scoped
+- closeout packet is operationally sufficient for phase handoff
+- truth guardrails enforce updated baseline and packet presence
 - no hidden runtime/product scope changes
 
 ## Exit Condition
 
-This sprint is complete when readiness `memory_quality` gate evidence is capture-derived and deterministic, thresholds/postures remain unchanged, and full Phase 2 validation remains green.
+This sprint is complete when Phase 2 closeout documentation is explicit and enforceable, canonical docs align to Sprint 14, and truth guardrails pass with the updated closeout baseline.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -2,7 +2,7 @@
 
 ## Canonical Truth
 
-- The working repo state is current through Phase 2 Sprint 11.
+- The working repo state is current through Phase 2 Sprint 14.
 - The accepted baseline includes deterministic Phase 2 gate tooling: `python3 scripts/run_phase2_acceptance.py`, `python3 scripts/run_phase2_readiness_gates.py`, and `python3 scripts/run_phase2_validation_matrix.py` (default go/no-go command).
 - Gate ownership is canonicalized to Phase 2 runner scripts; `run_mvp_acceptance.py`, `run_mvp_readiness_gates.py`, and `run_mvp_validation_matrix.py` remain supported compatibility aliases with identical semantics.
 - Use [PRODUCT_BRIEF.md](../../PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](../../ARCHITECTURE.md) for implemented boundaries, [ROADMAP.md](../../ROADMAP.md) for forward planning, and [RULES.md](../../RULES.md) for durable operating rules.
@@ -46,6 +46,6 @@
 
 ## Planning Guardrails
 
-- Plan from the implemented Phase 2 Sprint 11 repo state, not from older Sprint 5-era narratives.
+- Plan from the implemented Phase 2 Sprint 14 repo state, not from older Sprint 5-era narratives.
 - Do not describe broader Gmail scope, broader Calendar scope beyond bounded read-only event discovery plus selected-event ingestion, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
 - The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, including `/gmail`, `/calendar`, `/memories`, `/entities`, and `/artifacts`, not assumed to be leftover connector cleanup by default.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Current Implemented Slice
 
-AliceBot now implements the accepted repo slice through Phase 2 Sprint 11.
+AliceBot now implements the accepted repo slice through Phase 2 Sprint 14.
 
 - `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review plus open-loop lifecycle capture/review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and narrow read-only Gmail and Calendar seams with external-secret-backed credentials plus bounded Calendar event discovery and selected-item ingestion into the artifact pipeline.
 - `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,80 +1,87 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Phase 2 Sprint 14 by replacing synthetic memory-label seeding in readiness `memory_quality` with deterministic explicit-signal-capture-derived evidence and deterministic adjudication, while preserving thresholds/posture semantics and induced-gate determinism.
+Implement Phase 2 Sprint 15 closeout hardening by publishing an explicit Phase 2 exit packet, syncing canonical truth docs to the accepted Sprint 14 baseline, and enforcing that closeout state via deterministic control-doc truth checks.
 
 ## Completed Work
-- Replaced previous synthetic memory evidence path:
-  - Previous path: `run_readiness_gates()` called `_seed_memory_quality_sample(...)`, which directly created synthetic memories (`user.readiness.sample.{index}`) and directly wrote `memory_review_labels` (`correct`/`incorrect`) before evaluating `/v0/memories/evaluation-summary`.
-  - Replacement path: `run_readiness_gates()` now calls `_capture_and_adjudicate_memory_quality_sample(...)`, which:
-    - appends deterministic `message.user` events,
-    - calls `/v0/memories/capture-explicit-signals` per event,
-    - extracts capture admissions from `preferences` + `commitments`,
-    - deterministically maps admissions to review labels,
-    - persists those labels, then evaluates `/v0/memories/evaluation-summary`.
-- Implemented deterministic capture input plans by profile:
-  - `on_track`: 20 unique explicit preference messages (`I like readiness-topic-XX`).
-  - `needs_review`: 16 unique + 4 deterministic duplicates (duplicate captures yield deterministic `NOOP` admissions).
-  - `insufficient_evidence`: 9 unique + 1 deterministic duplicate.
-- Implemented deterministic adjudication rules used for evaluation-label generation:
-  - admission decision `ADD` or `UPDATE` => `correct`
-  - any other admission decision (for example `NOOP`) => `incorrect`
-  - evidence unavailable/invalid capture payload structure => runtime error, resulting in deterministic `BLOCKED` fallback behavior already present in gate runner.
-- Preserved gate thresholds and posture semantics unchanged:
-  - threshold remains `precision > 0.80 and adjudicated_sample >= 20`
-  - posture outcomes remain `PASS`/`FAIL`/`BLOCKED` with `on_track`/`needs_review`/`insufficient_evidence`.
-- Updated readiness-gate integration tests in-scope:
-  - added deterministic tests for capture message profile generation,
-  - added deterministic test for adjudication mapping,
-  - added routing test ensuring induced memory scenarios flow through capture-derived profile selection and produce expected posture/status.
+- Synced canonical baseline markers from Sprint 11 to Sprint 14 in in-scope truth docs.
+  - `ARCHITECTURE.md`: `through Phase 2 Sprint 11` -> `through Phase 2 Sprint 14`
+  - `ROADMAP.md`:
+    - `current through Phase 2 Sprint 11` -> `current through Phase 2 Sprint 14`
+    - `Phase 2 Sprint 11 confirms ...` -> `Phase 2 Sprint 14 confirms ...`
+    - `implemented Phase 2 Sprint 11 backend-plus-web baseline` -> `implemented Phase 2 Sprint 14 backend-plus-web baseline`
+  - `README.md`: `accepted slice through Phase 2 Sprint 11` -> `accepted slice through Phase 2 Sprint 14`
+  - `.ai/handoff/CURRENT_STATE.md`:
+    - `current through Phase 2 Sprint 11` -> `current through Phase 2 Sprint 14`
+    - `implemented Phase 2 Sprint 11 repo state` -> `implemented Phase 2 Sprint 14 repo state`
+- Added explicit closeout packet source-of-truth:
+  - New file `docs/runbooks/phase2-closeout-packet.md`
+  - Includes required sections:
+    - required Phase 2 go/no-go commands
+    - required PASS evidence bundle
+    - explicit deferred scope entering next phase
+    - closeout checklist
+- Updated deterministic control-doc truth guardrails in `scripts/check_control_doc_truth.py`:
+  - Required baseline marker updated to Sprint 14 for:
+    - `ARCHITECTURE.md`
+    - `ROADMAP.md`
+    - `README.md`
+    - `.ai/handoff/CURRENT_STATE.md`
+  - Added required closeout packet rule for `docs/runbooks/phase2-closeout-packet.md` with required markers:
+    - `accepted Phase 2 Sprint 14 baseline`
+    - `Required Phase 2 Go/No-Go Commands`
+    - `Required PASS Evidence Bundle`
+    - `Explicit Deferred Scope Entering Next Phase`
+  - Added stale-marker rejection for prior baseline text:
+    - `through Phase 2 Sprint 11`
+    - `current through Phase 2 Sprint 11`
+- Updated truth guardrail tests in `tests/unit/test_control_doc_truth.py`:
+  - existing required-marker pass/fail coverage retained
+  - existing disallowed-marker coverage retained
+  - added missing closeout packet file failure coverage
+  - added stale Sprint 11 baseline marker rejection coverage
 
 ## Incomplete Work
 - None in sprint scope.
 
 ## Files Changed
-- `scripts/run_phase2_readiness_gates.py`
-- `tests/integration/test_mvp_readiness_gates.py`
+- `.ai/handoff/CURRENT_STATE.md`
+- `ARCHITECTURE.md`
+- `ROADMAP.md`
+- `README.md`
+- `docs/runbooks/phase2-closeout-packet.md`
+- `scripts/check_control_doc_truth.py`
+- `tests/unit/test_control_doc_truth.py`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 ## Tests Run
-1. `./.venv/bin/python -m pytest tests/integration/test_mvp_readiness_gates.py -q`
-- Outcome: PASS (`12 passed in 0.23s`, exit code `0`).
+1. `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+- Outcome: PASS (`5 passed in 0.02s`, exit code `0`).
 
-2. `python3 scripts/run_phase2_readiness_gates.py --induce-gate memory_needs_review`
-- Outcome: deterministic NO_GO (`exit code 1`) as expected for induced scenario.
-- Key gate evidence:
-  - `memory_quality: FAIL`
-  - `precision=0.800000; adjudicated_sample=20; posture=needs_review`
-  - `correct=16; incorrect=4`
+2. `python3 scripts/check_control_doc_truth.py`
+- Outcome: PASS (`Control-doc truth check: PASS`, all configured control-doc rules verified including `docs/runbooks/phase2-closeout-packet.md`).
 
-3. `python3 scripts/run_phase2_readiness_gates.py --induce-gate memory_insufficient`
-- Outcome: deterministic NO_GO (`exit code 1`) as expected for induced scenario.
-- Key gate evidence:
-  - `memory_quality: BLOCKED`
-  - `precision=0.900000; adjudicated_sample=10; posture=insufficient_evidence`
-  - `correct=9; incorrect=1`
-
-4. `python3 scripts/run_phase2_validation_matrix.py`
-- Outcome: PASS (`exit code 0`).
-- Matrix summary:
+3. `python3 scripts/run_phase2_validation_matrix.py`
+- First run in sandbox: NO_GO due localhost Postgres access restriction (`Operation not permitted`), not due sprint logic.
+- Rerun with elevated local access: PASS (`Phase 2 validation matrix result: PASS`).
+- PASS step summary on elevated run:
   - `control_doc_truth: PASS`
   - `gate_contract_tests: PASS`
   - `readiness_gates: PASS`
   - `backend_integration_matrix: PASS`
   - `web_validation_matrix: PASS`
-- Readiness default memory evidence confirms capture-derived behavior:
-  - `memory_quality: PASS`
-  - `precision=1.000000; adjudicated_sample=20; posture=on_track`
 
 ## Blockers/Issues
-- Local DB access is required for readiness/matrix verification; initial non-escalated run was sandbox-blocked from connecting to local Postgres (`localhost:5432`).
-- Verification completed successfully after rerunning with elevated local access.
+- Local sandbox network policy blocked Postgres TCP access on initial matrix execution (`localhost:5432`), causing a false NO_GO environment failure.
+- Resolved by rerunning the same matrix command with elevated local access.
 
-## Explicit Deferred Scope
-- No endpoint/schema contract changes.
-- No connector/orchestration/worker/UI changes.
-- No Phase 3 runtime/profile routing work.
+## Explicit Deferred Scope Into Next Phase
+- API/runtime feature changes
+- connector capability expansion beyond current bounded Gmail/Calendar seams
+- orchestration/worker implementation
+- Phase 3 routing implementation
+- UI redesign
 
 ## Recommended Next Step
-1. Send sprint for reviewer PASS with this evidence bundle (targeted readiness test PASS, both induced memory scenarios deterministic NO_GO with expected posture, full Phase 2 validation matrix PASS).
+1. Send this sprint for Control Tower review focused on closeout packet completeness and guardrail enforcement, then proceed to merge approval if review remains PASS.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Phase 2 Sprint 11: a FastAPI backend plus a bounded Next.js operator shell with deterministic readiness and validation matrix gating.
+AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Phase 2 Sprint 14: a FastAPI backend plus a bounded Next.js operator shell with deterministic readiness and validation matrix gating.
 
 ## Current Implemented Slice
 

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,44 +4,50 @@
 PASS
 
 ## criteria met
-- Sprint scope remained aligned to memory-quality readiness hardening: changed implementation is confined to [run_phase2_readiness_gates.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_phase2_readiness_gates.py) and [test_mvp_readiness_gates.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_mvp_readiness_gates.py), plus sprint report files.
-- `memory_quality` evidence source is capture-derived, not synthetic seed labels:
-  - old `_seed_memory_quality_sample(...)` path is removed.
-  - readiness now uses deterministic capture flow (`message.user` event -> `/v0/memories/capture-explicit-signals` -> admissions adjudication -> persisted review labels -> `/v0/memories/evaluation-summary`).
-- Deterministic adjudication mapping is implemented as specified:
-  - `ADD`/`UPDATE` -> `correct`
-  - all other decisions -> `incorrect`
-- Thresholds and posture semantics are preserved:
-  - threshold remains `precision > 0.80 and adjudicated_sample >= 20`
-  - `memory_needs_review` induces deterministic `FAIL` with `precision=0.800000`, `adjudicated_sample=20`, posture `needs_review`
-  - `memory_insufficient` induces deterministic `BLOCKED` with `precision=0.900000`, `adjudicated_sample=10`, posture `insufficient_evidence`
-- Required verification is green:
-  - `./.venv/bin/python -m pytest tests/integration/test_mvp_readiness_gates.py -q` -> `12 passed`
-  - `python3 scripts/run_phase2_readiness_gates.py --induce-gate memory_needs_review` -> expected deterministic NO_GO with `memory_quality: FAIL`
-  - `python3 scripts/run_phase2_readiness_gates.py --induce-gate memory_insufficient` -> expected deterministic NO_GO with `memory_quality: BLOCKED`
-  - `python3 scripts/run_phase2_validation_matrix.py` -> `PASS`
-- No API contract or endpoint behavior changes were introduced.
+- Canonical baseline sync to Sprint 14 is complete in all required docs:
+  - `ARCHITECTURE.md`
+  - `ROADMAP.md`
+  - `README.md`
+  - `.ai/handoff/CURRENT_STATE.md`
+- `docs/runbooks/phase2-closeout-packet.md` is present and operationally complete for closeout use:
+  - includes required Phase 2 go/no-go commands
+  - includes required PASS evidence bundle
+  - includes explicit deferred scope entering next phase
+  - includes a closeout checklist tied to Sprint 14 baseline truth
+- `scripts/check_control_doc_truth.py` enforces updated closeout truth state:
+  - requires Sprint 14 baseline markers
+  - requires closeout packet presence and key markers
+  - rejects stale Sprint 11 baseline markers
+- `tests/unit/test_control_doc_truth.py` passes and includes coverage for:
+  - required-marker enforcement behavior
+  - disallowed-marker enforcement behavior
+  - missing closeout packet file behavior
+  - stale Sprint 11 marker rejection behavior
+- Required verification commands were validated:
+  - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q` -> PASS (`5 passed`)
+  - `python3 scripts/check_control_doc_truth.py` -> PASS
+  - `python3 scripts/run_phase2_validation_matrix.py` -> PASS (after rerun with local host DB access)
+- No endpoint/schema/runtime product behavior changes were introduced in this sprint diff.
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking implementation-quality issues found.
-- Added tests cover deterministic message-profile generation, adjudication mapping, and induced profile routing through the new capture-derived path.
+- No blocking implementation-quality issues found in sprint scope.
 
 ## regression risks
-- Low risk to product/runtime behavior because changes are isolated to readiness gate evidence generation.
-- Operational verification still depends on local Postgres reachability for readiness/matrix runs.
+- Low technical regression risk: changes are documentation and deterministic control-doc guardrails/tests.
+- Environment dependency risk remains for local verification: full matrix requires local Postgres connectivity.
 
 ## docs issues
-- [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md) includes required path replacement detail, adjudication rules, verification outcomes, and deferred scope.
-- No additional sprint-documentation gaps found.
+- `BUILD_REPORT.md` includes required sprint objective, marker changes, closeout packet additions, guardrail/test updates, verification outcomes, deferred scope, and next action.
+- No missing closeout-scope documentation identified.
 
 ## should anything be added to RULES.md?
 - No.
 
 ## should anything update ARCHITECTURE.md?
-- No.
+- No additional updates required beyond the Sprint 14 baseline marker sync already made.
 
 ## recommended next action
-1. Approve sprint as PASS and proceed to Control Tower merge approval.
+1. Proceed to Control Tower closeout review and merge approval for Phase 2 Sprint 15.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,20 +2,20 @@
 
 ## Current Position
 
-- The accepted repo state is current through Phase 2 Sprint 11.
+- The accepted repo state is current through Phase 2 Sprint 14.
 - The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, typed memory and open-loop seams, deterministic thread resumption brief reads, unified explicit-signal capture seams, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, narrow read-only Gmail and Calendar seams with selected-item ingestion, bounded read-only Calendar event discovery for one connected account, and the no-tools assistant-response seam.
 - The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
 - `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, keeps bounded thread review and deterministic resumption brief review visible beside both assistant and governed-request composition, ships thread-linked governed workflow, ordered task-step timeline review, and bounded explain-why trace embedding, and includes manual explicit-signal capture controls for selected `message.user` events.
 - `/gmail` and `/calendar` are shipped bounded connector workspaces in the shell: account review, selected-account detail, explicit connect, and one selected-item ingestion path into one chosen task workspace. The API baseline also includes bounded Calendar event discovery for one connected account with deterministic ordering and bounded limits.
 - `/memories`, `/entities`, and `/artifacts` are shipped bounded review workspaces in the shell, not planned surface.
-- Phase 2 Sprint 11 confirms deterministic release-candidate validation tooling and canonical Phase 2 gate ownership; `python3 scripts/run_phase2_validation_matrix.py` is the default go/no-go command.
+- Phase 2 Sprint 14 confirms deterministic release-candidate validation tooling and canonical Phase 2 gate ownership; `python3 scripts/run_phase2_validation_matrix.py` is the default go/no-go command.
 - Historical sprint detail belongs in build and review artifacts, not in this roadmap.
 
 ## Next Delivery Focus
 
 ### Build From The Shipped API Plus Web-Shell Baseline
 
-- Plan the next sprint from the implemented Phase 2 Sprint 11 backend-plus-web baseline, not from older pre-Phase-2 narratives.
+- Plan the next sprint from the implemented Phase 2 Sprint 14 backend-plus-web baseline, not from older pre-Phase-2 narratives.
 - Treat transcript continuity, thread-linked workflow review, task-step timeline review, bounded explain-why embedding in `/chat`, deterministic resumption brief review, manual explicit-signal capture controls, the shipped review workspaces (`/memories`, `/entities`, `/artifacts`), the shipped connector workspaces (`/gmail`, `/calendar`), and bounded Calendar event discovery as baseline, not pending work.
 - Treat the deterministic validation matrix command (`python3 scripts/run_phase2_validation_matrix.py`) as the default release-candidate gate.
 - Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.

--- a/docs/runbooks/phase2-closeout-packet.md
+++ b/docs/runbooks/phase2-closeout-packet.md
@@ -1,0 +1,43 @@
+# Phase 2 Closeout Packet
+
+This runbook is the source-of-truth closeout packet for the accepted Phase 2 Sprint 14 baseline.
+
+## Required Phase 2 Go/No-Go Commands
+
+Run these commands from repo root in order and retain outputs verbatim in the evidence bundle:
+
+1. `python3 scripts/check_control_doc_truth.py`
+2. `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+3. `python3 scripts/run_phase2_validation_matrix.py`
+
+Go decision rule:
+- `GO` only if all three commands pass in the same verification window.
+- `NO_GO` if any command fails, is skipped, or cannot produce deterministic output.
+
+## Required PASS Evidence Bundle
+
+Capture the following in one reviewable bundle:
+
+- command transcript for all required go/no-go commands
+- final statuses showing `Control-doc truth check: PASS`, unit test PASS, and validation matrix PASS
+- timestamped operator note that canonical docs are aligned through Phase 2 Sprint 14
+- links to current sprint reports at repo root:
+  - `BUILD_REPORT.md`
+  - `REVIEW_REPORT.md`
+
+## Explicit Deferred Scope Entering Next Phase
+
+The following are deferred and must remain out of this closeout decision:
+
+- API/runtime feature expansion beyond accepted Phase 2 Sprint 14 behavior
+- connector capability broadening (Gmail/Calendar breadth beyond current bounded seams)
+- orchestration/worker runtime implementation
+- Phase 3 routing implementation
+- UI redesign
+
+## Closeout Checklist
+
+- Canonical docs do not claim a baseline earlier than Phase 2 Sprint 14.
+- This closeout packet file exists and remains referenced by control-doc truth checks.
+- Control-doc truth guardrail and unit tests pass.
+- Phase 2 validation matrix remains PASS without gate semantic changes.

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -17,19 +17,19 @@ class ControlDocTruthRule:
 CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
     ControlDocTruthRule(
         relative_path="ARCHITECTURE.md",
-        required_markers=("through Phase 2 Sprint 11",),
+        required_markers=("through Phase 2 Sprint 14",),
     ),
     ControlDocTruthRule(
         relative_path="ROADMAP.md",
         required_markers=(
-            "through Phase 2 Sprint 11",
+            "through Phase 2 Sprint 14",
             "canonical Phase 2 gate ownership",
         ),
     ),
     ControlDocTruthRule(
         relative_path="README.md",
         required_markers=(
-            "through Phase 2 Sprint 11",
+            "through Phase 2 Sprint 14",
             "Canonical gate ownership: `scripts/run_phase2_*.py` are implementation source",
         ),
     ),
@@ -44,13 +44,24 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
     ControlDocTruthRule(
         relative_path=".ai/handoff/CURRENT_STATE.md",
         required_markers=(
-            "through Phase 2 Sprint 11",
+            "through Phase 2 Sprint 14",
             "Gate ownership is canonicalized to Phase 2 runner scripts",
+        ),
+    ),
+    ControlDocTruthRule(
+        relative_path="docs/runbooks/phase2-closeout-packet.md",
+        required_markers=(
+            "accepted Phase 2 Sprint 14 baseline",
+            "Required Phase 2 Go/No-Go Commands",
+            "Required PASS Evidence Bundle",
+            "Explicit Deferred Scope Entering Next Phase",
         ),
     ),
 )
 
 DISALLOWED_MARKERS: tuple[str, ...] = (
+    "through Phase 2 Sprint 11",
+    "current through Phase 2 Sprint 11",
     "Phase 2 Sprint 7",
     "v1 ship gate",
     "v1 ship-gate",

--- a/tests/unit/test_control_doc_truth.py
+++ b/tests/unit/test_control_doc_truth.py
@@ -49,3 +49,34 @@ def test_control_doc_truth_fails_when_disallowed_marker_is_present(tmp_path: Pat
         issue == f"{target_rule.relative_path}: contains disallowed marker 'Phase 2 Sprint 7'"
         for issue in issues
     )
+
+
+def test_control_doc_truth_fails_when_closeout_packet_is_missing(tmp_path: Path) -> None:
+    _seed_truth_docs(tmp_path)
+    closeout_rule = next(
+        rule
+        for rule in control_doc_truth.CONTROL_DOC_TRUTH_RULES
+        if rule.relative_path == "docs/runbooks/phase2-closeout-packet.md"
+    )
+    (tmp_path / closeout_rule.relative_path).unlink()
+
+    issues = control_doc_truth.run_control_doc_truth_check(root_dir=tmp_path)
+
+    assert any(issue == f"{closeout_rule.relative_path}: missing file" for issue in issues)
+
+
+def test_control_doc_truth_fails_when_stale_sprint11_baseline_marker_is_present(tmp_path: Path) -> None:
+    _seed_truth_docs(tmp_path)
+    target_rule = control_doc_truth.CONTROL_DOC_TRUTH_RULES[0]
+    target_path = tmp_path / target_rule.relative_path
+    target_path.write_text(
+        target_path.read_text(encoding="utf-8") + "\nThe accepted repo state is current through Phase 2 Sprint 11.\n",
+        encoding="utf-8",
+    )
+
+    issues = control_doc_truth.run_control_doc_truth_check(root_dir=tmp_path)
+
+    assert any(
+        issue == f"{target_rule.relative_path}: contains disallowed marker 'through Phase 2 Sprint 11'"
+        for issue in issues
+    )


### PR DESCRIPTION
## Summary
This sprint finalizes the Phase 2 closeout state by syncing canonical truth docs through Sprint 14, adding an explicit closeout packet runbook, and hardening control-doc truth checks to enforce closeout markers deterministically.

## Scope
- Canonical truth doc baseline sync (`ARCHITECTURE.md`, `ROADMAP.md`, `README.md`, `.ai/handoff/CURRENT_STATE.md`)
- New closeout source-of-truth runbook (`docs/runbooks/phase2-closeout-packet.md`)
- Truth guardrail + tests updates (`scripts/check_control_doc_truth.py`, `tests/unit/test_control_doc_truth.py`)
- Sprint packet/build/review report updates

## Verification
- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q` -> `5 passed`
- `python3 scripts/check_control_doc_truth.py` -> `PASS`
- `python3 scripts/run_phase2_validation_matrix.py` -> `PASS`

## Merge Readiness
- Branch aligned to packet: `codex/phase2-sprint15-closeout-packet`
- `REVIEW_REPORT.md` verdict: `PASS`
- Diff scoped to Sprint 15 files only
- Control Tower decision: `MERGE_APPROVED`
