### PR TITLE
Phase 3 Sprint 2: Web Agent Profile Adoption

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 3 Sprint 1: Multi-Agent Profile Backbone
+Phase 3 Sprint 2: Web Agent Profile Adoption
 
 ## Sprint Type
 
@@ -10,152 +10,160 @@ feature
 
 ## Sprint Reason
 
-Phase 2 closeout is complete and validation is green. The next non-redundant step is to open Phase 3 by introducing explicit agent profile identity so separate agents can be deployed without sharing one implicit runtime persona.
+Phase 3 Sprint 1 shipped and merged the backend profile backbone (`agent_profile_id` persistence, `/v0/agent-profiles`, profile metadata propagation). The operator shell still does not consume this surface, which creates a planning and usability gap for multi-agent deployment.
 
 ## Sprint Intent
 
-Add a minimal, deterministic backend backbone for agent profiles and thread-level profile binding, without changing existing tool orchestration breadth or connector scope.
+Adopt shipped profile identity in the web shell so profile choice and visibility are explicit during thread creation and thread review, while keeping backend scope unchanged.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase3-sprint1-agent-profile-backbone`
+- Branch Name: `codex/phase3-sprint2-web-agent-profile-adoption`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- This is the first implementation seam required for “multiple separate agents.”
-- It is orthogonal to completed Phase 2 hardening (gate/doc/closeout work), so it is not redundant.
-- It creates a durable identity boundary before opening broader routing/orchestration work.
+- It directly consumes the backend capability that just shipped in Phase 3 Sprint 1.
+- It is non-redundant: current web code does not call `GET /v0/agent-profiles` and does not use `agent_profile_id` on thread create/list/detail.
+- It closes a concrete operator-facing gap before any model routing or orchestration expansion.
+
+## Redundancy Guard
+
+- Already shipped in Sprint 1 (do not re-implement): profile registry, migration, thread persistence, API validation, compile/response metadata propagation.
+- Missing and required now: web client typing, profile fetch/read path, profile selection at thread create, and visible thread profile identity in chat surfaces.
 
 ## Design Truth
 
-- Keep existing default behavior for callers that do not provide a profile.
-- Persist explicit profile identity on thread records.
-- Keep the initial profile surface bounded: registry read + thread binding + response/compile propagation.
-- Do not widen tool execution, connector actions, or worker orchestration in this sprint.
+- Reuse shipped API seams as-is; no backend contract changes.
+- Preserve current fixture/live fallback behavior across `/chat`.
+- Keep deterministic default profile behavior explicit (`assistant_default`) when profile selection is unavailable.
+- Keep UX bounded and calm: one selector on create, lightweight profile visibility in thread review surfaces.
 
 ## Exact Surfaces In Scope
 
-- agent profile contracts and deterministic in-process registry
-- thread creation/list/detail profile binding
-- context compile / response output includes active profile identity
-- migration and tests for new thread profile column and behavior
+- web API client contract adoption for `agent_profile_id` and `/v0/agent-profiles`
+- chat-page live/fixture profile loading and fallback behavior
+- thread create UI profile selection
+- thread list/summary profile visibility
+- targeted tests for all above seams
 
 ## Exact Files In Scope
 
-- [contracts.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/contracts.py)
-- [main.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/main.py)
-- [store.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/store.py)
-- [phase3_profiles.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/phase3_profiles.py)
-- [20260324_0032_thread_agent_profiles.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/alembic/versions/20260324_0032_thread_agent_profiles.py)
-- [test_continuity_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_continuity_api.py)
-- [test_responses_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_responses_api.py)
-- [test_20260324_0032_thread_agent_profiles.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_20260324_0032_thread_agent_profiles.py)
+- [api.ts](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/lib/api.ts)
+- [api.test.ts](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/lib/api.test.ts)
+- [fixtures.ts](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/lib/fixtures.ts)
+- [page.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/app/chat/page.tsx)
+- [page.test.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/app/chat/page.test.tsx)
+- [thread-create.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-create.tsx)
+- [thread-create.test.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-create.test.tsx)
+- [thread-list.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-list.tsx)
+- [thread-list.test.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-list.test.tsx)
+- [thread-summary.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-summary.tsx)
+- [thread-summary.test.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-summary.test.tsx)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
 - [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
-- relevant verification under:
-  - `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py -q`
-  - `./.venv/bin/python -m pytest tests/unit/test_20260324_0032_thread_agent_profiles.py -q`
-  - `python3 scripts/run_phase2_validation_matrix.py`
 
 ## In Scope
 
-- Add deterministic Phase 3 profile registry module with at least:
-  - `assistant_default` profile
-  - one additional profile (for example `coach_default`) with distinct id/name/description
-- Add `agent_profile_id` thread column with migration:
-  - non-null with deterministic default `assistant_default`
-  - user-scoped reads preserved
-- Extend thread create request to optionally accept `agent_profile_id`:
-  - invalid profile id returns deterministic 422
-  - omitted profile id uses default
-- Expose profile identity in thread list/detail responses.
-- Include active `agent_profile_id` in context compile and `/v0/responses` response metadata.
-- Add a bounded read endpoint for available profiles:
-  - `GET /v0/agent-profiles`
+- Extend `ThreadItem` and `ThreadCreatePayload` in web API client with `agent_profile_id`.
+- Add deterministic web API client types/helpers for profile registry:
+  - `AgentProfileItem`
+  - `AgentProfileListSummary`
+  - `listAgentProfiles(apiBaseUrl)`
+- Update `/chat` loading path to fetch profile registry in live mode and preserve fixture behavior when unavailable.
+- Update thread create flow to allow profile selection and submit selected `agent_profile_id`.
+- Show selected thread profile identity in thread review surfaces (`ThreadList` and `ThreadSummary`) without noisy UI expansion.
+- Add/update tests covering:
+  - request payloads include selected profile id
+  - list/detail typing includes profile id
+  - live profile fetch success/fallback behavior
+  - profile identity rendering in list/summary
 
 ## Out of Scope
 
-- per-profile model-provider switching
-- external LLM provider integration changes
+- backend schema/migration changes
+- backend API contract changes for profile registry or thread create
+- per-profile model-provider routing/switching
+- profile CRUD endpoints
+- external LLM provider integration
 - auth model changes
-- runner/worker orchestration
-- connector scope expansion
-- web UI profile selector
+- runner/worker orchestration changes
 
 ## Required Deliverables
 
-- migration for thread profile binding
-- profile registry and API read surface
-- thread + compile + response profile propagation
-- integration and migration tests passing
-- updated sprint reports for this sprint only
+- web API client + chat UI consume shipped profile seams end-to-end
+- deterministic fallback behavior if profile registry is unavailable
+- updated web tests for the profile adoption seam
+- sprint build/review reports scoped to this sprint only
 
 ## Acceptance Criteria
 
-- Threads persist and return `agent_profile_id`.
-- Creating a thread with a valid non-default profile succeeds and remains isolated per user.
-- Creating a thread with invalid profile id fails deterministically.
-- `/v0/agent-profiles` returns deterministic profile registry payload.
-- `/v0/context/compile` and `/v0/responses` include active profile id metadata.
+- Thread create in live mode submits `agent_profile_id` along with `user_id` and `title`.
+- Web thread data types and reads retain `agent_profile_id` from API responses.
+- `/chat` reads `GET /v0/agent-profiles` in live mode and remains usable if that read fails.
+- Thread list and selected-thread summary visibly show active profile identity.
+- Fixture mode remains stable and deterministic with no regression to existing fallback paths.
+- `npm --prefix apps/web run test:mvp:validation-matrix` passes.
 - `python3 scripts/run_phase2_validation_matrix.py` remains PASS.
-- No out-of-scope behavior changes enter sprint.
+- No backend/API/migration scope enters this sprint.
 
 ## Implementation Constraints
 
-- keep deterministic outputs and stable ordering
-- do not introduce external dependencies
-- preserve existing endpoint behavior when `agent_profile_id` is omitted
-- keep migration reversible
+- do not introduce new dependencies
+- do not modify `apps/api` or migration files
+- keep profile default deterministic (`assistant_default`) when selection data is unavailable
+- preserve existing copy tone and visual containment in chat rail components
 
 ## Control Tower Task Cards
 
-### Task 1: Profile Registry + Contracts
+### Task 1: API Client + Fixture Contract Adoption
 Owner: tooling operative  
 Write scope:
-- `apps/api/src/alicebot_api/phase3_profiles.py`
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/main.py`
+- `apps/web/lib/api.ts`
+- `apps/web/lib/api.test.ts`
+- `apps/web/lib/fixtures.ts`
 
-### Task 2: Persistence + Migration
+### Task 2: Chat Data Loading + Fallback
 Owner: tooling operative  
 Write scope:
-- `apps/api/alembic/versions/20260324_0032_thread_agent_profiles.py`
-- `apps/api/src/alicebot_api/store.py`
+- `apps/web/app/chat/page.tsx`
+- `apps/web/app/chat/page.test.tsx`
 
-### Task 3: Verification
+### Task 3: Thread UI Adoption
 Owner: tooling operative  
 Write scope:
-- `tests/integration/test_continuity_api.py`
-- `tests/integration/test_responses_api.py`
-- `tests/unit/test_20260324_0032_thread_agent_profiles.py`
+- `apps/web/components/thread-create.tsx`
+- `apps/web/components/thread-create.test.tsx`
+- `apps/web/components/thread-list.tsx`
+- `apps/web/components/thread-list.test.tsx`
+- `apps/web/components/thread-summary.tsx`
+- `apps/web/components/thread-summary.test.tsx`
 
 ### Task 4: Integration Review
 Owner: control tower  
 Responsibilities:
-- verify profile identity seam is complete and bounded
-- verify no hidden Phase 3 scope expansion
-- verify phase2 matrix remains green
+- verify sprint stays web-adoption scoped
+- verify no backend rework or profile-registry duplication
+- verify validation matrix remains green
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact migration behavior and defaults
-- exact API/contract deltas
+- exact web contract/UI deltas for profile adoption
 - exact verification command outcomes
-- explicit deferred scope (routing/orchestration/model-provider switching)
+- explicit deferred scope (routing, provider switching, orchestration)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint remained profile-backbone scoped
-- thread/profile propagation and validation behavior correctness
-- migration safety and user isolation
+- sprint stayed bounded to web profile adoption
+- profile selection and visibility are correct and deterministic
+- fallback behavior is explicit and non-breaking
 - no hidden scope expansion
 
 ## Exit Condition
 
-This sprint is complete when the repo can persist and expose explicit thread-level agent profile identity with deterministic validation and tests, while keeping all prior Phase 2 gates green.
+This sprint is complete when the shipped Phase 3 profile backbone is fully adopted in the web chat operator surface (selection + visibility + tests) with deterministic fallback behavior and all required validation gates green.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,82 +1,78 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Phase 3 Sprint 1 (Multi-Agent Profile Backbone) by adding deterministic agent profile identity, persisting thread-level `agent_profile_id`, exposing profile registry read APIs, and propagating active profile metadata through context compile and response generation surfaces without expanding orchestration scope.
+Adopt Phase 3 Sprint 1 profile seams in the web operator shell by wiring `agent_profile_id` and `/v0/agent-profiles` into chat loading, thread creation, and thread review visibility while keeping backend scope unchanged.
 
 ## Completed Work
-- Added deterministic in-process Phase 3 profile registry:
-  - New module: `apps/api/src/alicebot_api/phase3_profiles.py`
-  - Profiles shipped:
-    - `assistant_default`
-    - `coach_default`
-  - Deterministic list/read helpers for profile ids and records.
-
-- Added thread profile persistence and binding:
-  - New Alembic migration: `apps/api/alembic/versions/20260324_0032_thread_agent_profiles.py`
-  - `threads.agent_profile_id` added as `text NOT NULL DEFAULT 'assistant_default'`
-  - Added DB constraint for deterministic current profile domain:
-    - `threads_agent_profile_id_check` in (`assistant_default`, `coach_default`)
-  - Added index:
-    - `threads_user_agent_profile_created_idx (user_id, agent_profile_id, created_at DESC, id DESC)`
-  - Store layer updated to read/write `agent_profile_id` on thread create/get/list.
-
-- Extended contracts and thread payloads:
-  - `ThreadCreateInput` now carries `agent_profile_id` (default `assistant_default`).
-  - `ThreadRecord` now includes `agent_profile_id`.
-  - Added deterministic contracts for `/v0/agent-profiles` list payload (`items` + `summary`).
-
-- Extended API surfaces in-scope:
-  - New endpoint: `GET /v0/agent-profiles` (deterministic registry payload + stable ordering summary).
-  - `POST /v0/threads` now accepts optional `agent_profile_id`.
-    - Omitted profile id defaults to `assistant_default`.
-    - Invalid profile id returns deterministic `422` payload:
-      - `code: invalid_agent_profile_id`
-      - stable message
-      - stable `allowed_agent_profile_ids` list.
-  - Thread list/detail/create payloads now expose persisted `agent_profile_id`.
-  - `POST /v0/context/compile` now includes metadata:
-    - `metadata.agent_profile_id` for the active thread profile.
-  - `POST /v0/responses` now includes metadata in both success and model-failure payloads:
-    - `metadata.agent_profile_id`.
-
-- Verification tests added/updated in sprint scope:
-  - Added migration unit test:
-    - `tests/unit/test_20260324_0032_thread_agent_profiles.py`
-  - Updated continuity integration coverage for:
-    - non-default thread profile create/read/list
-    - omitted `agent_profile_id` defaults to `assistant_default`
-    - invalid profile 422 behavior
-    - deterministic `/v0/agent-profiles` payload
-    - compile metadata propagation
-  - Updated responses integration coverage for response metadata propagation.
+- Web API contract adoption (`apps/web/lib/api.ts`):
+  - Extended `ThreadItem` with `agent_profile_id`.
+  - Extended `ThreadCreatePayload` with `agent_profile_id`.
+  - Added `DEFAULT_AGENT_PROFILE_ID` constant (`assistant_default`).
+  - Added profile registry types:
+    - `AgentProfileItem`
+    - `AgentProfileListSummary`
+  - Added `listAgentProfiles(apiBaseUrl)` for `GET /v0/agent-profiles`.
+- API/contract tests (`apps/web/lib/api.test.ts`):
+  - Verified thread create payload now includes `agent_profile_id`.
+  - Verified list/detail reads retain `agent_profile_id`.
+  - Verified profile registry read path hits `/v0/agent-profiles` and returns deterministic ids.
+- Fixture contract adoption (`apps/web/lib/fixtures.ts`):
+  - Added `agent_profile_id` to thread fixtures.
+  - Added deterministic profile fixtures (`assistant_default`, `coach_default`).
+  - Ensured fixture thread creation defaults to `assistant_default`.
+- Chat loading + fallback (`apps/web/app/chat/page.tsx`):
+  - Added live profile registry load via `listAgentProfiles`.
+  - Added deterministic fallback to fixture profile registry when live read fails.
+  - Normalized thread profile ids to explicit default (`assistant_default`) when missing.
+  - Passed profile registry into thread create/list/summary surfaces.
+- Chat page tests (`apps/web/app/chat/page.test.tsx`):
+  - Added profile registry mock coverage.
+  - Added explicit test for live profile read failure fallback while `/chat` remains usable.
+- Thread create UI adoption (`apps/web/components/thread-create.tsx`):
+  - Added profile selector to thread creation form.
+  - Submitted selected `agent_profile_id` with `user_id` and `title`.
+  - Preserved deterministic `assistant_default` fallback when profile list is unavailable.
+- Thread create tests (`apps/web/components/thread-create.test.tsx`):
+  - Verified selected profile id is sent in create payload.
+  - Verified deterministic default payload uses `assistant_default` without profile data.
+- Thread list visibility (`apps/web/components/thread-list.tsx`):
+  - Added visible profile badge per thread row.
+- Thread list tests (`apps/web/components/thread-list.test.tsx`):
+  - Verified profile identity rendering in thread rows.
+- Thread summary visibility (`apps/web/components/thread-summary.tsx`):
+  - Added visible selected-thread profile identity (badge + summary field).
+- Thread summary tests (`apps/web/components/thread-summary.test.tsx`):
+  - Verified profile identity rendering in selected-thread summary.
 
 ## Incomplete Work
-- None in sprint scope.
+- None within sprint scope.
 
 ## Files Changed
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/store.py`
-- `apps/api/src/alicebot_api/phase3_profiles.py`
-- `apps/api/alembic/versions/20260324_0032_thread_agent_profiles.py`
-- `tests/integration/test_continuity_api.py`
-- `tests/integration/test_responses_api.py`
-- `tests/unit/test_20260324_0032_thread_agent_profiles.py`
+- `.ai/active/SPRINT_PACKET.md` (pre-existing sprint packet update in workspace; not modified for implementation logic)
+- `apps/web/lib/api.ts`
+- `apps/web/lib/api.test.ts`
+- `apps/web/lib/fixtures.ts`
+- `apps/web/app/chat/page.tsx`
+- `apps/web/app/chat/page.test.tsx`
+- `apps/web/components/thread-create.tsx`
+- `apps/web/components/thread-create.test.tsx`
+- `apps/web/components/thread-list.tsx`
+- `apps/web/components/thread-list.test.tsx`
+- `apps/web/components/thread-summary.tsx`
+- `apps/web/components/thread-summary.test.tsx`
 - `BUILD_REPORT.md`
-- `REVIEW_REPORT.md`
 
 ## Tests Run
-1. `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py -q`
-- Initial sandbox run: blocked by local Postgres access policy (`localhost:5432 Operation not permitted`).
-- Elevated rerun outcome after adding omitted-profile coverage: PASS (`11 passed in 3.21s`).
+1. `npm --prefix apps/web run test -- lib/api.test.ts app/chat/page.test.tsx components/thread-create.test.tsx components/thread-list.test.tsx components/thread-summary.test.tsx`
+- Outcome: PASS (`5` files, `36` tests).
 
-2. `./.venv/bin/python -m pytest tests/unit/test_20260324_0032_thread_agent_profiles.py -q`
-- Outcome: PASS (`3 passed in 0.13s`).
+2. `npm --prefix apps/web run test:mvp:validation-matrix`
+- Outcome: PASS (`13` files, `65` tests).
 
 3. `python3 scripts/run_phase2_validation_matrix.py`
-- Initial sandbox run: NO_GO due sandbox DB access restrictions (not logic regressions).
+- Initial sandbox run: blocked on local Postgres access (`localhost:5432 Operation not permitted`).
 - Elevated rerun outcome: PASS.
-- PASS step summary:
+- Gate summary:
   - `control_doc_truth: PASS`
   - `gate_contract_tests: PASS`
   - `readiness_gates: PASS`
@@ -84,15 +80,13 @@ Implement Phase 3 Sprint 1 (Multi-Agent Profile Backbone) by adding deterministi
   - `web_validation_matrix: PASS`
 
 ## Blockers/Issues
-- Sandbox network restrictions prevented direct local Postgres access for integration/matrix runs.
-- Resolved by rerunning required verification commands with elevated local access.
+- Sandbox permissions blocked DB-backed validation matrix execution on first run.
+- Resolved by rerunning with elevated local access; no code blocker remained.
 
 ## Explicit Deferred Scope
-- Per-profile model/provider switching
-- Runner/worker orchestration changes
-- Connector capability expansion
-- Auth model changes
-- UI profile selector and web routing behavior changes
+- Per-profile model routing or provider switching.
+- Worker/runner orchestration changes.
+- Backend profile CRUD expansion.
 
 ## Recommended Next Step
-1. Proceed to Control Tower integration review focused on profile-boundary correctness and sprint-scope containment, then open PR from `codex/phase3-sprint1-agent-profile-backbone`.
+1. Hand off to Control Tower review focused on: profile selection correctness, thread profile visibility, and fallback determinism under live profile registry failure.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,38 +4,34 @@
 PASS
 
 ## criteria met
-- Threads persist and return `agent_profile_id` across create/list/detail surfaces.
-- Creating a thread with a valid non-default profile succeeds and remains user-isolated.
-- Creating a thread with invalid profile id fails deterministically (`422` with stable payload).
-- Creating a thread with omitted `agent_profile_id` defaults deterministically to `assistant_default` (explicit API + persistence coverage added).
-- `/v0/agent-profiles` returns deterministic registry payload and ordering metadata.
-- `/v0/context/compile` and `/v0/responses` include active `metadata.agent_profile_id`.
-- `python3 scripts/run_phase2_validation_matrix.py` remains PASS.
-- Sprint scope remained bounded to profile backbone surfaces with no hidden expansion.
+- Thread creation in live mode now submits `agent_profile_id` with `user_id` and `title` (verified in `apps/web/components/thread-create.tsx` and `apps/web/components/thread-create.test.tsx`).
+- Web thread contracts and read paths retain `agent_profile_id` across create/list/detail (`apps/web/lib/api.ts`, `apps/web/lib/api.test.ts`, `apps/web/app/chat/page.tsx`).
+- `/chat` performs live `GET /v0/agent-profiles` reads and remains usable when that read fails (fixture fallback path verified in `apps/web/app/chat/page.tsx` and `apps/web/app/chat/page.test.tsx`).
+- Thread profile identity is visibly rendered in both list and selected-thread summary surfaces (`apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`).
+- Fixture-mode behavior remains deterministic, including explicit `assistant_default` fallback when profile selection data is unavailable (`apps/web/lib/fixtures.ts`, `apps/web/components/thread-create.tsx`, `apps/web/app/chat/page.tsx`).
+- Required validation gates are green:
+  - `npm --prefix apps/web run test:mvp:validation-matrix` -> PASS
+  - `python3 scripts/run_phase2_validation_matrix.py` -> PASS (rerun with elevated local DB access)
+- Sprint scope stayed bounded to web profile adoption; no backend/API/migration implementation changes detected.
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking quality issues in sprint scope.
+- No blocking quality or safety issues found in the in-scope implementation.
 
 ## regression risks
-- Low: profile IDs are currently duplicated in the in-process registry and migration constraint domain; future profile expansion must update both in lockstep.
+- Low risk: if backend profile IDs expand while fixture profile seeds lag, labels in fallback/profile-name mapping may degrade to raw IDs until fixture registry is updated.
 
 ## docs issues
-- `BUILD_REPORT.md` is aligned with the implemented sprint scope and now includes omit-case default coverage.
+- `BUILD_REPORT.md` is present, scoped to this sprint, includes verification outcomes, and explicitly states deferred scope.
 
 ## should anything be added to RULES.md?
-- No required change for this sprint.
+- No.
 
 ## should anything update ARCHITECTURE.md?
-- Not required for sprint acceptance.
+- No architecture update is required for this sprint; this is a web adoption of an already-shipped backend seam.
 
 ## recommended next action
-1. Proceed to Control Tower merge review for Phase 3 Sprint 1.
-
-## reviewer verification (re-review run)
-- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py -q` -> PASS (`11 passed`)
-- `./.venv/bin/python -m pytest tests/integration/test_context_compile.py -q` -> PASS (`12 passed`)
-- `./.venv/bin/python -m pytest tests/unit/test_20260324_0032_thread_agent_profiles.py -q` -> PASS (`3 passed`)
-- `python3 scripts/run_phase2_validation_matrix.py` -> PASS
+1. Proceed to Control Tower merge review for Phase 3 Sprint 2.
+2. Optionally add a small non-blocking test for unknown profile-ID display fallback (raw ID rendering) to harden future profile-registry drift behavior.

--- a/apps/web/app/chat/page.test.tsx
+++ b/apps/web/app/chat/page.test.tsx
@@ -11,6 +11,7 @@ const {
   getThreadEventsMock,
   getThreadSessionsMock,
   hasLiveApiConfigMock,
+  listAgentProfilesMock,
   listThreadsMock,
 } = vi.hoisted(() => ({
   getApiConfigMock: vi.fn(),
@@ -19,6 +20,7 @@ const {
   getThreadEventsMock: vi.fn(),
   getThreadSessionsMock: vi.fn(),
   hasLiveApiConfigMock: vi.fn(),
+  listAgentProfilesMock: vi.fn(),
   listThreadsMock: vi.fn(),
 }));
 
@@ -57,6 +59,7 @@ vi.mock("../../lib/api", async () => {
     getThreadEvents: getThreadEventsMock,
     getThreadSessions: getThreadSessionsMock,
     hasLiveApiConfig: hasLiveApiConfigMock,
+    listAgentProfiles: listAgentProfilesMock,
     listThreads: listThreadsMock,
   };
 });
@@ -68,6 +71,7 @@ function buildResumptionBriefFixture() {
       thread: {
         id: "thread-1",
         title: "Gamma thread",
+        agent_profile_id: "assistant_default",
         created_at: "2026-03-17T10:00:00Z",
         updated_at: "2026-03-17T10:00:00Z",
       },
@@ -113,6 +117,7 @@ describe("ChatPage", () => {
     getThreadEventsMock.mockReset();
     getThreadSessionsMock.mockReset();
     hasLiveApiConfigMock.mockReset();
+    listAgentProfilesMock.mockReset();
     listThreadsMock.mockReset();
   });
 
@@ -128,11 +133,27 @@ describe("ChatPage", () => {
       defaultToolId: "tool-1",
     });
     hasLiveApiConfigMock.mockReturnValue(true);
+    listAgentProfilesMock.mockResolvedValue({
+      items: [
+        {
+          id: "assistant_default",
+          name: "Assistant Default",
+          description: "General-purpose assistant profile for baseline conversations.",
+        },
+        {
+          id: "coach_default",
+          name: "Coach Default",
+          description: "Coaching-oriented profile focused on guidance and accountability.",
+        },
+      ],
+      summary: { total_count: 2, order: ["id_asc"] },
+    });
     listThreadsMock.mockResolvedValue({
       items: [
         {
           id: "thread-1",
           title: "Gamma thread",
+          agent_profile_id: "assistant_default",
           created_at: "2026-03-17T10:00:00Z",
           updated_at: "2026-03-17T10:00:00Z",
         },
@@ -143,6 +164,7 @@ describe("ChatPage", () => {
       thread: {
         id: "thread-1",
         title: "Gamma thread",
+        agent_profile_id: "assistant_default",
         created_at: "2026-03-17T10:00:00Z",
         updated_at: "2026-03-17T10:00:00Z",
       },
@@ -161,9 +183,11 @@ describe("ChatPage", () => {
 
     expect(screen.getByText("Live continuity enabled")).toBeInTheDocument();
     expect(screen.getByText("Selected: Gamma thread")).toBeInTheDocument();
+    expect(screen.getAllByText("Profile Assistant Default").length).toBeGreaterThan(0);
     expect(screen.getByText("No assistant replies yet")).toBeInTheDocument();
     expect(screen.queryByText("Fixture response preview")).not.toBeInTheDocument();
     expect(screen.queryByText(/What do I need to know about the last Vitamin D request/i)).not.toBeInTheDocument();
+    expect(listAgentProfilesMock).toHaveBeenCalledWith("https://api.example.com");
   });
 
   it("does not seed fixture governed-request history when live API configuration is present", async () => {
@@ -174,11 +198,22 @@ describe("ChatPage", () => {
       defaultToolId: "tool-1",
     });
     hasLiveApiConfigMock.mockReturnValue(true);
+    listAgentProfilesMock.mockResolvedValue({
+      items: [
+        {
+          id: "assistant_default",
+          name: "Assistant Default",
+          description: "General-purpose assistant profile for baseline conversations.",
+        },
+      ],
+      summary: { total_count: 1, order: ["id_asc"] },
+    });
     listThreadsMock.mockResolvedValue({
       items: [
         {
           id: "thread-1",
           title: "Gamma thread",
+          agent_profile_id: "assistant_default",
           created_at: "2026-03-17T10:00:00Z",
           updated_at: "2026-03-17T10:00:00Z",
         },
@@ -189,6 +224,7 @@ describe("ChatPage", () => {
       thread: {
         id: "thread-1",
         title: "Gamma thread",
+        agent_profile_id: "assistant_default",
         created_at: "2026-03-17T10:00:00Z",
         updated_at: "2026-03-17T10:00:00Z",
       },
@@ -225,11 +261,22 @@ describe("ChatPage", () => {
       defaultToolId: "tool-1",
     });
     hasLiveApiConfigMock.mockReturnValue(true);
+    listAgentProfilesMock.mockResolvedValue({
+      items: [
+        {
+          id: "assistant_default",
+          name: "Assistant Default",
+          description: "General-purpose assistant profile for baseline conversations.",
+        },
+      ],
+      summary: { total_count: 1, order: ["id_asc"] },
+    });
     listThreadsMock.mockResolvedValue({
       items: [
         {
           id: "thread-1",
           title: "Gamma thread",
+          agent_profile_id: "assistant_default",
           created_at: "2026-03-17T10:00:00Z",
           updated_at: "2026-03-17T10:00:00Z",
         },
@@ -261,11 +308,22 @@ describe("ChatPage", () => {
       defaultToolId: "tool-1",
     });
     hasLiveApiConfigMock.mockReturnValue(true);
+    listAgentProfilesMock.mockResolvedValue({
+      items: [
+        {
+          id: "assistant_default",
+          name: "Assistant Default",
+          description: "General-purpose assistant profile for baseline conversations.",
+        },
+      ],
+      summary: { total_count: 1, order: ["id_asc"] },
+    });
     listThreadsMock.mockResolvedValue({
       items: [
         {
           id: "thread-1",
           title: "Gamma thread",
+          agent_profile_id: "assistant_default",
           created_at: "2026-03-17T10:00:00Z",
           updated_at: "2026-03-17T10:00:00Z",
         },
@@ -276,6 +334,7 @@ describe("ChatPage", () => {
       thread: {
         id: "thread-1",
         title: "Gamma thread",
+        agent_profile_id: "assistant_default",
         created_at: "2026-03-17T10:00:00Z",
         updated_at: "2026-03-17T10:00:00Z",
       },
@@ -295,5 +354,51 @@ describe("ChatPage", () => {
     expect(screen.getByText("Live continuity enabled")).toBeInTheDocument();
     expect(screen.getByText("Resumption brief unavailable")).toBeInTheDocument();
     expect(screen.getByText("resumption brief failed")).toBeInTheDocument();
+  });
+
+  it("falls back to fixture profiles when live profile registry read fails", async () => {
+    getApiConfigMock.mockReturnValue({
+      apiBaseUrl: "https://api.example.com",
+      userId: "user-1",
+      defaultThreadId: "thread-1",
+      defaultToolId: "tool-1",
+    });
+    hasLiveApiConfigMock.mockReturnValue(true);
+    listAgentProfilesMock.mockRejectedValue(new Error("profile registry failed"));
+    listThreadsMock.mockResolvedValue({
+      items: [
+        {
+          id: "thread-1",
+          title: "Gamma thread",
+          agent_profile_id: "coach_default",
+          created_at: "2026-03-17T10:00:00Z",
+          updated_at: "2026-03-17T10:00:00Z",
+        },
+      ],
+      summary: { total_count: 1, order: ["created_at_desc", "id_desc"] },
+    });
+    getThreadDetailMock.mockResolvedValue({
+      thread: {
+        id: "thread-1",
+        title: "Gamma thread",
+        agent_profile_id: "coach_default",
+        created_at: "2026-03-17T10:00:00Z",
+        updated_at: "2026-03-17T10:00:00Z",
+      },
+    });
+    getThreadSessionsMock.mockResolvedValue({
+      items: [],
+      summary: { thread_id: "thread-1", total_count: 0, order: [] },
+    });
+    getThreadEventsMock.mockResolvedValue({
+      items: [],
+      summary: { thread_id: "thread-1", total_count: 0, order: [] },
+    });
+    getThreadResumptionBriefMock.mockResolvedValue(buildResumptionBriefFixture());
+
+    render(await ChatPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText("Live continuity enabled")).toBeInTheDocument();
+    expect(screen.getAllByText("Profile Coach Default").length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -10,6 +10,7 @@ import { ThreadEventList } from "../../components/thread-event-list";
 import { ThreadList } from "../../components/thread-list";
 import { ThreadSummary } from "../../components/thread-summary";
 import type {
+  AgentProfileItem,
   ApiSource,
   ApprovalItem,
   ResumptionBrief,
@@ -23,6 +24,7 @@ import type {
 } from "../../lib/api";
 import {
   deriveThreadWorkflowState,
+  DEFAULT_AGENT_PROFILE_ID,
   getApiConfig,
   getTaskSteps,
   getThreadDetail,
@@ -30,6 +32,7 @@ import {
   getThreadResumptionBrief,
   getThreadSessions,
   hasLiveApiConfig,
+  listAgentProfiles,
   listApprovals,
   listThreads,
   listTasks,
@@ -38,8 +41,8 @@ import {
 } from "../../lib/api";
 import {
   approvalFixtures,
+  agentProfileFixtures,
   executionFixtures,
-  getFixtureThread,
   getFixtureThreadEvents,
   getFixtureThreadSessions,
   getFixtureTaskStepSummary,
@@ -65,6 +68,14 @@ type ContinuityViewModel = {
   selectedThread: ThreadItem | null;
   sessions: ThreadSessionItem[];
   events: ThreadEventItem[];
+};
+
+type ProfileRegistrySource = ApiSource | "unavailable";
+
+type ProfileRegistryViewModel = {
+  profiles: AgentProfileItem[];
+  source: ProfileRegistrySource;
+  unavailableReason?: string;
 };
 
 type WorkflowSource = ApiSource | "unavailable";
@@ -115,6 +126,22 @@ function normalizeTraceId(value: string | string[] | undefined) {
   }
 
   return value?.trim() ?? "";
+}
+
+function normalizeAgentProfileId(value: string | null | undefined) {
+  const profileId = value?.trim();
+  return profileId && profileId.length > 0 ? profileId : DEFAULT_AGENT_PROFILE_ID;
+}
+
+function normalizeThreadItem(thread: ThreadItem): ThreadItem {
+  return {
+    ...thread,
+    agent_profile_id: normalizeAgentProfileId(thread.agent_profile_id),
+  };
+}
+
+function normalizeThreadItems(items: ThreadItem[]) {
+  return items.map((item) => normalizeThreadItem(item));
 }
 
 function buildChatTraceHrefPrefix(mode: ChatMode, threadId: string) {
@@ -435,14 +462,18 @@ async function loadFixtureContinuity(
   requestedThreadId: string,
   defaultThreadId: string,
 ): Promise<ContinuityViewModel> {
-  const selectedThreadId = resolveSelectedThreadId(requestedThreadId, defaultThreadId, threadFixtures);
+  const threads = normalizeThreadItems(threadFixtures);
+  const selectedThreadId = resolveSelectedThreadId(requestedThreadId, defaultThreadId, threads);
+  const selectedThread = selectedThreadId
+    ? threads.find((item) => item.id === selectedThreadId) ?? null
+    : null;
 
   return {
     threadListSource: "fixture",
     continuitySource: "fixture",
-    threads: threadFixtures,
+    threads,
     selectedThreadId,
-    selectedThread: selectedThreadId ? getFixtureThread(selectedThreadId) : null,
+    selectedThread,
     sessions: selectedThreadId ? getFixtureThreadSessions(selectedThreadId) : [],
     events: selectedThreadId ? getFixtureThreadEvents(selectedThreadId) : [],
   };
@@ -456,7 +487,7 @@ async function loadLiveContinuity(
 ): Promise<ContinuityViewModel> {
   try {
     const threadResponse = await listThreads(apiBaseUrl, userId);
-    const threads = threadResponse.items;
+    const threads = normalizeThreadItems(threadResponse.items);
     const selectedThreadId = resolveSelectedThreadId(requestedThreadId, defaultThreadId, threads);
 
     if (!selectedThreadId) {
@@ -500,7 +531,7 @@ async function loadLiveContinuity(
       selectedThreadId,
       selectedThread:
         threadResult.status === "fulfilled"
-          ? threadResult.value.thread
+          ? normalizeThreadItem(threadResult.value.thread)
           : threads.find((thread) => thread.id === selectedThreadId) ?? null,
       sessions: sessionsResult.status === "fulfilled" ? sessionsResult.value.items : [],
       events: eventsResult.status === "fulfilled" ? eventsResult.value.items : [],
@@ -519,6 +550,30 @@ async function loadLiveContinuity(
   }
 }
 
+async function loadFixtureProfileRegistry(): Promise<ProfileRegistryViewModel> {
+  return {
+    profiles: agentProfileFixtures,
+    source: "fixture",
+  };
+}
+
+async function loadLiveProfileRegistry(apiBaseUrl: string): Promise<ProfileRegistryViewModel> {
+  try {
+    const response = await listAgentProfiles(apiBaseUrl);
+    return {
+      profiles: response.items,
+      source: "live",
+    };
+  } catch (error) {
+    return {
+      profiles: agentProfileFixtures,
+      source: "fixture",
+      unavailableReason:
+        error instanceof Error ? error.message : "Agent profile registry could not be loaded.",
+    };
+  }
+}
+
 export default async function ChatPage({ searchParams }: ChatPageProps) {
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
   const mode = normalizeMode(resolvedSearchParams?.mode);
@@ -526,14 +581,20 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
   const requestedTraceId = normalizeTraceId(resolvedSearchParams?.trace);
   const apiConfig = getApiConfig();
   const liveModeReady = hasLiveApiConfig(apiConfig);
-  const continuity = liveModeReady
-    ? await loadLiveContinuity(
-        apiConfig.apiBaseUrl,
-        apiConfig.userId,
-        requestedThreadId,
-        apiConfig.defaultThreadId,
-      )
-    : await loadFixtureContinuity(requestedThreadId, apiConfig.defaultThreadId);
+  const [continuity, profileRegistry] = liveModeReady
+    ? await Promise.all([
+        loadLiveContinuity(
+          apiConfig.apiBaseUrl,
+          apiConfig.userId,
+          requestedThreadId,
+          apiConfig.defaultThreadId,
+        ),
+        loadLiveProfileRegistry(apiConfig.apiBaseUrl),
+      ])
+    : await Promise.all([
+        loadFixtureContinuity(requestedThreadId, apiConfig.defaultThreadId),
+        loadFixtureProfileRegistry(),
+      ]);
   const workflow = liveModeReady
     ? await loadLiveWorkflow(apiConfig.apiBaseUrl, apiConfig.userId, continuity.selectedThreadId)
     : await loadFixtureWorkflow(continuity.selectedThreadId);
@@ -646,6 +707,7 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
             thread={continuity.selectedThread}
             sessions={continuity.sessions}
             events={continuity.events}
+            agentProfiles={profileRegistry.profiles}
             source={continuity.continuitySource}
             unavailableReason={continuity.unavailableReason}
             resumptionBrief={resumptionBrief.brief}
@@ -657,6 +719,7 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
             threads={continuity.threads}
             selectedThreadId={continuity.selectedThreadId}
             currentMode={mode}
+            agentProfiles={profileRegistry.profiles}
             source={continuity.threadListSource}
             unavailableReason={continuity.unavailableReason}
           />
@@ -675,6 +738,7 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
             apiBaseUrl={liveModeReady ? apiConfig.apiBaseUrl : undefined}
             userId={liveModeReady ? apiConfig.userId : undefined}
             currentMode={mode}
+            agentProfiles={profileRegistry.profiles}
           />
         </div>
       </div>

--- a/apps/web/components/thread-create.test.tsx
+++ b/apps/web/components/thread-create.test.tsx
@@ -40,6 +40,7 @@ describe("ThreadCreate", () => {
       thread: {
         id: "thread-2",
         title: "Delta thread",
+        agent_profile_id: "coach_default",
         created_at: "2026-03-17T11:00:00Z",
         updated_at: "2026-03-17T11:00:00Z",
       },
@@ -50,9 +51,24 @@ describe("ThreadCreate", () => {
         apiBaseUrl="https://api.example.com"
         userId="user-1"
         currentMode="assistant"
+        agentProfiles={[
+          {
+            id: "assistant_default",
+            name: "Assistant Default",
+            description: "General-purpose assistant profile for baseline conversations.",
+          },
+          {
+            id: "coach_default",
+            name: "Coach Default",
+            description: "Coaching-oriented profile focused on guidance and accountability.",
+          },
+        ]}
       />,
     );
 
+    fireEvent.change(screen.getByLabelText("Agent profile"), {
+      target: { value: "coach_default" },
+    });
     fireEvent.change(screen.getByLabelText("Thread title"), {
       target: { value: "Delta thread" },
     });
@@ -62,6 +78,7 @@ describe("ThreadCreate", () => {
       expect(createThreadMock).toHaveBeenCalledWith("https://api.example.com", {
         user_id: "user-1",
         title: "Delta thread",
+        agent_profile_id: "coach_default",
       });
     });
 
@@ -76,5 +93,38 @@ describe("ThreadCreate", () => {
     expect(
       screen.getByText(/Thread creation becomes available when the live web API base URL and user ID are configured/i),
     ).toBeInTheDocument();
+  });
+
+  it("defaults thread creation payload to assistant_default when no profile list is available", async () => {
+    createThreadMock.mockResolvedValue({
+      thread: {
+        id: "thread-3",
+        title: "Epsilon thread",
+        agent_profile_id: "assistant_default",
+        created_at: "2026-03-17T12:00:00Z",
+        updated_at: "2026-03-17T12:00:00Z",
+      },
+    });
+
+    render(
+      <ThreadCreate
+        apiBaseUrl="https://api.example.com"
+        userId="user-1"
+        currentMode="assistant"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Thread title"), {
+      target: { value: "Epsilon thread" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create thread" }));
+
+    await waitFor(() => {
+      expect(createThreadMock).toHaveBeenCalledWith("https://api.example.com", {
+        user_id: "user-1",
+        title: "Epsilon thread",
+        agent_profile_id: "assistant_default",
+      });
+    });
   });
 });

--- a/apps/web/components/thread-create.tsx
+++ b/apps/web/components/thread-create.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import type { FormEvent } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
-import { createThread } from "../lib/api";
+import { createThread, DEFAULT_AGENT_PROFILE_ID, type AgentProfileItem } from "../lib/api";
 import type { ChatMode } from "./mode-toggle";
 import { SectionCard } from "./section-card";
 import { StatusBadge } from "./status-badge";
@@ -13,6 +13,7 @@ type ThreadCreateProps = {
   apiBaseUrl?: string;
   userId?: string;
   currentMode: ChatMode;
+  agentProfiles?: AgentProfileItem[];
 };
 
 function buildThreadHref(mode: ChatMode, threadId: string) {
@@ -26,9 +27,15 @@ function buildThreadHref(mode: ChatMode, threadId: string) {
   return `/chat?${params.toString()}`;
 }
 
-export function ThreadCreate({ apiBaseUrl, userId, currentMode }: ThreadCreateProps) {
+export function ThreadCreate({
+  apiBaseUrl,
+  userId,
+  currentMode,
+  agentProfiles,
+}: ThreadCreateProps) {
   const router = useRouter();
   const [title, setTitle] = useState("");
+  const [selectedProfileId, setSelectedProfileId] = useState(DEFAULT_AGENT_PROFILE_ID);
   const [statusText, setStatusText] = useState(
     apiBaseUrl && userId
       ? "Create a new visible thread when the current conversation needs a fresh continuity boundary."
@@ -38,6 +45,25 @@ export function ThreadCreate({ apiBaseUrl, userId, currentMode }: ThreadCreatePr
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const liveModeReady = Boolean(apiBaseUrl && userId);
+  const profileOptions = agentProfiles && agentProfiles.length > 0
+    ? agentProfiles
+    : [
+        {
+          id: DEFAULT_AGENT_PROFILE_ID,
+          name: "Assistant Default",
+          description: "General-purpose assistant profile for baseline conversations.",
+        },
+      ];
+
+  useEffect(() => {
+    if (profileOptions.some((profile) => profile.id === selectedProfileId)) {
+      return;
+    }
+
+    const fallbackProfile =
+      profileOptions.find((profile) => profile.id === DEFAULT_AGENT_PROFILE_ID) ?? profileOptions[0];
+    setSelectedProfileId(fallbackProfile.id);
+  }, [profileOptions, selectedProfileId]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -66,6 +92,7 @@ export function ThreadCreate({ apiBaseUrl, userId, currentMode }: ThreadCreatePr
       const response = await createThread(apiBaseUrl!, {
         user_id: userId!,
         title: nextTitle,
+        agent_profile_id: selectedProfileId || DEFAULT_AGENT_PROFILE_ID,
       });
 
       setStatusTone("success");
@@ -89,6 +116,23 @@ export function ThreadCreate({ apiBaseUrl, userId, currentMode }: ThreadCreatePr
       description="Keep thread identity explicit instead of recycling one conversation container for unrelated work."
     >
       <form className="detail-stack" onSubmit={handleSubmit}>
+        <div className="form-field">
+          <label htmlFor="thread-agent-profile">Agent profile</label>
+          <select
+            id="thread-agent-profile"
+            name="thread-agent-profile"
+            value={selectedProfileId}
+            onChange={(event) => setSelectedProfileId(event.target.value)}
+            disabled={!liveModeReady || isSubmitting}
+          >
+            {profileOptions.map((profile) => (
+              <option key={profile.id} value={profile.id}>
+                {profile.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
         <div className="form-field">
           <label htmlFor="thread-title">Thread title</label>
           <input

--- a/apps/web/components/thread-list.test.tsx
+++ b/apps/web/components/thread-list.test.tsx
@@ -34,18 +34,32 @@ describe("ThreadList", () => {
           {
             id: "thread-1",
             title: "Gamma thread",
+            agent_profile_id: "assistant_default",
             created_at: "2026-03-17T10:00:00Z",
             updated_at: "2026-03-17T10:00:00Z",
           },
           {
             id: "thread-2",
             title: "Delta thread",
+            agent_profile_id: "coach_default",
             created_at: "2026-03-17T11:00:00Z",
             updated_at: "2026-03-17T11:00:00Z",
           },
         ]}
         selectedThreadId="thread-2"
         currentMode="request"
+        agentProfiles={[
+          {
+            id: "assistant_default",
+            name: "Assistant Default",
+            description: "General-purpose assistant profile for baseline conversations.",
+          },
+          {
+            id: "coach_default",
+            name: "Coach Default",
+            description: "Coaching-oriented profile focused on guidance and accountability.",
+          },
+        ]}
         source="live"
       />,
     );
@@ -59,5 +73,7 @@ describe("ThreadList", () => {
       "/chat?mode=request&thread=thread-2",
     );
     expect(screen.getByRole("link", { name: /Delta thread/i })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByText("Profile Assistant Default")).toBeInTheDocument();
+    expect(screen.getByText("Profile Coach Default")).toBeInTheDocument();
   });
 });

--- a/apps/web/components/thread-list.tsx
+++ b/apps/web/components/thread-list.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import type { ThreadItem } from "../lib/api";
+import { DEFAULT_AGENT_PROFILE_ID, type AgentProfileItem, type ThreadItem } from "../lib/api";
 import type { ChatMode } from "./mode-toggle";
 import { EmptyState } from "./empty-state";
 import { SectionCard } from "./section-card";
@@ -9,6 +9,7 @@ type ThreadListProps = {
   threads: ThreadItem[];
   selectedThreadId?: string;
   currentMode: ChatMode;
+  agentProfiles?: AgentProfileItem[];
   source: "live" | "fixture" | "unavailable";
   unavailableReason?: string;
 };
@@ -33,10 +34,18 @@ function buildThreadHref(mode: ChatMode, threadId: string) {
   return `/chat?${params.toString()}`;
 }
 
+function resolveAgentProfileName(
+  agentProfileId: string,
+  profiles: AgentProfileItem[],
+) {
+  return profiles.find((profile) => profile.id === agentProfileId)?.name ?? agentProfileId;
+}
+
 export function ThreadList({
   threads,
   selectedThreadId,
   currentMode,
+  agentProfiles = [],
   source,
   unavailableReason,
 }: ThreadListProps) {
@@ -67,6 +76,8 @@ export function ThreadList({
         <div className="history-list history-list--scrollable">
           {threads.map((thread) => {
             const isSelected = thread.id === selectedThreadId;
+            const agentProfileId = thread.agent_profile_id || DEFAULT_AGENT_PROFILE_ID;
+            const agentProfileName = resolveAgentProfileName(agentProfileId, agentProfiles);
 
             return (
               <Link
@@ -85,6 +96,7 @@ export function ThreadList({
 
                 <div className="list-row__meta">
                   <span className="meta-pill">Updated {formatDate(thread.updated_at)}</span>
+                  <span className="meta-pill">Profile {agentProfileName}</span>
                   <span className="meta-pill mono">{thread.id}</span>
                 </div>
               </Link>

--- a/apps/web/components/thread-summary.test.tsx
+++ b/apps/web/components/thread-summary.test.tsx
@@ -14,6 +14,7 @@ describe("ThreadSummary", () => {
         thread={{
           id: "thread-1",
           title: "Gamma thread",
+          agent_profile_id: "coach_default",
           created_at: "2026-03-17T10:00:00Z",
           updated_at: "2026-03-17T10:05:00Z",
         }}
@@ -38,6 +39,18 @@ describe("ThreadSummary", () => {
             created_at: "2026-03-17T10:01:00Z",
           },
         ]}
+        agentProfiles={[
+          {
+            id: "assistant_default",
+            name: "Assistant Default",
+            description: "General-purpose assistant profile for baseline conversations.",
+          },
+          {
+            id: "coach_default",
+            name: "Coach Default",
+            description: "Coaching-oriented profile focused on guidance and accountability.",
+          },
+        ]}
         source="live"
       />,
     );
@@ -48,6 +61,8 @@ describe("ThreadSummary", () => {
     expect(screen.getByText("Sessions")).toBeInTheDocument();
     expect(screen.getByText("Events")).toBeInTheDocument();
     expect(screen.getByText("active")).toBeInTheDocument();
+    expect(screen.getByText("Profile Coach Default")).toBeInTheDocument();
+    expect(screen.getByText("Agent profile")).toBeInTheDocument();
   });
 
   it("shows the explicit no-thread state when nothing is selected", () => {
@@ -70,6 +85,7 @@ describe("ThreadSummary", () => {
         thread={{
           id: "thread-1",
           title: "Gamma thread",
+          agent_profile_id: "assistant_default",
           created_at: "2026-03-17T10:00:00Z",
           updated_at: "2026-03-17T10:05:00Z",
         }}
@@ -82,6 +98,7 @@ describe("ThreadSummary", () => {
           thread: {
             id: "thread-1",
             title: "Gamma thread",
+            agent_profile_id: "assistant_default",
             created_at: "2026-03-17T10:00:00Z",
             updated_at: "2026-03-17T10:05:00Z",
           },
@@ -166,6 +183,7 @@ describe("ThreadSummary", () => {
         thread={{
           id: "thread-1",
           title: "Gamma thread",
+          agent_profile_id: "assistant_default",
           created_at: "2026-03-17T10:00:00Z",
           updated_at: "2026-03-17T10:05:00Z",
         }}

--- a/apps/web/components/thread-summary.tsx
+++ b/apps/web/components/thread-summary.tsx
@@ -1,4 +1,11 @@
-import type { ResumptionBrief, ThreadEventItem, ThreadItem, ThreadSessionItem } from "../lib/api";
+import {
+  DEFAULT_AGENT_PROFILE_ID,
+  type AgentProfileItem,
+  type ResumptionBrief,
+  type ThreadEventItem,
+  type ThreadItem,
+  type ThreadSessionItem,
+} from "../lib/api";
 import { EmptyState } from "./empty-state";
 import { SectionCard } from "./section-card";
 import { StatusBadge } from "./status-badge";
@@ -7,6 +14,7 @@ type ThreadSummaryProps = {
   thread: ThreadItem | null;
   sessions: ThreadSessionItem[];
   events: ThreadEventItem[];
+  agentProfiles?: AgentProfileItem[];
   source: "live" | "fixture" | "unavailable";
   unavailableReason?: string;
   resumptionBrief?: ResumptionBrief | null;
@@ -43,10 +51,15 @@ function summarizeEvent(event: ThreadEventItem) {
   return event.kind;
 }
 
+function resolveAgentProfileName(agentProfileId: string, profiles: AgentProfileItem[]) {
+  return profiles.find((profile) => profile.id === agentProfileId)?.name ?? agentProfileId;
+}
+
 export function ThreadSummary({
   thread,
   sessions,
   events,
+  agentProfiles = [],
   source,
   unavailableReason,
   resumptionBrief = null,
@@ -86,6 +99,8 @@ export function ThreadSummary({
   const latestSession = sessions[sessions.length - 1];
   const conversationCount = events.filter(isConversationEvent).length;
   const operationalCount = events.length - conversationCount;
+  const agentProfileId = thread.agent_profile_id || DEFAULT_AGENT_PROFILE_ID;
+  const agentProfileName = resolveAgentProfileName(agentProfileId, agentProfiles);
 
   return (
     <SectionCard
@@ -103,6 +118,7 @@ export function ThreadSummary({
           label={formatStatus(latestSession?.status)}
         />
         <div className="attribute-list">
+          <span className="meta-pill">Profile {agentProfileName}</span>
           <span className="meta-pill">Created {formatDate(thread.created_at)}</span>
           <span className="meta-pill">Updated {formatDate(thread.updated_at)}</span>
         </div>
@@ -124,6 +140,10 @@ export function ThreadSummary({
         <div>
           <dt>Review mode</dt>
           <dd>{source === "live" ? "Live continuity API" : "Fixture preview"}</dd>
+        </div>
+        <div>
+          <dt>Agent profile</dt>
+          <dd>{agentProfileName}</dd>
         </div>
       </dl>
 

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -38,6 +38,7 @@ import {
   listMemories,
   listMemoryLabels,
   listMemoryReviewQueue,
+  listAgentProfiles,
   getToolExecution,
   getTraceDetail,
   getTraceEvents,
@@ -427,6 +428,7 @@ describe("api helpers", () => {
             thread: {
               id: "thread-1",
               title: "Gamma thread",
+              agent_profile_id: "coach_default",
               created_at: "2026-03-17T10:00:00Z",
               updated_at: "2026-03-17T10:00:00Z",
             },
@@ -441,6 +443,7 @@ describe("api helpers", () => {
               {
                 id: "thread-1",
                 title: "Gamma thread",
+                agent_profile_id: "coach_default",
                 created_at: "2026-03-17T10:00:00Z",
                 updated_at: "2026-03-17T10:00:00Z",
               },
@@ -459,6 +462,7 @@ describe("api helpers", () => {
             thread: {
               id: "thread-1",
               title: "Gamma thread",
+              agent_profile_id: "coach_default",
               created_at: "2026-03-17T10:00:00Z",
               updated_at: "2026-03-17T10:00:00Z",
             },
@@ -510,16 +514,41 @@ describe("api helpers", () => {
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "assistant_default",
+                name: "Assistant Default",
+                description: "General-purpose assistant profile for baseline conversations.",
+              },
+              {
+                id: "coach_default",
+                name: "Coach Default",
+                description: "Coaching-oriented profile focused on guidance and accountability.",
+              },
+            ],
+            summary: {
+              total_count: 2,
+              order: ["id_asc"],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
       );
 
-    await createThread("https://api.example.com", {
+    const createPayload = await createThread("https://api.example.com", {
       user_id: "user-1",
       title: "Gamma thread",
+      agent_profile_id: "coach_default",
     });
-    await listThreads("https://api.example.com", "user-1");
-    await getThreadDetail("https://api.example.com", "thread-1", "user-1");
+    const threadListPayload = await listThreads("https://api.example.com", "user-1");
+    const threadDetailPayload = await getThreadDetail("https://api.example.com", "thread-1", "user-1");
     await getThreadSessions("https://api.example.com", "thread-1", "user-1");
     await getThreadEvents("https://api.example.com", "thread-1", "user-1");
+    const profileRegistryPayload = await listAgentProfiles("https://api.example.com");
 
     expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
       "https://api.example.com/v0/threads",
@@ -527,11 +556,20 @@ describe("api helpers", () => {
       "https://api.example.com/v0/threads/thread-1?user_id=user-1",
       "https://api.example.com/v0/threads/thread-1/sessions?user_id=user-1",
       "https://api.example.com/v0/threads/thread-1/events?user_id=user-1",
+      "https://api.example.com/v0/agent-profiles",
     ]);
     expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
       user_id: "user-1",
       title: "Gamma thread",
+      agent_profile_id: "coach_default",
     });
+    expect(createPayload.thread.agent_profile_id).toBe("coach_default");
+    expect(threadListPayload.items[0]?.agent_profile_id).toBe("coach_default");
+    expect(threadDetailPayload.thread.agent_profile_id).toBe("coach_default");
+    expect(profileRegistryPayload.items.map((item) => item.id)).toEqual([
+      "assistant_default",
+      "coach_default",
+    ]);
   });
 
   it("throws ApiError when approval resolution returns a backend error envelope", async () => {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -8,9 +8,12 @@ export type ApiConfig = {
   defaultToolId: string;
 };
 
+export const DEFAULT_AGENT_PROFILE_ID = "assistant_default";
+
 export type ThreadItem = {
   id: string;
   title: string;
+  agent_profile_id: string;
   created_at: string;
   updated_at: string;
 };
@@ -37,9 +40,21 @@ export type ThreadEventItem = {
 export type ThreadCreatePayload = {
   user_id: string;
   title: string;
+  agent_profile_id: string;
 };
 
 export type ThreadListSummary = {
+  total_count: number;
+  order: string[];
+};
+
+export type AgentProfileItem = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+export type AgentProfileListSummary = {
   total_count: number;
   order: string[];
 };
@@ -1182,6 +1197,13 @@ export function listThreads(apiBaseUrl: string, userId: string) {
     "/v0/threads",
     undefined,
     { user_id: userId },
+  );
+}
+
+export function listAgentProfiles(apiBaseUrl: string) {
+  return requestJson<{ items: AgentProfileItem[]; summary: AgentProfileListSummary }>(
+    apiBaseUrl,
+    "/v0/agent-profiles",
   );
 }
 

--- a/apps/web/lib/fixtures.ts
+++ b/apps/web/lib/fixtures.ts
@@ -1,4 +1,6 @@
 import type {
+  AgentProfileItem,
+  AgentProfileListSummary,
   ApprovalItem,
   ApprovalRequestPayload,
   CalendarAccountListSummary,
@@ -37,6 +39,7 @@ import type {
   ToolExecutionItem,
   ToolRecord,
 } from "./api";
+import { DEFAULT_AGENT_PROFILE_ID } from "./api";
 import type { TraceItem } from "../components/trace-list";
 
 const PURCHASE_TOOL: ToolRecord = {
@@ -64,22 +67,43 @@ export const threadFixtures: ThreadItem[] = [
   {
     id: THREAD_MAGNESIUM,
     title: "Magnesium continuity review",
+    agent_profile_id: "assistant_default",
     created_at: "2026-03-17T06:40:00Z",
     updated_at: "2026-03-17T08:45:00Z",
   },
   {
     id: THREAD_VITAMIN_D,
     title: "Vitamin D reorder follow-up",
+    agent_profile_id: "coach_default",
     created_at: "2026-03-16T13:58:00Z",
     updated_at: "2026-03-16T14:32:00Z",
   },
   {
     id: THREAD_CLEANUP,
     title: "Quarterly routine cleanup",
+    agent_profile_id: "assistant_default",
     created_at: "2026-03-15T09:20:00Z",
     updated_at: "2026-03-15T09:20:00Z",
   },
 ];
+
+export const agentProfileFixtures: AgentProfileItem[] = [
+  {
+    id: "assistant_default",
+    name: "Assistant Default",
+    description: "General-purpose assistant profile for baseline conversations.",
+  },
+  {
+    id: "coach_default",
+    name: "Coach Default",
+    description: "Coaching-oriented profile focused on guidance and accountability.",
+  },
+];
+
+export const agentProfileFixtureSummary: AgentProfileListSummary = {
+  total_count: agentProfileFixtures.length,
+  order: ["id_asc"],
+};
 
 export const threadSessionFixtures: Record<string, ThreadSessionItem[]> = {
   [THREAD_MAGNESIUM]: [
@@ -1723,6 +1747,7 @@ export function buildFixtureThread(title: string): ThreadItem {
   return {
     id: `fixture-thread-${nonce}`,
     title,
+    agent_profile_id: DEFAULT_AGENT_PROFILE_ID,
     created_at: timestamp,
     updated_at: timestamp,
   };


### PR DESCRIPTION
## Summary
This PR delivers **Phase 3 Sprint 2: Web Agent Profile Adoption** by wiring the already-shipped backend profile seams into the web chat operator shell.

The sprint keeps backend scope unchanged and focuses on deterministic web-side adoption:
- profile-aware thread contract usage (`agent_profile_id`)
- live profile registry loading (`GET /v0/agent-profiles`)
- explicit profile selection at thread creation
- visible profile identity in thread list and selected-thread summary
- deterministic fallback behavior when live profile reads are unavailable

## What Changed
- Updated web API client contracts and helpers in `apps/web/lib/api.ts`:
  - `ThreadItem.agent_profile_id`
  - `ThreadCreatePayload.agent_profile_id`
  - profile registry types and `listAgentProfiles()`
  - deterministic default profile constant (`assistant_default`)
- Updated fixture contracts in `apps/web/lib/fixtures.ts`:
  - profile-aware thread fixtures
  - deterministic profile fixture set (`assistant_default`, `coach_default`)
- Updated `/chat` loading behavior in `apps/web/app/chat/page.tsx`:
  - live profile registry fetch path
  - explicit fallback to deterministic fixture profile behavior on read failure
- Updated thread creation UX in `apps/web/components/thread-create.tsx`:
  - profile selector
  - create payload now sends selected `agent_profile_id`
- Updated profile visibility UX:
  - `apps/web/components/thread-list.tsx`
  - `apps/web/components/thread-summary.tsx`
- Added/updated tests across all in-scope seams:
  - API contract tests
  - chat-page fallback tests
  - thread-create payload tests
  - thread-list and thread-summary profile rendering tests

## Verification
### Required sprint validation
- `npm --prefix apps/web run test:mvp:validation-matrix` ✅ PASS (`13` files, `65` tests)
- `python3 scripts/run_phase2_validation_matrix.py` ✅ PASS
  - control_doc_truth: PASS
  - gate_contract_tests: PASS
  - readiness_gates: PASS
  - backend_integration_matrix: PASS
  - web_validation_matrix: PASS

## Scope Confirmation
- In-scope only: web profile-adoption surfaces plus sprint packet/build/review reports.
- No backend/API/migration implementation scope was added.
- Deferred by design: profile CRUD, provider/model routing, orchestration changes.

## Control Artifacts
- Active packet: `.ai/active/SPRINT_PACKET.md`
- Build report: `BUILD_REPORT.md`
- Review report: `REVIEW_REPORT.md` (`PASS`)
