### PR TITLE
Phase 3 Sprint 8: Profile-Scoped Execution Budget Isolation

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 3 Sprint 7: Profile-Scoped Model Routing
+Phase 3 Sprint 8: Profile-Scoped Execution Budget Isolation
 
 ## Sprint Type
 
@@ -10,24 +10,24 @@ feature
 
 ## Sprint Reason
 
-Sprint 6 established profile-scoped policy evaluation and routing. The next non-redundant gap is runtime model selection: response generation still uses one global model configuration from environment settings instead of active profile-specific routing.
+Sprint 7 completed profile-scoped response model routing. The next non-redundant gap is governed execution budget isolation: execution budgets are still user-global, so one profile can exhaust limits that should be isolated to another profile.
 
 ## Sprint Intent
 
-Route `/v0/responses` model selection by active thread profile using deterministic profile runtime configuration, while preserving safe fallback to current global settings.
+Scope execution-budget matching and counting to the active thread profile, with deterministic fallback to global budgets when no profile-specific budget matches.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase3-sprint7-profile-model-routing`
+- Branch Name: `codex/phase3-sprint8-profile-budget-scope`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- It is the next non-redundant seam after identity, memory isolation, and policy isolation.
-- It closes the remaining shared-runtime gap where all profiles currently invoke the same model config.
-- It enables true separate-agent runtime posture without introducing orchestration breadth.
+- It is the next non-redundant seam after identity, memory isolation, policy isolation, and model isolation.
+- It closes a remaining shared-governance gap where execution budgets can still cross-contaminate profiles.
+- It advances separate-agent runtime behavior without widening orchestration or connector scope.
 
 ## Redundancy Guard
 
@@ -37,136 +37,145 @@ Route `/v0/responses` model selection by active thread profile using determinist
 - Already shipped in Sprint 4: durable profile registry + thread FK.
 - Already shipped in Sprint 5: profile-scoped memory/context isolation.
 - Already shipped in Sprint 6: profile-scoped policy evaluation/routing.
-- Missing and required now: profile-scoped model/provider selection at response invocation.
+- Already shipped in Sprint 7: profile-scoped model/provider routing for `/v0/responses`.
+- Missing and required now: profile-scoped execution budget matching + counted execution history isolation.
 
 ## Design Truth
 
-- Profile records can carry runtime model config (`model_provider`, `model_name`).
-- Response generation resolves runtime model config from active thread profile.
-- Fallback remains deterministic:
-  - if profile runtime config is absent, use existing global settings.
-- Keep provider surface bounded; no new external connector/provider wiring in this sprint.
+- Execution budgets can optionally target one `agent_profile_id` while preserving global budget support via nullable scope.
+- Budget match precedence remains deterministic:
+  - first match active budgets scoped to the thread profile
+  - then match active global budgets (`agent_profile_id IS NULL`)
+  - within each scope, preserve existing selector specificity and stable ordering
+- Completed-execution counting for budget decisions must only include executions attributable to the same profile scope as the matched budget.
+- Keep tool/provider/orchestration surface bounded; this sprint is budget-scope isolation only.
 
 ## Exact Surfaces In Scope
 
-- profile runtime config schema + registry read wiring
-- response generation model selection by active profile
-- additive API/profile contracts exposing runtime config where needed
-- unit/integration tests for routing + fallback determinism
+- execution-budget schema/profile scope wiring
+- execution-budget API contracts and lifecycle responses with additive profile scope field
+- budget evaluation matching + counting with thread-profile-aware isolation and global fallback
+- unit/integration tests proving profile isolation and deterministic fallback behavior
 
 ## Exact Files In Scope
 
 - [store.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/store.py)
 - [main.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/main.py)
 - [contracts.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/contracts.py)
-- [phase3_profiles.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/phase3_profiles.py)
-- [response_generation.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/response_generation.py)
-- [20260325_0036_agent_profile_model_runtime.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/alembic/versions/20260325_0036_agent_profile_model_runtime.py)
-- [test_20260325_0036_agent_profile_model_runtime.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_20260325_0036_agent_profile_model_runtime.py)
-- [test_response_generation.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_response_generation.py)
-- [test_continuity_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_continuity_api.py)
-- [test_responses_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_responses_api.py)
+- [execution_budgets.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/execution_budgets.py)
+- [proxy_execution.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/proxy_execution.py)
+- [20260325_0037_execution_budget_agent_profile_scope.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/alembic/versions/20260325_0037_execution_budget_agent_profile_scope.py)
+- [test_20260325_0037_execution_budget_agent_profile_scope.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py)
+- [test_execution_budgets.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_execution_budgets.py)
+- [test_execution_budgets_main.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_execution_budgets_main.py)
+- [test_execution_budget_store.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_execution_budget_store.py)
+- [test_execution_budgets_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_execution_budgets_api.py)
+- [test_proxy_execution_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_proxy_execution_api.py)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
 - [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
 
 ## In Scope
 
-- Add runtime model columns to `agent_profiles` (nullable for backward compatibility):
-  - `model_provider`
-  - `model_name`
-- Seed deterministic runtime config for shipped profiles:
-  - `assistant_default`
-  - `coach_default`
-- Update profile registry read contracts to expose runtime config fields.
-- Update `/v0/responses` path to:
-  - resolve active thread profile
-  - select provider/model from profile runtime config when present
-  - fallback to `Settings.model_provider` / `Settings.model_name` when absent
-- Preserve existing error behavior, event shape, and trace contracts.
-- Add migration tests for schema + seed/runtime invariants.
-- Add unit tests for runtime selection/fallback logic.
-- Add integration tests proving:
-  - profile-specific model selection is used in response invocation
-  - fallback to global settings works deterministically when profile runtime is unset
-  - profile metadata and backward-compatible response envelope remain stable
+- Add nullable `agent_profile_id` to `execution_budgets` with FK to `agent_profiles`.
+- Update active-scope uniqueness/index strategy to include profile scope:
+  - one active budget per `(user_id, agent_profile_id, tool_key, domain_hint)` selector scope
+  - preserve deterministic ordering/index contracts
+- Update execution-budget create/list/get/lifecycle contracts to expose additive `agent_profile_id`.
+- Validate `agent_profile_id` on create when provided (must exist in registry).
+- Update budget evaluation to:
+  - resolve active thread profile from request thread
+  - match profile-scoped budgets first, then global budgets
+  - keep existing selector specificity ordering within each scope
+  - count only completed executions attributable to the matched profile scope
+- Preserve existing proxy execution event and trace contract shapes (additive fields only where necessary).
+- Add migration tests for schema/index invariants and rollback.
+- Add unit/integration coverage for profile-scoped budget matching, fallback, and blocked/allow decisions.
 
 ## Out of Scope
 
 - profile CRUD endpoints
-- introducing new provider integrations or secret handling changes
-- policy/tooling redesign
+- policy engine redesign beyond budget profile scope filtering
+- introducing new providers, connectors, or secret handling changes
+- orchestration/worker runtime changes
 - web UI changes
-- connector/auth/orchestration expansion
+- connector/auth expansion
 
 ## Required Deliverables
 
-- profile runtime model migration and registry wiring
-- response-generation profile model routing with deterministic fallback
-- passing unit/integration evidence for profile-scoped model selection
+- execution-budget profile-scope migration and store wiring
+- budget create/list/get serialization with additive profile scope fields
+- profile-aware budget evaluation and deterministic global fallback
+- passing unit/integration evidence for profile-scoped budget decisions
 - sprint build/review reports scoped to this sprint only
 
 ## Acceptance Criteria
 
-- Agent profiles persist deterministic runtime model config fields.
-- `/v0/responses` uses profile runtime model config for the active thread profile.
-- If profile runtime model config is absent, fallback to global settings remains deterministic.
-- Existing `/v0/responses` response envelope remains backward-compatible.
-- `./.venv/bin/python -m pytest tests/unit/test_20260325_0036_agent_profile_model_runtime.py -q` passes.
-- `./.venv/bin/python -m pytest tests/unit/test_response_generation.py -q` passes.
-- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py -q` passes.
+- `execution_budgets` persist optional `agent_profile_id` with FK integrity.
+- Budget create/list/get payloads include additive `agent_profile_id` and remain backward-compatible.
+- Budget evaluation for proxy execution is profile-isolated:
+  - profile-scoped budgets apply to matching thread profiles
+  - profile-scoped budgets do not throttle non-matching profiles
+  - deterministic fallback to global budgets works when no profile-scoped match exists
+- Existing proxy execution result/event/trace contracts remain backward-compatible.
+- `./.venv/bin/python -m pytest tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py -q` passes.
+- `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_execution_budgets_main.py tests/unit/test_execution_budget_store.py -q` passes.
+- `./.venv/bin/python -m pytest tests/integration/test_execution_budgets_api.py tests/integration/test_proxy_execution_api.py -q` passes.
 - `python3 scripts/run_phase2_validation_matrix.py` remains PASS.
-- No new-provider/orchestration scope expansion enters this sprint.
+- No provider/connector/orchestration scope expansion enters this sprint.
 
 ## Implementation Constraints
 
 - do not introduce new dependencies
-- preserve existing response/trace payload contracts (additive fields only where necessary)
+- preserve existing response/event/trace payload contracts (additive fields only where necessary)
 - keep migration reversible and forward-safe
-- keep profile list ordering deterministic (`id_asc`)
+- keep deterministic ordering contracts (`created_at_asc`, `id_asc`, `specificity_desc`)
 
 ## Control Tower Task Cards
 
-### Task 1: Profile Runtime Migration + Store Wiring
+### Task 1: Budget Profile-Scope Migration + Store Wiring
 Owner: tooling operative  
 Write scope:
-- `apps/api/alembic/versions/20260325_0036_agent_profile_model_runtime.py`
+- `apps/api/alembic/versions/20260325_0037_execution_budget_agent_profile_scope.py`
 - `apps/api/src/alicebot_api/store.py`
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/phase3_profiles.py`
 - `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/response_generation.py`
+- `apps/api/src/alicebot_api/execution_budgets.py`
+- `apps/api/src/alicebot_api/proxy_execution.py`
 
 ### Task 2: Verification
 Owner: tooling operative  
 Write scope:
-- `tests/unit/test_20260325_0036_agent_profile_model_runtime.py`
-- `tests/unit/test_response_generation.py`
-- `tests/integration/test_continuity_api.py`
-- `tests/integration/test_responses_api.py`
+- `tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py`
+- `tests/unit/test_execution_budgets.py`
+- `tests/unit/test_execution_budgets_main.py`
+- `tests/unit/test_execution_budget_store.py`
+- `tests/integration/test_execution_budgets_api.py`
+- `tests/integration/test_proxy_execution_api.py`
 
 ### Task 3: Integration Review
 Owner: control tower  
 Responsibilities:
-- verify sprint stays profile-model-routing scoped
-- verify no new-provider/orchestration expansion
+- verify sprint stays execution-budget-profile-scope scoped
+- verify profile isolation and global fallback are deterministic
+- verify no provider/connector/orchestration expansion
 - verify validation matrix remains green
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact profile-runtime migration and response-model-routing deltas
+- exact execution-budget profile-scope migration and routing/evaluation deltas
 - exact verification command outcomes
-- explicit deferred scope (new providers, orchestration, profile CRUD)
+- explicit deferred scope (providers/connectors, orchestration, profile CRUD)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint stayed bounded to profile model routing
-- profile runtime model selection and fallback behavior are deterministic and correct
-- API behavior remains backward-compatible
+- sprint stayed bounded to execution-budget profile scope
+- profile-scoped budget matching/counting and global fallback are deterministic and correct
+- API and proxy-execution behavior remain backward-compatible
 - no hidden scope expansion
 
 ## Exit Condition
 
-This sprint is complete when response model selection is profile-scoped and deterministic for the active thread profile, with migration/test evidence and all validation gates green.
+This sprint is complete when execution-budget decisions are profile-scoped and deterministic for the active thread profile, with migration/test evidence and all validation gates green.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,78 +1,75 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Phase 3 Sprint 7: Profile-Scoped Model Routing.
-
-Route `/v0/responses` model selection by active thread profile runtime config (`model_provider`, `model_name`) with deterministic fallback to global `Settings.model_provider` / `Settings.model_name` when profile runtime config is absent.
+Implement Phase 3 Sprint 8 execution-budget profile scope isolation by adding optional `agent_profile_id` scope to budgets, updating create/list/get contracts, and enforcing profile-aware budget matching/counting with deterministic global fallback.
 
 ## Completed Work
-- Added migration `20260325_0036_agent_profile_model_runtime`:
-- added nullable `agent_profiles.model_provider` and `agent_profiles.model_name`.
-- added bounded-provider/runtime-pairing constraints:
-- `agent_profiles_model_provider_check`
-- `agent_profiles_model_runtime_pairing_check`
-- seeded deterministic runtime config for shipped profiles:
-- `assistant_default` -> `openai_responses` / `gpt-5-mini`
-- `coach_default` -> `openai_responses` / `gpt-5`
-- Updated profile registry/store contract wiring:
-- `AgentProfileRow` now includes `model_provider`, `model_name`.
-- agent profile list/get SQL now selects runtime config columns.
-- `AgentProfileRecord` now includes additive runtime config fields.
-- profile registry serialization now exposes runtime fields in `/v0/agent-profiles` responses.
-- Implemented response model routing:
-- added `resolve_thread_model_runtime(...)` in `response_generation.py`.
-- `/v0/responses` now resolves active thread profile, uses profile runtime model/provider when both are present.
-- deterministic fallback to global settings when profile runtime is missing/incomplete or profile lookup is absent.
-- preserved existing response envelope/trace structure and failure semantics.
-- Added/updated sprint verification tests:
-- new migration unit test `test_20260325_0036_agent_profile_model_runtime.py`.
-- added runtime routing/fallback unit tests in `test_response_generation.py`.
-- updated continuity integration expectations for additive agent profile runtime fields.
-- updated responses integration to verify profile-specific model routing and deterministic fallback behavior.
+- Added migration `20260325_0037_execution_budget_agent_profile_scope`:
+  - Added nullable `execution_budgets.agent_profile_id`.
+  - Added FK `execution_budgets_agent_profile_id_fkey -> agent_profiles(id)`.
+  - Replaced selector/match indexing with profile-aware index `execution_budgets_user_profile_match_idx`.
+  - Replaced active uniqueness index to include profile scope via `COALESCE(agent_profile_id, '')` while preserving existing index name `execution_budgets_one_active_scope_idx`.
+  - Added reversible downgrade restoring pre-sprint index/column shape.
+- Wired store schema/query surface:
+  - `ExecutionBudgetRow` now includes `agent_profile_id`.
+  - Execution-budget INSERT/GET/LIST/DEACTIVATE/SUPERSEDE SQL now reads/writes `agent_profile_id`.
+  - `ContinuityStore.create_execution_budget(...)` now accepts `agent_profile_id`.
+- Updated API/contracts:
+  - `ExecutionBudgetCreateInput` now accepts/serializes `agent_profile_id`.
+  - `ExecutionBudgetRecord` now includes additive `agent_profile_id`.
+  - `/v0/execution-budgets` request model now accepts optional `agent_profile_id`.
+- Added create-time validation:
+  - Budget create validates provided `agent_profile_id` exists in profile registry (`store.get_agent_profile_optional`).
+- Implemented profile-aware budget evaluation behavior:
+  - Resolves active thread profile from `request.thread_id`.
+  - Matching precedence: profile-scoped active budgets first, then global (`agent_profile_id IS NULL`).
+  - Preserved selector ordering within each scope: `specificity_desc`, `created_at_asc`, `id_asc`.
+  - Completed-execution counting isolated to active thread profile scope (including global-fallback decisions) while preserving rolling-window behavior and history order.
+- Updated lifecycle/supersede scope handling:
+  - Supersede active-scope checks and duplicate scope messages now include profile scope.
+  - Replacement budget preserves source `agent_profile_id`.
+- Added/updated sprint-scoped tests:
+  - New migration test file for `0037` upgrade/downgrade/index/FK contracts.
+  - Updated unit store/main/execution-budget tests for additive `agent_profile_id` contract and profile-aware behavior.
+  - Updated integration execution-budget API tests for profile scope uniqueness/validation.
+  - Added integration proxy execution test for profile-first matching and global fallback isolation.
 
 ## Incomplete Work
 - None within sprint scope.
 
 ## Files Changed
-- `/Users/samirusani/Desktop/Codex/AliceBot/apps/api/alembic/versions/20260325_0036_agent_profile_model_runtime.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/store.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/contracts.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/phase3_profiles.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/response_generation.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_20260325_0036_agent_profile_model_runtime.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_response_generation.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_continuity_api.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_responses_api.py`
-- `/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md`
-- `/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md`
+- `apps/api/src/alicebot_api/store.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/execution_budgets.py`
+- `apps/api/alembic/versions/20260325_0037_execution_budget_agent_profile_scope.py`
+- `tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py`
+- `tests/unit/test_execution_budgets.py`
+- `tests/unit/test_execution_budgets_main.py`
+- `tests/unit/test_execution_budget_store.py`
+- `tests/integration/test_execution_budgets_api.py`
+- `tests/integration/test_proxy_execution_api.py`
+- `BUILD_REPORT.md`
 
 ## Tests Run
-1. `./.venv/bin/python -m pytest tests/unit/test_20260325_0036_agent_profile_model_runtime.py -q`
-- PASS (`4 passed in 0.22s`)
+- `./.venv/bin/python -m pytest tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py -q`
+  - PASS (`4 passed`)
+- `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_execution_budgets_main.py tests/unit/test_execution_budget_store.py -q`
+  - PASS (`26 passed`)
+- `./.venv/bin/python -m pytest tests/integration/test_execution_budgets_api.py tests/integration/test_proxy_execution_api.py -q`
+  - PASS (`24 passed`)
+- `python3 scripts/run_phase2_validation_matrix.py`
+  - PASS (`Phase 2 validation matrix result: PASS`)
+  - Note: one intermediate run had a transient web-test failure; immediate rerun passed with no code changes.
 
-2. `./.venv/bin/python -m pytest tests/unit/test_response_generation.py -q`
-- PASS (`6 passed in 0.24s`)
+## Blockers / Issues
+- No implementation blockers.
+- Environment note: integration and validation commands required local DB access outside sandbox constraints; commands were rerun with escalated permissions to complete verification.
 
-3. `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py -q`
-- PASS (`13 passed in 4.64s`)
-
-4. `python3 scripts/run_phase2_validation_matrix.py`
-- PASS
-- `control_doc_truth: PASS`
-- `gate_contract_tests: PASS`
-- `readiness_gates: PASS`
-- `backend_integration_matrix: PASS`
-- `web_validation_matrix: PASS`
-
-## Blockers/Issues
-- Sandbox denied localhost PostgreSQL access for DB-backed integration and matrix commands.
-- Resolved by rerunning required DB-backed commands with elevated permissions.
-
-## Explicit Deferred Scope
-- No profile CRUD endpoint work.
-- No new provider integrations or credential/orchestration expansion.
-- No policy/tooling redesign beyond routing to existing provider surface.
-- No web UI changes.
+## Deferred Scope (Explicit)
+- No provider/connector surface expansion.
+- No orchestration/worker runtime redesign.
+- No profile CRUD endpoint expansion.
 
 ## Recommended Next Step
-1. Control Tower review focused on deterministic profile runtime routing/fallback behavior and merge readiness.
+Open integration review (Control Tower Task 3) focused on deterministic profile-scope matching/counting and contract backward compatibility.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,37 +4,44 @@
 PASS
 
 ## criteria met
-- Sprint stayed bounded to profile-scoped model routing surfaces; no new provider/orchestration expansion was introduced.
-- Migration `20260325_0036_agent_profile_model_runtime.py` adds nullable `agent_profiles.model_provider` / `agent_profiles.model_name`, seeds deterministic runtime values for `assistant_default` and `coach_default`, and is reversible.
-- Profile registry/store contracts were updated additively (`model_provider`, `model_name`) and exposed through profile read paths.
-- `/v0/responses` now resolves runtime provider/model from the active thread profile and deterministically falls back to global settings when profile runtime is missing.
-- Existing response/trace behavior remains backward-compatible in observed payload structure (additive changes only where expected).
+- Sprint stayed bounded to execution-budget profile scope; no provider/connector/orchestration expansion was introduced.
+- `execution_budgets` profile scope persistence is implemented with migration `20260325_0037`:
+  - nullable `agent_profile_id` column
+  - FK `execution_budgets_agent_profile_id_fkey -> agent_profiles(id)`
+  - profile-aware active-scope uniqueness/index updates with reversible downgrade.
+- Budget API contracts are additively updated with `agent_profile_id` on create/list/get/lifecycle payloads.
+- Create-time validation rejects unknown `agent_profile_id` values via profile-registry lookup.
+- Budget evaluation behavior is profile-isolated and deterministic:
+  - profile-scoped matches are prioritized for the active thread profile
+  - global budgets are deterministic fallback when no profile-scoped match exists
+  - completed-execution counting is scoped to matched profile context for decisioning.
+- Proxy execution behavior remains backward-compatible in observed event/result/trace structure (no breaking schema changes introduced).
 - Required verification gates pass:
-- `./.venv/bin/python -m pytest tests/unit/test_20260325_0036_agent_profile_model_runtime.py -q` -> `4 passed`
-- `./.venv/bin/python -m pytest tests/unit/test_response_generation.py -q` -> `6 passed`
-- `./.venv/bin/python -m pytest tests/integration/test_continuity_api.py tests/integration/test_responses_api.py -q` -> `13 passed`
-- `python3 scripts/run_phase2_validation_matrix.py` -> `PASS`
+  - `./.venv/bin/python -m pytest tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py -q` -> `4 passed`
+  - `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_execution_budgets_main.py tests/unit/test_execution_budget_store.py -q` -> `26 passed`
+  - `./.venv/bin/python -m pytest tests/integration/test_execution_budgets_api.py tests/integration/test_proxy_execution_api.py -q` -> `24 passed`
+  - `python3 scripts/run_phase2_validation_matrix.py` -> `PASS`
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking implementation defects found in sprint-scoped code.
-- Non-blocking: migration unit coverage is statement-contract oriented; DB-level assertion coverage for new check constraints is indirect (via integration flow) rather than explicit.
+- No blocking implementation defects identified in sprint-scoped code.
+- Non-blocking: migration tests are statement-contract tests (order/text), not DB-level invariant assertions against a live upgraded schema.
 
 ## regression risks
 - Low.
-- Primary residual risk is operational drift from manual DB edits to profile runtime fields; migration constraints reduce this risk for standard writes.
+- Residual edge-case risk: if routing request thread identity is malformed/unresolvable, global-budget counting can become unscoped because profile context cannot be resolved.
 
 ## docs issues
-- No blocking docs gaps for sprint exit.
-- `BUILD_REPORT.md` reflects the implemented routing/migration deltas and required verification outcomes.
+- No blocking docs gaps.
+- `BUILD_REPORT.md` is consistent with observed implementation and verification outcomes.
 
 ## should anything be added to RULES.md?
-- Optional: add a rule that any nullable runtime-routing field change must include at least one deterministic fallback test and one negative-path invariance test.
+- Optional: add a rule that budget-governance scope changes must include one explicit malformed-context test (for missing/unresolvable thread profile) to pin fallback/count behavior.
 
 ## should anything update ARCHITECTURE.md?
-- Optional: add a short runtime-selection note documenting precedence as `thread profile runtime config -> global Settings fallback`.
+- Optional: add an execution-budget precedence note documenting exact order: `profile-scoped active match -> global active match`, with per-scope specificity ordering and profile-scoped counting semantics.
 
 ## recommended next action
-1. Proceed to Control Tower merge review for Phase 3 Sprint 7.
+1. Proceed to Control Tower integration approval and merge readiness for Phase 3 Sprint 8.

--- a/apps/api/alembic/versions/20260325_0037_execution_budget_agent_profile_scope.py
+++ b/apps/api/alembic/versions/20260325_0037_execution_budget_agent_profile_scope.py
@@ -1,0 +1,79 @@
+"""Add optional execution budget profile scope with deterministic active-scope uniqueness."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260325_0037"
+down_revision = "20260325_0036"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_STATEMENTS = (
+    """
+        ALTER TABLE execution_budgets
+          ADD COLUMN agent_profile_id text NULL;
+        """,
+    """
+        ALTER TABLE execution_budgets
+          ADD CONSTRAINT execution_budgets_agent_profile_id_fkey
+          FOREIGN KEY (agent_profile_id)
+          REFERENCES agent_profiles(id);
+        """,
+    "DROP INDEX IF EXISTS execution_budgets_user_match_idx",
+    "DROP INDEX IF EXISTS execution_budgets_one_active_scope_idx",
+    """
+        CREATE INDEX execution_budgets_user_profile_match_idx
+          ON execution_budgets (user_id, agent_profile_id, tool_key, domain_hint, created_at, id);
+        """,
+    """
+        CREATE UNIQUE INDEX execution_budgets_one_active_scope_idx
+          ON execution_budgets (
+            user_id,
+            COALESCE(agent_profile_id, ''),
+            COALESCE(tool_key, ''),
+            COALESCE(domain_hint, '')
+          )
+          WHERE status = 'active';
+        """,
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP INDEX IF EXISTS execution_budgets_one_active_scope_idx",
+    "DROP INDEX IF EXISTS execution_budgets_user_profile_match_idx",
+    """
+        ALTER TABLE execution_budgets
+          DROP CONSTRAINT IF EXISTS execution_budgets_agent_profile_id_fkey;
+        """,
+    """
+        ALTER TABLE execution_budgets
+          DROP COLUMN IF EXISTS agent_profile_id;
+        """,
+    """
+        CREATE INDEX execution_budgets_user_match_idx
+          ON execution_budgets (user_id, tool_key, domain_hint, created_at, id);
+        """,
+    """
+        CREATE UNIQUE INDEX execution_budgets_one_active_scope_idx
+          ON execution_budgets (
+            user_id,
+            COALESCE(tool_key, ''),
+            COALESCE(domain_hint, '')
+          )
+          WHERE status = 'active';
+        """,
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -1423,6 +1423,7 @@ class ExecutionBudgetCreateInput:
     tool_key: str | None = None
     domain_hint: str | None = None
     rolling_window_seconds: int | None = None
+    agent_profile_id: str | None = None
 
     def as_payload(self) -> JsonObject:
         payload: JsonObject = {
@@ -1431,6 +1432,7 @@ class ExecutionBudgetCreateInput:
         payload["tool_key"] = self.tool_key
         payload["domain_hint"] = self.domain_hint
         payload["rolling_window_seconds"] = self.rolling_window_seconds
+        payload["agent_profile_id"] = self.agent_profile_id
         return payload
 
 
@@ -2946,6 +2948,7 @@ class ApprovalResolutionResponse(TypedDict):
 
 class ExecutionBudgetRecord(TypedDict):
     id: str
+    agent_profile_id: str | None
     tool_key: str | None
     domain_hint: str | None
     max_completed_executions: int

--- a/apps/api/src/alicebot_api/execution_budgets.py
+++ b/apps/api/src/alicebot_api/execution_budgets.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 import psycopg
 
 from alicebot_api.contracts import (
+    DEFAULT_AGENT_PROFILE_ID,
     EXECUTION_BUDGET_LIFECYCLE_VERSION_V0,
     EXECUTION_BUDGET_LIST_ORDER,
     EXECUTION_BUDGET_MATCH_ORDER,
@@ -58,6 +59,7 @@ class ExecutionBudgetDecision:
 def serialize_execution_budget_row(row: ExecutionBudgetRow) -> ExecutionBudgetRecord:
     return {
         "id": str(row["id"]),
+        "agent_profile_id": cast(str | None, row["agent_profile_id"]),
         "tool_key": row["tool_key"],
         "domain_hint": row["domain_hint"],
         "max_completed_executions": row["max_completed_executions"],
@@ -85,6 +87,19 @@ def _validate_rolling_window_seconds(rolling_window_seconds: int | None) -> None
     if rolling_window_seconds is not None and rolling_window_seconds <= 0:
         raise ExecutionBudgetValidationError(
             "rolling_window_seconds must be greater than 0 when provided"
+        )
+
+
+def _validate_agent_profile_id(
+    store: ContinuityStore,
+    *,
+    agent_profile_id: str | None,
+) -> None:
+    if agent_profile_id is None:
+        return
+    if store.get_agent_profile_optional(agent_profile_id) is None:
+        raise ExecutionBudgetValidationError(
+            "agent_profile_id must reference an existing profile in the registry"
         )
 
 
@@ -122,27 +137,43 @@ def _trace_summary(trace_id: UUID, trace_events: list[tuple[str, dict[str, objec
 def _active_budget_rows_for_scope(
     store: ContinuityStore,
     *,
+    agent_profile_id: str | None,
     tool_key: str | None,
     domain_hint: str | None,
 ) -> list[ExecutionBudgetRow]:
     rows = [
         row
         for row in store.list_execution_budgets()
-        if row["tool_key"] == tool_key
+        if cast(str | None, row["agent_profile_id"]) == agent_profile_id
+        and row["tool_key"] == tool_key
         and row["domain_hint"] == domain_hint
         and cast(str, row["status"]) == "active"
     ]
     return sorted(rows, key=lambda row: (row["created_at"], row["id"]))
 
 
-def _scope_label(*, tool_key: str | None, domain_hint: str | None) -> str:
-    return f"tool_key={tool_key!r}, domain_hint={domain_hint!r}"
+def _scope_label(
+    *,
+    agent_profile_id: str | None,
+    tool_key: str | None,
+    domain_hint: str | None,
+) -> str:
+    return (
+        f"agent_profile_id={agent_profile_id!r}, "
+        f"tool_key={tool_key!r}, "
+        f"domain_hint={domain_hint!r}"
+    )
 
 
-def _duplicate_active_scope_message(*, tool_key: str | None, domain_hint: str | None) -> str:
+def _duplicate_active_scope_message(
+    *,
+    agent_profile_id: str | None,
+    tool_key: str | None,
+    domain_hint: str | None,
+) -> str:
     return (
         "active execution budget already exists for selector scope "
-        f"{_scope_label(tool_key=tool_key, domain_hint=domain_hint)}"
+        f"{_scope_label(agent_profile_id=agent_profile_id, tool_key=tool_key, domain_hint=domain_hint)}"
     )
 
 
@@ -204,19 +235,23 @@ def create_execution_budget_record(
 
     _validate_budget_scope(tool_key=request.tool_key, domain_hint=request.domain_hint)
     _validate_rolling_window_seconds(request.rolling_window_seconds)
+    _validate_agent_profile_id(store, agent_profile_id=request.agent_profile_id)
     if _active_budget_rows_for_scope(
         store,
+        agent_profile_id=request.agent_profile_id,
         tool_key=request.tool_key,
         domain_hint=request.domain_hint,
     ):
         raise ExecutionBudgetValidationError(
             _duplicate_active_scope_message(
+                agent_profile_id=request.agent_profile_id,
                 tool_key=request.tool_key,
                 domain_hint=request.domain_hint,
             )
         )
     try:
         row = store.create_execution_budget(
+            agent_profile_id=request.agent_profile_id,
             tool_key=request.tool_key,
             domain_hint=request.domain_hint,
             max_completed_executions=request.max_completed_executions,
@@ -226,6 +261,7 @@ def create_execution_budget_record(
         if _is_active_scope_uniqueness_error(exc):
             raise ExecutionBudgetValidationError(
                 _duplicate_active_scope_message(
+                    agent_profile_id=request.agent_profile_id,
                     tool_key=request.tool_key,
                     domain_hint=request.domain_hint,
                 )
@@ -448,13 +484,14 @@ def supersede_execution_budget_record(
 
     active_scope_rows = _active_budget_rows_for_scope(
         store,
+        agent_profile_id=cast(str | None, current["agent_profile_id"]),
         tool_key=current["tool_key"],
         domain_hint=current["domain_hint"],
     )
     if [row["id"] for row in active_scope_rows] != [current["id"]]:
         error = ExecutionBudgetLifecycleError(
             "execution budget selector scope must have exactly one active budget to supersede: "
-            f"{_scope_label(tool_key=current['tool_key'], domain_hint=current['domain_hint'])}"
+            f"{_scope_label(agent_profile_id=cast(str | None, current['agent_profile_id']), tool_key=current['tool_key'], domain_hint=current['domain_hint'])}"
         )
         trace = _record_lifecycle_trace(
             store,
@@ -506,6 +543,7 @@ def supersede_execution_budget_record(
                 )
             replacement = store.create_execution_budget(
                 budget_id=replacement_budget_id,
+                agent_profile_id=cast(str | None, current["agent_profile_id"]),
                 tool_key=current["tool_key"],
                 domain_hint=current["domain_hint"],
                 max_completed_executions=request.max_completed_executions,
@@ -516,6 +554,7 @@ def supersede_execution_budget_record(
         if _is_active_scope_uniqueness_error(exc):
             error = ExecutionBudgetLifecycleError(
                 _duplicate_active_scope_message(
+                    agent_profile_id=cast(str | None, current["agent_profile_id"]),
                     tool_key=current["tool_key"],
                     domain_hint=current["domain_hint"],
                 )
@@ -649,19 +688,63 @@ def _matches_budget(
 def _matching_budget_rows(
     store: ContinuityStore,
     *,
+    active_thread_profile_id: str | None,
     tool_key: str,
     domain_hint: str | None,
 ) -> list[ExecutionBudgetRow]:
-    rows = [
-        row
-        for row in store.list_execution_budgets()
-        if cast(str, row["status"]) == "active"
-        and _matches_budget(row, tool_key=tool_key, domain_hint=domain_hint)
-    ]
-    return sorted(
-        rows,
-        key=lambda row: (-_budget_specificity(row), row["created_at"], row["id"]),
-    )
+    scoped_rows: list[ExecutionBudgetRow] = []
+    global_rows: list[ExecutionBudgetRow] = []
+    for row in store.list_execution_budgets():
+        budget_row = cast(ExecutionBudgetRow, row)
+        if cast(str, budget_row["status"]) != "active":
+            continue
+        if not _matches_budget(budget_row, tool_key=tool_key, domain_hint=domain_hint):
+            continue
+        budget_profile_id = cast(str | None, budget_row["agent_profile_id"])
+        if active_thread_profile_id is not None and budget_profile_id == active_thread_profile_id:
+            scoped_rows.append(budget_row)
+        elif budget_profile_id is None:
+            global_rows.append(budget_row)
+    scoped_rows.sort(key=lambda row: (-_budget_specificity(row), row["created_at"], row["id"]))
+    global_rows.sort(key=lambda row: (-_budget_specificity(row), row["created_at"], row["id"]))
+    return [*scoped_rows, *global_rows]
+
+
+def _thread_profile_id_optional(
+    store: ContinuityStore,
+    *,
+    thread_id: UUID,
+) -> str | None:
+    thread = store.get_thread_optional(thread_id)
+    if thread is None:
+        return None
+    profile_id = cast(str | None, thread.get("agent_profile_id"))
+    if profile_id is None:
+        return DEFAULT_AGENT_PROFILE_ID
+    return profile_id
+
+
+def _resolve_request_thread_profile_id(
+    store: ContinuityStore,
+    *,
+    request: ToolRoutingRequestRecord,
+) -> str | None:
+    try:
+        thread_id = UUID(request["thread_id"])
+    except (TypeError, ValueError):
+        return None
+    return _thread_profile_id_optional(store, thread_id=thread_id)
+
+
+def _count_profile_scope_id(
+    *,
+    matched_budget: ExecutionBudgetRow,
+    active_thread_profile_id: str | None,
+) -> str | None:
+    matched_budget_profile_id = cast(str | None, matched_budget["agent_profile_id"])
+    if matched_budget_profile_id is not None:
+        return matched_budget_profile_id
+    return active_thread_profile_id
 
 
 def _execution_matches_budget(row: ToolExecutionRow, budget: ExecutionBudgetRow) -> bool:
@@ -702,16 +785,27 @@ def _counted_completed_execution_rows(
     *,
     matched_budget: ExecutionBudgetRow,
     evaluation_time: datetime,
+    count_profile_scope_id: str | None,
 ) -> list[ToolExecutionRow]:
     window_started_at = _window_started_at(
         evaluation_time=evaluation_time,
         rolling_window_seconds=matched_budget["rolling_window_seconds"],
     )
     counted_rows: list[ToolExecutionRow] = []
+    thread_profile_cache: dict[UUID, str | None] = {}
     for row in store.list_tool_executions():
         execution_row = cast(ToolExecutionRow, row)
         if not _execution_matches_budget(execution_row, matched_budget):
             continue
+        if count_profile_scope_id is not None:
+            thread_id = execution_row["thread_id"]
+            if thread_id not in thread_profile_cache:
+                thread_profile_cache[thread_id] = _thread_profile_id_optional(
+                    store,
+                    thread_id=thread_id,
+                )
+            if thread_profile_cache[thread_id] != count_profile_scope_id:
+                continue
         if window_started_at is not None and execution_row["executed_at"] < window_started_at:
             continue
         counted_rows.append(execution_row)
@@ -751,8 +845,10 @@ def evaluate_execution_budget(
     tool: ToolRecord,
     request: ToolRoutingRequestRecord,
 ) -> ExecutionBudgetDecision:
+    active_thread_profile_id = _resolve_request_thread_profile_id(store, request=request)
     matching_budgets = _matching_budget_rows(
         store,
+        active_thread_profile_id=active_thread_profile_id,
         tool_key=tool["tool_key"],
         domain_hint=request["domain_hint"],
     )
@@ -775,6 +871,10 @@ def evaluate_execution_budget(
                 store,
                 matched_budget=matched_budget,
                 evaluation_time=evaluation_time,
+                count_profile_scope_id=_count_profile_scope_id(
+                    matched_budget=matched_budget,
+                    active_thread_profile_id=active_thread_profile_id,
+                ),
             )
         )
         projected_completed_execution_count = completed_execution_count + 1

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -792,6 +792,7 @@ class TransitionTaskStepRequest(BaseModel):
 
 class CreateExecutionBudgetRequest(BaseModel):
     user_id: UUID
+    agent_profile_id: str | None = Field(default=None, min_length=1, max_length=100)
     tool_key: str | None = Field(default=None, min_length=1, max_length=200)
     domain_hint: str | None = Field(default=None, min_length=1, max_length=200)
     max_completed_executions: int = Field(ge=1, le=1000000)
@@ -2588,6 +2589,7 @@ def create_execution_budget(request: CreateExecutionBudgetRequest) -> JSONRespon
                 ContinuityStore(conn),
                 user_id=request.user_id,
                 request=ExecutionBudgetCreateInput(
+                    agent_profile_id=request.agent_profile_id,
                     tool_key=request.tool_key,
                     domain_hint=request.domain_hint,
                     max_completed_executions=request.max_completed_executions,

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -437,6 +437,7 @@ class ToolExecutionRow(TypedDict):
 class ExecutionBudgetRow(TypedDict):
     id: UUID
     user_id: UUID
+    agent_profile_id: str | None
     tool_key: str | None
     domain_hint: str | None
     max_completed_executions: int
@@ -3075,6 +3076,7 @@ INSERT_EXECUTION_BUDGET_SQL = """
                 INSERT INTO execution_budgets (
                   id,
                   user_id,
+                  agent_profile_id,
                   tool_key,
                   domain_hint,
                   max_completed_executions,
@@ -3088,11 +3090,13 @@ INSERT_EXECUTION_BUDGET_SQL = """
                   %s,
                   %s,
                   %s,
+                  %s,
                   %s
                 )
                 RETURNING
                   id,
                   user_id,
+                  agent_profile_id,
                   tool_key,
                   domain_hint,
                   max_completed_executions,
@@ -3108,6 +3112,7 @@ GET_EXECUTION_BUDGET_SQL = """
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   tool_key,
                   domain_hint,
                   max_completed_executions,
@@ -3125,6 +3130,7 @@ LIST_EXECUTION_BUDGETS_SQL = """
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   tool_key,
                   domain_hint,
                   max_completed_executions,
@@ -3147,6 +3153,7 @@ DEACTIVATE_EXECUTION_BUDGET_SQL = """
                 RETURNING
                   id,
                   user_id,
+                  agent_profile_id,
                   tool_key,
                   domain_hint,
                   max_completed_executions,
@@ -3168,6 +3175,7 @@ SUPERSEDE_EXECUTION_BUDGET_SQL = """
                 RETURNING
                   id,
                   user_id,
+                  agent_profile_id,
                   tool_key,
                   domain_hint,
                   max_completed_executions,
@@ -4540,6 +4548,7 @@ class ContinuityStore:
         self,
         *,
         budget_id: UUID | None = None,
+        agent_profile_id: str | None = None,
         tool_key: str | None,
         domain_hint: str | None,
         max_completed_executions: int,
@@ -4551,6 +4560,7 @@ class ContinuityStore:
             INSERT_EXECUTION_BUDGET_SQL,
             (
                 budget_id,
+                agent_profile_id,
                 tool_key,
                 domain_hint,
                 max_completed_executions,

--- a/tests/integration/test_execution_budgets_api.py
+++ b/tests/integration/test_execution_budgets_api.py
@@ -81,6 +81,7 @@ def seed_user(database_url: str, *, email: str) -> dict[str, UUID]:
 def create_budget(
     *,
     user_id: UUID,
+    agent_profile_id: str | None = None,
     tool_key: str | None,
     domain_hint: str | None,
     max_completed_executions: int,
@@ -90,6 +91,8 @@ def create_budget(
         "user_id": str(user_id),
         "max_completed_executions": max_completed_executions,
     }
+    if agent_profile_id is not None:
+        payload["agent_profile_id"] = agent_profile_id
     if tool_key is not None:
         payload["tool_key"] = tool_key
     if domain_hint is not None:
@@ -139,6 +142,7 @@ def test_execution_budget_endpoints_create_list_and_get_in_deterministic_order(
 
     assert first_status == 201
     assert second_status == 201
+    assert second_payload["execution_budget"]["agent_profile_id"] is None
     assert second_payload["execution_budget"]["status"] == "active"
     assert second_payload["execution_budget"]["deactivated_at"] is None
     assert second_payload["execution_budget"]["rolling_window_seconds"] == 3600
@@ -216,8 +220,70 @@ def test_create_execution_budget_endpoint_rejects_duplicate_active_scope(
     assert first_status == 201
     assert second_status == 400
     assert second_payload == {
-        "detail": "active execution budget already exists for selector scope tool_key='proxy.echo', domain_hint='docs'"
+        "detail": (
+            "active execution budget already exists for selector scope "
+            "agent_profile_id=None, tool_key='proxy.echo', domain_hint='docs'"
+        )
     }
+
+
+def test_create_execution_budget_endpoint_rejects_unknown_agent_profile_id(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    owner = seed_user(migrated_database_urls["app"], email="owner@example.com")
+    monkeypatch.setattr(main_module, "get_settings", lambda: Settings(database_url=migrated_database_urls["app"]))
+
+    status_code, payload = create_budget(
+        user_id=owner["user_id"],
+        agent_profile_id="profile_missing",
+        tool_key="proxy.echo",
+        domain_hint=None,
+        max_completed_executions=1,
+    )
+
+    assert status_code == 400
+    assert payload == {
+        "detail": "agent_profile_id must reference an existing profile in the registry"
+    }
+
+
+def test_create_execution_budget_endpoint_allows_same_selector_across_profile_scopes(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    owner = seed_user(migrated_database_urls["app"], email="owner@example.com")
+    monkeypatch.setattr(main_module, "get_settings", lambda: Settings(database_url=migrated_database_urls["app"]))
+
+    scoped_status, scoped_payload = create_budget(
+        user_id=owner["user_id"],
+        agent_profile_id="assistant_default",
+        tool_key="proxy.echo",
+        domain_hint="docs",
+        max_completed_executions=1,
+    )
+    global_status, global_payload = create_budget(
+        user_id=owner["user_id"],
+        agent_profile_id=None,
+        tool_key="proxy.echo",
+        domain_hint="docs",
+        max_completed_executions=2,
+    )
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v0/execution-budgets",
+        query_params={"user_id": str(owner["user_id"])},
+    )
+
+    assert scoped_status == 201
+    assert global_status == 201
+    assert scoped_payload["execution_budget"]["agent_profile_id"] == "assistant_default"
+    assert global_payload["execution_budget"]["agent_profile_id"] is None
+    assert list_status == 200
+    assert [item["id"] for item in list_payload["items"]] == [
+        scoped_payload["execution_budget"]["id"],
+        global_payload["execution_budget"]["id"],
+    ]
 
 
 def test_deactivate_execution_budget_endpoint_updates_reads_and_emits_trace(

--- a/tests/integration/test_proxy_execution_api.py
+++ b/tests/integration/test_proxy_execution_api.py
@@ -77,6 +77,19 @@ def seed_user(database_url: str, *, email: str) -> dict[str, UUID]:
     }
 
 
+def create_thread(
+    database_url: str,
+    *,
+    user_id: UUID,
+    title: str,
+    agent_profile_id: str,
+) -> UUID:
+    with user_connection(database_url, user_id) as conn:
+        store = ContinuityStore(conn)
+        thread = store.create_thread(title, agent_profile_id)
+    return thread["id"]
+
+
 def create_tool_and_policy(
     database_url: str,
     *,
@@ -136,6 +149,7 @@ def create_execution_budget(
     database_url: str,
     *,
     user_id: UUID,
+    agent_profile_id: str | None = None,
     tool_key: str | None,
     domain_hint: str | None,
     max_completed_executions: int,
@@ -144,6 +158,7 @@ def create_execution_budget(
     with user_connection(database_url, user_id) as conn:
         store = ContinuityStore(conn)
         budget = store.create_execution_budget(
+            agent_profile_id=agent_profile_id,
             tool_key=tool_key,
             domain_hint=domain_hint,
             max_completed_executions=max_completed_executions,
@@ -1300,6 +1315,144 @@ def test_execute_approved_proxy_endpoint_uses_replacement_budget_after_supersess
         "order": ["specificity_desc", "created_at_asc", "id_asc"],
         "history_order": ["executed_at_asc", "id_asc"],
     }
+
+
+def test_execute_approved_proxy_endpoint_applies_profile_scope_before_global_fallback(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    owner = seed_user(migrated_database_urls["app"], email="owner@example.com")
+    coach_thread_id = create_thread(
+        migrated_database_urls["app"],
+        user_id=owner["user_id"],
+        title="Coach profile thread",
+        agent_profile_id="coach_default",
+    )
+    monkeypatch.setattr(main_module, "get_settings", lambda: Settings(database_url=migrated_database_urls["app"]))
+    tool_id = create_tool_and_policy(
+        migrated_database_urls["app"],
+        user_id=owner["user_id"],
+        tool_key="proxy.echo",
+    )
+    assistant_budget_id = create_execution_budget(
+        migrated_database_urls["app"],
+        user_id=owner["user_id"],
+        agent_profile_id="assistant_default",
+        tool_key="proxy.echo",
+        domain_hint=None,
+        max_completed_executions=1,
+    )
+    global_budget_id = create_execution_budget(
+        migrated_database_urls["app"],
+        user_id=owner["user_id"],
+        agent_profile_id=None,
+        tool_key="proxy.echo",
+        domain_hint=None,
+        max_completed_executions=1,
+    )
+
+    assistant_first_status, assistant_first_payload = create_pending_approval(
+        user_id=owner["user_id"],
+        thread_id=owner["thread_id"],
+        tool_id=tool_id,
+    )
+    assistant_second_status, assistant_second_payload = create_pending_approval(
+        user_id=owner["user_id"],
+        thread_id=owner["thread_id"],
+        tool_id=tool_id,
+    )
+    coach_first_status, coach_first_payload = create_pending_approval(
+        user_id=owner["user_id"],
+        thread_id=coach_thread_id,
+        tool_id=tool_id,
+    )
+    coach_second_status, coach_second_payload = create_pending_approval(
+        user_id=owner["user_id"],
+        thread_id=coach_thread_id,
+        tool_id=tool_id,
+    )
+    assert assistant_first_status == 200
+    assert assistant_second_status == 200
+    assert coach_first_status == 200
+    assert coach_second_status == 200
+
+    for approval_payload in (
+        assistant_first_payload,
+        assistant_second_payload,
+        coach_first_payload,
+        coach_second_payload,
+    ):
+        approve_status, _ = invoke_request(
+            "POST",
+            f"/v0/approvals/{approval_payload['approval']['id']}/approve",
+            payload={"user_id": str(owner["user_id"])},
+        )
+        assert approve_status == 200
+
+    assistant_first_execute_status, assistant_first_execute_payload = invoke_request(
+        "POST",
+        f"/v0/approvals/{assistant_first_payload['approval']['id']}/execute",
+        payload={"user_id": str(owner["user_id"])},
+    )
+    coach_first_execute_status, coach_first_execute_payload = invoke_request(
+        "POST",
+        f"/v0/approvals/{coach_first_payload['approval']['id']}/execute",
+        payload={"user_id": str(owner["user_id"])},
+    )
+    coach_second_execute_status, coach_second_execute_payload = invoke_request(
+        "POST",
+        f"/v0/approvals/{coach_second_payload['approval']['id']}/execute",
+        payload={"user_id": str(owner["user_id"])},
+    )
+    assistant_second_execute_status, assistant_second_execute_payload = invoke_request(
+        "POST",
+        f"/v0/approvals/{assistant_second_payload['approval']['id']}/execute",
+        payload={"user_id": str(owner["user_id"])},
+    )
+
+    assert assistant_first_execute_status == 200
+    assert coach_first_execute_status == 200
+    assert coach_second_execute_status == 200
+    assert assistant_second_execute_status == 200
+    assert assistant_first_execute_payload["result"]["status"] == "completed"
+    assert coach_first_execute_payload["result"]["status"] == "completed"
+    assert coach_second_execute_payload["result"]["status"] == "blocked"
+    assert assistant_second_execute_payload["result"]["status"] == "blocked"
+
+    with user_connection(migrated_database_urls["app"], owner["user_id"]) as conn:
+        store = ContinuityStore(conn)
+        assistant_first_trace_events = store.list_trace_events(
+            UUID(assistant_first_execute_payload["trace"]["trace_id"])
+        )
+        coach_first_trace_events = store.list_trace_events(
+            UUID(coach_first_execute_payload["trace"]["trace_id"])
+        )
+        coach_second_trace_events = store.list_trace_events(
+            UUID(coach_second_execute_payload["trace"]["trace_id"])
+        )
+        assistant_second_trace_events = store.list_trace_events(
+            UUID(assistant_second_execute_payload["trace"]["trace_id"])
+        )
+
+    assert assistant_first_trace_events[2]["payload"]["matched_budget_id"] == str(assistant_budget_id)
+    assert assistant_first_trace_events[2]["payload"]["completed_execution_count"] == 0
+    assert assistant_first_trace_events[2]["payload"]["projected_completed_execution_count"] == 1
+    assert assistant_first_trace_events[2]["payload"]["reason"] == "within_budget"
+
+    assert coach_first_trace_events[2]["payload"]["matched_budget_id"] == str(global_budget_id)
+    assert coach_first_trace_events[2]["payload"]["completed_execution_count"] == 0
+    assert coach_first_trace_events[2]["payload"]["projected_completed_execution_count"] == 1
+    assert coach_first_trace_events[2]["payload"]["reason"] == "within_budget"
+
+    assert coach_second_trace_events[2]["payload"]["matched_budget_id"] == str(global_budget_id)
+    assert coach_second_trace_events[2]["payload"]["completed_execution_count"] == 1
+    assert coach_second_trace_events[2]["payload"]["projected_completed_execution_count"] == 2
+    assert coach_second_trace_events[2]["payload"]["reason"] == "budget_exceeded"
+
+    assert assistant_second_trace_events[2]["payload"]["matched_budget_id"] == str(assistant_budget_id)
+    assert assistant_second_trace_events[2]["payload"]["completed_execution_count"] == 1
+    assert assistant_second_trace_events[2]["payload"]["projected_completed_execution_count"] == 2
+    assert assistant_second_trace_events[2]["payload"]["reason"] == "budget_exceeded"
 
 
 def test_execute_approved_proxy_execution_budget_is_user_scoped(

--- a/tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py
+++ b/tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260325_0037_execution_budget_agent_profile_scope"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == list(module._UPGRADE_STATEMENTS)
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_execution_budget_profile_scope_upgrade_contract() -> None:
+    module = load_migration_module()
+
+    assert "ADD COLUMN agent_profile_id text NULL" in module._UPGRADE_STATEMENTS[0]
+    assert "execution_budgets_agent_profile_id_fkey" in module._UPGRADE_STATEMENTS[1]
+    assert "FOREIGN KEY (agent_profile_id)" in module._UPGRADE_STATEMENTS[1]
+    assert "REFERENCES agent_profiles(id)" in module._UPGRADE_STATEMENTS[1]
+    assert "DROP INDEX IF EXISTS execution_budgets_user_match_idx" in module._UPGRADE_STATEMENTS[2]
+    assert "DROP INDEX IF EXISTS execution_budgets_one_active_scope_idx" in module._UPGRADE_STATEMENTS[3]
+    assert "execution_budgets_user_profile_match_idx" in module._UPGRADE_STATEMENTS[4]
+    assert "(user_id, agent_profile_id, tool_key, domain_hint, created_at, id)" in module._UPGRADE_STATEMENTS[4]
+    assert "execution_budgets_one_active_scope_idx" in module._UPGRADE_STATEMENTS[5]
+    assert "COALESCE(agent_profile_id, '')" in module._UPGRADE_STATEMENTS[5]
+    assert "COALESCE(tool_key, '')" in module._UPGRADE_STATEMENTS[5]
+    assert "COALESCE(domain_hint, '')" in module._UPGRADE_STATEMENTS[5]
+    assert "WHERE status = 'active'" in module._UPGRADE_STATEMENTS[5]
+
+
+def test_execution_budget_profile_scope_downgrade_contract() -> None:
+    module = load_migration_module()
+
+    assert "DROP INDEX IF EXISTS execution_budgets_one_active_scope_idx" in module._DOWNGRADE_STATEMENTS[0]
+    assert "DROP INDEX IF EXISTS execution_budgets_user_profile_match_idx" in module._DOWNGRADE_STATEMENTS[1]
+    assert "DROP CONSTRAINT IF EXISTS execution_budgets_agent_profile_id_fkey" in module._DOWNGRADE_STATEMENTS[2]
+    assert "DROP COLUMN IF EXISTS agent_profile_id" in module._DOWNGRADE_STATEMENTS[3]
+    assert "CREATE INDEX execution_budgets_user_match_idx" in module._DOWNGRADE_STATEMENTS[4]
+    assert "(user_id, tool_key, domain_hint, created_at, id)" in module._DOWNGRADE_STATEMENTS[4]
+    assert "CREATE UNIQUE INDEX execution_budgets_one_active_scope_idx" in module._DOWNGRADE_STATEMENTS[5]
+    assert "COALESCE(tool_key, '')" in module._DOWNGRADE_STATEMENTS[5]
+    assert "COALESCE(domain_hint, '')" in module._DOWNGRADE_STATEMENTS[5]
+    assert "WHERE status = 'active'" in module._DOWNGRADE_STATEMENTS[5]

--- a/tests/unit/test_execution_budget_store.py
+++ b/tests/unit/test_execution_budget_store.py
@@ -43,6 +43,7 @@ def test_execution_budget_store_methods_use_expected_queries_and_parameters() ->
     replacement_budget_id = uuid4()
     row = {
         "id": execution_budget_id,
+        "agent_profile_id": None,
         "tool_key": "proxy.echo",
         "domain_hint": "docs",
         "max_completed_executions": 2,
@@ -65,6 +66,7 @@ def test_execution_budget_store_methods_use_expected_queries_and_parameters() ->
     store = ContinuityStore(RecordingConnection(cursor))
 
     created = store.create_execution_budget(
+        agent_profile_id=None,
         tool_key="proxy.echo",
         domain_hint="docs",
         max_completed_executions=2,
@@ -89,7 +91,7 @@ def test_execution_budget_store_methods_use_expected_queries_and_parameters() ->
 
     create_query, create_params = cursor.executed[0]
     assert "INSERT INTO execution_budgets" in create_query
-    assert create_params == (None, "proxy.echo", "docs", 2, 3600, None)
+    assert create_params == (None, None, "proxy.echo", "docs", 2, 3600, None)
     assert "FROM execution_budgets" in cursor.executed[1][0]
     assert "ORDER BY created_at ASC, id ASC" in cursor.executed[2][0]
     assert "UPDATE execution_budgets" in cursor.executed[3][0]

--- a/tests/unit/test_execution_budgets.py
+++ b/tests/unit/test_execution_budgets.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from alicebot_api.contracts import (
+    DEFAULT_AGENT_PROFILE_ID,
     ExecutionBudgetCreateInput,
     ExecutionBudgetDeactivateInput,
     ExecutionBudgetSupersedeInput,
@@ -51,6 +52,10 @@ class ExecutionBudgetStoreStub:
         self.base_time = datetime(2026, 3, 13, 11, 0, tzinfo=UTC)
         self.user_id = uuid4()
         self.thread_id = uuid4()
+        self.agent_profiles = {DEFAULT_AGENT_PROFILE_ID, "coach_default"}
+        self.thread_profiles: dict[UUID, str] = {
+            self.thread_id: DEFAULT_AGENT_PROFILE_ID,
+        }
         self.budgets: list[dict[str, object]] = []
         self.executions: list[dict[str, object]] = []
         self.traces: list[dict[str, object]] = []
@@ -62,14 +67,31 @@ class ExecutionBudgetStoreStub:
         return self.base_time + timedelta(minutes=len(self.executions))
 
     def get_thread_optional(self, thread_id: UUID) -> dict[str, object] | None:
-        if thread_id != self.thread_id:
+        if thread_id not in self.thread_profiles:
             return None
         return {
-            "id": self.thread_id,
+            "id": thread_id,
             "user_id": self.user_id,
             "title": "Budget lifecycle thread",
+            "agent_profile_id": self.thread_profiles[thread_id],
             "created_at": self.base_time,
             "updated_at": self.base_time,
+        }
+
+    def create_thread(self, *, agent_profile_id: str) -> UUID:
+        thread_id = uuid4()
+        self.thread_profiles[thread_id] = agent_profile_id
+        return thread_id
+
+    def get_agent_profile_optional(self, profile_id: str) -> dict[str, object] | None:
+        if profile_id not in self.agent_profiles:
+            return None
+        return {
+            "id": profile_id,
+            "name": profile_id,
+            "description": "",
+            "model_provider": None,
+            "model_name": None,
         }
 
     def create_trace(
@@ -118,6 +140,7 @@ class ExecutionBudgetStoreStub:
         self,
         *,
         budget_id: UUID | None = None,
+        agent_profile_id: str | None = None,
         tool_key: str | None,
         domain_hint: str | None,
         max_completed_executions: int,
@@ -127,6 +150,7 @@ class ExecutionBudgetStoreStub:
         row = {
             "id": uuid4() if budget_id is None else budget_id,
             "user_id": self.user_id,
+            "agent_profile_id": agent_profile_id,
             "tool_key": tool_key,
             "domain_hint": domain_hint,
             "max_completed_executions": max_completed_executions,
@@ -182,14 +206,16 @@ class ExecutionBudgetStoreStub:
         domain_hint: str | None,
         status: str,
         offset_minutes: int,
+        thread_id: UUID | None = None,
     ) -> None:
+        execution_thread_id = self.thread_id if thread_id is None else thread_id
         tool_id = uuid4()
         self.executions.append(
             {
                 "id": uuid4(),
                 "user_id": self.user_id,
                 "approval_id": uuid4(),
-                "thread_id": self.thread_id,
+                "thread_id": execution_thread_id,
                 "tool_id": tool_id,
                 "trace_id": uuid4(),
                 "request_event_id": None,
@@ -197,7 +223,7 @@ class ExecutionBudgetStoreStub:
                 "status": status,
                 "handler_key": None if status == "blocked" else tool_key,
                 "request": {
-                    "thread_id": str(self.thread_id),
+                    "thread_id": str(execution_thread_id),
                     "tool_id": str(tool_id),
                     "action": "tool.run",
                     "scope": "workspace",
@@ -268,6 +294,53 @@ def test_create_execution_budget_rejects_duplicate_active_scope() -> None:
         )
 
 
+def test_create_execution_budget_allows_same_selector_across_profile_scopes() -> None:
+    store = ExecutionBudgetStoreStub()
+    default_budget = create_execution_budget_record(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ExecutionBudgetCreateInput(
+            agent_profile_id=DEFAULT_AGENT_PROFILE_ID,
+            tool_key="proxy.echo",
+            domain_hint="docs",
+            max_completed_executions=1,
+        ),
+    )
+    global_budget = create_execution_budget_record(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ExecutionBudgetCreateInput(
+            agent_profile_id=None,
+            tool_key="proxy.echo",
+            domain_hint="docs",
+            max_completed_executions=2,
+        ),
+    )
+
+    assert default_budget["execution_budget"]["agent_profile_id"] == DEFAULT_AGENT_PROFILE_ID
+    assert global_budget["execution_budget"]["agent_profile_id"] is None
+    assert len(store.budgets) == 2
+
+
+def test_create_execution_budget_rejects_unknown_agent_profile_id() -> None:
+    store = ExecutionBudgetStoreStub()
+
+    with pytest.raises(
+        ExecutionBudgetValidationError,
+        match="agent_profile_id must reference an existing profile in the registry",
+    ):
+        create_execution_budget_record(
+            store,  # type: ignore[arg-type]
+            user_id=store.user_id,
+            request=ExecutionBudgetCreateInput(
+                agent_profile_id="profile_missing",
+                tool_key="proxy.echo",
+                domain_hint=None,
+                max_completed_executions=1,
+            ),
+        )
+
+
 def test_create_execution_budget_includes_optional_rolling_window_seconds() -> None:
     store = ExecutionBudgetStoreStub()
 
@@ -283,6 +356,7 @@ def test_create_execution_budget_includes_optional_rolling_window_seconds() -> N
     )
 
     assert payload["execution_budget"]["rolling_window_seconds"] == 3600
+    assert payload["execution_budget"]["agent_profile_id"] is None
     assert store.budgets[0]["rolling_window_seconds"] == 3600
 
 
@@ -556,6 +630,88 @@ def test_evaluate_execution_budget_prefers_more_specific_active_match_and_ignore
         "order": ["specificity_desc", "created_at_asc", "id_asc"],
         "history_order": ["executed_at_asc", "id_asc"],
     }
+    assert decision.blocked_result is None
+
+
+def test_evaluate_execution_budget_prefers_profile_scoped_budget_before_global_fallback() -> None:
+    store = ExecutionBudgetStoreStub()
+    global_budget = store.create_execution_budget(
+        agent_profile_id=None,
+        tool_key="proxy.echo",
+        domain_hint=None,
+        max_completed_executions=1,
+    )
+    profile_budget = store.create_execution_budget(
+        agent_profile_id=DEFAULT_AGENT_PROFILE_ID,
+        tool_key="proxy.echo",
+        domain_hint=None,
+        max_completed_executions=2,
+    )
+    store.seed_execution(
+        tool_key="proxy.echo",
+        domain_hint=None,
+        status="completed",
+        offset_minutes=0,
+        thread_id=store.thread_id,
+    )
+
+    decision = evaluate_execution_budget(
+        store,  # type: ignore[arg-type]
+        tool={"id": str(uuid4()), "tool_key": "proxy.echo"},
+        request={
+            "thread_id": str(store.thread_id),
+            "tool_id": str(uuid4()),
+            "action": "tool.run",
+            "scope": "workspace",
+            "domain_hint": None,
+            "risk_hint": None,
+            "attributes": {},
+        },
+    )
+
+    assert decision.record["matched_budget_id"] == str(profile_budget["id"])
+    assert decision.record["completed_execution_count"] == 1
+    assert decision.record["projected_completed_execution_count"] == 2
+    assert decision.record["reason"] == "within_budget"
+    assert decision.blocked_result is None
+    assert str(global_budget["id"]) != decision.record["matched_budget_id"]
+
+
+def test_evaluate_execution_budget_global_fallback_counts_only_active_thread_profile_history() -> None:
+    store = ExecutionBudgetStoreStub()
+    coach_thread_id = store.create_thread(agent_profile_id="coach_default")
+    global_budget = store.create_execution_budget(
+        agent_profile_id=None,
+        tool_key="proxy.echo",
+        domain_hint=None,
+        max_completed_executions=1,
+    )
+    store.seed_execution(
+        tool_key="proxy.echo",
+        domain_hint=None,
+        status="completed",
+        offset_minutes=0,
+        thread_id=store.thread_id,
+    )
+
+    decision = evaluate_execution_budget(
+        store,  # type: ignore[arg-type]
+        tool={"id": str(uuid4()), "tool_key": "proxy.echo"},
+        request={
+            "thread_id": str(coach_thread_id),
+            "tool_id": str(uuid4()),
+            "action": "tool.run",
+            "scope": "workspace",
+            "domain_hint": None,
+            "risk_hint": None,
+            "attributes": {},
+        },
+    )
+
+    assert decision.record["matched_budget_id"] == str(global_budget["id"])
+    assert decision.record["completed_execution_count"] == 0
+    assert decision.record["projected_completed_execution_count"] == 1
+    assert decision.record["reason"] == "within_budget"
     assert decision.blocked_result is None
 
 

--- a/tests/unit/test_execution_budgets_main.py
+++ b/tests/unit/test_execution_budgets_main.py
@@ -31,6 +31,7 @@ def test_create_execution_budget_endpoint_returns_payload(monkeypatch) -> None:
         return {
             "execution_budget": {
                 "id": "budget-123",
+                "agent_profile_id": "assistant_default",
                 "tool_key": "proxy.echo",
                 "domain_hint": None,
                 "max_completed_executions": 1,
@@ -50,6 +51,7 @@ def test_create_execution_budget_endpoint_returns_payload(monkeypatch) -> None:
     response = main_module.create_execution_budget(
         main_module.CreateExecutionBudgetRequest(
             user_id=user_id,
+            agent_profile_id="assistant_default",
             tool_key="proxy.echo",
             domain_hint=None,
             max_completed_executions=1,
@@ -63,6 +65,7 @@ def test_create_execution_budget_endpoint_returns_payload(monkeypatch) -> None:
     assert captured["current_user_id"] == user_id
     assert captured["store_type"] == "ContinuityStore"
     assert captured["user_id"] == user_id
+    assert captured["request"].agent_profile_id == "assistant_default"
     assert captured["request"].tool_key == "proxy.echo"
     assert captured["request"].rolling_window_seconds == 3600
 
@@ -117,6 +120,7 @@ def test_list_execution_budgets_endpoint_returns_payload(monkeypatch) -> None:
             "items": [
                 {
                     "id": "budget-123",
+                    "agent_profile_id": None,
                     "tool_key": "proxy.echo",
                     "domain_hint": None,
                     "max_completed_executions": 1,
@@ -169,6 +173,7 @@ def test_get_execution_budget_endpoint_returns_payload(monkeypatch) -> None:
         return {
             "execution_budget": {
                 "id": str(execution_budget_id),
+                "agent_profile_id": None,
                 "tool_key": "proxy.echo",
                 "domain_hint": None,
                 "max_completed_executions": 1,
@@ -242,6 +247,7 @@ def test_deactivate_execution_budget_endpoint_returns_payload(monkeypatch) -> No
         return {
             "execution_budget": {
                 "id": str(execution_budget_id),
+                "agent_profile_id": None,
                 "tool_key": "proxy.echo",
                 "domain_hint": None,
                 "max_completed_executions": 1,
@@ -326,6 +332,7 @@ def test_supersede_execution_budget_endpoint_returns_payload(monkeypatch) -> Non
         return {
             "superseded_budget": {
                 "id": str(execution_budget_id),
+                "agent_profile_id": None,
                 "tool_key": "proxy.echo",
                 "domain_hint": None,
                 "max_completed_executions": 1,
@@ -338,6 +345,7 @@ def test_supersede_execution_budget_endpoint_returns_payload(monkeypatch) -> Non
             },
             "replacement_budget": {
                 "id": "budget-456",
+                "agent_profile_id": None,
                 "tool_key": "proxy.echo",
                 "domain_hint": None,
                 "max_completed_executions": 3,


### PR DESCRIPTION
## Summary
This PR implements Phase 3 Sprint 8 by isolating execution-budget governance to the active thread profile.

### What changed
- Added optional `agent_profile_id` scope to `execution_budgets` via migration `20260325_0037_execution_budget_agent_profile_scope`.
- Updated budget storage and API contracts to read/write/serialize additive `agent_profile_id` fields.
- Added create-time validation so provided `agent_profile_id` values must exist in the profile registry.
- Updated execution-budget matching and counting so decisions are profile-aware:
  - match profile-scoped active budgets for the thread profile first
  - fallback deterministically to global budgets when no profile-scoped match exists
  - keep existing specificity/ordering behavior within each scope
- Added sprint-scoped unit/integration coverage for migration contracts, profile isolation behavior, and global fallback behavior.

## Scope Guardrails
- No provider/connector expansion
- No orchestration/runtime redesign
- No profile CRUD expansion
- No web UI changes

## Verification
From sprint reports:
- `./.venv/bin/python -m pytest tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py -q` -> `4 passed`
- `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_execution_budgets_main.py tests/unit/test_execution_budget_store.py -q` -> `26 passed`
- `./.venv/bin/python -m pytest tests/integration/test_execution_budgets_api.py tests/integration/test_proxy_execution_api.py -q` -> `24 passed`
- `python3 scripts/run_phase2_validation_matrix.py` -> `PASS`

## Control Tower
- Review verdict: `PASS`
- Integration decision: `MERGE_APPROVED`
