### PR TITLE
Phase 3 Sprint 9: Budget Context Invariance Hardening

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,32 +2,32 @@
 
 ## Sprint Title
 
-Phase 3 Sprint 8: Profile-Scoped Execution Budget Isolation
+Phase 3 Sprint 9: Budget Context Invariance Hardening
 
 ## Sprint Type
 
-feature
+hardening
 
 ## Sprint Reason
 
-Sprint 7 completed profile-scoped response model routing. The next non-redundant gap is governed execution budget isolation: execution budgets are still user-global, so one profile can exhaust limits that should be isolated to another profile.
+Sprint 8 completed profile-scoped execution-budget isolation. The remaining non-redundant correctness gap is context invariance: malformed or unresolvable thread/profile context can degrade budget counting/match isolation behavior.
 
 ## Sprint Intent
 
-Scope execution-budget matching and counting to the active thread profile, with deterministic fallback to global budgets when no profile-specific budget matches.
+Make budget decisioning fail-closed and profile-safe when thread context is malformed/unresolvable, and make counted execution history strictly profile-attributable.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase3-sprint8-profile-budget-scope`
+- Branch Name: `codex/phase3-sprint9-budget-context-invariance`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- It is the next non-redundant seam after identity, memory isolation, policy isolation, and model isolation.
-- It closes a remaining shared-governance gap where execution budgets can still cross-contaminate profiles.
-- It advances separate-agent runtime behavior without widening orchestration or connector scope.
+- It directly closes the only explicit residual risk called out in Sprint 8 review.
+- It hardens separate-agent isolation semantics under malformed state, not just happy-path contracts.
+- It preserves momentum toward MVP/Phase 3 completion without reopening schema breadth.
 
 ## Redundancy Guard
 
@@ -38,38 +38,35 @@ Scope execution-budget matching and counting to the active thread profile, with 
 - Already shipped in Sprint 5: profile-scoped memory/context isolation.
 - Already shipped in Sprint 6: profile-scoped policy evaluation/routing.
 - Already shipped in Sprint 7: profile-scoped model/provider routing for `/v0/responses`.
-- Missing and required now: profile-scoped execution budget matching + counted execution history isolation.
+- Already shipped in Sprint 8: profile-scoped execution-budget matching + counted execution isolation for normal context.
+- Missing and required now: deterministic fail-closed handling and invariance guarantees for malformed/unresolvable thread context.
 
 ## Design Truth
 
-- Execution budgets can optionally target one `agent_profile_id` while preserving global budget support via nullable scope.
-- Budget match precedence remains deterministic:
-  - first match active budgets scoped to the thread profile
-  - then match active global budgets (`agent_profile_id IS NULL`)
-  - within each scope, preserve existing selector specificity and stable ordering
-- Completed-execution counting for budget decisions must only include executions attributable to the same profile scope as the matched budget.
-- Keep tool/provider/orchestration surface bounded; this sprint is budget-scope isolation only.
+- Budget decisioning must resolve runtime thread/profile context deterministically before counting/match finalization.
+- If request thread context is missing/unresolvable at execution time, decisioning is fail-closed with explicit deterministic reasoning (no unscoped fallback counting).
+- Historical execution rows with malformed/unresolvable thread context are excluded from profile-scoped counted history.
+- Matching precedence remains unchanged for valid context:
+  - profile-scoped active budgets first
+  - global active budgets second
+  - existing selector specificity ordering retained within scope
+- Keep scope strictly bounded to invariance hardening; no provider, connector, or orchestration expansion.
 
 ## Exact Surfaces In Scope
 
-- execution-budget schema/profile scope wiring
-- execution-budget API contracts and lifecycle responses with additive profile scope field
-- budget evaluation matching + counting with thread-profile-aware isolation and global fallback
-- unit/integration tests proving profile isolation and deterministic fallback behavior
+- execution-budget decisioning invariance for malformed/unresolvable runtime context
+- proxy execution fail-closed behavior when decision context is invalid
+- additive trace/decision diagnostics for invalid context handling
+- unit/integration regression coverage for malformed request and malformed history rows
 
 ## Exact Files In Scope
 
-- [store.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/store.py)
-- [main.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/main.py)
 - [contracts.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/contracts.py)
 - [execution_budgets.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/execution_budgets.py)
 - [proxy_execution.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/proxy_execution.py)
-- [20260325_0037_execution_budget_agent_profile_scope.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/alembic/versions/20260325_0037_execution_budget_agent_profile_scope.py)
-- [test_20260325_0037_execution_budget_agent_profile_scope.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py)
 - [test_execution_budgets.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_execution_budgets.py)
-- [test_execution_budgets_main.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_execution_budgets_main.py)
-- [test_execution_budget_store.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_execution_budget_store.py)
-- [test_execution_budgets_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_execution_budgets_api.py)
+- [test_proxy_execution.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_proxy_execution.py)
+- [test_proxy_execution_main.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_proxy_execution_main.py)
 - [test_proxy_execution_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_proxy_execution_api.py)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
@@ -77,25 +74,25 @@ Scope execution-budget matching and counting to the active thread profile, with 
 
 ## In Scope
 
-- Add nullable `agent_profile_id` to `execution_budgets` with FK to `agent_profiles`.
-- Update active-scope uniqueness/index strategy to include profile scope:
-  - one active budget per `(user_id, agent_profile_id, tool_key, domain_hint)` selector scope
-  - preserve deterministic ordering/index contracts
-- Update execution-budget create/list/get/lifecycle contracts to expose additive `agent_profile_id`.
-- Validate `agent_profile_id` on create when provided (must exist in registry).
-- Update budget evaluation to:
-  - resolve active thread profile from request thread
-  - match profile-scoped budgets first, then global budgets
-  - keep existing selector specificity ordering within each scope
-  - count only completed executions attributable to the matched profile scope
-- Preserve existing proxy execution event and trace contract shapes (additive fields only where necessary).
-- Add migration tests for schema/index invariants and rollback.
-- Add unit/integration coverage for profile-scoped budget matching, fallback, and blocked/allow decisions.
+- Harden budget evaluation context resolution:
+  - resolve request thread/profile deterministically before budget counting
+  - explicitly handle missing/unresolvable thread context as fail-closed path
+- Harden counted execution filtering:
+  - exclude historical executions with malformed/unresolvable thread context from scoped counts
+  - preserve deterministic ordering/rolling-window behavior for valid rows
+- Add additive diagnostics on blocked fail-closed decisions to make reason visible in traces/results.
+- Preserve backward compatibility for existing proxy response envelopes and trace event ordering.
+- Add unit coverage for:
+  - invalid runtime thread context behavior
+  - malformed execution-history row behavior
+  - deterministic blocked reason contracts
+- Add integration coverage proving proxy execution blocks deterministically when context invariants are violated.
 
 ## Out of Scope
 
-- profile CRUD endpoints
-- policy engine redesign beyond budget profile scope filtering
+- schema/migration changes
+- execution-budget CRUD redesign
+- policy engine redesign
 - introducing new providers, connectors, or secret handling changes
 - orchestration/worker runtime changes
 - web UI changes
@@ -103,24 +100,19 @@ Scope execution-budget matching and counting to the active thread profile, with 
 
 ## Required Deliverables
 
-- execution-budget profile-scope migration and store wiring
-- budget create/list/get serialization with additive profile scope fields
-- profile-aware budget evaluation and deterministic global fallback
-- passing unit/integration evidence for profile-scoped budget decisions
+- fail-closed invariance handling for malformed/unresolvable budget runtime context
+- deterministic counting behavior under malformed history conditions
+- passing unit/integration evidence for invariance hardening behavior
 - sprint build/review reports scoped to this sprint only
 
 ## Acceptance Criteria
 
-- `execution_budgets` persist optional `agent_profile_id` with FK integrity.
-- Budget create/list/get payloads include additive `agent_profile_id` and remain backward-compatible.
-- Budget evaluation for proxy execution is profile-isolated:
-  - profile-scoped budgets apply to matching thread profiles
-  - profile-scoped budgets do not throttle non-matching profiles
-  - deterministic fallback to global budgets works when no profile-scoped match exists
-- Existing proxy execution result/event/trace contracts remain backward-compatible.
-- `./.venv/bin/python -m pytest tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py -q` passes.
-- `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_execution_budgets_main.py tests/unit/test_execution_budget_store.py -q` passes.
-- `./.venv/bin/python -m pytest tests/integration/test_execution_budgets_api.py tests/integration/test_proxy_execution_api.py -q` passes.
+- Budget decisioning does not execute with unresolvable request thread/profile context.
+- Malformed/unresolvable historical execution rows do not contaminate scoped budget counts.
+- Proxy execution returns deterministic blocked outcomes for invalid-context invariance failures.
+- Existing proxy execution event/result/trace contracts remain backward-compatible (additive diagnostics only).
+- `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_proxy_execution.py tests/unit/test_proxy_execution_main.py -q` passes.
+- `./.venv/bin/python -m pytest tests/integration/test_proxy_execution_api.py -q` passes.
 - `python3 scripts/run_phase2_validation_matrix.py` remains PASS.
 - No provider/connector/orchestration scope expansion enters this sprint.
 
@@ -128,54 +120,50 @@ Scope execution-budget matching and counting to the active thread profile, with 
 
 - do not introduce new dependencies
 - preserve existing response/event/trace payload contracts (additive fields only where necessary)
-- keep migration reversible and forward-safe
-- keep deterministic ordering contracts (`created_at_asc`, `id_asc`, `specificity_desc`)
+- keep deterministic ordering contracts (`created_at_asc`, `id_asc`, `specificity_desc`, rolling-window semantics)
+- no new DB migration in this sprint unless an explicit Control Tower scope change is issued
 
 ## Control Tower Task Cards
 
-### Task 1: Budget Profile-Scope Migration + Store Wiring
+### Task 1: Runtime Invariance Hardening
 Owner: tooling operative  
 Write scope:
-- `apps/api/alembic/versions/20260325_0037_execution_budget_agent_profile_scope.py`
-- `apps/api/src/alicebot_api/store.py`
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/main.py`
 - `apps/api/src/alicebot_api/execution_budgets.py`
 - `apps/api/src/alicebot_api/proxy_execution.py`
 
 ### Task 2: Verification
 Owner: tooling operative  
 Write scope:
-- `tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py`
 - `tests/unit/test_execution_budgets.py`
-- `tests/unit/test_execution_budgets_main.py`
-- `tests/unit/test_execution_budget_store.py`
-- `tests/integration/test_execution_budgets_api.py`
+- `tests/unit/test_proxy_execution.py`
+- `tests/unit/test_proxy_execution_main.py`
 - `tests/integration/test_proxy_execution_api.py`
 
 ### Task 3: Integration Review
 Owner: control tower  
 Responsibilities:
-- verify sprint stays execution-budget-profile-scope scoped
-- verify profile isolation and global fallback are deterministic
+- verify sprint stays budget-context-invariance scoped
+- verify fail-closed behavior for invalid context is deterministic
 - verify no provider/connector/orchestration expansion
 - verify validation matrix remains green
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact execution-budget profile-scope migration and routing/evaluation deltas
+- exact invariance-hardening decisioning deltas
 - exact verification command outcomes
-- explicit deferred scope (providers/connectors, orchestration, profile CRUD)
+- explicit deferred scope (schema expansion, providers/connectors, orchestration, profile CRUD)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint stayed bounded to execution-budget profile scope
-- profile-scoped budget matching/counting and global fallback are deterministic and correct
+- sprint stayed bounded to budget context invariance hardening
+- malformed-context fail-closed behavior is deterministic and correct
+- profile-scoped counting remains isolated under malformed-history pressure
 - API and proxy-execution behavior remain backward-compatible
 - no hidden scope expansion
 
 ## Exit Condition
 
-This sprint is complete when execution-budget decisions are profile-scoped and deterministic for the active thread profile, with migration/test evidence and all validation gates green.
+This sprint is complete when proxy execution budget decisioning is fail-closed under invalid context and profile-scoped counting remains deterministic under malformed-history conditions, with test evidence and validation gates green.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,75 +1,60 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Phase 3 Sprint 8 execution-budget profile scope isolation by adding optional `agent_profile_id` scope to budgets, updating create/list/get contracts, and enforcing profile-aware budget matching/counting with deterministic global fallback.
+Implement Phase 3 Sprint 9 budget context invariance hardening so execution-budget decisioning is fail-closed for malformed/unresolvable runtime thread/profile context, and counted history remains strictly profile-attributable under malformed history pressure.
 
 ## Completed Work
-- Added migration `20260325_0037_execution_budget_agent_profile_scope`:
-  - Added nullable `execution_budgets.agent_profile_id`.
-  - Added FK `execution_budgets_agent_profile_id_fkey -> agent_profiles(id)`.
-  - Replaced selector/match indexing with profile-aware index `execution_budgets_user_profile_match_idx`.
-  - Replaced active uniqueness index to include profile scope via `COALESCE(agent_profile_id, '')` while preserving existing index name `execution_budgets_one_active_scope_idx`.
-  - Added reversible downgrade restoring pre-sprint index/column shape.
-- Wired store schema/query surface:
-  - `ExecutionBudgetRow` now includes `agent_profile_id`.
-  - Execution-budget INSERT/GET/LIST/DEACTIVATE/SUPERSEDE SQL now reads/writes `agent_profile_id`.
-  - `ContinuityStore.create_execution_budget(...)` now accepts `agent_profile_id`.
-- Updated API/contracts:
-  - `ExecutionBudgetCreateInput` now accepts/serializes `agent_profile_id`.
-  - `ExecutionBudgetRecord` now includes additive `agent_profile_id`.
-  - `/v0/execution-budgets` request model now accepts optional `agent_profile_id`.
-- Added create-time validation:
-  - Budget create validates provided `agent_profile_id` exists in profile registry (`store.get_agent_profile_optional`).
-- Implemented profile-aware budget evaluation behavior:
-  - Resolves active thread profile from `request.thread_id`.
-  - Matching precedence: profile-scoped active budgets first, then global (`agent_profile_id IS NULL`).
-  - Preserved selector ordering within each scope: `specificity_desc`, `created_at_asc`, `id_asc`.
-  - Completed-execution counting isolated to active thread profile scope (including global-fallback decisions) while preserving rolling-window behavior and history order.
-- Updated lifecycle/supersede scope handling:
-  - Supersede active-scope checks and duplicate scope messages now include profile scope.
-  - Replacement budget preserves source `agent_profile_id`.
-- Added/updated sprint-scoped tests:
-  - New migration test file for `0037` upgrade/downgrade/index/FK contracts.
-  - Updated unit store/main/execution-budget tests for additive `agent_profile_id` contract and profile-aware behavior.
-  - Updated integration execution-budget API tests for profile scope uniqueness/validation.
-  - Added integration proxy execution test for profile-first matching and global fallback isolation.
+- Hardened budget decisioning runtime context resolution in `execution_budgets.py`:
+  - Added deterministic request-context resolution before budget matching/counting finalization.
+  - Added explicit fail-closed decision path for invalid request context (`decision=block`, `reason=invalid_request_context`).
+  - Added deterministic blocked result messaging for invalid context invariance failures.
+- Hardened counted execution filtering invariance in `execution_budgets.py`:
+  - Counted history now requires a valid/parseable `request.thread_id`.
+  - Counted history now requires `request.thread_id` to match persisted `tool_executions.thread_id`.
+  - Counted history rows with missing/malformed/unresolvable thread/profile context are excluded from scoped counts.
+- Added additive diagnostics in contracts and decision payloads:
+  - Added `invalid_request_context` to `ExecutionBudgetDecisionReason`.
+  - Added additive optional decision diagnostics: `request_thread_id`, `context_resolution`, `context_reason`.
+- Added additive proxy trace diagnostics in `proxy_execution.py`:
+  - For invalid-context budget blocks, dispatch trace includes additive `budget_context` payload.
+  - Preserved existing proxy response envelope and trace ordering.
+- Added/updated regression coverage:
+  - Unit tests for malformed runtime context fail-closed behavior.
+  - Unit tests for unresolvable runtime thread/profile context fail-closed behavior.
+  - Unit tests for malformed history-row exclusion from scoped counts.
+  - Unit + integration tests for deterministic proxy blocked outcomes and additive diagnostics on invalid context.
 
 ## Incomplete Work
 - None within sprint scope.
 
 ## Files Changed
-- `apps/api/src/alicebot_api/store.py`
-- `apps/api/src/alicebot_api/main.py`
 - `apps/api/src/alicebot_api/contracts.py`
 - `apps/api/src/alicebot_api/execution_budgets.py`
-- `apps/api/alembic/versions/20260325_0037_execution_budget_agent_profile_scope.py`
-- `tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py`
+- `apps/api/src/alicebot_api/proxy_execution.py`
 - `tests/unit/test_execution_budgets.py`
-- `tests/unit/test_execution_budgets_main.py`
-- `tests/unit/test_execution_budget_store.py`
-- `tests/integration/test_execution_budgets_api.py`
+- `tests/unit/test_proxy_execution.py`
+- `tests/unit/test_proxy_execution_main.py`
 - `tests/integration/test_proxy_execution_api.py`
 - `BUILD_REPORT.md`
+- `REVIEW_REPORT.md`
 
 ## Tests Run
-- `./.venv/bin/python -m pytest tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py -q`
-  - PASS (`4 passed`)
-- `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_execution_budgets_main.py tests/unit/test_execution_budget_store.py -q`
-  - PASS (`26 passed`)
-- `./.venv/bin/python -m pytest tests/integration/test_execution_budgets_api.py tests/integration/test_proxy_execution_api.py -q`
-  - PASS (`24 passed`)
+- `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_proxy_execution.py tests/unit/test_proxy_execution_main.py -q`
+  - PASS (`37 passed in 0.63s`)
+- `./.venv/bin/python -m pytest tests/integration/test_proxy_execution_api.py -q`
+  - PASS (`16 passed in 7.53s`)
 - `python3 scripts/run_phase2_validation_matrix.py`
   - PASS (`Phase 2 validation matrix result: PASS`)
-  - Note: one intermediate run had a transient web-test failure; immediate rerun passed with no code changes.
 
 ## Blockers / Issues
 - No implementation blockers.
-- Environment note: integration and validation commands required local DB access outside sandbox constraints; commands were rerun with escalated permissions to complete verification.
+- Environment constraint encountered: local Postgres-backed integration/validation commands required elevated permissions outside default sandbox. Commands succeeded after rerun with escalation.
 
 ## Deferred Scope (Explicit)
-- No provider/connector surface expansion.
+- No schema/migration expansion.
+- No provider or connector expansion.
 - No orchestration/worker runtime redesign.
-- No profile CRUD endpoint expansion.
+- No profile CRUD redesign/expansion.
 
 ## Recommended Next Step
-Open integration review (Control Tower Task 3) focused on deterministic profile-scope matching/counting and contract backward compatibility.
+Control Tower integration review: validate deterministic fail-closed invalid-context behavior and malformed-history exclusion invariants, then proceed to sprint branch PR review/merge flow.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,44 +4,32 @@
 PASS
 
 ## criteria met
-- Sprint stayed bounded to execution-budget profile scope; no provider/connector/orchestration expansion was introduced.
-- `execution_budgets` profile scope persistence is implemented with migration `20260325_0037`:
-  - nullable `agent_profile_id` column
-  - FK `execution_budgets_agent_profile_id_fkey -> agent_profiles(id)`
-  - profile-aware active-scope uniqueness/index updates with reversible downgrade.
-- Budget API contracts are additively updated with `agent_profile_id` on create/list/get/lifecycle payloads.
-- Create-time validation rejects unknown `agent_profile_id` values via profile-registry lookup.
-- Budget evaluation behavior is profile-isolated and deterministic:
-  - profile-scoped matches are prioritized for the active thread profile
-  - global budgets are deterministic fallback when no profile-scoped match exists
-  - completed-execution counting is scoped to matched profile context for decisioning.
-- Proxy execution behavior remains backward-compatible in observed event/result/trace structure (no breaking schema changes introduced).
-- Required verification gates pass:
-  - `./.venv/bin/python -m pytest tests/unit/test_20260325_0037_execution_budget_agent_profile_scope.py -q` -> `4 passed`
-  - `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_execution_budgets_main.py tests/unit/test_execution_budget_store.py -q` -> `26 passed`
-  - `./.venv/bin/python -m pytest tests/integration/test_execution_budgets_api.py tests/integration/test_proxy_execution_api.py -q` -> `24 passed`
-  - `python3 scripts/run_phase2_validation_matrix.py` -> `PASS`
+- Budget decisioning is fail-closed for invalid/unresolvable runtime context (`invalid_request_context`) before budget matching/count finalization.
+- Malformed/unresolvable historical execution rows are excluded from counted history (invalid/missing `request.thread_id`, non-UUID values, mismatched `request.thread_id` vs persisted `thread_id`, and unresolvable thread/profile context).
+- Proxy execution returns deterministic blocked outcomes for invalid-context invariance failures, including deterministic blocked reason text and additive decision diagnostics.
+- Existing proxy response/event/trace contracts remain backward-compatible; changes are additive (`request_thread_id`, `context_resolution`, `context_reason`, and optional dispatch `budget_context`).
+- Required test command passed: `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_proxy_execution.py tests/unit/test_proxy_execution_main.py -q` (`37 passed`).
+- Required test command passed: `./.venv/bin/python -m pytest tests/integration/test_proxy_execution_api.py -q` (`16 passed`).
+- Required gate command passed: `python3 scripts/run_phase2_validation_matrix.py` (`Phase 2 validation matrix result: PASS`).
+- Sprint stayed in scope (no provider/connector/orchestration/schema expansion detected).
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking implementation defects identified in sprint-scoped code.
-- Non-blocking: migration tests are statement-contract tests (order/text), not DB-level invariant assertions against a live upgraded schema.
+- None found in sprint scope.
 
 ## regression risks
-- Low.
-- Residual edge-case risk: if routing request thread identity is malformed/unresolvable, global-budget counting can become unscoped because profile context cannot be resolved.
+- Low risk. Intentional fail-closed behavior will now block execution when legacy/corrupt request thread context is malformed or unresolvable; this is expected by sprint intent.
 
 ## docs issues
-- No blocking docs gaps.
-- `BUILD_REPORT.md` is consistent with observed implementation and verification outcomes.
+- None blocking. `BUILD_REPORT.md` captures implemented deltas, command outcomes, and deferred scope as required.
 
 ## should anything be added to RULES.md?
-- Optional: add a rule that budget-governance scope changes must include one explicit malformed-context test (for missing/unresolvable thread profile) to pin fallback/count behavior.
+- No required changes.
 
 ## should anything update ARCHITECTURE.md?
-- Optional: add an execution-budget precedence note documenting exact order: `profile-scoped active match -> global active match`, with per-scope specificity ordering and profile-scoped counting semantics.
+- No required changes.
 
 ## recommended next action
-1. Proceed to Control Tower integration approval and merge readiness for Phase 3 Sprint 8.
+- Proceed with Control Tower integration approval and sprint PR merge flow.

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -51,7 +51,13 @@ TaskStepStatus = Literal["created", "approved", "executed", "blocked", "denied"]
 ProxyExecutionStatus = Literal["completed", "blocked"]
 ExecutionBudgetStatus = Literal["active", "inactive", "superseded"]
 ExecutionBudgetDecision = Literal["allow", "block"]
-ExecutionBudgetDecisionReason = Literal["no_matching_budget", "within_budget", "budget_exceeded"]
+ExecutionBudgetDecisionReason = Literal[
+    "no_matching_budget",
+    "within_budget",
+    "budget_exceeded",
+    "invalid_request_context",
+]
+ExecutionBudgetContextResolution = Literal["resolved", "invalid"]
 ExecutionBudgetCountScope = Literal["lifetime", "rolling_window"]
 ExecutionBudgetLifecycleAction = Literal["deactivate", "supersede"]
 ExecutionBudgetLifecycleOutcome = Literal["deactivated", "superseded", "rejected"]
@@ -3010,6 +3016,9 @@ class ExecutionBudgetDecisionRecord(TypedDict):
     reason: ExecutionBudgetDecisionReason
     order: list[str]
     history_order: list[str]
+    request_thread_id: NotRequired[str | None]
+    context_resolution: NotRequired[ExecutionBudgetContextResolution]
+    context_reason: NotRequired[str | None]
 
 
 class ExecutionBudgetLifecycleRequestTracePayload(TypedDict):
@@ -3153,6 +3162,12 @@ class ProxyExecutionApprovalTracePayload(TypedDict):
     eligible_for_execution: bool
 
 
+class ProxyExecutionBudgetContextTracePayload(TypedDict):
+    request_thread_id: str | None
+    context_resolution: ExecutionBudgetContextResolution
+    context_reason: str | None
+
+
 class ProxyExecutionDispatchTracePayload(TypedDict):
     approval_id: str
     task_step_id: str
@@ -3163,6 +3178,7 @@ class ProxyExecutionDispatchTracePayload(TypedDict):
     reason: str | None
     result_status: ProxyExecutionStatus | None
     output: JsonObject | None
+    budget_context: NotRequired[ProxyExecutionBudgetContextTracePayload]
 
 
 class ProxyExecutionSummaryTracePayload(TypedDict):

--- a/apps/api/src/alicebot_api/execution_budgets.py
+++ b/apps/api/src/alicebot_api/execution_budgets.py
@@ -56,6 +56,14 @@ class ExecutionBudgetDecision:
     blocked_result: ToolExecutionResultRecord | None
 
 
+@dataclass(frozen=True, slots=True)
+class _RequestContextResolution:
+    request_thread_id: str | None
+    active_thread_profile_id: str | None
+    context_resolution: str
+    context_reason: str | None
+
+
 def serialize_execution_budget_row(row: ExecutionBudgetRow) -> ExecutionBudgetRecord:
     return {
         "id": str(row["id"]),
@@ -720,20 +728,51 @@ def _thread_profile_id_optional(
         return None
     profile_id = cast(str | None, thread.get("agent_profile_id"))
     if profile_id is None:
-        return DEFAULT_AGENT_PROFILE_ID
+        profile_id = DEFAULT_AGENT_PROFILE_ID
+    if store.get_agent_profile_optional(profile_id) is None:
+        return None
     return profile_id
 
 
-def _resolve_request_thread_profile_id(
+def _resolve_request_context(
     store: ContinuityStore,
     *,
     request: ToolRoutingRequestRecord,
-) -> str | None:
+) -> _RequestContextResolution:
+    request_thread_id = request.get("thread_id")
+    if not isinstance(request_thread_id, str):
+        return _RequestContextResolution(
+            request_thread_id=None,
+            active_thread_profile_id=None,
+            context_resolution="invalid",
+            context_reason="request.thread_id is missing",
+        )
     try:
-        thread_id = UUID(request["thread_id"])
+        thread_id = UUID(request_thread_id)
     except (TypeError, ValueError):
-        return None
-    return _thread_profile_id_optional(store, thread_id=thread_id)
+        return _RequestContextResolution(
+            request_thread_id=request_thread_id,
+            active_thread_profile_id=None,
+            context_resolution="invalid",
+            context_reason=f"request.thread_id '{request_thread_id}' is not a valid UUID",
+        )
+    active_thread_profile_id = _thread_profile_id_optional(store, thread_id=thread_id)
+    if active_thread_profile_id is None:
+        return _RequestContextResolution(
+            request_thread_id=request_thread_id,
+            active_thread_profile_id=None,
+            context_resolution="invalid",
+            context_reason=(
+                f"request.thread_id '{request_thread_id}' did not resolve to a visible "
+                "thread/profile context"
+            ),
+        )
+    return _RequestContextResolution(
+        request_thread_id=request_thread_id,
+        active_thread_profile_id=active_thread_profile_id,
+        context_resolution="resolved",
+        context_reason=None,
+    )
 
 
 def _count_profile_scope_id(
@@ -797,15 +836,26 @@ def _counted_completed_execution_rows(
         execution_row = cast(ToolExecutionRow, row)
         if not _execution_matches_budget(execution_row, matched_budget):
             continue
-        if count_profile_scope_id is not None:
-            thread_id = execution_row["thread_id"]
-            if thread_id not in thread_profile_cache:
-                thread_profile_cache[thread_id] = _thread_profile_id_optional(
-                    store,
-                    thread_id=thread_id,
-                )
-            if thread_profile_cache[thread_id] != count_profile_scope_id:
-                continue
+        request_payload = cast(dict[str, object], execution_row["request"])
+        request_thread_id_raw = request_payload.get("thread_id")
+        if not isinstance(request_thread_id_raw, str):
+            continue
+        try:
+            request_thread_id = UUID(request_thread_id_raw)
+        except (TypeError, ValueError):
+            continue
+        if request_thread_id != execution_row["thread_id"]:
+            continue
+        if request_thread_id not in thread_profile_cache:
+            thread_profile_cache[request_thread_id] = _thread_profile_id_optional(
+                store,
+                thread_id=request_thread_id,
+            )
+        row_profile_id = thread_profile_cache[request_thread_id]
+        if row_profile_id is None:
+            continue
+        if count_profile_scope_id is not None and row_profile_id != count_profile_scope_id:
+            continue
         if window_started_at is not None and execution_row["executed_at"] < window_started_at:
             continue
         counted_rows.append(execution_row)
@@ -839,18 +889,39 @@ def _blocked_result(
     }
 
 
+def _invalid_context_blocked_result(
+    decision: ExecutionBudgetDecisionRecord,
+) -> ToolExecutionResultRecord:
+    context_reason = cast(str | None, decision.get("context_reason"))
+    reason = "execution budget invariance blocks execution: invalid request thread/profile context"
+    if context_reason is not None:
+        reason = f"{reason}: {context_reason}"
+    return {
+        "handler_key": None,
+        "status": "blocked",
+        "output": None,
+        "reason": reason,
+        "budget_decision": decision,
+    }
+
+
 def evaluate_execution_budget(
     store: ContinuityStore,
     *,
     tool: ToolRecord,
     request: ToolRoutingRequestRecord,
 ) -> ExecutionBudgetDecision:
-    active_thread_profile_id = _resolve_request_thread_profile_id(store, request=request)
-    matching_budgets = _matching_budget_rows(
-        store,
-        active_thread_profile_id=active_thread_profile_id,
-        tool_key=tool["tool_key"],
-        domain_hint=request["domain_hint"],
+    request_context = _resolve_request_context(store, request=request)
+    active_thread_profile_id = request_context.active_thread_profile_id
+    matching_budgets = (
+        []
+        if request_context.context_resolution == "invalid"
+        else _matching_budget_rows(
+            store,
+            active_thread_profile_id=active_thread_profile_id,
+            tool_key=tool["tool_key"],
+            domain_hint=request["domain_hint"],
+        )
     )
     matched_budget = matching_budgets[0] if matching_budgets else None
     evaluation_time = _current_time(store)
@@ -904,6 +975,15 @@ def evaluate_execution_budget(
         "order": list(EXECUTION_BUDGET_MATCH_ORDER),
         "history_order": list(TOOL_EXECUTION_LIST_ORDER),
     }
+
+    if request_context.context_resolution == "invalid":
+        record["decision"] = "block"
+        record["reason"] = "invalid_request_context"
+        record["request_thread_id"] = request_context.request_thread_id
+        record["context_resolution"] = request_context.context_resolution
+        record["context_reason"] = request_context.context_reason
+        blocked_result = _invalid_context_blocked_result(record)
+        return ExecutionBudgetDecision(record=record, blocked_result=blocked_result)
 
     if matched_budget is None:
         return ExecutionBudgetDecision(record=record, blocked_result=None)

--- a/apps/api/src/alicebot_api/proxy_execution.py
+++ b/apps/api/src/alicebot_api/proxy_execution.py
@@ -11,6 +11,7 @@ from alicebot_api.contracts import (
     TRACE_KIND_PROXY_EXECUTE,
     ApprovalRecord,
     ProxyExecutionApprovalTracePayload,
+    ProxyExecutionBudgetContextTracePayload,
     ProxyExecutionBudgetPrecheckTracePayload,
     ProxyExecutionDispatchTracePayload,
     ProxyExecutionEventSummary,
@@ -132,6 +133,18 @@ def _tool_execution_result(
     if budget_decision is not None:
         payload["budget_decision"] = cast(dict[str, object], budget_decision)
     return payload
+
+
+def _budget_context_trace_payload(
+    budget_decision: ProxyExecutionBudgetPrecheckTracePayload,
+) -> ProxyExecutionBudgetContextTracePayload | None:
+    if budget_decision["reason"] != "invalid_request_context":
+        return None
+    return {
+        "request_thread_id": cast(str | None, budget_decision.get("request_thread_id")),
+        "context_resolution": "invalid",
+        "context_reason": cast(str | None, budget_decision.get("context_reason")),
+    }
 
 
 def _persist_tool_execution(
@@ -286,6 +299,9 @@ def execute_approved_proxy_request(
             "result_status": budget_decision.blocked_result["status"],
             "output": budget_decision.blocked_result["output"],
         }
+        budget_context = _budget_context_trace_payload(budget_trace_payload)
+        if budget_context is not None:
+            dispatch_payload["budget_context"] = budget_context
         summary_payload: ProxyExecutionSummaryTracePayload = {
             "approval_id": approval["id"],
             "task_step_id": linked_task_step_id,

--- a/tests/integration/test_proxy_execution_api.py
+++ b/tests/integration/test_proxy_execution_api.py
@@ -182,6 +182,24 @@ def set_execution_executed_at(
         conn.commit()
 
 
+def set_approval_request_thread_id(
+    admin_database_url: str,
+    *,
+    approval_id: UUID,
+    request_thread_id: str,
+) -> None:
+    with psycopg.connect(admin_database_url) as conn:
+        conn.execute(
+            """
+            UPDATE approvals
+            SET request = jsonb_set(request, '{thread_id}', to_jsonb(%s::text), true)
+            WHERE id = %s
+            """,
+            (request_thread_id, approval_id),
+        )
+        conn.commit()
+
+
 def test_execute_approved_proxy_endpoint_executes_only_approved_requests(
     migrated_database_urls,
     monkeypatch,
@@ -708,6 +726,97 @@ def test_execute_approved_proxy_endpoint_updates_the_explicitly_linked_later_ste
     assert tool_executions[1]["task_step_id"] == UUID(create_step_payload["task_step"]["id"])
     assert task_steps[1]["outcome"]["execution_id"] == str(tool_executions[1]["id"])
     assert len(proxy_traces) == 2
+
+
+def test_execute_approved_proxy_endpoint_fail_closes_when_runtime_context_is_invalid(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    owner = seed_user(migrated_database_urls["app"], email="owner@example.com")
+    monkeypatch.setattr(main_module, "get_settings", lambda: Settings(database_url=migrated_database_urls["app"]))
+    tool_id = create_tool_and_policy(
+        migrated_database_urls["app"],
+        user_id=owner["user_id"],
+        tool_key="proxy.echo",
+    )
+
+    create_status, create_payload = create_pending_approval(
+        user_id=owner["user_id"],
+        thread_id=owner["thread_id"],
+        tool_id=tool_id,
+    )
+    assert create_status == 200
+
+    approve_status, _ = invoke_request(
+        "POST",
+        f"/v0/approvals/{create_payload['approval']['id']}/approve",
+        payload={"user_id": str(owner["user_id"])},
+    )
+    assert approve_status == 200
+
+    set_approval_request_thread_id(
+        migrated_database_urls["admin"],
+        approval_id=UUID(create_payload["approval"]["id"]),
+        request_thread_id="not-a-uuid",
+    )
+
+    execute_status, execute_payload = invoke_request(
+        "POST",
+        f"/v0/approvals/{create_payload['approval']['id']}/execute",
+        payload={"user_id": str(owner["user_id"])},
+    )
+
+    assert execute_status == 200
+    assert execute_payload["events"] is None
+    assert execute_payload["result"] == {
+        "handler_key": None,
+        "status": "blocked",
+        "output": None,
+        "reason": (
+            "execution budget invariance blocks execution: invalid request thread/profile "
+            "context: request.thread_id 'not-a-uuid' is not a valid UUID"
+        ),
+        "budget_decision": {
+            "matched_budget_id": None,
+            "tool_key": "proxy.echo",
+            "domain_hint": None,
+            "budget_tool_key": None,
+            "budget_domain_hint": None,
+            "max_completed_executions": None,
+            "rolling_window_seconds": None,
+            "count_scope": "lifetime",
+            "window_started_at": None,
+            "completed_execution_count": 0,
+            "projected_completed_execution_count": 1,
+            "decision": "block",
+            "reason": "invalid_request_context",
+            "order": ["specificity_desc", "created_at_asc", "id_asc"],
+            "history_order": ["executed_at_asc", "id_asc"],
+            "request_thread_id": "not-a-uuid",
+            "context_resolution": "invalid",
+            "context_reason": "request.thread_id 'not-a-uuid' is not a valid UUID",
+        },
+    }
+
+    with user_connection(migrated_database_urls["app"], owner["user_id"]) as conn:
+        store = ContinuityStore(conn)
+        stored_executions = store.list_tool_executions()
+        blocked_trace_events = store.list_trace_events(UUID(execute_payload["trace"]["trace_id"]))
+        thread_events = store.list_thread_events(owner["thread_id"])
+
+    assert len(stored_executions) == 1
+    assert stored_executions[0]["status"] == "blocked"
+    assert stored_executions[0]["result"] == execute_payload["result"]
+    assert stored_executions[0]["request_event_id"] is None
+    assert stored_executions[0]["result_event_id"] is None
+    assert thread_events == []
+    assert blocked_trace_events[2]["payload"] == execute_payload["result"]["budget_decision"]
+    assert blocked_trace_events[3]["payload"]["dispatch_status"] == "blocked"
+    assert blocked_trace_events[3]["payload"]["budget_context"] == {
+        "request_thread_id": "not-a-uuid",
+        "context_resolution": "invalid",
+        "context_reason": "request.thread_id 'not-a-uuid' is not a valid UUID",
+    }
 
 
 def test_execute_approved_proxy_endpoint_blocks_when_execution_budget_is_exceeded(

--- a/tests/unit/test_execution_budgets.py
+++ b/tests/unit/test_execution_budgets.py
@@ -582,6 +582,148 @@ def test_get_execution_budget_record_raises_clear_error_when_missing() -> None:
         )
 
 
+def test_evaluate_execution_budget_fail_closed_when_request_thread_context_is_malformed() -> None:
+    store = ExecutionBudgetStoreStub()
+    store.create_execution_budget(
+        tool_key="proxy.echo",
+        domain_hint=None,
+        max_completed_executions=10,
+    )
+
+    decision = evaluate_execution_budget(
+        store,  # type: ignore[arg-type]
+        tool={"id": str(uuid4()), "tool_key": "proxy.echo"},
+        request={
+            "thread_id": "not-a-uuid",
+            "tool_id": str(uuid4()),
+            "action": "tool.run",
+            "scope": "workspace",
+            "domain_hint": None,
+            "risk_hint": None,
+            "attributes": {},
+        },
+    )
+
+    assert decision.record == {
+        "matched_budget_id": None,
+        "tool_key": "proxy.echo",
+        "domain_hint": None,
+        "budget_tool_key": None,
+        "budget_domain_hint": None,
+        "max_completed_executions": None,
+        "rolling_window_seconds": None,
+        "count_scope": "lifetime",
+        "window_started_at": None,
+        "completed_execution_count": 0,
+        "projected_completed_execution_count": 1,
+        "decision": "block",
+        "reason": "invalid_request_context",
+        "order": ["specificity_desc", "created_at_asc", "id_asc"],
+        "history_order": ["executed_at_asc", "id_asc"],
+        "request_thread_id": "not-a-uuid",
+        "context_resolution": "invalid",
+        "context_reason": "request.thread_id 'not-a-uuid' is not a valid UUID",
+    }
+    assert decision.blocked_result == {
+        "handler_key": None,
+        "status": "blocked",
+        "output": None,
+        "reason": (
+            "execution budget invariance blocks execution: invalid request "
+            "thread/profile context: request.thread_id 'not-a-uuid' is not a valid UUID"
+        ),
+        "budget_decision": decision.record,
+    }
+
+
+def test_evaluate_execution_budget_fail_closed_when_request_thread_profile_is_unresolvable() -> None:
+    store = ExecutionBudgetStoreStub()
+    broken_thread_id = store.create_thread(agent_profile_id="profile_missing")
+    store.create_execution_budget(
+        tool_key="proxy.echo",
+        domain_hint=None,
+        max_completed_executions=10,
+    )
+
+    decision = evaluate_execution_budget(
+        store,  # type: ignore[arg-type]
+        tool={"id": str(uuid4()), "tool_key": "proxy.echo"},
+        request={
+            "thread_id": str(broken_thread_id),
+            "tool_id": str(uuid4()),
+            "action": "tool.run",
+            "scope": "workspace",
+            "domain_hint": None,
+            "risk_hint": None,
+            "attributes": {},
+        },
+    )
+
+    assert decision.record["decision"] == "block"
+    assert decision.record["reason"] == "invalid_request_context"
+    assert decision.record["request_thread_id"] == str(broken_thread_id)
+    assert decision.record["context_resolution"] == "invalid"
+    assert decision.record["context_reason"] == (
+        f"request.thread_id '{broken_thread_id}' did not resolve to a visible "
+        "thread/profile context"
+    )
+    assert decision.blocked_result is not None
+    assert decision.blocked_result["status"] == "blocked"
+    assert decision.blocked_result["reason"] == (
+        "execution budget invariance blocks execution: invalid request thread/profile context: "
+        f"request.thread_id '{broken_thread_id}' did not resolve to a visible thread/profile context"
+    )
+
+
+def test_evaluate_execution_budget_excludes_malformed_history_rows_from_profile_scoped_counts() -> None:
+    store = ExecutionBudgetStoreStub()
+    matched = store.create_execution_budget(
+        tool_key="proxy.echo",
+        domain_hint=None,
+        max_completed_executions=2,
+    )
+    store.seed_execution(tool_key="proxy.echo", domain_hint=None, status="completed", offset_minutes=0)
+    store.seed_execution(tool_key="proxy.echo", domain_hint=None, status="completed", offset_minutes=1)
+    store.seed_execution(tool_key="proxy.echo", domain_hint=None, status="completed", offset_minutes=2)
+    malformed_thread_id_row = store.executions[1]
+    malformed_thread_id_row["request"]["thread_id"] = "not-a-uuid"  # type: ignore[index]
+    missing_thread_id_row = store.executions[2]
+    missing_thread_id_row["request"].pop("thread_id")  # type: ignore[index]
+
+    decision = evaluate_execution_budget(
+        store,  # type: ignore[arg-type]
+        tool={"id": str(uuid4()), "tool_key": "proxy.echo"},
+        request={
+            "thread_id": str(store.thread_id),
+            "tool_id": str(uuid4()),
+            "action": "tool.run",
+            "scope": "workspace",
+            "domain_hint": None,
+            "risk_hint": None,
+            "attributes": {},
+        },
+    )
+
+    assert decision.record == {
+        "matched_budget_id": str(matched["id"]),
+        "tool_key": "proxy.echo",
+        "domain_hint": None,
+        "budget_tool_key": "proxy.echo",
+        "budget_domain_hint": None,
+        "max_completed_executions": 2,
+        "rolling_window_seconds": None,
+        "count_scope": "lifetime",
+        "window_started_at": None,
+        "completed_execution_count": 1,
+        "projected_completed_execution_count": 2,
+        "decision": "allow",
+        "reason": "within_budget",
+        "order": ["specificity_desc", "created_at_asc", "id_asc"],
+        "history_order": ["executed_at_asc", "id_asc"],
+    }
+    assert decision.blocked_result is None
+
+
 def test_evaluate_execution_budget_prefers_more_specific_active_match_and_ignores_inactive_rows() -> None:
     store = ExecutionBudgetStoreStub()
     inactive = store.create_execution_budget(

--- a/tests/unit/test_proxy_execution.py
+++ b/tests/unit/test_proxy_execution.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from alicebot_api.approvals import ApprovalNotFoundError
-from alicebot_api.contracts import ProxyExecutionRequestInput
+from alicebot_api.contracts import DEFAULT_AGENT_PROFILE_ID, ProxyExecutionRequestInput
 from alicebot_api.proxy_execution import (
     PROXY_EXECUTION_REQUEST_EVENT_KIND,
     PROXY_EXECUTION_RESULT_EVENT_KIND,
@@ -22,6 +22,10 @@ class ProxyExecutionStoreStub:
         self.base_time = datetime(2026, 3, 13, 9, 0, tzinfo=UTC)
         self.user_id = uuid4()
         self.thread_id = uuid4()
+        self.agent_profiles = {DEFAULT_AGENT_PROFILE_ID}
+        self.thread_profiles: dict[UUID, str] = {
+            self.thread_id: DEFAULT_AGENT_PROFILE_ID,
+        }
         self.locked_task_ids: list[UUID] = []
         self.approvals: dict[UUID, dict[str, object]] = {}
         self.tasks: list[dict[str, object]] = []
@@ -122,6 +126,7 @@ class ProxyExecutionStoreStub:
     def seed_execution_budget(
         self,
         *,
+        agent_profile_id: str | None = None,
         tool_key: str | None,
         domain_hint: str | None,
         max_completed_executions: int,
@@ -131,6 +136,7 @@ class ProxyExecutionStoreStub:
         row = {
             "id": uuid4(),
             "user_id": self.user_id,
+            "agent_profile_id": agent_profile_id,
             "tool_key": tool_key,
             "domain_hint": domain_hint,
             "max_completed_executions": max_completed_executions,
@@ -147,6 +153,30 @@ class ProxyExecutionStoreStub:
 
     def get_approval_optional(self, approval_id: UUID) -> dict[str, object] | None:
         return self.approvals.get(approval_id)
+
+    def get_thread_optional(self, thread_id: UUID) -> dict[str, object] | None:
+        profile_id = self.thread_profiles.get(thread_id)
+        if profile_id is None:
+            return None
+        return {
+            "id": thread_id,
+            "user_id": self.user_id,
+            "title": "Proxy execution thread",
+            "agent_profile_id": profile_id,
+            "created_at": self.base_time,
+            "updated_at": self.base_time,
+        }
+
+    def get_agent_profile_optional(self, profile_id: str) -> dict[str, object] | None:
+        if profile_id not in self.agent_profiles:
+            return None
+        return {
+            "id": profile_id,
+            "name": profile_id,
+            "description": "",
+            "model_provider": None,
+            "model_name": None,
+        }
 
     def create_trace(
         self,
@@ -766,6 +796,70 @@ def test_execute_approved_proxy_request_returns_blocked_budget_response_and_pers
         "task.step.lifecycle.summary",
     ]
     assert store.trace_events[2]["payload"] == payload["result"]["budget_decision"]
+
+
+def test_execute_approved_proxy_request_fail_closes_when_budget_context_is_invalid() -> None:
+    store = ProxyExecutionStoreStub()
+    approval = store.seed_approval(status="approved", tool_key="proxy.echo")
+    approval["request"]["thread_id"] = "not-a-uuid"  # type: ignore[index]
+
+    payload = execute_approved_proxy_request(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ProxyExecutionRequestInput(approval_id=approval["id"]),
+    )
+
+    assert payload["events"] is None
+    assert payload["result"] == {
+        "handler_key": None,
+        "status": "blocked",
+        "output": None,
+        "reason": (
+            "execution budget invariance blocks execution: invalid request thread/profile "
+            "context: request.thread_id 'not-a-uuid' is not a valid UUID"
+        ),
+        "budget_decision": {
+            "matched_budget_id": None,
+            "tool_key": "proxy.echo",
+            "domain_hint": None,
+            "budget_tool_key": None,
+            "budget_domain_hint": None,
+            "max_completed_executions": None,
+            "rolling_window_seconds": None,
+            "count_scope": "lifetime",
+            "window_started_at": None,
+            "completed_execution_count": 0,
+            "projected_completed_execution_count": 1,
+            "decision": "block",
+            "reason": "invalid_request_context",
+            "order": ["specificity_desc", "created_at_asc", "id_asc"],
+            "history_order": ["executed_at_asc", "id_asc"],
+            "request_thread_id": "not-a-uuid",
+            "context_resolution": "invalid",
+            "context_reason": "request.thread_id 'not-a-uuid' is not a valid UUID",
+        },
+    }
+    assert store.events == []
+    assert len(store.tool_executions) == 1
+    assert store.tool_executions[0]["status"] == "blocked"
+    assert store.tool_executions[0]["result"] == payload["result"]
+    assert [event["kind"] for event in store.trace_events] == [
+        "tool.proxy.execute.request",
+        "tool.proxy.execute.approval",
+        "tool.proxy.execute.budget",
+        "tool.proxy.execute.dispatch",
+        "tool.proxy.execute.summary",
+        "task.lifecycle.state",
+        "task.lifecycle.summary",
+        "task.step.lifecycle.state",
+        "task.step.lifecycle.summary",
+    ]
+    assert store.trace_events[2]["payload"] == payload["result"]["budget_decision"]
+    assert store.trace_events[3]["payload"]["budget_context"] == {
+        "request_thread_id": "not-a-uuid",
+        "context_resolution": "invalid",
+        "context_reason": "request.thread_id 'not-a-uuid' is not a valid UUID",
+    }
 
 
 def test_execute_approved_proxy_request_rejects_missing_visible_approval() -> None:

--- a/tests/unit/test_proxy_execution_main.py
+++ b/tests/unit/test_proxy_execution_main.py
@@ -287,3 +287,91 @@ def test_execute_approved_proxy_endpoint_returns_budget_blocked_payload(monkeypa
 
     assert response.status_code == 200
     assert json.loads(response.body)["events"] is None
+
+
+def test_execute_approved_proxy_endpoint_returns_invalid_context_budget_blocked_payload(monkeypatch) -> None:
+    user_id = uuid4()
+    approval_id = uuid4()
+    settings = Settings(database_url="postgresql://app")
+
+    @contextmanager
+    def fake_user_connection(*_args, **_kwargs):
+        yield object()
+
+    def fake_execute_approved_proxy_request(*_args, **_kwargs):
+        return {
+            "request": {"approval_id": str(approval_id), "task_step_id": "task-step-123"},
+            "approval": {
+                "id": str(approval_id),
+                "thread_id": "thread-123",
+                "task_step_id": "task-step-123",
+                "status": "approved",
+                "request": {
+                    "thread_id": "thread-123",
+                    "tool_id": "tool-123",
+                    "action": "tool.run",
+                    "scope": "workspace",
+                    "domain_hint": None,
+                    "risk_hint": None,
+                    "attributes": {"message": "hello"},
+                },
+                "tool": {"id": "tool-123", "tool_key": "proxy.echo"},
+                "routing": {
+                    "decision": "approval_required",
+                    "reasons": [],
+                    "trace": {"trace_id": "routing-trace-123", "trace_event_count": 3},
+                },
+                "created_at": "2026-03-13T09:00:00+00:00",
+                "resolution": {
+                    "resolved_at": "2026-03-13T09:30:00+00:00",
+                    "resolved_by_user_id": str(user_id),
+                },
+            },
+            "tool": {"id": "tool-123", "tool_key": "proxy.echo"},
+            "result": {
+                "handler_key": None,
+                "status": "blocked",
+                "output": None,
+                "reason": (
+                    "execution budget invariance blocks execution: invalid request thread/profile "
+                    "context: request.thread_id 'not-a-uuid' is not a valid UUID"
+                ),
+                "budget_decision": {
+                    "matched_budget_id": None,
+                    "tool_key": "proxy.echo",
+                    "domain_hint": None,
+                    "budget_tool_key": None,
+                    "budget_domain_hint": None,
+                    "max_completed_executions": None,
+                    "rolling_window_seconds": None,
+                    "count_scope": "lifetime",
+                    "window_started_at": None,
+                    "completed_execution_count": 0,
+                    "projected_completed_execution_count": 1,
+                    "decision": "block",
+                    "reason": "invalid_request_context",
+                    "order": ["specificity_desc", "created_at_asc", "id_asc"],
+                    "history_order": ["executed_at_asc", "id_asc"],
+                    "request_thread_id": "not-a-uuid",
+                    "context_resolution": "invalid",
+                    "context_reason": "request.thread_id 'not-a-uuid' is not a valid UUID",
+                },
+            },
+            "events": None,
+            "trace": {"trace_id": "proxy-trace-456", "trace_event_count": 5},
+        }
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(main_module, "execute_approved_proxy_request", fake_execute_approved_proxy_request)
+
+    response = main_module.execute_approved_proxy(
+        approval_id,
+        main_module.ExecuteApprovedProxyRequest(user_id=user_id),
+    )
+
+    assert response.status_code == 200
+    payload = json.loads(response.body)
+    assert payload["events"] is None
+    assert payload["result"]["status"] == "blocked"
+    assert payload["result"]["budget_decision"]["reason"] == "invalid_request_context"


### PR DESCRIPTION
## Summary
This PR delivers Phase 3 Sprint 9 by hardening execution-budget decisioning to preserve profile isolation under malformed or unresolvable runtime context.

### What changed
- Hardened runtime context resolution in budget decisioning to run deterministically before final matching/counting.
- Added explicit fail-closed handling for invalid request context (`invalid_request_context`) so execution is blocked instead of falling back to unscoped behavior.
- Tightened counted-history eligibility so malformed/unresolvable historical rows do not contaminate profile-scoped counts.
- Added additive diagnostics for blocked decisions:
  - `request_thread_id`
  - `context_resolution`
  - `context_reason`
- Added additive proxy trace diagnostics (`budget_context`) for invalid-context blocked outcomes.
- Added sprint-scoped unit/integration tests for malformed runtime context, malformed history exclusion, and deterministic blocked behavior.

## Scope Guardrails
- No schema/migration changes
- No provider/connector expansion
- No orchestration/worker runtime redesign
- No profile CRUD expansion

## Verification
From sprint reports:
- `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_proxy_execution.py tests/unit/test_proxy_execution_main.py -q` -> `37 passed`
- `./.venv/bin/python -m pytest tests/integration/test_proxy_execution_api.py -q` -> `16 passed`
- `python3 scripts/run_phase2_validation_matrix.py` -> `PASS`

## Control Tower
- Review verdict: `PASS`
- Integration decision: `MERGE_APPROVED`
