### PR TITLE
Phase 3 Sprint 5: Profile-Scoped Memory and Context Isolation

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 3 Sprint 2: Web Agent Profile Adoption
+Phase 3 Sprint 5: Profile-Scoped Memory and Context Isolation
 
 ## Sprint Type
 
@@ -10,160 +10,168 @@ feature
 
 ## Sprint Reason
 
-Phase 3 Sprint 1 shipped and merged the backend profile backbone (`agent_profile_id` persistence, `/v0/agent-profiles`, profile metadata propagation). The operator shell still does not consume this surface, which creates a planning and usability gap for multi-agent deployment.
+Sprint 4 stabilizes durable profile identity in the registry and thread FK binding. The next non-redundant gap is isolation: context compilation still reads user memories globally, so different agent profiles can share memory context unintentionally. Current `main` does not yet include that Sprint 4 registry baseline, so this sprint carries the minimal prerequisite registry artifacts forward to keep the migration/runtime chain coherent.
 
 ## Sprint Intent
 
-Adopt shipped profile identity in the web shell so profile choice and visibility are explicit during thread creation and thread review, while keeping backend scope unchanged.
+Bind memory selection to active thread profile by adding profile attribution on memory records and enforcing profile-scoped context retrieval, while preserving backward-compatible defaults.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase3-sprint2-web-agent-profile-adoption`
+- Branch Name: `codex/phase3-sprint5-profile-memory-context-isolation`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- It directly consumes the backend capability that just shipped in Phase 3 Sprint 1.
-- It is non-redundant: current web code does not call `GET /v0/agent-profiles` and does not use `agent_profile_id` on thread create/list/detail.
-- It closes a concrete operator-facing gap before any model routing or orchestration expansion.
+- It is the next non-redundant seam after profile identity + registry.
+- It closes cross-profile memory bleed risk in `POST /v0/context/compile` and `POST /v0/responses`.
+- It establishes a durable boundary needed before profile-specific policy/provider routing.
 
 ## Redundancy Guard
 
-- Already shipped in Sprint 1 (do not re-implement): profile registry, migration, thread persistence, API validation, compile/response metadata propagation.
-- Missing and required now: web client typing, profile fetch/read path, profile selection at thread create, and visible thread profile identity in chat surfaces.
+- Already shipped in Sprint 1: thread-level profile identity + metadata propagation.
+- Already shipped in Sprint 2: web profile selection/visibility.
+- Already shipped in Sprint 3: profile-aware response prompting.
+- Required Sprint 4 baseline not yet present on `main` and carried here as prerequisite only: durable profile registry migration/runtime wiring.
+- Missing and required now: profile-scoped memory attribution and profile-bound context retrieval.
 
 ## Design Truth
 
-- Reuse shipped API seams as-is; no backend contract changes.
-- Preserve current fixture/live fallback behavior across `/chat`.
-- Keep deterministic default profile behavior explicit (`assistant_default`) when profile selection is unavailable.
-- Keep UX bounded and calm: one selector on create, lightweight profile visibility in thread review surfaces.
+- Memory rows carry explicit `agent_profile_id` bound to the profile registry.
+- Memory retrieval for compile/response uses the selected thread profile boundary.
+- Existing behavior defaults safely to `assistant_default` where profile attribution is omitted.
+- API envelopes remain stable; profile fields may be additive where necessary.
 
 ## Exact Surfaces In Scope
 
-- web API client contract adoption for `agent_profile_id` and `/v0/agent-profiles`
-- chat-page live/fixture profile loading and fallback behavior
-- thread create UI profile selection
-- thread list/summary profile visibility
-- targeted tests for all above seams
+- memory schema/profile attribution migration
+- store-layer memory read/write updates with profile filtering
+- compile/response memory retrieval path updated to active thread profile scope
+- prerequisite profile-registry baseline carry-forward required by migration/runtime chain
+- integration and unit tests for isolation and backward-compatible defaults
 
 ## Exact Files In Scope
 
-- [api.ts](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/lib/api.ts)
-- [api.test.ts](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/lib/api.test.ts)
-- [fixtures.ts](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/lib/fixtures.ts)
-- [page.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/app/chat/page.tsx)
-- [page.test.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/app/chat/page.test.tsx)
-- [thread-create.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-create.tsx)
-- [thread-create.test.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-create.test.tsx)
-- [thread-list.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-list.tsx)
-- [thread-list.test.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-list.test.tsx)
-- [thread-summary.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-summary.tsx)
-- [thread-summary.test.tsx](/Users/samirusani/Desktop/Codex/AliceBot/apps/web/components/thread-summary.test.tsx)
+- [store.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/store.py)
+- [compiler.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/compiler.py)
+- [main.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/main.py)
+- [contracts.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/contracts.py)
+- [memory.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/memory.py)
+- [phase3_profiles.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/phase3_profiles.py)
+- [20260324_0033_agent_profile_registry.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/alembic/versions/20260324_0033_agent_profile_registry.py)
+- [20260324_0034_memory_agent_profile_scope.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/alembic/versions/20260324_0034_memory_agent_profile_scope.py)
+- [test_20260324_0033_agent_profile_registry.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_20260324_0033_agent_profile_registry.py)
+- [test_20260324_0034_memory_agent_profile_scope.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_20260324_0034_memory_agent_profile_scope.py)
+- [test_memory.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_memory.py)
+- [test_memory_store.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_memory_store.py)
+- [test_context_compile.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_context_compile.py)
+- [test_memory_review_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_memory_review_api.py)
+- [test_continuity_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_continuity_api.py)
+- [test_responses_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_responses_api.py)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
 - [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
 
 ## In Scope
 
-- Extend `ThreadItem` and `ThreadCreatePayload` in web API client with `agent_profile_id`.
-- Add deterministic web API client types/helpers for profile registry:
-  - `AgentProfileItem`
-  - `AgentProfileListSummary`
-  - `listAgentProfiles(apiBaseUrl)`
-- Update `/chat` loading path to fetch profile registry in live mode and preserve fixture behavior when unavailable.
-- Update thread create flow to allow profile selection and submit selected `agent_profile_id`.
-- Show selected thread profile identity in thread review surfaces (`ThreadList` and `ThreadSummary`) without noisy UI expansion.
-- Add/update tests covering:
-  - request payloads include selected profile id
-  - list/detail typing includes profile id
-  - live profile fetch success/fallback behavior
-  - profile identity rendering in list/summary
+- Add `agent_profile_id` to `memories` with:
+  - non-null default `assistant_default`
+  - FK to `agent_profiles(id)`
+  - deterministic index for scoped retrieval (`user_id`, `agent_profile_id`, `updated_at`, `created_at`, `id`)
+- Backfill existing memory rows to `assistant_default` via migration default semantics.
+- Update memory create/upsert flows so new/updated memory rows preserve explicit profile attribution.
+- Update context compilation path to fetch memories scoped to active thread profile.
+- Keep existing response/context metadata profile propagation behavior unchanged.
+- Carry forward required Sprint 4 registry foundation (`0033` migration + profile-registry runtime wiring/tests) without adding CRUD/provider/orchestration scope.
+- Add unit migration tests for upgrade/rollback and profile FK/default invariants.
+- Add integration coverage proving:
+  - compile for `assistant_default` and `coach_default` threads returns profile-scoped memory slices
+  - response generation inherits scoped compile behavior
+  - existing default path remains deterministic when profile is omitted
 
 ## Out of Scope
 
-- backend schema/migration changes
-- backend API contract changes for profile registry or thread create
-- per-profile model-provider routing/switching
 - profile CRUD endpoints
-- external LLM provider integration
-- auth model changes
-- runner/worker orchestration changes
+- per-profile provider/model routing
+- policy/tooling profile scoping
+- web UI changes
+- connector/auth/orchestration expansion
 
 ## Required Deliverables
 
-- web API client + chat UI consume shipped profile seams end-to-end
-- deterministic fallback behavior if profile registry is unavailable
-- updated web tests for the profile adoption seam
+- memory profile-scope migration and store wiring
+- compile/response memory retrieval isolation by active profile
+- passing unit/integration evidence for profile-scoped memory behavior
 - sprint build/review reports scoped to this sprint only
 
 ## Acceptance Criteria
 
-- Thread create in live mode submits `agent_profile_id` along with `user_id` and `title`.
-- Web thread data types and reads retain `agent_profile_id` from API responses.
-- `/chat` reads `GET /v0/agent-profiles` in live mode and remains usable if that read fails.
-- Thread list and selected-thread summary visibly show active profile identity.
-- Fixture mode remains stable and deterministic with no regression to existing fallback paths.
-- `npm --prefix apps/web run test:mvp:validation-matrix` passes.
+- Memory rows are profile-attributed and FK-bound to registry profiles.
+- Compile for a thread includes only memories from that thread’s active profile domain.
+- `/v0/responses` remains backward-compatible while using profile-scoped compile behavior.
+- Default behavior remains deterministic (`assistant_default`) when profile attribution is omitted.
+- `./.venv/bin/python -m pytest tests/unit/test_20260324_0034_memory_agent_profile_scope.py -q` passes.
+- `./.venv/bin/python -m pytest tests/integration/test_context_compile.py tests/integration/test_responses_api.py tests/integration/test_memory_review_api.py -q` passes.
 - `python3 scripts/run_phase2_validation_matrix.py` remains PASS.
-- No backend/API/migration scope enters this sprint.
+- No provider/policy/orchestration scope expansion enters this sprint.
 
 ## Implementation Constraints
 
 - do not introduce new dependencies
-- do not modify `apps/api` or migration files
-- keep profile default deterministic (`assistant_default`) when selection data is unavailable
-- preserve existing copy tone and visual containment in chat rail components
+- preserve existing response and compile payload contracts
+- keep migration reversible and forward-safe
+- keep scoped retrieval ordering deterministic with existing memory ordering rules
 
 ## Control Tower Task Cards
 
-### Task 1: API Client + Fixture Contract Adoption
+### Task 1: Memory Scope Migration + Store Wiring
 Owner: tooling operative  
 Write scope:
-- `apps/web/lib/api.ts`
-- `apps/web/lib/api.test.ts`
-- `apps/web/lib/fixtures.ts`
+- `apps/api/alembic/versions/20260324_0033_agent_profile_registry.py`
+- `apps/api/alembic/versions/20260324_0034_memory_agent_profile_scope.py`
+- `apps/api/src/alicebot_api/store.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/compiler.py`
+- `apps/api/src/alicebot_api/memory.py`
+- `apps/api/src/alicebot_api/phase3_profiles.py`
 
-### Task 2: Chat Data Loading + Fallback
+### Task 2: Verification
 Owner: tooling operative  
 Write scope:
-- `apps/web/app/chat/page.tsx`
-- `apps/web/app/chat/page.test.tsx`
+- `tests/unit/test_20260324_0033_agent_profile_registry.py`
+- `tests/unit/test_20260324_0034_memory_agent_profile_scope.py`
+- `tests/unit/test_memory.py`
+- `tests/unit/test_memory_store.py`
+- `tests/integration/test_context_compile.py`
+- `tests/integration/test_continuity_api.py`
+- `tests/integration/test_memory_review_api.py`
+- `tests/integration/test_responses_api.py`
+- `apps/api/src/alicebot_api/main.py`
 
-### Task 3: Thread UI Adoption
-Owner: tooling operative  
-Write scope:
-- `apps/web/components/thread-create.tsx`
-- `apps/web/components/thread-create.test.tsx`
-- `apps/web/components/thread-list.tsx`
-- `apps/web/components/thread-list.test.tsx`
-- `apps/web/components/thread-summary.tsx`
-- `apps/web/components/thread-summary.test.tsx`
-
-### Task 4: Integration Review
+### Task 3: Integration Review
 Owner: control tower  
 Responsibilities:
-- verify sprint stays web-adoption scoped
-- verify no backend rework or profile-registry duplication
+- verify sprint stays memory-scope isolation scoped
+- verify no provider/policy/orchestration expansion
 - verify validation matrix remains green
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact web contract/UI deltas for profile adoption
+- exact memory-profile-scope migration and compile isolation deltas
 - exact verification command outcomes
-- explicit deferred scope (routing, provider switching, orchestration)
+- explicit deferred scope (policy/provider/orchestration/profile CRUD)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint stayed bounded to web profile adoption
-- profile selection and visibility are correct and deterministic
-- fallback behavior is explicit and non-breaking
+- sprint stayed bounded to memory/context profile isolation
+- memory profile attribution and scoped compile behavior are correct and deterministic
+- API behavior remains backward-compatible
 - no hidden scope expansion
 
 ## Exit Condition
 
-This sprint is complete when the shipped Phase 3 profile backbone is fully adopted in the web chat operator surface (selection + visibility + tests) with deterministic fallback behavior and all required validation gates green.
+This sprint is complete when context memory selection is profile-scoped and deterministic for the active thread profile, with migration/test evidence and all validation gates green.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,92 +1,111 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Adopt Phase 3 Sprint 1 profile seams in the web operator shell by wiring `agent_profile_id` and `/v0/agent-profiles` into chat loading, thread creation, and thread review visibility while keeping backend scope unchanged.
+Phase 3 Sprint 5: Profile-Scoped Memory and Context Isolation.
+
+Implement durable profile attribution on memory rows and enforce profile-scoped memory behavior across compile/response and admission paths, while preserving deterministic `assistant_default` fallback when attribution is omitted.
 
 ## Completed Work
-- Web API contract adoption (`apps/web/lib/api.ts`):
-  - Extended `ThreadItem` with `agent_profile_id`.
-  - Extended `ThreadCreatePayload` with `agent_profile_id`.
-  - Added `DEFAULT_AGENT_PROFILE_ID` constant (`assistant_default`).
-  - Added profile registry types:
-    - `AgentProfileItem`
-    - `AgentProfileListSummary`
-  - Added `listAgentProfiles(apiBaseUrl)` for `GET /v0/agent-profiles`.
-- API/contract tests (`apps/web/lib/api.test.ts`):
-  - Verified thread create payload now includes `agent_profile_id`.
-  - Verified list/detail reads retain `agent_profile_id`.
-  - Verified profile registry read path hits `/v0/agent-profiles` and returns deterministic ids.
-- Fixture contract adoption (`apps/web/lib/fixtures.ts`):
-  - Added `agent_profile_id` to thread fixtures.
-  - Added deterministic profile fixtures (`assistant_default`, `coach_default`).
-  - Ensured fixture thread creation defaults to `assistant_default`.
-- Chat loading + fallback (`apps/web/app/chat/page.tsx`):
-  - Added live profile registry load via `listAgentProfiles`.
-  - Added deterministic fallback to fixture profile registry when live read fails.
-  - Normalized thread profile ids to explicit default (`assistant_default`) when missing.
-  - Passed profile registry into thread create/list/summary surfaces.
-- Chat page tests (`apps/web/app/chat/page.test.tsx`):
-  - Added profile registry mock coverage.
-  - Added explicit test for live profile read failure fallback while `/chat` remains usable.
-- Thread create UI adoption (`apps/web/components/thread-create.tsx`):
-  - Added profile selector to thread creation form.
-  - Submitted selected `agent_profile_id` with `user_id` and `title`.
-  - Preserved deterministic `assistant_default` fallback when profile list is unavailable.
-- Thread create tests (`apps/web/components/thread-create.test.tsx`):
-  - Verified selected profile id is sent in create payload.
-  - Verified deterministic default payload uses `assistant_default` without profile data.
-- Thread list visibility (`apps/web/components/thread-list.tsx`):
-  - Added visible profile badge per thread row.
-- Thread list tests (`apps/web/components/thread-list.test.tsx`):
-  - Verified profile identity rendering in thread rows.
-- Thread summary visibility (`apps/web/components/thread-summary.tsx`):
-  - Added visible selected-thread profile identity (badge + summary field).
-- Thread summary tests (`apps/web/components/thread-summary.test.tsx`):
-  - Verified profile identity rendering in selected-thread summary.
+- Carried forward required Sprint 4 registry baseline not yet present on `main`:
+- migration `20260324_0033_agent_profile_registry`
+- DB-backed profile registry runtime wiring in `phase3_profiles.py`
+- continuity integration coverage updates that match DB-backed registry behavior
+- Added migration `20260324_0034_memory_agent_profile_scope`:
+- Added `memories.agent_profile_id text NOT NULL DEFAULT 'assistant_default'`.
+- Added FK `memories_agent_profile_id_fkey` -> `agent_profiles(id)`.
+- Replaced global memory-key uniqueness with profile-scoped uniqueness:
+- dropped `memories_user_id_memory_key_key`
+- added `memories_user_profile_memory_key_key` on `(user_id, agent_profile_id, memory_key)`
+- Added deterministic retrieval index `memories_user_profile_updated_created_id_idx` on `(user_id, agent_profile_id, updated_at, created_at, id)`.
+- Hardened downgrade safety:
+- before restoring `UNIQUE (user_id, memory_key)`, downgrade deterministically rewrites only duplicate cross-profile keys (ranked suffix strategy) so rollback does not fail on post-upgrade cross-profile duplicates.
+- Updated store wiring:
+- `create_memory(..., agent_profile_id='assistant_default')`
+- `get_memory_by_key_and_profile(memory_key, agent_profile_id)`
+- `list_context_memories_for_profile(agent_profile_id=...)`
+- `retrieve_semantic_memory_matches_for_profile(..., agent_profile_id=...)`
+- Updated memory admission write path (`memory.py`):
+- derives profile domain from `source_event_ids` -> source event threads -> thread `agent_profile_id`
+- validates optional explicit `agent_profile_id` (when provided) and enforces consistency with derived source profile
+- rejects mixed-profile `source_event_ids` deterministically
+- scopes upsert lookup by profile (`memory_key + agent_profile_id`)
+- persists new rows with resolved profile attribution
+- includes resolved profile in revision candidate payload
+- Updated API contract/request plumbing:
+- `MemoryCandidateInput` supports optional `agent_profile_id`
+- `/v0/memories/admit` request supports optional `agent_profile_id` and passes through
+- Kept compile/response profile-scoped read behavior in place and verified:
+- compile memory retrieval remains bounded to active thread profile
+- semantic retrieval in compile remains bounded to active thread profile
+- Added/updated tests:
+- `tests/unit/test_20260324_0034_memory_agent_profile_scope.py` (migration invariants including profile-scoped uniqueness)
+- `tests/unit/test_memory.py` (admission profile-scoped upsert + mixed-profile rejection)
+- `tests/unit/test_memory_store.py` (store SQL/params expectations after profile column exposure)
+- `tests/integration/test_memory_review_api.py`:
+- same `memory_key` admitted from assistant/coach threads persists separately by profile
+- mixed-profile source event set is rejected
+- explicit `agent_profile_id` mismatch is rejected
+- unknown `agent_profile_id` is rejected
+- Existing compile/response isolation tests continue passing
 
 ## Incomplete Work
-- None within sprint scope.
+- None within sprint objective.
 
 ## Files Changed
-- `.ai/active/SPRINT_PACKET.md` (pre-existing sprint packet update in workspace; not modified for implementation logic)
-- `apps/web/lib/api.ts`
-- `apps/web/lib/api.test.ts`
-- `apps/web/lib/fixtures.ts`
-- `apps/web/app/chat/page.tsx`
-- `apps/web/app/chat/page.test.tsx`
-- `apps/web/components/thread-create.tsx`
-- `apps/web/components/thread-create.test.tsx`
-- `apps/web/components/thread-list.tsx`
-- `apps/web/components/thread-list.test.tsx`
-- `apps/web/components/thread-summary.tsx`
-- `apps/web/components/thread-summary.test.tsx`
+- `apps/api/alembic/versions/20260324_0033_agent_profile_registry.py`
+- `apps/api/alembic/versions/20260324_0034_memory_agent_profile_scope.py`
+- `apps/api/src/alicebot_api/store.py`
+- `apps/api/src/alicebot_api/compiler.py`
+- `apps/api/src/alicebot_api/memory.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/phase3_profiles.py`
+- `tests/unit/test_20260324_0033_agent_profile_registry.py`
+- `tests/unit/test_20260324_0034_memory_agent_profile_scope.py`
+- `tests/unit/test_memory.py`
+- `tests/unit/test_memory_store.py`
+- `tests/integration/test_context_compile.py`
+- `tests/integration/test_continuity_api.py`
+- `tests/integration/test_memory_review_api.py`
+- `tests/integration/test_responses_api.py`
+- `.ai/active/SPRINT_PACKET.md`
 - `BUILD_REPORT.md`
+- `REVIEW_REPORT.md`
+
+## Scope Hygiene
+- Sprint branch includes Sprint 5 memory-scope work plus the minimal Sprint 4 registry baseline required for migration/runtime coherence on a `main` base that does not yet contain Sprint 4.
+- No additional scope expansion entered beyond that prerequisite baseline and Sprint 5 targets.
 
 ## Tests Run
-1. `npm --prefix apps/web run test -- lib/api.test.ts app/chat/page.test.tsx components/thread-create.test.tsx components/thread-list.test.tsx components/thread-summary.test.tsx`
-- Outcome: PASS (`5` files, `36` tests).
+1. `./.venv/bin/python -m pytest tests/unit/test_20260324_0033_agent_profile_registry.py -q`
+- PASS (`3 passed`)
 
-2. `npm --prefix apps/web run test:mvp:validation-matrix`
-- Outcome: PASS (`13` files, `65` tests).
+2. `./.venv/bin/python -m pytest tests/unit/test_20260324_0034_memory_agent_profile_scope.py -q`
+- PASS (`4 passed`)
 
-3. `python3 scripts/run_phase2_validation_matrix.py`
-- Initial sandbox run: blocked on local Postgres access (`localhost:5432 Operation not permitted`).
-- Elevated rerun outcome: PASS.
-- Gate summary:
-  - `control_doc_truth: PASS`
-  - `gate_contract_tests: PASS`
-  - `readiness_gates: PASS`
-  - `backend_integration_matrix: PASS`
-  - `web_validation_matrix: PASS`
+3. `./.venv/bin/python -m pytest tests/unit/test_memory.py -q`
+- PASS (`23 passed`)
+
+4. `./.venv/bin/python -m pytest tests/unit/test_memory_store.py tests/unit/test_20260324_0034_memory_agent_profile_scope.py -q`
+- PASS (`10 passed`)
+
+5. `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py -q`
+- PASS (`7 passed`)
+
+6. `./.venv/bin/python -m pytest tests/integration/test_context_compile.py tests/integration/test_responses_api.py tests/integration/test_memory_review_api.py -q`
+- PASS (`30 passed`)
+
+7. `python3 scripts/run_phase2_validation_matrix.py`
+- PASS
+- `control_doc_truth: PASS`
+- `gate_contract_tests: PASS`
+- `readiness_gates: PASS`
+- `backend_integration_matrix: PASS`
+- `web_validation_matrix: PASS`
 
 ## Blockers/Issues
-- Sandbox permissions blocked DB-backed validation matrix execution on first run.
-- Resolved by rerunning with elevated local access; no code blocker remained.
-
-## Explicit Deferred Scope
-- Per-profile model routing or provider switching.
-- Worker/runner orchestration changes.
-- Backend profile CRUD expansion.
+- Sandbox networking blocked localhost Postgres access for DB-backed tests.
+- Resolved by running required DB-backed commands with elevated permissions.
 
 ## Recommended Next Step
-1. Hand off to Control Tower review focused on: profile selection correctness, thread profile visibility, and fallback determinism under live profile registry failure.
+1. Control Tower final review and merge for Phase 3 Sprint 5 with emphasis on migration rollout sequencing and profile-domain admission semantics.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,34 +4,34 @@
 PASS
 
 ## criteria met
-- Thread creation in live mode now submits `agent_profile_id` with `user_id` and `title` (verified in `apps/web/components/thread-create.tsx` and `apps/web/components/thread-create.test.tsx`).
-- Web thread contracts and read paths retain `agent_profile_id` across create/list/detail (`apps/web/lib/api.ts`, `apps/web/lib/api.test.ts`, `apps/web/app/chat/page.tsx`).
-- `/chat` performs live `GET /v0/agent-profiles` reads and remains usable when that read fails (fixture fallback path verified in `apps/web/app/chat/page.tsx` and `apps/web/app/chat/page.test.tsx`).
-- Thread profile identity is visibly rendered in both list and selected-thread summary surfaces (`apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`).
-- Fixture-mode behavior remains deterministic, including explicit `assistant_default` fallback when profile selection data is unavailable (`apps/web/lib/fixtures.ts`, `apps/web/components/thread-create.tsx`, `apps/web/app/chat/page.tsx`).
-- Required validation gates are green:
-  - `npm --prefix apps/web run test:mvp:validation-matrix` -> PASS
-  - `python3 scripts/run_phase2_validation_matrix.py` -> PASS (rerun with elevated local DB access)
-- Sprint scope stayed bounded to web profile adoption; no backend/API/migration implementation changes detected.
+- Admission profile scope is enforced end-to-end:
+- derives profile from `source_event_ids` thread context ([memory.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/memory.py:574)).
+- rejects mixed-profile source events deterministically ([memory.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/memory.py:592)).
+- validates explicit `agent_profile_id` for existence + source-profile consistency ([memory.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/memory.py:599)).
+- Admission upsert is profile-scoped by `(memory_key, agent_profile_id)` ([memory.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/memory.py:775), [store.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/store.py:748)).
+- Schema isolation is in place (`UNIQUE (user_id, agent_profile_id, memory_key)`) and downgrade now handles cross-profile duplicates before restoring legacy uniqueness ([20260324_0034_memory_agent_profile_scope.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/alembic/versions/20260324_0034_memory_agent_profile_scope.py:28), [20260324_0034_memory_agent_profile_scope.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/alembic/versions/20260324_0034_memory_agent_profile_scope.py:39)).
+- Branch diff is Sprint 5 scoped plus required Sprint 4 registry prerequisite files needed because `main` does not yet include Sprint 4.
+- Added direct admission-path negative coverage for explicit profile mismatch and unknown profile:
+- unit: [test_memory.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_memory.py:501)
+- integration: [test_memory_review_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_memory_review_api.py:537)
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking quality or safety issues found in the in-scope implementation.
+- None blocking for sprint scope.
 
 ## regression risks
-- Low risk: if backend profile IDs expand while fixture profile seeds lag, labels in fallback/profile-name mapping may degrade to raw IDs until fixture registry is updated.
+- Low. Profile-scoped admission/read behavior and rollback guards are covered by unit, integration, and matrix gates.
 
 ## docs issues
-- `BUILD_REPORT.md` is present, scoped to this sprint, includes verification outcomes, and explicitly states deferred scope.
+- None. `BUILD_REPORT.md` documents Sprint 5 scope and required Sprint 4 prerequisite carry-forward.
 
 ## should anything be added to RULES.md?
-- No.
+- Optional: keep a standing rule that profile-scope admission changes must include explicit negative-path tests for profile mismatch/invalid profile IDs.
 
 ## should anything update ARCHITECTURE.md?
-- No architecture update is required for this sprint; this is a web adoption of an already-shipped backend seam.
+- Optional: codify downgrade duplicate-key rewrite behavior for profile-domain memory keys during rollback.
 
 ## recommended next action
-1. Proceed to Control Tower merge review for Phase 3 Sprint 2.
-2. Optionally add a small non-blocking test for unknown profile-ID display fallback (raw ID rendering) to harden future profile-registry drift behavior.
+1. Proceed to Control Tower final merge review for Phase 3 Sprint 5.

--- a/apps/api/alembic/versions/20260324_0033_agent_profile_registry.py
+++ b/apps/api/alembic/versions/20260324_0033_agent_profile_registry.py
@@ -1,0 +1,80 @@
+"""Create durable agent profile registry and bind thread profile FK."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260324_0033"
+down_revision = "20260324_0032"
+branch_labels = None
+depends_on = None
+
+AGENT_PROFILE_SEED_ROWS = (
+    (
+        "assistant_default",
+        "Assistant Default",
+        "General-purpose assistant profile for baseline conversations.",
+    ),
+    (
+        "coach_default",
+        "Coach Default",
+        "Coaching-oriented profile focused on guidance and accountability.",
+    ),
+)
+
+AGENT_PROFILE_IDS = tuple(profile_id for profile_id, *_ in AGENT_PROFILE_SEED_ROWS)
+_AGENT_PROFILE_IDS_SQL = ", ".join(f"'{value}'" for value in AGENT_PROFILE_IDS)
+_AGENT_PROFILE_SEED_VALUES_SQL = ", ".join(
+    f"('{profile_id}', '{name}', '{description}')"
+    for profile_id, name, description in AGENT_PROFILE_SEED_ROWS
+)
+
+_UPGRADE_STATEMENTS = (
+    """
+        CREATE TABLE agent_profiles (
+          id text PRIMARY KEY,
+          name text NOT NULL,
+          description text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          CONSTRAINT agent_profiles_id_nonempty_check
+            CHECK (char_length(id) > 0),
+          CONSTRAINT agent_profiles_name_nonempty_check
+            CHECK (char_length(name) > 0),
+          CONSTRAINT agent_profiles_description_nonempty_check
+            CHECK (char_length(description) > 0)
+        )
+        """,
+    f"""
+        INSERT INTO agent_profiles (id, name, description)
+        VALUES {_AGENT_PROFILE_SEED_VALUES_SQL}
+        """,
+    "GRANT SELECT ON agent_profiles TO alicebot_app",
+    "ALTER TABLE threads DROP CONSTRAINT IF EXISTS threads_agent_profile_id_check",
+    """
+        ALTER TABLE threads
+          ADD CONSTRAINT threads_agent_profile_id_fkey
+          FOREIGN KEY (agent_profile_id)
+          REFERENCES agent_profiles(id)
+        """,
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "ALTER TABLE threads DROP CONSTRAINT IF EXISTS threads_agent_profile_id_fkey",
+    f"""
+        ALTER TABLE threads
+          ADD CONSTRAINT threads_agent_profile_id_check
+          CHECK (agent_profile_id IN ({_AGENT_PROFILE_IDS_SQL}))
+        """,
+    "DROP TABLE IF EXISTS agent_profiles",
+)
+
+
+def upgrade() -> None:
+    for statement in _UPGRADE_STATEMENTS:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    for statement in _DOWNGRADE_STATEMENTS:
+        op.execute(statement)

--- a/apps/api/alembic/versions/20260324_0034_memory_agent_profile_scope.py
+++ b/apps/api/alembic/versions/20260324_0034_memory_agent_profile_scope.py
@@ -1,0 +1,87 @@
+"""Scope memory records to durable agent profiles."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260324_0034"
+down_revision = "20260324_0033"
+branch_labels = None
+depends_on = None
+
+DEFAULT_AGENT_PROFILE_ID = "assistant_default"
+
+_UPGRADE_STATEMENTS = (
+    f"""
+        ALTER TABLE memories
+          ADD COLUMN agent_profile_id text NOT NULL DEFAULT '{DEFAULT_AGENT_PROFILE_ID}'
+        """,
+    """
+        ALTER TABLE memories
+          ADD CONSTRAINT memories_agent_profile_id_fkey
+          FOREIGN KEY (agent_profile_id)
+          REFERENCES agent_profiles(id)
+        """,
+    "ALTER TABLE memories DROP CONSTRAINT IF EXISTS memories_user_id_memory_key_key",
+    """
+        ALTER TABLE memories
+          ADD CONSTRAINT memories_user_profile_memory_key_key
+          UNIQUE (user_id, agent_profile_id, memory_key)
+        """,
+    """
+        CREATE INDEX memories_user_profile_updated_created_id_idx
+          ON memories (user_id, agent_profile_id, updated_at, created_at, id)
+        """,
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP INDEX IF EXISTS memories_user_profile_updated_created_id_idx",
+    "ALTER TABLE memories DROP CONSTRAINT IF EXISTS memories_user_profile_memory_key_key",
+    """
+        WITH ranked_memories AS (
+          SELECT
+            id,
+            user_id,
+            memory_key,
+            agent_profile_id,
+            ROW_NUMBER() OVER (
+              PARTITION BY user_id, memory_key
+              ORDER BY
+                CASE
+                  WHEN agent_profile_id = 'assistant_default' THEN 0
+                  ELSE 1
+                END ASC,
+                created_at ASC,
+                id ASC
+            ) AS duplicate_rank
+          FROM memories
+        )
+        UPDATE memories
+        SET memory_key = ranked_memories.memory_key
+          || '#profile:'
+          || ranked_memories.agent_profile_id
+          || '#'
+          || ranked_memories.id::text
+        FROM ranked_memories
+        WHERE memories.id = ranked_memories.id
+          AND ranked_memories.duplicate_rank > 1
+        """,
+    """
+        ALTER TABLE memories
+          ADD CONSTRAINT memories_user_id_memory_key_key
+          UNIQUE (user_id, memory_key)
+        """,
+    "ALTER TABLE memories DROP CONSTRAINT IF EXISTS memories_agent_profile_id_fkey",
+    "ALTER TABLE memories DROP COLUMN IF EXISTS agent_profile_id",
+)
+
+
+def upgrade() -> None:
+    for statement in _UPGRADE_STATEMENTS:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    for statement in _DOWNGRADE_STATEMENTS:
+        op.execute(statement)

--- a/apps/api/src/alicebot_api/compiler.py
+++ b/apps/api/src/alicebot_api/compiler.py
@@ -94,6 +94,7 @@ HYBRID_ARTIFACT_MERGED_ORDER = [
     "sequence_no_asc",
     "id_asc",
 ]
+DEFAULT_AGENT_PROFILE_ID = "assistant_default"
 
 
 @dataclass(frozen=True, slots=True)
@@ -165,6 +166,52 @@ def _serialize_thread(thread: ThreadRow) -> dict[str, str]:
         "created_at": thread["created_at"].isoformat(),
         "updated_at": thread["updated_at"].isoformat(),
     }
+
+
+def _resolve_thread_agent_profile_id(thread: ThreadRow) -> str:
+    return str(thread.get("agent_profile_id", DEFAULT_AGENT_PROFILE_ID))
+
+
+def _list_context_memories_for_profile(
+    store: ContinuityStore,
+    *,
+    agent_profile_id: str,
+) -> list[MemoryRow]:
+    list_for_profile = getattr(store, "list_context_memories_for_profile", None)
+    if callable(list_for_profile):
+        return list_for_profile(agent_profile_id=agent_profile_id)
+    return [
+        memory
+        for memory in store.list_context_memories()
+        if str(memory.get("agent_profile_id", DEFAULT_AGENT_PROFILE_ID)) == agent_profile_id
+    ]
+
+
+def _retrieve_semantic_memory_matches_for_profile(
+    store: ContinuityStore,
+    *,
+    embedding_config_id: UUID,
+    query_vector: list[float],
+    limit: int,
+    agent_profile_id: str,
+) -> list[SemanticMemoryRetrievalRow]:
+    retrieve_for_profile = getattr(store, "retrieve_semantic_memory_matches_for_profile", None)
+    if callable(retrieve_for_profile):
+        return retrieve_for_profile(
+            embedding_config_id=embedding_config_id,
+            query_vector=query_vector,
+            limit=limit,
+            agent_profile_id=agent_profile_id,
+        )
+    return [
+        memory
+        for memory in store.retrieve_semantic_memory_matches(
+            embedding_config_id=embedding_config_id,
+            query_vector=query_vector,
+            limit=limit,
+        )
+        if str(memory.get("agent_profile_id", DEFAULT_AGENT_PROFILE_ID)) == agent_profile_id
+    ]
 
 
 def _serialize_session(session: SessionRow) -> dict[str, str | None]:
@@ -618,6 +665,7 @@ def _compile_memory_section(
     store: ContinuityStore,
     *,
     memories: list[MemoryRow],
+    agent_profile_id: str,
     limits: ContextCompilerLimits,
     semantic_retrieval: CompileContextSemanticRetrievalInput | None,
 ) -> CompiledMemorySection:
@@ -637,10 +685,12 @@ def _compile_memory_section(
     )
     _config, query_vector = validate_semantic_memory_retrieval_request(store, request=request)
     ordered_semantic_candidates = sorted(
-        store.retrieve_semantic_memory_matches(
+        _retrieve_semantic_memory_matches_for_profile(
+            store,
             embedding_config_id=semantic_retrieval.embedding_config_id,
             query_vector=query_vector,
             limit=_UNBOUNDED_SEMANTIC_RETRIEVAL_LIMIT,
+            agent_profile_id=agent_profile_id,
         ),
         key=_semantic_memory_sort_key,
     )
@@ -1301,6 +1351,7 @@ def compile_resumption_brief(
     bounded_event_limit = max(0, event_limit)
     bounded_open_loop_limit = max(0, open_loop_limit)
     bounded_memory_limit = max(0, memory_limit)
+    agent_profile_id = _resolve_thread_agent_profile_id(thread)
 
     conversation_kinds = frozenset(RESUMPTION_BRIEF_CONVERSATION_EVENT_KINDS)
     ordered_conversation_events = [
@@ -1337,7 +1388,14 @@ def compile_resumption_brief(
     }
 
     ordered_memories = sorted(
-        [memory for memory in store.list_context_memories() if memory["status"] == "active"],
+        [
+            memory
+            for memory in _list_context_memories_for_profile(
+                store,
+                agent_profile_id=agent_profile_id,
+            )
+            if memory["status"] == "active"
+        ],
         key=_memory_sort_key,
     )
     included_memories = ordered_memories[-bounded_memory_limit:] if bounded_memory_limit > 0 else []
@@ -1725,13 +1783,15 @@ def compile_and_persist_trace(
 ) -> CompiledTraceRun:
     user = store.get_user(user_id)
     thread = store.get_thread(thread_id)
+    agent_profile_id = _resolve_thread_agent_profile_id(thread)
     sessions = store.list_thread_sessions(thread_id)
     events = store.list_thread_events(thread_id)
-    memories = store.list_context_memories()
+    memories = _list_context_memories_for_profile(store, agent_profile_id=agent_profile_id)
     open_loops = store.list_open_loops(status="open")
     memory_section = _compile_memory_section(
         store,
         memories=memories,
+        agent_profile_id=agent_profile_id,
         limits=limits,
         semantic_retrieval=semantic_retrieval,
     )

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -1013,6 +1013,7 @@ class MemoryCandidateInput:
     memory_key: str
     value: JsonValue | None
     source_event_ids: tuple[UUID, ...]
+    agent_profile_id: str | None = None
     delete_requested: bool = False
     memory_type: str | None = None
     confidence: float | None = None
@@ -1029,6 +1030,8 @@ class MemoryCandidateInput:
             "source_event_ids": [str(source_event_id) for source_event_id in self.source_event_ids],
             "delete_requested": self.delete_requested,
         }
+        if self.agent_profile_id is not None:
+            payload["agent_profile_id"] = self.agent_profile_id
         payload["value"] = self.value
         if self.memory_type is not None:
             payload["memory_type"] = self.memory_type

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -7,6 +7,8 @@ from fastapi import FastAPI, Query
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from fastapi.responses import JSONResponse
+import psycopg
+from psycopg.rows import dict_row
 from urllib.parse import urlsplit, urlunsplit
 
 from alicebot_api.compiler import compile_and_persist_trace, compile_resumption_brief
@@ -481,6 +483,7 @@ class AdmitMemoryRequest(BaseModel):
     memory_key: str = Field(min_length=1, max_length=200)
     value: object | None = None
     source_event_ids: list[UUID] = Field(min_length=1)
+    agent_profile_id: str | None = Field(default=None, min_length=1, max_length=100)
     delete_requested: bool = False
     memory_type: str | None = Field(default=None, min_length=1, max_length=100)
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
@@ -900,7 +903,9 @@ def healthcheck() -> JSONResponse:
 
 @app.get("/v0/agent-profiles")
 def list_agent_profiles() -> JSONResponse:
-    items = list_registered_agent_profiles()
+    settings = get_settings()
+    with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+        items = list_registered_agent_profiles(ContinuityStore(conn))
     summary: AgentProfileListSummary = {
         "total_count": len(items),
         "order": list(AGENT_PROFILE_LIST_ORDER),
@@ -1062,28 +1067,30 @@ def create_thread(request: CreateThreadRequest) -> JSONResponse:
         if request.agent_profile_id is not None
         else DEFAULT_AGENT_PROFILE_ID
     )
-    if get_registered_agent_profile(agent_profile_id) is None:
-        allowed_agent_profile_ids = list_registered_agent_profile_ids()
-        return JSONResponse(
-            status_code=422,
-            content={
-                "detail": {
-                    "code": "invalid_agent_profile_id",
-                    "message": (
-                        "agent_profile_id must be one of: "
-                        + ", ".join(allowed_agent_profile_ids)
-                    ),
-                    "allowed_agent_profile_ids": allowed_agent_profile_ids,
-                }
-            },
-        )
     thread_input = ThreadCreateInput(
         title=request.title,
         agent_profile_id=agent_profile_id,
     )
 
     with user_connection(settings.database_url, request.user_id) as conn:
-        created = ContinuityStore(conn).create_thread(
+        store = ContinuityStore(conn)
+        if get_registered_agent_profile(store, agent_profile_id) is None:
+            allowed_agent_profile_ids = list_registered_agent_profile_ids(store)
+            return JSONResponse(
+                status_code=422,
+                content={
+                    "detail": {
+                        "code": "invalid_agent_profile_id",
+                        "message": (
+                            "agent_profile_id must be one of: "
+                            + ", ".join(allowed_agent_profile_ids)
+                        ),
+                        "allowed_agent_profile_ids": allowed_agent_profile_ids,
+                    }
+                },
+            )
+
+        created = store.create_thread(
             thread_input.title,
             thread_input.agent_profile_id,
         )
@@ -1302,6 +1309,7 @@ def admit_memory(request: AdmitMemoryRequest) -> JSONResponse:
                     memory_key=request.memory_key,
                     value=request.value,
                     source_event_ids=tuple(request.source_event_ids),
+                    agent_profile_id=request.agent_profile_id,
                     delete_requested=request.delete_requested,
                     memory_type=request.memory_type,
                     confidence=request.confidence,

--- a/apps/api/src/alicebot_api/memory.py
+++ b/apps/api/src/alicebot_api/memory.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from alicebot_api.contracts import (
     AdmissionDecisionOutput,
+    DEFAULT_AGENT_PROFILE_ID,
     DEFAULT_MEMORY_CONFIRMATION_STATUS,
     DEFAULT_MEMORY_TYPE,
     DEFAULT_MEMORY_REVIEW_LIMIT,
@@ -53,6 +54,7 @@ from alicebot_api.contracts import (
 )
 from alicebot_api.store import (
     ContinuityStore,
+    EventRow,
     JsonObject,
     LabelCountRow,
     MemoryReviewLabelRow,
@@ -569,7 +571,56 @@ def _dedupe_source_event_ids(source_event_ids: tuple[UUID, ...]) -> tuple[UUID, 
     return tuple(deduped)
 
 
-def _validate_source_events(store: ContinuityStore, source_event_ids: tuple[UUID, ...]) -> list[str]:
+def _resolve_agent_profile_id_from_source_events(
+    store: ContinuityStore,
+    *,
+    source_events: list[EventRow],
+) -> str:
+    thread_ids = sorted({event["thread_id"] for event in source_events}, key=str)
+    if not thread_ids:
+        return DEFAULT_AGENT_PROFILE_ID
+
+    resolved_profile_ids: set[str] = set()
+    for thread_id in thread_ids:
+        thread = store.get_thread_optional(thread_id)
+        if thread is None:
+            raise MemoryAdmissionValidationError(
+                f"source_event thread {thread_id} was not found"
+            )
+        resolved_profile_ids.add(str(thread.get("agent_profile_id", DEFAULT_AGENT_PROFILE_ID)))
+
+    if len(resolved_profile_ids) > 1:
+        raise MemoryAdmissionValidationError(
+            "source_event_ids must all belong to threads with the same agent_profile_id"
+        )
+    return next(iter(resolved_profile_ids))
+
+
+def _resolve_memory_agent_profile_id(
+    store: ContinuityStore,
+    *,
+    candidate: MemoryCandidateInput,
+    derived_agent_profile_id: str,
+) -> str:
+    candidate_profile_id = candidate.agent_profile_id
+    resolved_profile_id = (
+        derived_agent_profile_id if candidate_profile_id is None else candidate_profile_id
+    )
+    if store.get_agent_profile_optional(resolved_profile_id) is None:
+        raise MemoryAdmissionValidationError(
+            f"agent_profile_id must reference an existing profile: {resolved_profile_id}"
+        )
+    if candidate_profile_id is not None and candidate_profile_id != derived_agent_profile_id:
+        raise MemoryAdmissionValidationError(
+            "agent_profile_id must match the profile resolved from source_event_ids"
+        )
+    return resolved_profile_id
+
+
+def _validate_source_events(
+    store: ContinuityStore,
+    source_event_ids: tuple[UUID, ...],
+) -> tuple[list[str], str]:
     normalized_event_ids = _dedupe_source_event_ids(source_event_ids)
     if not normalized_event_ids:
         raise MemoryAdmissionValidationError(
@@ -587,11 +638,21 @@ def _validate_source_events(store: ContinuityStore, source_event_ids: tuple[UUID
             "source_event_ids must all reference existing events owned by the user: "
             + ", ".join(missing_event_ids)
         )
-    return [str(source_event_id) for source_event_id in normalized_event_ids]
+    derived_profile_id = _resolve_agent_profile_id_from_source_events(
+        store,
+        source_events=source_events,
+    )
+    return [str(source_event_id) for source_event_id in normalized_event_ids], derived_profile_id
 
 
-def _candidate_payload(candidate: MemoryCandidateInput) -> JsonObject:
-    return candidate.as_payload()
+def _candidate_payload(
+    candidate: MemoryCandidateInput,
+    *,
+    resolved_agent_profile_id: str,
+) -> JsonObject:
+    payload = candidate.as_payload()
+    payload["agent_profile_id"] = resolved_agent_profile_id
+    return payload
 
 
 def _create_open_loop_for_memory(
@@ -702,8 +763,19 @@ def admit_memory_candidate(
 ) -> AdmissionDecisionOutput:
     del user_id
 
-    source_event_ids = _validate_source_events(store, candidate.source_event_ids)
-    existing_memory = store.get_memory_by_key(candidate.memory_key)
+    source_event_ids, derived_agent_profile_id = _validate_source_events(
+        store,
+        candidate.source_event_ids,
+    )
+    agent_profile_id = _resolve_memory_agent_profile_id(
+        store,
+        candidate=candidate,
+        derived_agent_profile_id=derived_agent_profile_id,
+    )
+    existing_memory = store.get_memory_by_key_and_profile(
+        memory_key=candidate.memory_key,
+        agent_profile_id=agent_profile_id,
+    )
     resolved_metadata = _resolve_memory_typed_metadata(
         existing_memory=existing_memory,
         candidate=candidate,
@@ -745,7 +817,10 @@ def admit_memory_candidate(
             previous_value=existing_memory["value"],
             new_value=None,
             source_event_ids=source_event_ids,
-            candidate=_candidate_payload(candidate),
+            candidate=_candidate_payload(
+                candidate,
+                resolved_agent_profile_id=agent_profile_id,
+            ),
         )
         return AdmissionDecisionOutput(
             action="DELETE",
@@ -775,6 +850,7 @@ def admit_memory_candidate(
             valid_from=resolved_metadata["valid_from"],
             valid_to=resolved_metadata["valid_to"],
             last_confirmed_at=resolved_metadata["last_confirmed_at"],
+            agent_profile_id=agent_profile_id,
         )
         revision = store.append_memory_revision(
             memory_id=memory["id"],
@@ -783,7 +859,10 @@ def admit_memory_candidate(
             previous_value=None,
             new_value=candidate.value,
             source_event_ids=source_event_ids,
-            candidate=_candidate_payload(candidate),
+            candidate=_candidate_payload(
+                candidate,
+                resolved_agent_profile_id=agent_profile_id,
+            ),
         )
         return AdmissionDecisionOutput(
             action="ADD",
@@ -843,7 +922,10 @@ def admit_memory_candidate(
         previous_value=existing_memory["value"],
         new_value=candidate.value,
         source_event_ids=source_event_ids,
-        candidate=_candidate_payload(candidate),
+        candidate=_candidate_payload(
+            candidate,
+            resolved_agent_profile_id=agent_profile_id,
+        ),
     )
     return AdmissionDecisionOutput(
         action="UPDATE",

--- a/apps/api/src/alicebot_api/phase3_profiles.py
+++ b/apps/api/src/alicebot_api/phase3_profiles.py
@@ -1,55 +1,33 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from alicebot_api.contracts import AgentProfileRecord, DEFAULT_AGENT_PROFILE_ID
+from alicebot_api.store import ContinuityStore
 
 
-@dataclass(frozen=True, slots=True)
-class AgentProfileDefinition:
-    profile_id: str
-    name: str
-    description: str
-
-    def as_record(self) -> AgentProfileRecord:
-        return {
-            "id": self.profile_id,
-            "name": self.name,
-            "description": self.description,
+def list_agent_profiles(store: ContinuityStore) -> list[AgentProfileRecord]:
+    return [
+        {
+            "id": profile["id"],
+            "name": profile["name"],
+            "description": profile["description"],
         }
+        for profile in store.list_agent_profiles()
+    ]
 
 
-_PHASE3_PROFILE_REGISTRY: tuple[AgentProfileDefinition, ...] = (
-    AgentProfileDefinition(
-        profile_id="assistant_default",
-        name="Assistant Default",
-        description="General-purpose assistant profile for baseline conversations.",
-    ),
-    AgentProfileDefinition(
-        profile_id="coach_default",
-        name="Coach Default",
-        description="Coaching-oriented profile focused on guidance and accountability.",
-    ),
-)
-
-_PHASE3_PROFILE_LOOKUP: dict[str, AgentProfileDefinition] = {
-    profile.profile_id: profile for profile in _PHASE3_PROFILE_REGISTRY
-}
+def list_agent_profile_ids(store: ContinuityStore) -> list[str]:
+    return [profile["id"] for profile in store.list_agent_profiles()]
 
 
-def list_agent_profiles() -> list[AgentProfileRecord]:
-    return [profile.as_record() for profile in _PHASE3_PROFILE_REGISTRY]
-
-
-def list_agent_profile_ids() -> list[str]:
-    return [profile.profile_id for profile in _PHASE3_PROFILE_REGISTRY]
-
-
-def get_agent_profile(profile_id: str) -> AgentProfileRecord | None:
-    profile = _PHASE3_PROFILE_LOOKUP.get(profile_id)
+def get_agent_profile(store: ContinuityStore, profile_id: str) -> AgentProfileRecord | None:
+    profile = store.get_agent_profile_optional(profile_id)
     if profile is None:
         return None
-    return profile.as_record()
+    return {
+        "id": profile["id"],
+        "name": profile["name"],
+        "description": profile["description"],
+    }
 
 
 def get_default_agent_profile_id() -> str:

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -29,6 +29,12 @@ class ThreadRow(TypedDict):
     updated_at: datetime
 
 
+class AgentProfileRow(TypedDict):
+    id: str
+    name: str
+    description: str
+
+
 class SessionRow(TypedDict):
     id: UUID
     user_id: UUID
@@ -86,6 +92,7 @@ class TraceReviewRow(TypedDict):
 class MemoryRow(TypedDict):
     id: UUID
     user_id: UUID
+    agent_profile_id: str
     memory_key: str
     value: JsonValue
     status: str
@@ -165,6 +172,7 @@ class MemoryEmbeddingRow(TypedDict):
 class SemanticMemoryRetrievalRow(TypedDict):
     id: UUID
     user_id: UUID
+    agent_profile_id: str
     memory_key: str
     value: JsonValue
     status: str
@@ -476,6 +484,18 @@ LIST_THREADS_SQL = """
                 ORDER BY created_at DESC, id DESC
                 """
 
+LIST_AGENT_PROFILES_SQL = """
+                SELECT id, name, description
+                FROM agent_profiles
+                ORDER BY id ASC
+                """
+
+GET_AGENT_PROFILE_SQL = """
+                SELECT id, name, description
+                FROM agent_profiles
+                WHERE id = %s
+                """
+
 INSERT_SESSION_SQL = """
                 INSERT INTO sessions (user_id, thread_id, status)
                 VALUES (app.current_user_id(), %s, %s)
@@ -614,11 +634,13 @@ INSERT_MEMORY_SQL = """
                   valid_from,
                   valid_to,
                   last_confirmed_at,
+                  agent_profile_id,
                   created_at,
                   updated_at
                 )
                 VALUES (
                   app.current_user_id(),
+                  %s,
                   %s,
                   %s,
                   %s,
@@ -636,6 +658,7 @@ INSERT_MEMORY_SQL = """
                 RETURNING
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -656,6 +679,7 @@ GET_MEMORY_SQL = """
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -678,6 +702,7 @@ LIST_MEMORIES_BY_IDS_SQL = """
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -701,6 +726,7 @@ GET_MEMORY_BY_KEY_SQL = """
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -719,10 +745,35 @@ GET_MEMORY_BY_KEY_SQL = """
                 WHERE memory_key = %s
                 """
 
+GET_MEMORY_BY_KEY_AND_PROFILE_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  agent_profile_id,
+                  memory_key,
+                  value,
+                  status,
+                  source_event_ids,
+                  memory_type,
+                  confidence,
+                  salience,
+                  confirmation_status,
+                  valid_from,
+                  valid_to,
+                  last_confirmed_at,
+                  created_at,
+                  updated_at,
+                  deleted_at
+                FROM memories
+                WHERE memory_key = %s
+                  AND agent_profile_id = %s
+                """
+
 LIST_MEMORIES_SQL = """
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -767,6 +818,7 @@ LIST_REVIEW_MEMORIES_SQL = """
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -790,6 +842,7 @@ LIST_REVIEW_MEMORIES_BY_STATUS_SQL = """
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -814,6 +867,7 @@ LIST_UNLABELED_REVIEW_MEMORIES_SQL = """
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -843,6 +897,7 @@ LIST_CONTEXT_MEMORIES_SQL = """
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -858,6 +913,30 @@ LIST_CONTEXT_MEMORIES_SQL = """
                   updated_at,
                   deleted_at
                 FROM memories
+                ORDER BY updated_at ASC, created_at ASC, id ASC
+                """
+
+LIST_CONTEXT_MEMORIES_FOR_PROFILE_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  agent_profile_id,
+                  memory_key,
+                  value,
+                  status,
+                  source_event_ids,
+                  memory_type,
+                  confidence,
+                  salience,
+                  confirmation_status,
+                  valid_from,
+                  valid_to,
+                  last_confirmed_at,
+                  created_at,
+                  updated_at,
+                  deleted_at
+                FROM memories
+                WHERE agent_profile_id = %s
                 ORDER BY updated_at ASC, created_at ASC, id ASC
                 """
 
@@ -882,6 +961,7 @@ UPDATE_MEMORY_SQL = """
                 RETURNING
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -1304,6 +1384,7 @@ RETRIEVE_SEMANTIC_MEMORY_MATCHES_SQL = """
                 SELECT
                   memories.id,
                   memories.user_id,
+                  memories.agent_profile_id,
                   memories.memory_key,
                   memories.value,
                   memories.status,
@@ -1328,6 +1409,40 @@ RETRIEVE_SEMANTIC_MEMORY_MATCHES_SQL = """
                 WHERE memory_embeddings.embedding_config_id = %s
                   AND memory_embeddings.dimensions = %s
                   AND memories.status = 'active'
+                ORDER BY score DESC, memories.created_at ASC, memories.id ASC
+                LIMIT %s
+                """
+
+RETRIEVE_SEMANTIC_MEMORY_MATCHES_FOR_PROFILE_SQL = """
+                SELECT
+                  memories.id,
+                  memories.user_id,
+                  memories.agent_profile_id,
+                  memories.memory_key,
+                  memories.value,
+                  memories.status,
+                  memories.source_event_ids,
+                  memories.memory_type,
+                  memories.confidence,
+                  memories.salience,
+                  memories.confirmation_status,
+                  memories.valid_from,
+                  memories.valid_to,
+                  memories.last_confirmed_at,
+                  memories.created_at,
+                  memories.updated_at,
+                  memories.deleted_at,
+                  1 - (
+                    replace(memory_embeddings.vector::text, ' ', '')::vector <=> %s::vector
+                  ) AS score
+                FROM memory_embeddings
+                JOIN memories
+                  ON memories.id = memory_embeddings.memory_id
+                 AND memories.user_id = memory_embeddings.user_id
+                WHERE memory_embeddings.embedding_config_id = %s
+                  AND memory_embeddings.dimensions = %s
+                  AND memories.status = 'active'
+                  AND memories.agent_profile_id = %s
                 ORDER BY score DESC, memories.created_at ASC, memories.id ASC
                 LIMIT %s
                 """
@@ -3131,6 +3246,12 @@ class ContinuityStore:
     def list_threads(self) -> list[ThreadRow]:
         return self._fetch_all(LIST_THREADS_SQL)
 
+    def list_agent_profiles(self) -> list[AgentProfileRow]:
+        return self._fetch_all(LIST_AGENT_PROFILES_SQL)
+
+    def get_agent_profile_optional(self, profile_id: str) -> AgentProfileRow | None:
+        return self._fetch_optional_one(GET_AGENT_PROFILE_SQL, (profile_id,))
+
     def create_session(self, thread_id: UUID, status: str = "active") -> SessionRow:
         return self._fetch_one("create_session", INSERT_SESSION_SQL, (thread_id, status))
 
@@ -3223,6 +3344,7 @@ class ContinuityStore:
         valid_from: datetime | None = None,
         valid_to: datetime | None = None,
         last_confirmed_at: datetime | None = None,
+        agent_profile_id: str = "assistant_default",
     ) -> MemoryRow:
         return self._fetch_one(
             "create_memory",
@@ -3239,6 +3361,7 @@ class ContinuityStore:
                 valid_from,
                 valid_to,
                 last_confirmed_at,
+                agent_profile_id,
             ),
         )
 
@@ -3255,6 +3378,17 @@ class ContinuityStore:
 
     def get_memory_by_key(self, memory_key: str) -> MemoryRow | None:
         return self._fetch_optional_one(GET_MEMORY_BY_KEY_SQL, (memory_key,))
+
+    def get_memory_by_key_and_profile(
+        self,
+        *,
+        memory_key: str,
+        agent_profile_id: str,
+    ) -> MemoryRow | None:
+        return self._fetch_optional_one(
+            GET_MEMORY_BY_KEY_AND_PROFILE_SQL,
+            (memory_key, agent_profile_id),
+        )
 
     def list_memories(self) -> list[MemoryRow]:
         return self._fetch_all(LIST_MEMORIES_SQL)
@@ -3277,6 +3411,9 @@ class ContinuityStore:
 
     def list_context_memories(self) -> list[MemoryRow]:
         return self._fetch_all(LIST_CONTEXT_MEMORIES_SQL)
+
+    def list_context_memories_for_profile(self, *, agent_profile_id: str) -> list[MemoryRow]:
+        return self._fetch_all(LIST_CONTEXT_MEMORIES_FOR_PROFILE_SQL, (agent_profile_id,))
 
     def update_memory(
         self,
@@ -3555,6 +3692,25 @@ class ContinuityStore:
                 self._vector_literal(query_vector),
                 embedding_config_id,
                 len(query_vector),
+                limit,
+            ),
+        )
+
+    def retrieve_semantic_memory_matches_for_profile(
+        self,
+        *,
+        embedding_config_id: UUID,
+        query_vector: list[float],
+        limit: int,
+        agent_profile_id: str,
+    ) -> list[SemanticMemoryRetrievalRow]:
+        return self._fetch_all(
+            RETRIEVE_SEMANTIC_MEMORY_MATCHES_FOR_PROFILE_SQL,
+            (
+                self._vector_literal(query_vector),
+                embedding_config_id,
+                len(query_vector),
+                agent_profile_id,
                 limit,
             ),
         )

--- a/tests/integration/test_context_compile.py
+++ b/tests/integration/test_context_compile.py
@@ -2144,3 +2144,176 @@ def test_traces_and_trace_events_respect_per_user_isolation(migrated_database_ur
         assert trace_count["count"] == 0
         assert trace_event_count["count"] == 0
         assert store.list_trace_events(trace_id) == []
+
+
+def test_compile_context_scopes_memories_to_active_thread_profile(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = uuid4()
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, "scoped@example.com", "Scoped User")
+        assistant_thread = store.create_thread("Assistant thread")
+        coach_thread = store.create_thread("Coach thread", agent_profile_id="coach_default")
+        assistant_session = store.create_session(assistant_thread["id"], status="active")
+        coach_session = store.create_session(coach_thread["id"], status="active")
+        assistant_event = store.append_event(
+            assistant_thread["id"],
+            assistant_session["id"],
+            "message.user",
+            {"text": "remember assistant preference"},
+        )
+        coach_event = store.append_event(
+            coach_thread["id"],
+            coach_session["id"],
+            "message.user",
+            {"text": "remember coaching preference"},
+        )
+        # Omitted profile attribution must default deterministically to assistant_default.
+        store.create_memory(
+            memory_key="user.preference.assistant.profile_scope",
+            value={"likes": "espresso"},
+            status="active",
+            source_event_ids=[str(assistant_event["id"])],
+        )
+        store.create_memory(
+            memory_key="user.preference.coach.profile_scope",
+            value={"likes": "pour over"},
+            status="active",
+            source_event_ids=[str(coach_event["id"])],
+            agent_profile_id="coach_default",
+        )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    assistant_status, assistant_payload = invoke_compile_context(
+        {
+            "user_id": str(user_id),
+            "thread_id": str(assistant_thread["id"]),
+            "max_memories": 10,
+        }
+    )
+    coach_status, coach_payload = invoke_compile_context(
+        {
+            "user_id": str(user_id),
+            "thread_id": str(coach_thread["id"]),
+            "max_memories": 10,
+        }
+    )
+
+    assert assistant_status == 200
+    assert assistant_payload["metadata"] == {"agent_profile_id": "assistant_default"}
+    assert [memory["memory_key"] for memory in assistant_payload["context_pack"]["memories"]] == [
+        "user.preference.assistant.profile_scope"
+    ]
+
+    assert coach_status == 200
+    assert coach_payload["metadata"] == {"agent_profile_id": "coach_default"}
+    assert [memory["memory_key"] for memory in coach_payload["context_pack"]["memories"]] == [
+        "user.preference.coach.profile_scope"
+    ]
+
+
+def test_compile_context_scopes_semantic_memory_retrieval_to_active_thread_profile(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = uuid4()
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, "semantic-scope@example.com", "Semantic Scope")
+        assistant_thread = store.create_thread("Assistant semantic thread")
+        coach_thread = store.create_thread("Coach semantic thread", agent_profile_id="coach_default")
+        assistant_session = store.create_session(assistant_thread["id"], status="active")
+        coach_session = store.create_session(coach_thread["id"], status="active")
+        assistant_event = store.append_event(
+            assistant_thread["id"],
+            assistant_session["id"],
+            "message.user",
+            {"text": "assistant memory evidence"},
+        )
+        coach_event = store.append_event(
+            coach_thread["id"],
+            coach_session["id"],
+            "message.user",
+            {"text": "coach memory evidence"},
+        )
+        assistant_memory = store.create_memory(
+            memory_key="user.preference.semantic.assistant_scope",
+            value={"likes": "latte"},
+            status="active",
+            source_event_ids=[str(assistant_event["id"])],
+        )
+        coach_memory = store.create_memory(
+            memory_key="user.preference.semantic.coach_scope",
+            value={"likes": "flat white"},
+            status="active",
+            source_event_ids=[str(coach_event["id"])],
+            agent_profile_id="coach_default",
+        )
+        embedding_config = store.create_embedding_config(
+            provider="openai",
+            model="text-embedding-3-large",
+            version="2026-03-24",
+            dimensions=3,
+            status="active",
+            metadata={"task": "semantic_scope_validation"},
+        )
+        store.create_memory_embedding(
+            memory_id=assistant_memory["id"],
+            embedding_config_id=embedding_config["id"],
+            dimensions=3,
+            vector=[1.0, 0.0, 0.0],
+        )
+        store.create_memory_embedding(
+            memory_id=coach_memory["id"],
+            embedding_config_id=embedding_config["id"],
+            dimensions=3,
+            vector=[1.0, 0.0, 0.0],
+        )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    assistant_status, assistant_payload = invoke_compile_context(
+        {
+            "user_id": str(user_id),
+            "thread_id": str(assistant_thread["id"]),
+            "max_memories": 10,
+            "semantic": {
+                "embedding_config_id": str(embedding_config["id"]),
+                "query_vector": [1.0, 0.0, 0.0],
+                "limit": 10,
+            },
+        }
+    )
+    coach_status, coach_payload = invoke_compile_context(
+        {
+            "user_id": str(user_id),
+            "thread_id": str(coach_thread["id"]),
+            "max_memories": 10,
+            "semantic": {
+                "embedding_config_id": str(embedding_config["id"]),
+                "query_vector": [1.0, 0.0, 0.0],
+                "limit": 10,
+            },
+        }
+    )
+
+    assert assistant_status == 200
+    assert [memory["memory_key"] for memory in assistant_payload["context_pack"]["memories"]] == [
+        "user.preference.semantic.assistant_scope"
+    ]
+
+    assert coach_status == 200
+    assert [memory["memory_key"] for memory in coach_payload["context_pack"]["memories"]] == [
+        "user.preference.semantic.coach_scope"
+    ]

--- a/tests/integration/test_continuity_api.py
+++ b/tests/integration/test_continuity_api.py
@@ -717,11 +717,14 @@ def test_thread_creation_rejects_invalid_agent_profile_id_with_deterministic_422
     }
 
 
-def test_agent_profiles_endpoint_returns_deterministic_registry_payload(monkeypatch) -> None:
+def test_agent_profiles_endpoint_returns_deterministic_registry_payload(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(
         main_module,
         "get_settings",
-        lambda: Settings(database_url="postgresql://unused"),
+        lambda: Settings(database_url=migrated_database_urls["app"]),
     )
 
     status, payload = invoke_request("GET", "/v0/agent-profiles")

--- a/tests/integration/test_memory_review_api.py
+++ b/tests/integration/test_memory_review_api.py
@@ -404,6 +404,218 @@ def test_memory_review_endpoints_roundtrip_non_default_typed_metadata(
         assert payload["last_confirmed_at"].startswith("2026-03-20T09:00:00")
 
 
+def test_memory_admit_endpoint_scopes_same_memory_key_by_thread_profile(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = uuid4()
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, "profiled-admit@example.com", "Profiled Admit")
+        assistant_thread = store.create_thread("Assistant memory thread")
+        coach_thread = store.create_thread("Coach memory thread", agent_profile_id="coach_default")
+        assistant_session = store.create_session(assistant_thread["id"], status="active")
+        coach_session = store.create_session(coach_thread["id"], status="active")
+        assistant_event_id = store.append_event(
+            assistant_thread["id"],
+            assistant_session["id"],
+            "message.user",
+            {"text": "assistant profile memory evidence"},
+        )["id"]
+        coach_event_id = store.append_event(
+            coach_thread["id"],
+            coach_session["id"],
+            "message.user",
+            {"text": "coach profile memory evidence"},
+        )["id"]
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    assistant_status, assistant_payload = invoke_request(
+        "POST",
+        "/v0/memories/admit",
+        payload={
+            "user_id": str(user_id),
+            "memory_key": "user.preference.profiled.coffee",
+            "value": {"likes": "black"},
+            "source_event_ids": [str(assistant_event_id)],
+        },
+    )
+    coach_add_status, coach_add_payload = invoke_request(
+        "POST",
+        "/v0/memories/admit",
+        payload={
+            "user_id": str(user_id),
+            "memory_key": "user.preference.profiled.coffee",
+            "value": {"likes": "oat milk"},
+            "source_event_ids": [str(coach_event_id)],
+        },
+    )
+    coach_update_status, coach_update_payload = invoke_request(
+        "POST",
+        "/v0/memories/admit",
+        payload={
+            "user_id": str(user_id),
+            "memory_key": "user.preference.profiled.coffee",
+            "value": {"likes": "cortado"},
+            "source_event_ids": [str(coach_event_id)],
+        },
+    )
+
+    assert assistant_status == 200
+    assert assistant_payload["decision"] == "ADD"
+    assert coach_add_status == 200
+    assert coach_add_payload["decision"] == "ADD"
+    assert coach_update_status == 200
+    assert coach_update_payload["decision"] == "UPDATE"
+    assert assistant_payload["memory"]["id"] != coach_add_payload["memory"]["id"]
+    assert coach_update_payload["memory"]["id"] == coach_add_payload["memory"]["id"]
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        assistant_memory = store.get_memory(UUID(assistant_payload["memory"]["id"]))
+        coach_memory = store.get_memory(UUID(coach_add_payload["memory"]["id"]))
+
+    assert assistant_memory["agent_profile_id"] == "assistant_default"
+    assert assistant_memory["value"] == {"likes": "black"}
+    assert coach_memory["agent_profile_id"] == "coach_default"
+    assert coach_memory["value"] == {"likes": "cortado"}
+
+
+def test_memory_admit_endpoint_rejects_mixed_profile_source_events(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = uuid4()
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, "mixed-profile@example.com", "Mixed Profile")
+        assistant_thread = store.create_thread("Assistant mixed thread")
+        coach_thread = store.create_thread("Coach mixed thread", agent_profile_id="coach_default")
+        assistant_session = store.create_session(assistant_thread["id"], status="active")
+        coach_session = store.create_session(coach_thread["id"], status="active")
+        assistant_event_id = store.append_event(
+            assistant_thread["id"],
+            assistant_session["id"],
+            "message.user",
+            {"text": "assistant profile evidence"},
+        )["id"]
+        coach_event_id = store.append_event(
+            coach_thread["id"],
+            coach_session["id"],
+            "message.user",
+            {"text": "coach profile evidence"},
+        )["id"]
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status_code, payload = invoke_request(
+        "POST",
+        "/v0/memories/admit",
+        payload={
+            "user_id": str(user_id),
+            "memory_key": "user.preference.profiled.invalid",
+            "value": {"likes": "espresso"},
+            "source_event_ids": [str(assistant_event_id), str(coach_event_id)],
+        },
+    )
+
+    assert status_code == 400
+    assert payload == {
+        "detail": "source_event_ids must all belong to threads with the same agent_profile_id"
+    }
+
+
+def test_memory_admit_endpoint_rejects_explicit_agent_profile_mismatch(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = uuid4()
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, "mismatch-profile@example.com", "Mismatch Profile")
+        assistant_thread = store.create_thread("Assistant mismatch thread")
+        assistant_session = store.create_session(assistant_thread["id"], status="active")
+        assistant_event_id = store.append_event(
+            assistant_thread["id"],
+            assistant_session["id"],
+            "message.user",
+            {"text": "assistant profile mismatch evidence"},
+        )["id"]
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status_code, payload = invoke_request(
+        "POST",
+        "/v0/memories/admit",
+        payload={
+            "user_id": str(user_id),
+            "memory_key": "user.preference.profiled.mismatch",
+            "value": {"likes": "espresso"},
+            "source_event_ids": [str(assistant_event_id)],
+            "agent_profile_id": "coach_default",
+        },
+    )
+
+    assert status_code == 400
+    assert payload == {
+        "detail": "agent_profile_id must match the profile resolved from source_event_ids"
+    }
+
+
+def test_memory_admit_endpoint_rejects_unknown_agent_profile_id(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = uuid4()
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, "unknown-profile@example.com", "Unknown Profile")
+        assistant_thread = store.create_thread("Assistant unknown-profile thread")
+        assistant_session = store.create_session(assistant_thread["id"], status="active")
+        assistant_event_id = store.append_event(
+            assistant_thread["id"],
+            assistant_session["id"],
+            "message.user",
+            {"text": "assistant profile unknown evidence"},
+        )["id"]
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status_code, payload = invoke_request(
+        "POST",
+        "/v0/memories/admit",
+        payload={
+            "user_id": str(user_id),
+            "memory_key": "user.preference.profiled.unknown",
+            "value": {"likes": "espresso"},
+            "source_event_ids": [str(assistant_event_id)],
+            "agent_profile_id": "unknown_profile",
+        },
+    )
+
+    assert status_code == 400
+    assert payload == {
+        "detail": "agent_profile_id must reference an existing profile: unknown_profile"
+    }
+
+
 def test_memory_review_endpoints_enforce_per_user_isolation_and_not_found_behavior(
     migrated_database_urls,
     monkeypatch,

--- a/tests/integration/test_responses_api.py
+++ b/tests/integration/test_responses_api.py
@@ -385,3 +385,89 @@ def test_generate_response_respects_per_user_isolation(migrated_database_urls, m
         owner_events = ContinuityStore(conn).list_thread_events(owner["thread_id"])
 
     assert [event["sequence_no"] for event in owner_events] == [1]
+
+
+def test_generate_response_inherits_profile_scoped_memory_compile_behavior(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = uuid4()
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, "profile-response@example.com", "Profile Response")
+        assistant_thread = store.create_thread("Assistant response thread")
+        coach_thread = store.create_thread("Coach response thread", agent_profile_id="coach_default")
+        assistant_session = store.create_session(assistant_thread["id"], status="active")
+        coach_session = store.create_session(coach_thread["id"], status="active")
+        assistant_event = store.append_event(
+            assistant_thread["id"],
+            assistant_session["id"],
+            "message.user",
+            {"text": "assistant memory evidence"},
+        )
+        coach_event = store.append_event(
+            coach_thread["id"],
+            coach_session["id"],
+            "message.user",
+            {"text": "coach memory evidence"},
+        )
+        assistant_memory = store.create_memory(
+            memory_key="user.preference.response.assistant_scope",
+            value={"likes": "americano"},
+            status="active",
+            source_event_ids=[str(assistant_event["id"])],
+        )
+        coach_memory = store.create_memory(
+            memory_key="user.preference.response.coach_scope",
+            value={"likes": "macchiato"},
+            status="active",
+            source_event_ids=[str(coach_event["id"])],
+            agent_profile_id="coach_default",
+        )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            database_url=migrated_database_urls["app"],
+            model_provider="openai_responses",
+            model_name="gpt-5-mini",
+            model_api_key="test-key",
+        ),
+    )
+    monkeypatch.setattr(
+        response_generation_module,
+        "invoke_model",
+        lambda **_kwargs: response_generation_module.ModelInvocationResponse(
+            provider="openai_responses",
+            model="gpt-5-mini",
+            response_id="resp_profile_scope",
+            finish_reason="completed",
+            output_text="Scoped response.",
+            usage={"input_tokens": 10, "output_tokens": 3, "total_tokens": 13},
+        ),
+    )
+
+    status_code, payload = invoke_generate_response(
+        {
+            "user_id": str(user_id),
+            "thread_id": str(coach_thread["id"]),
+            "message": "Use my coaching profile context.",
+            "max_memories": 10,
+        }
+    )
+
+    assert status_code == 200
+    assert payload["metadata"] == {"agent_profile_id": "coach_default"}
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        compile_trace_events = store.list_trace_events(UUID(payload["trace"]["compile_trace_id"]))
+
+    memory_decision_ids = [
+        event["payload"]["entity_id"]
+        for event in compile_trace_events
+        if event["payload"].get("entity_type") == "memory"
+    ]
+    assert str(coach_memory["id"]) in memory_decision_ids
+    assert str(assistant_memory["id"]) not in memory_decision_ids

--- a/tests/unit/test_20260324_0033_agent_profile_registry.py
+++ b/tests/unit/test_20260324_0033_agent_profile_registry.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260324_0033_agent_profile_registry"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == list(module._UPGRADE_STATEMENTS)
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_seeded_registry_rows_and_thread_binding_contract() -> None:
+    module = load_migration_module()
+
+    assert module.AGENT_PROFILE_SEED_ROWS == (
+        (
+            "assistant_default",
+            "Assistant Default",
+            "General-purpose assistant profile for baseline conversations.",
+        ),
+        (
+            "coach_default",
+            "Coach Default",
+            "Coaching-oriented profile focused on guidance and accountability.",
+        ),
+    )
+    assert module.AGENT_PROFILE_IDS == ("assistant_default", "coach_default")
+    assert "threads_agent_profile_id_check" in module._UPGRADE_STATEMENTS[3]
+    assert "threads_agent_profile_id_fkey" in module._UPGRADE_STATEMENTS[4]

--- a/tests/unit/test_20260324_0034_memory_agent_profile_scope.py
+++ b/tests/unit/test_20260324_0034_memory_agent_profile_scope.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260324_0034_memory_agent_profile_scope"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == list(module._UPGRADE_STATEMENTS)
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_memory_profile_scope_upgrade_contract() -> None:
+    module = load_migration_module()
+
+    assert module.DEFAULT_AGENT_PROFILE_ID == "assistant_default"
+    assert "ADD COLUMN agent_profile_id text NOT NULL DEFAULT 'assistant_default'" in module._UPGRADE_STATEMENTS[0]
+    assert "FOREIGN KEY (agent_profile_id)" in module._UPGRADE_STATEMENTS[1]
+    assert "REFERENCES agent_profiles(id)" in module._UPGRADE_STATEMENTS[1]
+    assert "DROP CONSTRAINT IF EXISTS memories_user_id_memory_key_key" in module._UPGRADE_STATEMENTS[2]
+    assert "memories_user_profile_memory_key_key" in module._UPGRADE_STATEMENTS[3]
+    assert "UNIQUE (user_id, agent_profile_id, memory_key)" in module._UPGRADE_STATEMENTS[3]
+    assert "memories_user_profile_updated_created_id_idx" in module._UPGRADE_STATEMENTS[4]
+    assert "(user_id, agent_profile_id, updated_at, created_at, id)" in module._UPGRADE_STATEMENTS[4]
+
+
+def test_memory_profile_scope_downgrade_contract_handles_cross_profile_duplicates() -> None:
+    module = load_migration_module()
+
+    assert "DROP CONSTRAINT IF EXISTS memories_user_profile_memory_key_key" in module._DOWNGRADE_STATEMENTS[1]
+    assert "ROW_NUMBER() OVER" in module._DOWNGRADE_STATEMENTS[2]
+    assert "PARTITION BY user_id, memory_key" in module._DOWNGRADE_STATEMENTS[2]
+    assert "memory_key = ranked_memories.memory_key" in module._DOWNGRADE_STATEMENTS[2]
+    assert "#profile:" in module._DOWNGRADE_STATEMENTS[2]
+    assert "ADD CONSTRAINT memories_user_id_memory_key_key" in module._DOWNGRADE_STATEMENTS[3]

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -35,17 +35,51 @@ class MemoryStoreStub:
     def __init__(self) -> None:
         self.base_time = datetime(2026, 3, 11, 12, 0, tzinfo=UTC)
         self.events: dict[UUID, dict[str, object]] = {}
-        self.memory: dict[str, object] | None = None
+        self.threads: dict[UUID, dict[str, object]] = {}
+        self.memories: dict[tuple[str, str], dict[str, object]] = {}
         self.revisions: list[dict[str, object]] = []
         self.open_loops: list[dict[str, object]] = []
+        self.allowed_profiles: dict[str, dict[str, str]] = {
+            "assistant_default": {
+                "id": "assistant_default",
+                "name": "Assistant Default",
+                "description": "Default profile",
+            },
+            "coach_default": {
+                "id": "coach_default",
+                "name": "Coach Default",
+                "description": "Coach profile",
+            },
+        }
 
     def list_events_by_ids(self, event_ids: list[UUID]) -> list[dict[str, object]]:
         return [self.events[event_id] for event_id in event_ids if event_id in self.events]
 
+    def get_thread_optional(self, thread_id: UUID) -> dict[str, object] | None:
+        return self.threads.get(thread_id)
+
+    def get_agent_profile_optional(self, profile_id: str) -> dict[str, str] | None:
+        return self.allowed_profiles.get(profile_id)
+
+    def _find_memory_by_id(self, memory_id: UUID) -> dict[str, object] | None:
+        for memory in self.memories.values():
+            if memory["id"] == memory_id:
+                return memory
+        return None
+
     def get_memory_by_key(self, memory_key: str) -> dict[str, object] | None:
-        if self.memory is None or self.memory["memory_key"] != memory_key:
-            return None
-        return self.memory
+        for memory in self.memories.values():
+            if memory["memory_key"] == memory_key:
+                return memory
+        return None
+
+    def get_memory_by_key_and_profile(
+        self,
+        *,
+        memory_key: str,
+        agent_profile_id: str,
+    ) -> dict[str, object] | None:
+        return self.memories.get((memory_key, agent_profile_id))
 
     def create_memory(
         self,
@@ -61,10 +95,12 @@ class MemoryStoreStub:
         valid_from: datetime | None = None,
         valid_to: datetime | None = None,
         last_confirmed_at: datetime | None = None,
+        agent_profile_id: str = "assistant_default",
     ) -> dict[str, object]:
-        self.memory = {
+        memory = {
             "id": uuid4(),
             "user_id": uuid4(),
+            "agent_profile_id": agent_profile_id,
             "memory_key": memory_key,
             "value": value,
             "status": status,
@@ -80,7 +116,8 @@ class MemoryStoreStub:
             "updated_at": self.base_time,
             "deleted_at": None,
         }
-        return self.memory
+        self.memories[(memory_key, agent_profile_id)] = memory
+        return memory
 
     def update_memory(
         self,
@@ -97,11 +134,11 @@ class MemoryStoreStub:
         valid_to: datetime | None = None,
         last_confirmed_at: datetime | None = None,
     ) -> dict[str, object]:
-        assert self.memory is not None
-        assert self.memory["id"] == memory_id
+        existing_memory = self._find_memory_by_id(memory_id)
+        assert existing_memory is not None
         updated_at = self.base_time + timedelta(minutes=len(self.revisions) + 1)
-        self.memory = {
-            **self.memory,
+        updated_memory = {
+            **existing_memory,
             "value": value,
             "status": status,
             "source_event_ids": source_event_ids,
@@ -115,7 +152,8 @@ class MemoryStoreStub:
             "updated_at": updated_at,
             "deleted_at": updated_at if status == "deleted" else None,
         }
-        return self.memory
+        self.memories[(updated_memory["memory_key"], updated_memory["agent_profile_id"])] = updated_memory
+        return updated_memory
 
     def append_memory_revision(
         self,
@@ -128,9 +166,10 @@ class MemoryStoreStub:
         source_event_ids: list[str],
         candidate: dict[str, object],
     ) -> dict[str, object]:
+        existing_memory = self._find_memory_by_id(memory_id)
         revision = {
             "id": uuid4(),
-            "user_id": self.memory["user_id"] if self.memory is not None else uuid4(),
+            "user_id": existing_memory["user_id"] if existing_memory is not None else uuid4(),
             "memory_id": memory_id,
             "sequence_no": len(self.revisions) + 1,
             "action": action,
@@ -155,9 +194,10 @@ class MemoryStoreStub:
         resolved_at: datetime | None,
         resolution_note: str | None,
     ) -> dict[str, object]:
+        memory = None if memory_id is None else self._find_memory_by_id(memory_id)
         created = {
             "id": uuid4(),
-            "user_id": self.memory["user_id"] if self.memory is not None else uuid4(),
+            "user_id": memory["user_id"] if memory is not None else uuid4(),
             "memory_id": memory_id,
             "title": title,
             "status": status,
@@ -172,10 +212,16 @@ class MemoryStoreStub:
         return created
 
 
-def seed_event(store: MemoryStoreStub) -> UUID:
+def seed_event(store: MemoryStoreStub, *, agent_profile_id: str = "assistant_default") -> UUID:
     event_id = uuid4()
+    thread_id = uuid4()
+    store.threads[thread_id] = {
+        "id": thread_id,
+        "agent_profile_id": agent_profile_id,
+    }
     store.events[event_id] = {
         "id": event_id,
+        "thread_id": thread_id,
         "sequence_no": 1,
         "kind": "message.user",
         "payload": {"text": "evidence"},
@@ -385,6 +431,111 @@ def test_admit_memory_candidate_marks_memory_deleted_and_appends_revision() -> N
     assert decision.revision["sequence_no"] == 1
     assert decision.revision["action"] == "DELETE"
     assert decision.revision["new_value"] is None
+
+
+def test_admit_memory_candidate_scopes_upserts_by_derived_agent_profile() -> None:
+    store = MemoryStoreStub()
+    assistant_event_id = seed_event(store, agent_profile_id="assistant_default")
+    coach_event_id = seed_event(store, agent_profile_id="coach_default")
+
+    assistant_decision = admit_memory_candidate(
+        store,  # type: ignore[arg-type]
+        user_id=uuid4(),
+        candidate=MemoryCandidateInput(
+            memory_key="user.preference.coffee",
+            value={"likes": "black"},
+            source_event_ids=(assistant_event_id,),
+        ),
+    )
+    coach_add_decision = admit_memory_candidate(
+        store,  # type: ignore[arg-type]
+        user_id=uuid4(),
+        candidate=MemoryCandidateInput(
+            memory_key="user.preference.coffee",
+            value={"likes": "oat milk"},
+            source_event_ids=(coach_event_id,),
+        ),
+    )
+    coach_update_decision = admit_memory_candidate(
+        store,  # type: ignore[arg-type]
+        user_id=uuid4(),
+        candidate=MemoryCandidateInput(
+            memory_key="user.preference.coffee",
+            value={"likes": "macchiato"},
+            source_event_ids=(coach_event_id,),
+        ),
+    )
+
+    assert assistant_decision.action == "ADD"
+    assert coach_add_decision.action == "ADD"
+    assert coach_update_decision.action == "UPDATE"
+    assert assistant_decision.memory is not None
+    assert coach_add_decision.memory is not None
+    assert coach_update_decision.memory is not None
+    assert assistant_decision.memory["id"] != coach_add_decision.memory["id"]
+    assert coach_update_decision.memory["id"] == coach_add_decision.memory["id"]
+    assert assistant_decision.memory["value"] == {"likes": "black"}
+    assert coach_update_decision.memory["value"] == {"likes": "macchiato"}
+
+
+def test_admit_memory_candidate_rejects_mixed_profile_source_events() -> None:
+    store = MemoryStoreStub()
+    assistant_event_id = seed_event(store, agent_profile_id="assistant_default")
+    coach_event_id = seed_event(store, agent_profile_id="coach_default")
+
+    with pytest.raises(
+        MemoryAdmissionValidationError,
+        match="source_event_ids must all belong to threads with the same agent_profile_id",
+    ):
+        admit_memory_candidate(
+            store,  # type: ignore[arg-type]
+            user_id=uuid4(),
+            candidate=MemoryCandidateInput(
+                memory_key="user.preference.coffee",
+                value={"likes": "black"},
+                source_event_ids=(assistant_event_id, coach_event_id),
+            ),
+        )
+
+
+def test_admit_memory_candidate_rejects_explicit_agent_profile_mismatch() -> None:
+    store = MemoryStoreStub()
+    assistant_event_id = seed_event(store, agent_profile_id="assistant_default")
+
+    with pytest.raises(
+        MemoryAdmissionValidationError,
+        match="agent_profile_id must match the profile resolved from source_event_ids",
+    ):
+        admit_memory_candidate(
+            store,  # type: ignore[arg-type]
+            user_id=uuid4(),
+            candidate=MemoryCandidateInput(
+                memory_key="user.preference.coffee",
+                value={"likes": "black"},
+                source_event_ids=(assistant_event_id,),
+                agent_profile_id="coach_default",
+            ),
+        )
+
+
+def test_admit_memory_candidate_rejects_unknown_agent_profile_id() -> None:
+    store = MemoryStoreStub()
+    assistant_event_id = seed_event(store, agent_profile_id="assistant_default")
+
+    with pytest.raises(
+        MemoryAdmissionValidationError,
+        match="agent_profile_id must reference an existing profile: unknown_profile",
+    ):
+        admit_memory_candidate(
+            store,  # type: ignore[arg-type]
+            user_id=uuid4(),
+            candidate=MemoryCandidateInput(
+                memory_key="user.preference.coffee",
+                value={"likes": "black"},
+                source_event_ids=(assistant_event_id,),
+                agent_profile_id="unknown_profile",
+            ),
+        )
 
 
 class MemoryReviewStoreStub:

--- a/tests/unit/test_memory_store.py
+++ b/tests/unit/test_memory_store.py
@@ -137,6 +137,7 @@ def test_memory_methods_use_expected_queries_and_payload_serialization() -> None
     assert create_params[8] is None
     assert create_params[9] is None
     assert create_params[10] is None
+    assert create_params[11] == "assistant_default"
 
     update_query, update_params = cursor.executed[1]
     assert "UPDATE memories" in update_query
@@ -184,6 +185,7 @@ def test_memory_methods_use_expected_queries_and_payload_serialization() -> None
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -271,6 +273,7 @@ def test_memory_review_read_methods_use_explicit_order_filter_and_limit() -> Non
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,
@@ -303,6 +306,7 @@ def test_memory_review_read_methods_use_explicit_order_filter_and_limit() -> Non
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,


### PR DESCRIPTION
## Summary
Phase 3 Sprint 5 implements profile-scoped memory/context isolation and includes the minimal Sprint 4 registry prerequisite carry-forward required because `main` did not yet contain that baseline.

## Scope
- Added profile-scoped memory migration (`20260324_0034`) and required predecessor migration (`20260324_0033`) for coherent Alembic chain.
- Enforced profile-scoped memory admission/read behavior across store/compiler/main/memory paths.
- Preserved deterministic defaults and backward-compatible API envelopes.
- Updated integration and unit coverage for profile-scoped behavior and negative paths.
- Updated sprint control artifacts (`SPRINT_PACKET.md`, `BUILD_REPORT.md`, `REVIEW_REPORT.md`).

## Verification
- `./.venv/bin/python -m pytest tests/unit/test_20260324_0033_agent_profile_registry.py -q` ✅
- `./.venv/bin/python -m pytest tests/unit/test_20260324_0034_memory_agent_profile_scope.py -q` ✅
- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py -q` ✅
- `./.venv/bin/python -m pytest tests/integration/test_context_compile.py tests/integration/test_responses_api.py tests/integration/test_memory_review_api.py -q` ✅
- `python3 scripts/run_phase2_validation_matrix.py` ✅ PASS

## Notes
- Sprint scope remains bounded to Sprint 5 memory isolation plus explicit Sprint 4 prerequisite carry-forward.
- No provider/policy/orchestration expansion was introduced.
