### PR TITLE
Phase 3 Sprint 1: Multi-agent profile backbone

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,145 +2,160 @@
 
 ## Sprint Title
 
-Phase 2 Sprint 15: Phase-Closeout Packet And Exit Guardrail
+Phase 3 Sprint 1: Multi-Agent Profile Backbone
 
 ## Sprint Type
 
-hardening
+feature
 
 ## Sprint Reason
 
-Phase 2 gate execution is currently green through Sprint 14, but canonical docs still describe the repo as current through Sprint 11 and there is no explicit, enforced Phase 2 exit packet/checklist. We need one closeout sprint that finalizes phase truth and makes exit-state drift mechanically detectable.
+Phase 2 closeout is complete and validation is green. The next non-redundant step is to open Phase 3 by introducing explicit agent profile identity so separate agents can be deployed without sharing one implicit runtime persona.
 
 ## Sprint Intent
 
-Create an explicit Phase 2 closeout packet, sync canonical truth docs to Sprint 14, and update truth guardrails so the closeout state is enforced deterministically.
+Add a minimal, deterministic backend backbone for agent profiles and thread-level profile binding, without changing existing tool orchestration breadth or connector scope.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase2-sprint15-closeout-packet`
+- Branch Name: `codex/phase3-sprint1-agent-profile-backbone`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- We are on track technically (`python3 scripts/run_phase2_validation_matrix.py` is PASS), but closeout governance artifacts lag.
-- Repeated “what phase are we in” friction comes from missing enforced exit packet, not missing core functionality.
-- This is a non-redundant closeout sprint: it converts current state into an explicit, enforceable phase-complete baseline.
+- This is the first implementation seam required for “multiple separate agents.”
+- It is orthogonal to completed Phase 2 hardening (gate/doc/closeout work), so it is not redundant.
+- It creates a durable identity boundary before opening broader routing/orchestration work.
 
 ## Design Truth
 
-- No endpoint/schema/runtime feature changes.
-- Keep existing gate thresholds and matrix behavior unchanged.
-- Closeout should be encoded as deterministic file+marker truth, not ad hoc interpretation.
+- Keep existing default behavior for callers that do not provide a profile.
+- Persist explicit profile identity on thread records.
+- Keep the initial profile surface bounded: registry read + thread binding + response/compile propagation.
+- Do not widen tool execution, connector actions, or worker orchestration in this sprint.
 
 ## Exact Surfaces In Scope
 
-- canonical truth doc sync to Sprint 14 baseline
-- explicit Phase 2 exit packet documentation
-- deterministic control-doc truth guardrail update for closeout state
+- agent profile contracts and deterministic in-process registry
+- thread creation/list/detail profile binding
+- context compile / response output includes active profile identity
+- migration and tests for new thread profile column and behavior
 
 ## Exact Files In Scope
 
-- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md)
-- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md)
-- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md)
-- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md)
-- [check_control_doc_truth.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/check_control_doc_truth.py)
-- [test_control_doc_truth.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_control_doc_truth.py)
-- [phase2-closeout-packet.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/phase2-closeout-packet.md)
+- [contracts.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/contracts.py)
+- [main.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/main.py)
+- [store.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/store.py)
+- [phase3_profiles.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/phase3_profiles.py)
+- [20260324_0032_thread_agent_profiles.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/alembic/versions/20260324_0032_thread_agent_profiles.py)
+- [test_continuity_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_continuity_api.py)
+- [test_responses_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_responses_api.py)
+- [test_20260324_0032_thread_agent_profiles.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_20260324_0032_thread_agent_profiles.py)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
 - [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
 - relevant verification under:
-  - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-  - `python3 scripts/check_control_doc_truth.py`
+  - `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py -q`
+  - `./.venv/bin/python -m pytest tests/unit/test_20260324_0032_thread_agent_profiles.py -q`
   - `python3 scripts/run_phase2_validation_matrix.py`
 
 ## In Scope
 
-- Update canonical docs to reflect accepted state through Phase 2 Sprint 14.
-- Add a dedicated closeout runbook packet documenting:
-  - required Phase 2 go/no-go commands
-  - required PASS evidence bundle
-  - explicit deferred scope entering next phase
-- Update control-doc truth rules to require closeout packet presence and Sprint 14 baseline markers.
-- Update unit tests for truth guardrails to cover new required markers and stale-marker rejection behavior.
+- Add deterministic Phase 3 profile registry module with at least:
+  - `assistant_default` profile
+  - one additional profile (for example `coach_default`) with distinct id/name/description
+- Add `agent_profile_id` thread column with migration:
+  - non-null with deterministic default `assistant_default`
+  - user-scoped reads preserved
+- Extend thread create request to optionally accept `agent_profile_id`:
+  - invalid profile id returns deterministic 422
+  - omitted profile id uses default
+- Expose profile identity in thread list/detail responses.
+- Include active `agent_profile_id` in context compile and `/v0/responses` response metadata.
+- Add a bounded read endpoint for available profiles:
+  - `GET /v0/agent-profiles`
 
 ## Out of Scope
 
-- API/runtime feature work
-- connector capability expansion
-- orchestration/worker implementation
-- UI redesign
-- Phase 3 routing implementation
+- per-profile model-provider switching
+- external LLM provider integration changes
+- auth model changes
+- runner/worker orchestration
+- connector scope expansion
+- web UI profile selector
 
 ## Required Deliverables
 
-- canonical docs synced to Sprint 14 baseline
-- `docs/runbooks/phase2-closeout-packet.md` committed as closeout source-of-truth
-- truth guardrail rules and tests updated and passing
-- sprint reports updated for this sprint only
+- migration for thread profile binding
+- profile registry and API read surface
+- thread + compile + response profile propagation
+- integration and migration tests passing
+- updated sprint reports for this sprint only
 
 ## Acceptance Criteria
 
-- Canonical docs no longer claim Sprint 11 as current baseline.
-- `python3 scripts/check_control_doc_truth.py` passes with updated closeout markers.
-- `tests/unit/test_control_doc_truth.py` passes with updated rule assertions.
-- `docs/runbooks/phase2-closeout-packet.md` clearly defines the Phase 2 exit evidence bundle and deferred scope boundary.
+- Threads persist and return `agent_profile_id`.
+- Creating a thread with a valid non-default profile succeeds and remains isolated per user.
+- Creating a thread with invalid profile id fails deterministically.
+- `/v0/agent-profiles` returns deterministic profile registry payload.
+- `/v0/context/compile` and `/v0/responses` include active profile id metadata.
 - `python3 scripts/run_phase2_validation_matrix.py` remains PASS.
-- No product/runtime endpoint behavior changes are introduced.
+- No out-of-scope behavior changes enter sprint.
 
 ## Implementation Constraints
 
-- keep checks deterministic and machine-independent
-- avoid adding dependencies
-- preserve existing gate command semantics
-- do not broaden scope beyond closeout docs/guardrails
+- keep deterministic outputs and stable ordering
+- do not introduce external dependencies
+- preserve existing endpoint behavior when `agent_profile_id` is omitted
+- keep migration reversible
 
 ## Control Tower Task Cards
 
-### Task 1: Canonical Truth Sync
+### Task 1: Profile Registry + Contracts
 Owner: tooling operative  
 Write scope:
-- `ARCHITECTURE.md`
-- `ROADMAP.md`
-- `README.md`
-- `.ai/handoff/CURRENT_STATE.md`
+- `apps/api/src/alicebot_api/phase3_profiles.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/main.py`
 
-### Task 2: Closeout Guardrail
+### Task 2: Persistence + Migration
 Owner: tooling operative  
 Write scope:
-- `docs/runbooks/phase2-closeout-packet.md`
-- `scripts/check_control_doc_truth.py`
-- `tests/unit/test_control_doc_truth.py`
+- `apps/api/alembic/versions/20260324_0032_thread_agent_profiles.py`
+- `apps/api/src/alicebot_api/store.py`
 
-### Task 3: Integration Review
+### Task 3: Verification
+Owner: tooling operative  
+Write scope:
+- `tests/integration/test_continuity_api.py`
+- `tests/integration/test_responses_api.py`
+- `tests/unit/test_20260324_0032_thread_agent_profiles.py`
+
+### Task 4: Integration Review
 Owner: control tower  
 Responsibilities:
-- verify closeout packet completeness
-- verify canonical truth sync to Sprint 14
-- verify guardrail coverage for closeout markers
-- verify strict no hidden scope expansion
+- verify profile identity seam is complete and bounded
+- verify no hidden Phase 3 scope expansion
+- verify phase2 matrix remains green
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact canonical-doc baseline marker changes
-- exact closeout packet contents added
-- exact truth-guardrail rule/test changes
+- exact migration behavior and defaults
+- exact API/contract deltas
 - exact verification command outcomes
-- explicit deferred scope into next phase
+- explicit deferred scope (routing/orchestration/model-provider switching)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint remained closeout-doc-and-guardrail scoped
-- closeout packet is operationally sufficient for phase handoff
-- truth guardrails enforce updated baseline and packet presence
-- no hidden runtime/product scope changes
+- sprint remained profile-backbone scoped
+- thread/profile propagation and validation behavior correctness
+- migration safety and user isolation
+- no hidden scope expansion
 
 ## Exit Condition
 
-This sprint is complete when Phase 2 closeout documentation is explicit and enforceable, canonical docs align to Sprint 14, and truth guardrails pass with the updated closeout baseline.
+This sprint is complete when the repo can persist and expose explicit thread-level agent profile identity with deterministic validation and tests, while keeping all prior Phase 2 gates green.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,71 +1,82 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Phase 2 Sprint 15 closeout hardening by publishing an explicit Phase 2 exit packet, syncing canonical truth docs to the accepted Sprint 14 baseline, and enforcing that closeout state via deterministic control-doc truth checks.
+Implement Phase 3 Sprint 1 (Multi-Agent Profile Backbone) by adding deterministic agent profile identity, persisting thread-level `agent_profile_id`, exposing profile registry read APIs, and propagating active profile metadata through context compile and response generation surfaces without expanding orchestration scope.
 
 ## Completed Work
-- Synced canonical baseline markers from Sprint 11 to Sprint 14 in in-scope truth docs.
-  - `ARCHITECTURE.md`: `through Phase 2 Sprint 11` -> `through Phase 2 Sprint 14`
-  - `ROADMAP.md`:
-    - `current through Phase 2 Sprint 11` -> `current through Phase 2 Sprint 14`
-    - `Phase 2 Sprint 11 confirms ...` -> `Phase 2 Sprint 14 confirms ...`
-    - `implemented Phase 2 Sprint 11 backend-plus-web baseline` -> `implemented Phase 2 Sprint 14 backend-plus-web baseline`
-  - `README.md`: `accepted slice through Phase 2 Sprint 11` -> `accepted slice through Phase 2 Sprint 14`
-  - `.ai/handoff/CURRENT_STATE.md`:
-    - `current through Phase 2 Sprint 11` -> `current through Phase 2 Sprint 14`
-    - `implemented Phase 2 Sprint 11 repo state` -> `implemented Phase 2 Sprint 14 repo state`
-- Added explicit closeout packet source-of-truth:
-  - New file `docs/runbooks/phase2-closeout-packet.md`
-  - Includes required sections:
-    - required Phase 2 go/no-go commands
-    - required PASS evidence bundle
-    - explicit deferred scope entering next phase
-    - closeout checklist
-- Updated deterministic control-doc truth guardrails in `scripts/check_control_doc_truth.py`:
-  - Required baseline marker updated to Sprint 14 for:
-    - `ARCHITECTURE.md`
-    - `ROADMAP.md`
-    - `README.md`
-    - `.ai/handoff/CURRENT_STATE.md`
-  - Added required closeout packet rule for `docs/runbooks/phase2-closeout-packet.md` with required markers:
-    - `accepted Phase 2 Sprint 14 baseline`
-    - `Required Phase 2 Go/No-Go Commands`
-    - `Required PASS Evidence Bundle`
-    - `Explicit Deferred Scope Entering Next Phase`
-  - Added stale-marker rejection for prior baseline text:
-    - `through Phase 2 Sprint 11`
-    - `current through Phase 2 Sprint 11`
-- Updated truth guardrail tests in `tests/unit/test_control_doc_truth.py`:
-  - existing required-marker pass/fail coverage retained
-  - existing disallowed-marker coverage retained
-  - added missing closeout packet file failure coverage
-  - added stale Sprint 11 baseline marker rejection coverage
+- Added deterministic in-process Phase 3 profile registry:
+  - New module: `apps/api/src/alicebot_api/phase3_profiles.py`
+  - Profiles shipped:
+    - `assistant_default`
+    - `coach_default`
+  - Deterministic list/read helpers for profile ids and records.
+
+- Added thread profile persistence and binding:
+  - New Alembic migration: `apps/api/alembic/versions/20260324_0032_thread_agent_profiles.py`
+  - `threads.agent_profile_id` added as `text NOT NULL DEFAULT 'assistant_default'`
+  - Added DB constraint for deterministic current profile domain:
+    - `threads_agent_profile_id_check` in (`assistant_default`, `coach_default`)
+  - Added index:
+    - `threads_user_agent_profile_created_idx (user_id, agent_profile_id, created_at DESC, id DESC)`
+  - Store layer updated to read/write `agent_profile_id` on thread create/get/list.
+
+- Extended contracts and thread payloads:
+  - `ThreadCreateInput` now carries `agent_profile_id` (default `assistant_default`).
+  - `ThreadRecord` now includes `agent_profile_id`.
+  - Added deterministic contracts for `/v0/agent-profiles` list payload (`items` + `summary`).
+
+- Extended API surfaces in-scope:
+  - New endpoint: `GET /v0/agent-profiles` (deterministic registry payload + stable ordering summary).
+  - `POST /v0/threads` now accepts optional `agent_profile_id`.
+    - Omitted profile id defaults to `assistant_default`.
+    - Invalid profile id returns deterministic `422` payload:
+      - `code: invalid_agent_profile_id`
+      - stable message
+      - stable `allowed_agent_profile_ids` list.
+  - Thread list/detail/create payloads now expose persisted `agent_profile_id`.
+  - `POST /v0/context/compile` now includes metadata:
+    - `metadata.agent_profile_id` for the active thread profile.
+  - `POST /v0/responses` now includes metadata in both success and model-failure payloads:
+    - `metadata.agent_profile_id`.
+
+- Verification tests added/updated in sprint scope:
+  - Added migration unit test:
+    - `tests/unit/test_20260324_0032_thread_agent_profiles.py`
+  - Updated continuity integration coverage for:
+    - non-default thread profile create/read/list
+    - omitted `agent_profile_id` defaults to `assistant_default`
+    - invalid profile 422 behavior
+    - deterministic `/v0/agent-profiles` payload
+    - compile metadata propagation
+  - Updated responses integration coverage for response metadata propagation.
 
 ## Incomplete Work
 - None in sprint scope.
 
 ## Files Changed
-- `.ai/handoff/CURRENT_STATE.md`
-- `ARCHITECTURE.md`
-- `ROADMAP.md`
-- `README.md`
-- `docs/runbooks/phase2-closeout-packet.md`
-- `scripts/check_control_doc_truth.py`
-- `tests/unit/test_control_doc_truth.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/store.py`
+- `apps/api/src/alicebot_api/phase3_profiles.py`
+- `apps/api/alembic/versions/20260324_0032_thread_agent_profiles.py`
+- `tests/integration/test_continuity_api.py`
+- `tests/integration/test_responses_api.py`
+- `tests/unit/test_20260324_0032_thread_agent_profiles.py`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 ## Tests Run
-1. `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-- Outcome: PASS (`5 passed in 0.02s`, exit code `0`).
+1. `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py -q`
+- Initial sandbox run: blocked by local Postgres access policy (`localhost:5432 Operation not permitted`).
+- Elevated rerun outcome after adding omitted-profile coverage: PASS (`11 passed in 3.21s`).
 
-2. `python3 scripts/check_control_doc_truth.py`
-- Outcome: PASS (`Control-doc truth check: PASS`, all configured control-doc rules verified including `docs/runbooks/phase2-closeout-packet.md`).
+2. `./.venv/bin/python -m pytest tests/unit/test_20260324_0032_thread_agent_profiles.py -q`
+- Outcome: PASS (`3 passed in 0.13s`).
 
 3. `python3 scripts/run_phase2_validation_matrix.py`
-- First run in sandbox: NO_GO due localhost Postgres access restriction (`Operation not permitted`), not due sprint logic.
-- Rerun with elevated local access: PASS (`Phase 2 validation matrix result: PASS`).
-- PASS step summary on elevated run:
+- Initial sandbox run: NO_GO due sandbox DB access restrictions (not logic regressions).
+- Elevated rerun outcome: PASS.
+- PASS step summary:
   - `control_doc_truth: PASS`
   - `gate_contract_tests: PASS`
   - `readiness_gates: PASS`
@@ -73,15 +84,15 @@ Implement Phase 2 Sprint 15 closeout hardening by publishing an explicit Phase 2
   - `web_validation_matrix: PASS`
 
 ## Blockers/Issues
-- Local sandbox network policy blocked Postgres TCP access on initial matrix execution (`localhost:5432`), causing a false NO_GO environment failure.
-- Resolved by rerunning the same matrix command with elevated local access.
+- Sandbox network restrictions prevented direct local Postgres access for integration/matrix runs.
+- Resolved by rerunning required verification commands with elevated local access.
 
-## Explicit Deferred Scope Into Next Phase
-- API/runtime feature changes
-- connector capability expansion beyond current bounded Gmail/Calendar seams
-- orchestration/worker implementation
-- Phase 3 routing implementation
-- UI redesign
+## Explicit Deferred Scope
+- Per-profile model/provider switching
+- Runner/worker orchestration changes
+- Connector capability expansion
+- Auth model changes
+- UI profile selector and web routing behavior changes
 
 ## Recommended Next Step
-1. Send this sprint for Control Tower review focused on closeout packet completeness and guardrail enforcement, then proceed to merge approval if review remains PASS.
+1. Proceed to Control Tower integration review focused on profile-boundary correctness and sprint-scope containment, then open PR from `codex/phase3-sprint1-agent-profile-backbone`.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,50 +4,38 @@
 PASS
 
 ## criteria met
-- Canonical baseline sync to Sprint 14 is complete in all required docs:
-  - `ARCHITECTURE.md`
-  - `ROADMAP.md`
-  - `README.md`
-  - `.ai/handoff/CURRENT_STATE.md`
-- `docs/runbooks/phase2-closeout-packet.md` is present and operationally complete for closeout use:
-  - includes required Phase 2 go/no-go commands
-  - includes required PASS evidence bundle
-  - includes explicit deferred scope entering next phase
-  - includes a closeout checklist tied to Sprint 14 baseline truth
-- `scripts/check_control_doc_truth.py` enforces updated closeout truth state:
-  - requires Sprint 14 baseline markers
-  - requires closeout packet presence and key markers
-  - rejects stale Sprint 11 baseline markers
-- `tests/unit/test_control_doc_truth.py` passes and includes coverage for:
-  - required-marker enforcement behavior
-  - disallowed-marker enforcement behavior
-  - missing closeout packet file behavior
-  - stale Sprint 11 marker rejection behavior
-- Required verification commands were validated:
-  - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q` -> PASS (`5 passed`)
-  - `python3 scripts/check_control_doc_truth.py` -> PASS
-  - `python3 scripts/run_phase2_validation_matrix.py` -> PASS (after rerun with local host DB access)
-- No endpoint/schema/runtime product behavior changes were introduced in this sprint diff.
+- Threads persist and return `agent_profile_id` across create/list/detail surfaces.
+- Creating a thread with a valid non-default profile succeeds and remains user-isolated.
+- Creating a thread with invalid profile id fails deterministically (`422` with stable payload).
+- Creating a thread with omitted `agent_profile_id` defaults deterministically to `assistant_default` (explicit API + persistence coverage added).
+- `/v0/agent-profiles` returns deterministic registry payload and ordering metadata.
+- `/v0/context/compile` and `/v0/responses` include active `metadata.agent_profile_id`.
+- `python3 scripts/run_phase2_validation_matrix.py` remains PASS.
+- Sprint scope remained bounded to profile backbone surfaces with no hidden expansion.
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking implementation-quality issues found in sprint scope.
+- No blocking quality issues in sprint scope.
 
 ## regression risks
-- Low technical regression risk: changes are documentation and deterministic control-doc guardrails/tests.
-- Environment dependency risk remains for local verification: full matrix requires local Postgres connectivity.
+- Low: profile IDs are currently duplicated in the in-process registry and migration constraint domain; future profile expansion must update both in lockstep.
 
 ## docs issues
-- `BUILD_REPORT.md` includes required sprint objective, marker changes, closeout packet additions, guardrail/test updates, verification outcomes, deferred scope, and next action.
-- No missing closeout-scope documentation identified.
+- `BUILD_REPORT.md` is aligned with the implemented sprint scope and now includes omit-case default coverage.
 
 ## should anything be added to RULES.md?
-- No.
+- No required change for this sprint.
 
 ## should anything update ARCHITECTURE.md?
-- No additional updates required beyond the Sprint 14 baseline marker sync already made.
+- Not required for sprint acceptance.
 
 ## recommended next action
-1. Proceed to Control Tower closeout review and merge approval for Phase 2 Sprint 15.
+1. Proceed to Control Tower merge review for Phase 3 Sprint 1.
+
+## reviewer verification (re-review run)
+- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py -q` -> PASS (`11 passed`)
+- `./.venv/bin/python -m pytest tests/integration/test_context_compile.py -q` -> PASS (`12 passed`)
+- `./.venv/bin/python -m pytest tests/unit/test_20260324_0032_thread_agent_profiles.py -q` -> PASS (`3 passed`)
+- `python3 scripts/run_phase2_validation_matrix.py` -> PASS

--- a/apps/api/alembic/versions/20260324_0032_thread_agent_profiles.py
+++ b/apps/api/alembic/versions/20260324_0032_thread_agent_profiles.py
@@ -1,0 +1,52 @@
+"""Bind deterministic Phase 3 agent profile identity to threads."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260324_0032"
+down_revision = "20260323_0031"
+branch_labels = None
+depends_on = None
+
+AGENT_PROFILE_IDS = (
+    "assistant_default",
+    "coach_default",
+)
+
+DEFAULT_AGENT_PROFILE_ID = "assistant_default"
+
+_AGENT_PROFILE_IDS_SQL = ", ".join(f"'{value}'" for value in AGENT_PROFILE_IDS)
+
+_UPGRADE_STATEMENTS = (
+    f"""
+        ALTER TABLE threads
+          ADD COLUMN agent_profile_id text NOT NULL DEFAULT '{DEFAULT_AGENT_PROFILE_ID}'
+        """,
+    f"""
+        ALTER TABLE threads
+          ADD CONSTRAINT threads_agent_profile_id_check
+          CHECK (agent_profile_id IN ({_AGENT_PROFILE_IDS_SQL}))
+        """,
+    """
+        CREATE INDEX threads_user_agent_profile_created_idx
+          ON threads (user_id, agent_profile_id, created_at DESC, id DESC)
+        """,
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP INDEX IF EXISTS threads_user_agent_profile_created_idx",
+    "ALTER TABLE threads DROP CONSTRAINT IF EXISTS threads_agent_profile_id_check",
+    "ALTER TABLE threads DROP COLUMN IF EXISTS agent_profile_id",
+)
+
+
+def upgrade() -> None:
+    for statement in _UPGRADE_STATEMENTS:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    for statement in _DOWNGRADE_STATEMENTS:
+        op.execute(statement)

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -136,8 +136,10 @@ TRACE_KIND_RESPONSE_GENERATE = "response.generate"
 TRACE_REVIEW_LIST_ORDER = ["created_at_desc", "id_desc"]
 TRACE_REVIEW_EVENT_LIST_ORDER = ["sequence_no_asc", "id_asc"]
 THREAD_LIST_ORDER = ["created_at_desc", "id_desc"]
+AGENT_PROFILE_LIST_ORDER = ["id_asc"]
 THREAD_SESSION_LIST_ORDER = ["started_at_asc", "created_at_asc", "id_asc"]
 THREAD_EVENT_LIST_ORDER = ["sequence_no_asc"]
+DEFAULT_AGENT_PROFILE_ID = "assistant_default"
 RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0 = "resumption_brief_v0"
 RESUMPTION_BRIEF_CONVERSATION_EVENT_KINDS = ["message.user", "message.assistant"]
 RESUMPTION_BRIEF_CONVERSATION_ORDER = ["sequence_no_asc"]
@@ -388,14 +390,32 @@ class TraceEventRecord:
     payload: JsonObject
 
 
+class AgentProfileRecord(TypedDict):
+    id: str
+    name: str
+    description: str
+
+
+class AgentProfileListSummary(TypedDict):
+    total_count: int
+    order: list[str]
+
+
+class AgentProfileListResponse(TypedDict):
+    items: list[AgentProfileRecord]
+    summary: AgentProfileListSummary
+
+
 @dataclass(frozen=True, slots=True)
 class ThreadCreateInput:
     title: str
+    agent_profile_id: str = DEFAULT_AGENT_PROFILE_ID
 
 
 class ThreadRecord(TypedDict):
     id: str
     title: str
+    agent_profile_id: str
     created_at: str
     updated_at: str
 

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -12,9 +12,12 @@ from urllib.parse import urlsplit, urlunsplit
 from alicebot_api.compiler import compile_and_persist_trace, compile_resumption_brief
 from alicebot_api.config import Settings, get_settings
 from alicebot_api.contracts import (
+    AGENT_PROFILE_LIST_ORDER,
     ApprovalApproveInput,
     ApprovalRejectInput,
     ApprovalRequestCreateInput,
+    AgentProfileListResponse,
+    AgentProfileListSummary,
     ArtifactScopedSemanticArtifactChunkRetrievalInput,
     CompileContextArtifactScopedSemanticArtifactRetrievalInput,
     CompileContextArtifactScopedArtifactRetrievalInput,
@@ -25,6 +28,7 @@ from alicebot_api.contracts import (
     ConsentUpsertInput,
     CompileContextSemanticRetrievalInput,
     DEFAULT_ARTIFACT_CHUNK_RETRIEVAL_LIMIT,
+    DEFAULT_AGENT_PROFILE_ID,
     DEFAULT_CALENDAR_EVENT_LIST_LIMIT,
     DEFAULT_MAX_EVENTS,
     DEFAULT_MAX_ENTITY_EDGES,
@@ -113,6 +117,11 @@ from alicebot_api.contracts import (
     ThreadSessionListResponse,
     ThreadSessionListSummary,
     ThreadSessionRecord,
+)
+from alicebot_api.phase3_profiles import (
+    get_agent_profile as get_registered_agent_profile,
+    list_agent_profile_ids as list_registered_agent_profile_ids,
+    list_agent_profiles as list_registered_agent_profiles,
 )
 from alicebot_api.artifacts import (
     TaskArtifactAlreadyExistsError,
@@ -457,6 +466,7 @@ class GenerateResponseRequest(BaseModel):
 class CreateThreadRequest(BaseModel):
     user_id: UUID
     title: str = Field(min_length=1, max_length=200)
+    agent_profile_id: str | None = Field(default=None, min_length=1, max_length=100)
 
 
 class AdmitMemoryOpenLoopRequest(BaseModel):
@@ -796,12 +806,18 @@ class SupersedeExecutionBudgetRequest(BaseModel):
 
 
 def _serialize_thread(thread: ThreadRow) -> ThreadRecord:
+    agent_profile_id = _thread_agent_profile_id(thread)
     return {
         "id": str(thread["id"]),
         "title": thread["title"],
+        "agent_profile_id": agent_profile_id,
         "created_at": thread["created_at"].isoformat(),
         "updated_at": thread["updated_at"].isoformat(),
     }
+
+
+def _thread_agent_profile_id(thread: ThreadRow) -> str:
+    return str(thread.get("agent_profile_id", DEFAULT_AGENT_PROFILE_ID))
 
 
 def _serialize_thread_session(session: SessionRow) -> ThreadSessionRecord:
@@ -882,6 +898,23 @@ def healthcheck() -> JSONResponse:
     )
 
 
+@app.get("/v0/agent-profiles")
+def list_agent_profiles() -> JSONResponse:
+    items = list_registered_agent_profiles()
+    summary: AgentProfileListSummary = {
+        "total_count": len(items),
+        "order": list(AGENT_PROFILE_LIST_ORDER),
+    }
+    payload: AgentProfileListResponse = {
+        "items": items,
+        "summary": summary,
+    }
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
 @app.post("/v0/context/compile")
 def compile_context(request: CompileContextRequest) -> JSONResponse:
     settings = get_settings()
@@ -927,8 +960,10 @@ def compile_context(request: CompileContextRequest) -> JSONResponse:
 
     try:
         with user_connection(settings.database_url, request.user_id) as conn:
+            store = ContinuityStore(conn)
+            thread = store.get_thread(request.thread_id)
             result = compile_and_persist_trace(
-                ContinuityStore(conn),
+                store,
                 user_id=request.user_id,
                 thread_id=request.thread_id,
                 limits=ContextCompilerLimits(
@@ -968,6 +1003,7 @@ def compile_context(request: CompileContextRequest) -> JSONResponse:
                 "trace_id": result.trace_id,
                 "trace_event_count": result.trace_event_count,
                 "context_pack": result.context_pack,
+                "metadata": {"agent_profile_id": _thread_agent_profile_id(thread)},
             }
         ),
     )
@@ -979,8 +1015,10 @@ def generate_assistant_response(request: GenerateResponseRequest) -> JSONRespons
 
     try:
         with user_connection(settings.database_url, request.user_id) as conn:
+            store = ContinuityStore(conn)
+            thread = store.get_thread(request.thread_id)
             result = generate_response(
-                store=ContinuityStore(conn),
+                store=store,
                 settings=settings,
                 user_id=request.user_id,
                 thread_id=request.thread_id,
@@ -1003,23 +1041,52 @@ def generate_assistant_response(request: GenerateResponseRequest) -> JSONRespons
                 {
                     "detail": result.detail,
                     "trace": result.trace,
+                    "metadata": {"agent_profile_id": _thread_agent_profile_id(thread)},
                 }
             ),
         )
 
+    response_payload = dict(result)
+    response_payload["metadata"] = {"agent_profile_id": _thread_agent_profile_id(thread)}
     return JSONResponse(
         status_code=200,
-        content=jsonable_encoder(result),
+        content=jsonable_encoder(response_payload),
     )
 
 
 @app.post("/v0/threads")
 def create_thread(request: CreateThreadRequest) -> JSONResponse:
     settings = get_settings()
-    thread_input = ThreadCreateInput(title=request.title)
+    agent_profile_id = (
+        request.agent_profile_id
+        if request.agent_profile_id is not None
+        else DEFAULT_AGENT_PROFILE_ID
+    )
+    if get_registered_agent_profile(agent_profile_id) is None:
+        allowed_agent_profile_ids = list_registered_agent_profile_ids()
+        return JSONResponse(
+            status_code=422,
+            content={
+                "detail": {
+                    "code": "invalid_agent_profile_id",
+                    "message": (
+                        "agent_profile_id must be one of: "
+                        + ", ".join(allowed_agent_profile_ids)
+                    ),
+                    "allowed_agent_profile_ids": allowed_agent_profile_ids,
+                }
+            },
+        )
+    thread_input = ThreadCreateInput(
+        title=request.title,
+        agent_profile_id=agent_profile_id,
+    )
 
     with user_connection(settings.database_url, request.user_id) as conn:
-        created = ContinuityStore(conn).create_thread(thread_input.title)
+        created = ContinuityStore(conn).create_thread(
+            thread_input.title,
+            thread_input.agent_profile_id,
+        )
 
     payload: ThreadCreateResponse = {"thread": _serialize_thread(created)}
     return JSONResponse(

--- a/apps/api/src/alicebot_api/phase3_profiles.py
+++ b/apps/api/src/alicebot_api/phase3_profiles.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from alicebot_api.contracts import AgentProfileRecord, DEFAULT_AGENT_PROFILE_ID
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProfileDefinition:
+    profile_id: str
+    name: str
+    description: str
+
+    def as_record(self) -> AgentProfileRecord:
+        return {
+            "id": self.profile_id,
+            "name": self.name,
+            "description": self.description,
+        }
+
+
+_PHASE3_PROFILE_REGISTRY: tuple[AgentProfileDefinition, ...] = (
+    AgentProfileDefinition(
+        profile_id="assistant_default",
+        name="Assistant Default",
+        description="General-purpose assistant profile for baseline conversations.",
+    ),
+    AgentProfileDefinition(
+        profile_id="coach_default",
+        name="Coach Default",
+        description="Coaching-oriented profile focused on guidance and accountability.",
+    ),
+)
+
+_PHASE3_PROFILE_LOOKUP: dict[str, AgentProfileDefinition] = {
+    profile.profile_id: profile for profile in _PHASE3_PROFILE_REGISTRY
+}
+
+
+def list_agent_profiles() -> list[AgentProfileRecord]:
+    return [profile.as_record() for profile in _PHASE3_PROFILE_REGISTRY]
+
+
+def list_agent_profile_ids() -> list[str]:
+    return [profile.profile_id for profile in _PHASE3_PROFILE_REGISTRY]
+
+
+def get_agent_profile(profile_id: str) -> AgentProfileRecord | None:
+    profile = _PHASE3_PROFILE_LOOKUP.get(profile_id)
+    if profile is None:
+        return None
+    return profile.as_record()
+
+
+def get_default_agent_profile_id() -> str:
+    return DEFAULT_AGENT_PROFILE_ID

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -24,6 +24,7 @@ class ThreadRow(TypedDict):
     id: UUID
     user_id: UUID
     title: str
+    agent_profile_id: str
     created_at: datetime
     updated_at: datetime
 
@@ -458,19 +459,19 @@ GET_USER_SQL = """
                 """
 
 INSERT_THREAD_SQL = """
-                INSERT INTO threads (user_id, title)
-                VALUES (app.current_user_id(), %s)
-                RETURNING id, user_id, title, created_at, updated_at
+                INSERT INTO threads (user_id, title, agent_profile_id)
+                VALUES (app.current_user_id(), %s, %s)
+                RETURNING id, user_id, title, agent_profile_id, created_at, updated_at
                 """
 
 GET_THREAD_SQL = """
-                SELECT id, user_id, title, created_at, updated_at
+                SELECT id, user_id, title, agent_profile_id, created_at, updated_at
                 FROM threads
                 WHERE id = %s
                 """
 
 LIST_THREADS_SQL = """
-                SELECT id, user_id, title, created_at, updated_at
+                SELECT id, user_id, title, agent_profile_id, created_at, updated_at
                 FROM threads
                 ORDER BY created_at DESC, id DESC
                 """
@@ -3118,8 +3119,8 @@ class ContinuityStore:
     def get_user(self, user_id: UUID) -> UserRow:
         return self._fetch_one("get_user", GET_USER_SQL, (user_id,))
 
-    def create_thread(self, title: str) -> ThreadRow:
-        return self._fetch_one("create_thread", INSERT_THREAD_SQL, (title,))
+    def create_thread(self, title: str, agent_profile_id: str = "assistant_default") -> ThreadRow:
+        return self._fetch_one("create_thread", INSERT_THREAD_SQL, (title, agent_profile_id))
 
     def get_thread(self, thread_id: UUID) -> ThreadRow:
         return self._fetch_one("get_thread", GET_THREAD_SQL, (thread_id,))

--- a/tests/integration/test_continuity_api.py
+++ b/tests/integration/test_continuity_api.py
@@ -135,10 +135,18 @@ def set_session_timestamps(
             )
 
 
-def serialize_thread(*, thread_id: UUID, title: str, created_at: datetime, updated_at: datetime) -> dict[str, Any]:
+def serialize_thread(
+    *,
+    thread_id: UUID,
+    title: str,
+    created_at: datetime,
+    updated_at: datetime,
+    agent_profile_id: str,
+) -> dict[str, Any]:
     return {
         "id": str(thread_id),
         "title": title,
+        "agent_profile_id": agent_profile_id,
         "created_at": created_at.isoformat(),
         "updated_at": updated_at.isoformat(),
     }
@@ -192,11 +200,13 @@ def test_thread_continuity_endpoints_create_list_detail_sessions_and_events(
         payload={
             "user_id": str(seeded["user_id"]),
             "title": "Gamma thread",
+            "agent_profile_id": "coach_default",
         },
     )
 
     assert create_status == 201
     assert create_payload["thread"]["title"] == "Gamma thread"
+    assert create_payload["thread"]["agent_profile_id"] == "coach_default"
 
     api_thread_id = UUID(create_payload["thread"]["id"])
     shared_created_at = datetime(2026, 3, 17, 9, 0, tzinfo=UTC)
@@ -277,18 +287,21 @@ def test_thread_continuity_endpoints_create_list_detail_sessions_and_events(
                 title="Gamma thread",
                 created_at=newer_created_at,
                 updated_at=newer_created_at,
+                agent_profile_id="coach_default",
             ),
             serialize_thread(
                 thread_id=tied_threads[0]["id"],
                 title=tied_threads[0]["title"],
                 created_at=shared_created_at,
                 updated_at=shared_created_at,
+                agent_profile_id="assistant_default",
             ),
             serialize_thread(
                 thread_id=tied_threads[1]["id"],
                 title=tied_threads[1]["title"],
                 created_at=shared_created_at,
                 updated_at=shared_created_at,
+                agent_profile_id="assistant_default",
             ),
         ],
         "summary": {
@@ -304,6 +317,7 @@ def test_thread_continuity_endpoints_create_list_detail_sessions_and_events(
             title="Beta thread",
             created_at=shared_created_at,
             updated_at=shared_created_at,
+            agent_profile_id="assistant_default",
         )
     }
 
@@ -346,6 +360,36 @@ def test_thread_continuity_endpoints_create_list_detail_sessions_and_events(
             "order": ["sequence_no_asc"],
         },
     }
+
+
+def test_thread_creation_defaults_agent_profile_id_when_omitted(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = create_user(migrated_database_urls["app"], email="owner@example.com")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "POST",
+        "/v0/threads",
+        payload={
+            "user_id": str(user_id),
+            "title": "Default profile thread",
+        },
+    )
+
+    assert status == 201
+    assert payload["thread"]["agent_profile_id"] == "assistant_default"
+
+    thread_id = UUID(payload["thread"]["id"])
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        stored_thread = ContinuityStore(conn).get_thread(thread_id)
+
+    assert stored_thread["agent_profile_id"] == "assistant_default"
 
 
 def test_thread_resumption_brief_endpoint_returns_bounded_sections_and_workflow_posture(
@@ -640,3 +684,96 @@ def test_thread_continuity_endpoints_enforce_user_isolation_and_not_found(
     assert brief_payload == {"detail": f"thread {owner['second_thread']['id']} was not found"}
     assert missing_brief_status == 404
     assert missing_brief_payload == {"detail": f"thread {missing_thread_id} was not found"}
+
+
+def test_thread_creation_rejects_invalid_agent_profile_id_with_deterministic_422(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = create_user(migrated_database_urls["app"], email="owner@example.com")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "POST",
+        "/v0/threads",
+        payload={
+            "user_id": str(user_id),
+            "title": "Invalid profile thread",
+            "agent_profile_id": "not_a_profile",
+        },
+    )
+
+    assert status == 422
+    assert payload == {
+        "detail": {
+            "code": "invalid_agent_profile_id",
+            "message": "agent_profile_id must be one of: assistant_default, coach_default",
+            "allowed_agent_profile_ids": ["assistant_default", "coach_default"],
+        }
+    }
+
+
+def test_agent_profiles_endpoint_returns_deterministic_registry_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url="postgresql://unused"),
+    )
+
+    status, payload = invoke_request("GET", "/v0/agent-profiles")
+
+    assert status == 200
+    assert payload == {
+        "items": [
+            {
+                "id": "assistant_default",
+                "name": "Assistant Default",
+                "description": "General-purpose assistant profile for baseline conversations.",
+            },
+            {
+                "id": "coach_default",
+                "name": "Coach Default",
+                "description": "Coaching-oriented profile focused on guidance and accountability.",
+            },
+        ],
+        "summary": {"total_count": 2, "order": ["id_asc"]},
+    }
+
+
+def test_context_compile_includes_active_agent_profile_metadata(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = create_user(migrated_database_urls["app"], email="owner@example.com")
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        thread = store.create_thread("Profile metadata thread", agent_profile_id="coach_default")
+        session = store.create_session(thread["id"], status="active")
+        store.append_event(
+            thread["id"],
+            session["id"],
+            "message.user",
+            {"text": "Compile metadata check"},
+        )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "POST",
+        "/v0/context/compile",
+        payload={
+            "user_id": str(user_id),
+            "thread_id": str(thread["id"]),
+        },
+    )
+
+    assert status == 200
+    assert payload["metadata"] == {"agent_profile_id": "coach_default"}

--- a/tests/integration/test_responses_api.py
+++ b/tests/integration/test_responses_api.py
@@ -61,13 +61,14 @@ def seed_response_thread(
     *,
     email: str = "owner@example.com",
     display_name: str = "Owner",
+    agent_profile_id: str = "assistant_default",
 ) -> dict[str, object]:
     user_id = uuid4()
 
     with user_connection(database_url, user_id) as conn:
         store = ContinuityStore(conn)
         store.create_user(user_id, email, display_name)
-        thread = store.create_thread("Response thread")
+        thread = store.create_thread("Response thread", agent_profile_id=agent_profile_id)
         session = store.create_session(thread["id"], status="active")
         prior_event = store.append_event(
             thread["id"],
@@ -95,7 +96,10 @@ def test_generate_response_persists_user_and_assistant_events_and_trace_metadata
     migrated_database_urls,
     monkeypatch,
 ) -> None:
-    seeded = seed_response_thread(migrated_database_urls["app"])
+    seeded = seed_response_thread(
+        migrated_database_urls["app"],
+        agent_profile_id="coach_default",
+    )
     captured: dict[str, object] = {}
 
     monkeypatch.setattr(
@@ -132,6 +136,7 @@ def test_generate_response_persists_user_and_assistant_events_and_trace_metadata
     )
 
     assert status_code == 200
+    assert payload["metadata"] == {"agent_profile_id": "coach_default"}
     assert payload["assistant"] == {
         "event_id": payload["assistant"]["event_id"],
         "sequence_no": 3,
@@ -254,6 +259,7 @@ def test_generate_response_persists_optional_cached_token_telemetry_in_event_and
     )
 
     assert status_code == 200
+    assert payload["metadata"] == {"agent_profile_id": "assistant_default"}
 
     with user_connection(migrated_database_urls["app"], seeded["user_id"]) as conn:
         store = ContinuityStore(conn)
@@ -308,6 +314,7 @@ def test_generate_response_returns_clean_failure_without_persisting_assistant_ev
 
     assert status_code == 502
     assert payload["detail"] == "upstream timeout"
+    assert payload["metadata"] == {"agent_profile_id": "assistant_default"}
     assert payload["trace"]["compile_trace_event_count"] > 0
     assert payload["trace"]["response_trace_event_count"] == 2
 

--- a/tests/unit/test_20260324_0032_thread_agent_profiles.py
+++ b/tests/unit/test_20260324_0032_thread_agent_profiles.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260324_0032_thread_agent_profiles"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == list(module._UPGRADE_STATEMENTS)
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_agent_profile_domain_and_default_match_sprint_contract() -> None:
+    module = load_migration_module()
+
+    assert module.AGENT_PROFILE_IDS == ("assistant_default", "coach_default")
+    assert module.DEFAULT_AGENT_PROFILE_ID == "assistant_default"


### PR DESCRIPTION
## Summary
This sprint introduces the minimal deterministic Phase 3 profile backbone by adding persisted thread-level `agent_profile_id`, bounded profile registry APIs, and profile metadata propagation into compile/response outputs.

## Scope
- Profile contracts and deterministic in-process registry
- Thread create/list/detail profile binding with default behavior preserved
- Context compile and response metadata propagation
- Migration + tests for thread profile column and behavior

## Verification
- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py -q` -> `11 passed`
- `./.venv/bin/python -m pytest tests/unit/test_20260324_0032_thread_agent_profiles.py -q` -> `3 passed`
- `python3 scripts/run_phase2_validation_matrix.py` -> `PASS`

## Merge Readiness
- Branch aligned to packet: `codex/phase3-sprint1-agent-profile-backbone`
- `REVIEW_REPORT.md` verdict: `PASS`
- Diff scoped to Sprint 1 files only
- Control Tower decision: `MERGE_APPROVED`
