### PR TITLE
Phase 3 Sprint 10: Closeout Truth Sync + Gate Canonicalization

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,32 +2,32 @@
 
 ## Sprint Title
 
-Phase 3 Sprint 9: Budget Context Invariance Hardening
+Phase 3 Sprint 10: Closeout Truth Sync + Phase Gate Canonicalization
 
 ## Sprint Type
 
-hardening
+control-plane
 
 ## Sprint Reason
 
-Sprint 8 completed profile-scoped execution-budget isolation. The remaining non-redundant correctness gap is context invariance: malformed or unresolvable thread/profile context can degrade budget counting/match isolation behavior.
+Sprint 9 closed the last known runtime invariance gap for profile-isolated execution budgets. The next non-redundant blocker to MVP/Phase 3 completion is control-plane drift: canonical docs and control-doc checks still anchor to a Phase 2 Sprint 14 baseline.
 
 ## Sprint Intent
 
-Make budget decisioning fail-closed and profile-safe when thread context is malformed/unresolvable, and make counted execution history strictly profile-attributable.
+Re-anchor canonical truth, validation entrypoints, and closeout runbooks to the accepted Phase 3 Sprint 9 baseline without changing product runtime behavior.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase3-sprint9-budget-context-invariance`
+- Branch Name: `codex/phase3-sprint10-closeout-truth-sync`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- It directly closes the only explicit residual risk called out in Sprint 8 review.
-- It hardens separate-agent isolation semantics under malformed state, not just happy-path contracts.
-- It preserves momentum toward MVP/Phase 3 completion without reopening schema breadth.
+- It closes the remaining planning/validation drift risk before phase completion.
+- It enables deterministic “are we done?” checks using phase-correct runbooks and truth guards.
+- It avoids redundant runtime work by focusing only on docs/gates canonicalization.
 
 ## Redundancy Guard
 
@@ -38,132 +38,127 @@ Make budget decisioning fail-closed and profile-safe when thread context is malf
 - Already shipped in Sprint 5: profile-scoped memory/context isolation.
 - Already shipped in Sprint 6: profile-scoped policy evaluation/routing.
 - Already shipped in Sprint 7: profile-scoped model/provider routing for `/v0/responses`.
-- Already shipped in Sprint 8: profile-scoped execution-budget matching + counted execution isolation for normal context.
-- Missing and required now: deterministic fail-closed handling and invariance guarantees for malformed/unresolvable thread context.
+- Already shipped in Sprint 8: profile-scoped execution-budget matching + counted execution isolation.
+- Already shipped in Sprint 9: fail-closed context invariance hardening for budget decisioning.
+- Missing and required now: Phase 3 canonical truth + gate/runbook alignment for deterministic closeout.
 
 ## Design Truth
 
-- Budget decisioning must resolve runtime thread/profile context deterministically before counting/match finalization.
-- If request thread context is missing/unresolvable at execution time, decisioning is fail-closed with explicit deterministic reasoning (no unscoped fallback counting).
-- Historical execution rows with malformed/unresolvable thread context are excluded from profile-scoped counted history.
-- Matching precedence remains unchanged for valid context:
-  - profile-scoped active budgets first
-  - global active budgets second
-  - existing selector specificity ordering retained within scope
-- Keep scope strictly bounded to invariance hardening; no provider, connector, or orchestration expansion.
+- Canonical docs must state the accepted repo baseline through Phase 3 Sprint 9, not Phase 2 Sprint 14.
+- Control-doc truth checks must enforce Phase 3 markers and reject stale Phase 2 baseline claims where now obsolete.
+- Phase gate entrypoints should include Phase 3 names, preserving compatibility aliases to existing gate semantics.
+- This sprint is documentation and control-plane only; runtime API/web behavior must remain unchanged.
 
 ## Exact Surfaces In Scope
 
-- execution-budget decisioning invariance for malformed/unresolvable runtime context
-- proxy execution fail-closed behavior when decision context is invalid
-- additive trace/decision diagnostics for invalid context handling
-- unit/integration regression coverage for malformed request and malformed history rows
+- canonical truth docs baseline alignment (architecture/roadmap/readme/handoff)
+- control-doc truth guardrail update + unit tests
+- Phase 3 gate entrypoint scripts (compatibility wrappers allowed)
+- Phase 3 closeout runbook packet and evidence requirements
 
 ## Exact Files In Scope
 
-- [contracts.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/contracts.py)
-- [execution_budgets.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/execution_budgets.py)
-- [proxy_execution.py](/Users/samirusani/Desktop/Codex/AliceBot/apps/api/src/alicebot_api/proxy_execution.py)
-- [test_execution_budgets.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_execution_budgets.py)
-- [test_proxy_execution.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_proxy_execution.py)
-- [test_proxy_execution_main.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_proxy_execution_main.py)
-- [test_proxy_execution_api.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/integration/test_proxy_execution_api.py)
+- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md)
+- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md)
+- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md)
+- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md)
+- [scripts/check_control_doc_truth.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/check_control_doc_truth.py)
+- [tests/unit/test_control_doc_truth.py](/Users/samirusani/Desktop/Codex/AliceBot/tests/unit/test_control_doc_truth.py)
+- [scripts/run_phase3_acceptance.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_phase3_acceptance.py)
+- [scripts/run_phase3_readiness_gates.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_phase3_readiness_gates.py)
+- [scripts/run_phase3_validation_matrix.py](/Users/samirusani/Desktop/Codex/AliceBot/scripts/run_phase3_validation_matrix.py)
+- [docs/runbooks/phase3-closeout-packet.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/runbooks/phase3-closeout-packet.md)
 - [BUILD_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/BUILD_REPORT.md)
 - [REVIEW_REPORT.md](/Users/samirusani/Desktop/Codex/AliceBot/REVIEW_REPORT.md)
 - [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
 
 ## In Scope
 
-- Harden budget evaluation context resolution:
-  - resolve request thread/profile deterministically before budget counting
-  - explicitly handle missing/unresolvable thread context as fail-closed path
-- Harden counted execution filtering:
-  - exclude historical executions with malformed/unresolvable thread context from scoped counts
-  - preserve deterministic ordering/rolling-window behavior for valid rows
-- Add additive diagnostics on blocked fail-closed decisions to make reason visible in traces/results.
-- Preserve backward compatibility for existing proxy response envelopes and trace event ordering.
-- Add unit coverage for:
-  - invalid runtime thread context behavior
-  - malformed execution-history row behavior
-  - deterministic blocked reason contracts
-- Add integration coverage proving proxy execution blocks deterministically when context invariants are violated.
+- Update canonical docs to reflect accepted baseline through Phase 3 Sprint 9.
+- Update control-doc truth markers/rules and keep stale-marker rejection accurate.
+- Add Phase 3 gate entrypoint scripts as compatibility wrappers to current deterministic gate runners.
+- Add Phase 3 closeout runbook with required commands, PASS evidence bundle, and deferred-scope statement.
+- Keep root `BUILD_REPORT.md`/`REVIEW_REPORT.md` conventions explicit.
+- Validate docs and gate tooling through targeted unit and gate commands.
 
 ## Out of Scope
 
+- runtime API logic changes
+- web UI behavior changes
 - schema/migration changes
-- execution-budget CRUD redesign
-- policy engine redesign
-- introducing new providers, connectors, or secret handling changes
+- provider/connector/auth capability expansion
 - orchestration/worker runtime changes
-- web UI changes
-- connector/auth expansion
+- profile CRUD expansion
 
 ## Required Deliverables
 
-- fail-closed invariance handling for malformed/unresolvable budget runtime context
-- deterministic counting behavior under malformed history conditions
-- passing unit/integration evidence for invariance hardening behavior
+- canonical docs aligned to Phase 3 Sprint 9 baseline
+- control-doc truth guard and unit tests updated and passing
+- Phase 3 gate entrypoint scripts present and executable
+- Phase 3 closeout runbook present with deterministic go/no-go checklist
 - sprint build/review reports scoped to this sprint only
 
 ## Acceptance Criteria
 
-- Budget decisioning does not execute with unresolvable request thread/profile context.
-- Malformed/unresolvable historical execution rows do not contaminate scoped budget counts.
-- Proxy execution returns deterministic blocked outcomes for invalid-context invariance failures.
-- Existing proxy execution event/result/trace contracts remain backward-compatible (additive diagnostics only).
-- `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_proxy_execution.py tests/unit/test_proxy_execution_main.py -q` passes.
-- `./.venv/bin/python -m pytest tests/integration/test_proxy_execution_api.py -q` passes.
-- `python3 scripts/run_phase2_validation_matrix.py` remains PASS.
+- `python3 scripts/check_control_doc_truth.py` passes with Phase 3 markers.
+- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q` passes.
+- `python3 scripts/run_phase3_validation_matrix.py` passes.
+- `python3 scripts/run_phase2_validation_matrix.py` remains PASS (compatibility guarantee).
+- Canonical docs do not claim a baseline earlier than accepted Phase 3 Sprint 9.
+- No runtime API/web/schema capability expansion enters this sprint.
 - No provider/connector/orchestration scope expansion enters this sprint.
 
 ## Implementation Constraints
 
 - do not introduce new dependencies
-- preserve existing response/event/trace payload contracts (additive fields only where necessary)
-- keep deterministic ordering contracts (`created_at_asc`, `id_asc`, `specificity_desc`, rolling-window semantics)
-- no new DB migration in this sprint unless an explicit Control Tower scope change is issued
+- keep script behavior deterministic and machine-independent
+- use repo-relative paths and machine-independent command examples in docs
+- preserve existing runtime product behavior (docs/control-plane only)
 
 ## Control Tower Task Cards
 
-### Task 1: Runtime Invariance Hardening
+### Task 1: Canonical Truth Sync
 Owner: tooling operative  
 Write scope:
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/execution_budgets.py`
-- `apps/api/src/alicebot_api/proxy_execution.py`
+- `ARCHITECTURE.md`
+- `ROADMAP.md`
+- `README.md`
+- `.ai/handoff/CURRENT_STATE.md`
 
-### Task 2: Verification
+### Task 2: Control Guard + Gate Entry Points
 Owner: tooling operative  
 Write scope:
-- `tests/unit/test_execution_budgets.py`
-- `tests/unit/test_proxy_execution.py`
-- `tests/unit/test_proxy_execution_main.py`
-- `tests/integration/test_proxy_execution_api.py`
+- `scripts/check_control_doc_truth.py`
+- `tests/unit/test_control_doc_truth.py`
+- `scripts/run_phase3_acceptance.py`
+- `scripts/run_phase3_readiness_gates.py`
+- `scripts/run_phase3_validation_matrix.py`
+- `docs/runbooks/phase3-closeout-packet.md`
 
 ### Task 3: Integration Review
 Owner: control tower  
 Responsibilities:
-- verify sprint stays budget-context-invariance scoped
-- verify fail-closed behavior for invalid context is deterministic
-- verify no provider/connector/orchestration expansion
+- verify sprint stays docs/control-plane scoped
+- verify phase baseline markers and closeout runbook are internally consistent
+- verify no runtime/schema expansion
 - verify validation matrix remains green
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
-- exact invariance-hardening decisioning deltas
+- exact canonical-doc and control-guard deltas
 - exact verification command outcomes
-- explicit deferred scope (schema expansion, providers/connectors, orchestration, profile CRUD)
+- explicit deferred scope (runtime/schema/providers/connectors/orchestration/profile CRUD)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
-- sprint stayed bounded to budget context invariance hardening
-- malformed-context fail-closed behavior is deterministic and correct
-- profile-scoped counting remains isolated under malformed-history pressure
-- API and proxy-execution behavior remain backward-compatible
+- sprint stayed bounded to closeout truth-sync scope
+- canonical docs and truth checks align on Phase 3 baseline markers
+- phase3 gate wrappers and closeout runbook are deterministic and coherent
+- runtime behavior remained unchanged
 - no hidden scope expansion
 
 ## Exit Condition
 
-This sprint is complete when proxy execution budget decisioning is fail-closed under invalid context and profile-scoped counting remains deterministic under malformed-history conditions, with test evidence and validation gates green.
+This sprint is complete when canonical docs, control-doc truth checks, and gate entrypoints consistently represent the accepted Phase 3 Sprint 9 baseline, with all required verification commands passing and no runtime-scope expansion.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -2,9 +2,9 @@
 
 ## Canonical Truth
 
-- The working repo state is current through Phase 2 Sprint 14.
-- The accepted baseline includes deterministic Phase 2 gate tooling: `python3 scripts/run_phase2_acceptance.py`, `python3 scripts/run_phase2_readiness_gates.py`, and `python3 scripts/run_phase2_validation_matrix.py` (default go/no-go command).
-- Gate ownership is canonicalized to Phase 2 runner scripts; `run_mvp_acceptance.py`, `run_mvp_readiness_gates.py`, and `run_mvp_validation_matrix.py` remain supported compatibility aliases with identical semantics.
+- The working repo state is current through Phase 3 Sprint 9.
+- The accepted baseline includes deterministic Phase 3 gate entrypoints: `python3 scripts/run_phase3_acceptance.py`, `python3 scripts/run_phase3_readiness_gates.py`, and `python3 scripts/run_phase3_validation_matrix.py` (default go/no-go command).
+- Gate entrypoints are canonicalized to Phase 3 runner script names; `run_phase2_acceptance.py`, `run_phase2_readiness_gates.py`, `run_phase2_validation_matrix.py`, and `run_mvp_*` aliases remain supported compatibility entrypoints with identical semantics.
 - Use [PRODUCT_BRIEF.md](../../PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](../../ARCHITECTURE.md) for implemented boundaries, [ROADMAP.md](../../ROADMAP.md) for forward planning, and [RULES.md](../../RULES.md) for durable operating rules.
 - The live sprint reports are [BUILD_REPORT.md](../../BUILD_REPORT.md) and [REVIEW_REPORT.md](../../REVIEW_REPORT.md) at repo root; older accepted sprint history belongs in [docs/archive/sprints](../../docs/archive/sprints), not in this handoff.
 
@@ -46,6 +46,6 @@
 
 ## Planning Guardrails
 
-- Plan from the implemented Phase 2 Sprint 14 repo state, not from older Sprint 5-era narratives.
+- Plan from the implemented Phase 3 Sprint 9 repo state, not from older Sprint 5-era narratives.
 - Do not describe broader Gmail scope, broader Calendar scope beyond bounded read-only event discovery plus selected-event ingestion, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
 - The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, including `/gmail`, `/calendar`, `/memories`, `/entities`, and `/artifacts`, not assumed to be leftover connector cleanup by default.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Current Implemented Slice
 
-AliceBot now implements the accepted repo slice through Phase 2 Sprint 14.
+AliceBot now implements the accepted repo slice through Phase 3 Sprint 9.
 
 - `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review plus open-loop lifecycle capture/review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and narrow read-only Gmail and Calendar seams with external-secret-backed credentials plus bounded Calendar event discovery and selected-item ingestion into the artifact pipeline.
 - `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
@@ -19,7 +19,7 @@ The repo is intentionally still narrow. Document ingestion remains local and det
 
 - `docker-compose.yml` starts local Postgres with `pgvector`, Redis, and MinIO.
 - `scripts/dev_up.sh`, `scripts/migrate.sh`, and `scripts/api_dev.sh` provide the local startup path.
-- `scripts/run_phase2_acceptance.py`, `scripts/run_phase2_readiness_gates.py`, and `scripts/run_phase2_validation_matrix.py` provide deterministic Phase 2 gate entrypoints; the validation matrix command is the default go/no-go gate, and MVP script names remain compatible aliases with identical semantics.
+- `scripts/run_phase3_acceptance.py`, `scripts/run_phase3_readiness_gates.py`, and `scripts/run_phase3_validation_matrix.py` are the canonical Phase 3 gate entrypoints; they preserve deterministic gate semantics by delegating to existing Phase 2 implementations. `scripts/run_phase2_*.py` and `scripts/run_mvp_*.py` remain supported compatibility entrypoints with identical semantics.
 - `apps/api` exposes FastAPI endpoints for:
   - continuity and response generation: `/healthz`, `POST /v0/threads`, `GET /v0/threads`, `GET /v0/threads/{thread_id}`, `GET /v0/threads/{thread_id}/sessions`, `GET /v0/threads/{thread_id}/events`, `GET /v0/threads/{thread_id}/resumption-brief`, `POST /v0/context/compile`, `POST /v0/responses`
   - memory and open-loop seams, including `POST /v0/memories/admit`, `POST /v0/memories/capture-explicit-signals`, `GET /v0/open-loops`, `GET /v0/open-loops/{open_loop_id}`, `POST /v0/open-loops`, `POST /v0/open-loops/{open_loop_id}/status`, and `POST /v0/open-loops/extract-explicit-commitments`

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,60 +1,63 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Phase 3 Sprint 9 budget context invariance hardening so execution-budget decisioning is fail-closed for malformed/unresolvable runtime thread/profile context, and counted history remains strictly profile-attributable under malformed history pressure.
+Implement Phase 3 Sprint 10 closeout truth sync and phase-gate canonicalization by re-anchoring canonical docs, control-doc truth checks, phase gate entrypoints, and closeout runbooks to the accepted Phase 3 Sprint 9 baseline without changing runtime behavior.
 
 ## Completed Work
-- Hardened budget decisioning runtime context resolution in `execution_budgets.py`:
-  - Added deterministic request-context resolution before budget matching/counting finalization.
-  - Added explicit fail-closed decision path for invalid request context (`decision=block`, `reason=invalid_request_context`).
-  - Added deterministic blocked result messaging for invalid context invariance failures.
-- Hardened counted execution filtering invariance in `execution_budgets.py`:
-  - Counted history now requires a valid/parseable `request.thread_id`.
-  - Counted history now requires `request.thread_id` to match persisted `tool_executions.thread_id`.
-  - Counted history rows with missing/malformed/unresolvable thread/profile context are excluded from scoped counts.
-- Added additive diagnostics in contracts and decision payloads:
-  - Added `invalid_request_context` to `ExecutionBudgetDecisionReason`.
-  - Added additive optional decision diagnostics: `request_thread_id`, `context_resolution`, `context_reason`.
-- Added additive proxy trace diagnostics in `proxy_execution.py`:
-  - For invalid-context budget blocks, dispatch trace includes additive `budget_context` payload.
-  - Preserved existing proxy response envelope and trace ordering.
-- Added/updated regression coverage:
-  - Unit tests for malformed runtime context fail-closed behavior.
-  - Unit tests for unresolvable runtime thread/profile context fail-closed behavior.
-  - Unit tests for malformed history-row exclusion from scoped counts.
-  - Unit + integration tests for deterministic proxy blocked outcomes and additive diagnostics on invalid context.
+- Canonical truth docs re-anchored from Phase 2 Sprint 14 to Phase 3 Sprint 9:
+  - Updated baseline marker language in `ARCHITECTURE.md`, `ROADMAP.md`, `README.md`, and `.ai/handoff/CURRENT_STATE.md`.
+  - Updated gate-entrypoint language to Phase 3 names while preserving compatibility semantics for existing Phase 2 and MVP script names.
+- Control-doc truth guardrail updated for Phase 3 baseline:
+  - `scripts/check_control_doc_truth.py` now requires Phase 3 markers in canonical docs and the Phase 3 closeout packet path.
+  - Added stale-marker rejection for obsolete Phase 2 Sprint 14 baseline/gate-ownership markers.
+- Control-doc truth unit tests updated:
+  - `tests/unit/test_control_doc_truth.py` now targets `docs/runbooks/phase3-closeout-packet.md` and verifies stale Phase 2 Sprint 14 marker rejection.
+- Added Phase 3 gate entrypoint wrappers (compatibility-preserving control-plane layer):
+  - `scripts/run_phase3_acceptance.py` -> delegates to `scripts/run_phase2_acceptance.py`.
+  - `scripts/run_phase3_readiness_gates.py` -> delegates to `scripts/run_phase2_readiness_gates.py`.
+  - `scripts/run_phase3_validation_matrix.py` -> delegates to `scripts/run_phase2_validation_matrix.py`.
+- Added Phase 3 closeout packet runbook:
+  - `docs/runbooks/phase3-closeout-packet.md` with required go/no-go commands, PASS evidence bundle requirements, deferred-scope statement, and deterministic checklist.
 
 ## Incomplete Work
 - None within sprint scope.
 
 ## Files Changed
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/execution_budgets.py`
-- `apps/api/src/alicebot_api/proxy_execution.py`
-- `tests/unit/test_execution_budgets.py`
-- `tests/unit/test_proxy_execution.py`
-- `tests/unit/test_proxy_execution_main.py`
-- `tests/integration/test_proxy_execution_api.py`
+- `.ai/handoff/CURRENT_STATE.md`
+- `ARCHITECTURE.md`
+- `ROADMAP.md`
+- `README.md`
+- `scripts/check_control_doc_truth.py`
+- `tests/unit/test_control_doc_truth.py`
+- `scripts/run_phase3_acceptance.py`
+- `scripts/run_phase3_readiness_gates.py`
+- `scripts/run_phase3_validation_matrix.py`
+- `docs/runbooks/phase3-closeout-packet.md`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 ## Tests Run
-- `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_proxy_execution.py tests/unit/test_proxy_execution_main.py -q`
-  - PASS (`37 passed in 0.63s`)
-- `./.venv/bin/python -m pytest tests/integration/test_proxy_execution_api.py -q`
-  - PASS (`16 passed in 7.53s`)
+- `python3 scripts/check_control_doc_truth.py`
+  - PASS (`Control-doc truth check: PASS`; all configured control docs verified including `docs/runbooks/phase3-closeout-packet.md`)
+- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+  - PASS (`5 passed in 0.03s`)
+- `python3 scripts/run_phase3_validation_matrix.py`
+  - PASS (Phase 3 wrapper executed Phase 2 matrix semantics; matrix steps all PASS: `control_doc_truth`, `gate_contract_tests`, `readiness_gates`, `backend_integration_matrix`, `web_validation_matrix`; final `Phase 2 validation matrix result: PASS`)
 - `python3 scripts/run_phase2_validation_matrix.py`
-  - PASS (`Phase 2 validation matrix result: PASS`)
+  - PASS (compatibility guarantee confirmed; matrix steps all PASS; final `Phase 2 validation matrix result: PASS`)
 
 ## Blockers / Issues
-- No implementation blockers.
-- Environment constraint encountered: local Postgres-backed integration/validation commands required elevated permissions outside default sandbox. Commands succeeded after rerun with escalation.
+- Initial non-escalated validation-matrix execution could not connect to local Postgres in sandbox (`Operation not permitted` on localhost:5432).
+- Resolved by re-running validation commands with elevated permissions; all required commands then passed.
 
 ## Deferred Scope (Explicit)
+- No runtime API logic changes.
+- No web UI behavior changes.
 - No schema/migration expansion.
-- No provider or connector expansion.
-- No orchestration/worker runtime redesign.
-- No profile CRUD redesign/expansion.
+- No provider expansion.
+- No connector capability expansion.
+- No orchestration/worker runtime changes.
+- No profile CRUD expansion.
 
 ## Recommended Next Step
-Control Tower integration review: validate deterministic fail-closed invalid-context behavior and malformed-history exclusion invariants, then proceed to sprint branch PR review/merge flow.
+Control Tower integration review to confirm closeout truth-sync alignment, then proceed with sprint PR/merge flow.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Phase 2 Sprint 14: a FastAPI backend plus a bounded Next.js operator shell with deterministic readiness and validation matrix gating.
+AliceBot is a private, permissioned personal AI operating system. The current repo contains the accepted slice through Phase 3 Sprint 9: a FastAPI backend plus a bounded Next.js operator shell with deterministic readiness and validation matrix gating.
 
 ## Current Implemented Slice
 
@@ -21,11 +21,12 @@ AliceBot is a private, permissioned personal AI operating system. The current re
 
 Useful checks:
 
-- Canonical gate ownership: `scripts/run_phase2_*.py` are implementation source; `scripts/run_mvp_*.py` are compatibility aliases.
+- Canonical gate entrypoints: `scripts/run_phase3_*.py` are the control-plane entrypoint wrappers; `scripts/run_phase2_*.py` and `scripts/run_mvp_*.py` remain compatibility entrypoints with identical semantics.
 - API health: [http://127.0.0.1:8000/healthz](http://127.0.0.1:8000/healthz)
-- Phase 2 acceptance gate: `python3 scripts/run_phase2_acceptance.py`
-- Phase 2 readiness gates: `python3 scripts/run_phase2_readiness_gates.py`
-- Phase 2 default go/no-go validation gate: `python3 scripts/run_phase2_validation_matrix.py`
+- Phase 3 acceptance gate: `python3 scripts/run_phase3_acceptance.py`
+- Phase 3 readiness gates: `python3 scripts/run_phase3_readiness_gates.py`
+- Phase 3 default go/no-go validation gate: `python3 scripts/run_phase3_validation_matrix.py`
+- Phase 2 compatibility validation gate: `python3 scripts/run_phase2_validation_matrix.py`
 - MVP alias gates (identical semantics): `python3 scripts/run_mvp_acceptance.py`, `python3 scripts/run_mvp_readiness_gates.py`, `python3 scripts/run_mvp_validation_matrix.py`
 - Backend tests: `./.venv/bin/python -m pytest tests/unit tests/integration`
 - Web tests: `pnpm --dir apps/web test`

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,32 +4,41 @@
 PASS
 
 ## criteria met
-- Budget decisioning is fail-closed for invalid/unresolvable runtime context (`invalid_request_context`) before budget matching/count finalization.
-- Malformed/unresolvable historical execution rows are excluded from counted history (invalid/missing `request.thread_id`, non-UUID values, mismatched `request.thread_id` vs persisted `thread_id`, and unresolvable thread/profile context).
-- Proxy execution returns deterministic blocked outcomes for invalid-context invariance failures, including deterministic blocked reason text and additive decision diagnostics.
-- Existing proxy response/event/trace contracts remain backward-compatible; changes are additive (`request_thread_id`, `context_resolution`, `context_reason`, and optional dispatch `budget_context`).
-- Required test command passed: `./.venv/bin/python -m pytest tests/unit/test_execution_budgets.py tests/unit/test_proxy_execution.py tests/unit/test_proxy_execution_main.py -q` (`37 passed`).
-- Required test command passed: `./.venv/bin/python -m pytest tests/integration/test_proxy_execution_api.py -q` (`16 passed`).
-- Required gate command passed: `python3 scripts/run_phase2_validation_matrix.py` (`Phase 2 validation matrix result: PASS`).
-- Sprint stayed in scope (no provider/connector/orchestration/schema expansion detected).
+- Sprint stayed within closeout truth-sync scope (docs/control-plane only). No runtime API, web behavior, schema, provider, connector, orchestration, or profile-CRUD expansion detected in the diff.
+- Canonical baseline alignment to Phase 3 Sprint 9 is present in `ARCHITECTURE.md`, `ROADMAP.md`, `README.md`, and `.ai/handoff/CURRENT_STATE.md`.
+- Control truth checks were updated to Phase 3 markers and Phase 3 closeout packet path in `scripts/check_control_doc_truth.py`.
+- Stale Phase 2 Sprint 14 ownership/baseline markers are rejected by the control truth guard.
+- Unit coverage for control truth guard was updated and passes (`tests/unit/test_control_doc_truth.py`).
+- Phase 3 gate entrypoint wrappers exist, are executable, and delegate to Phase 2 scripts with compatibility semantics:
+  - `scripts/run_phase3_acceptance.py`
+  - `scripts/run_phase3_readiness_gates.py`
+  - `scripts/run_phase3_validation_matrix.py`
+- Phase 3 closeout packet is present and coherent (`docs/runbooks/phase3-closeout-packet.md`) with required commands, evidence bundle, deferred scope, and checklist.
+- Acceptance commands verified:
+  - `python3 scripts/check_control_doc_truth.py` -> PASS
+  - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q` -> PASS (`5 passed`)
+  - `python3 scripts/run_phase3_validation_matrix.py` -> PASS
+  - `python3 scripts/run_phase2_validation_matrix.py` -> PASS
 
 ## criteria missed
 - None.
 
 ## quality issues
-- None found in sprint scope.
+- No blocking implementation quality issues found.
+- Non-blocking: no direct unit tests for `run_phase3_acceptance.py` and `run_phase3_readiness_gates.py` wrappers themselves (validation matrix wrapper is exercised). Current risk is low because wrappers are thin delegates.
 
 ## regression risks
-- Low risk. Intentional fail-closed behavior will now block execution when legacy/corrupt request thread context is malformed or unresolvable; this is expected by sprint intent.
+- Low. Phase 3 scripts are wrapper entrypoints over existing Phase 2 deterministic runners, so runtime gate behavior remains anchored to known semantics.
+- Low operational risk: validation matrix commands require local Postgres connectivity; sandbox-restricted environments can report false failures unless run with appropriate permissions.
 
 ## docs issues
-- None blocking. `BUILD_REPORT.md` captures implemented deltas, command outcomes, and deferred scope as required.
+- None blocking. Canonical docs, control truth guard, and runbook language are internally consistent on the accepted Phase 3 Sprint 9 baseline.
 
 ## should anything be added to RULES.md?
 - No required changes.
 
 ## should anything update ARCHITECTURE.md?
-- No required changes.
+- No additional updates required beyond this sprint’s baseline truth-sync edits.
 
 ## recommended next action
-- Proceed with Control Tower integration approval and sprint PR merge flow.
+- Proceed with Control Tower sign-off and merge.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,22 +2,22 @@
 
 ## Current Position
 
-- The accepted repo state is current through Phase 2 Sprint 14.
+- The accepted repo state is current through Phase 3 Sprint 9.
 - The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, typed memory and open-loop seams, deterministic thread resumption brief reads, unified explicit-signal capture seams, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, narrow read-only Gmail and Calendar seams with selected-item ingestion, bounded read-only Calendar event discovery for one connected account, and the no-tools assistant-response seam.
 - The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
 - `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, keeps bounded thread review and deterministic resumption brief review visible beside both assistant and governed-request composition, ships thread-linked governed workflow, ordered task-step timeline review, and bounded explain-why trace embedding, and includes manual explicit-signal capture controls for selected `message.user` events.
 - `/gmail` and `/calendar` are shipped bounded connector workspaces in the shell: account review, selected-account detail, explicit connect, and one selected-item ingestion path into one chosen task workspace. The API baseline also includes bounded Calendar event discovery for one connected account with deterministic ordering and bounded limits.
 - `/memories`, `/entities`, and `/artifacts` are shipped bounded review workspaces in the shell, not planned surface.
-- Phase 2 Sprint 14 confirms deterministic release-candidate validation tooling and canonical Phase 2 gate ownership; `python3 scripts/run_phase2_validation_matrix.py` is the default go/no-go command.
+- Phase 3 Sprint 9 confirms deterministic release-candidate validation tooling and canonical Phase 3 gate entrypoints; `python3 scripts/run_phase3_validation_matrix.py` is the default go/no-go command, with `python3 scripts/run_phase2_validation_matrix.py` retained as a compatibility guarantee command.
 - Historical sprint detail belongs in build and review artifacts, not in this roadmap.
 
 ## Next Delivery Focus
 
 ### Build From The Shipped API Plus Web-Shell Baseline
 
-- Plan the next sprint from the implemented Phase 2 Sprint 14 backend-plus-web baseline, not from older pre-Phase-2 narratives.
+- Plan the next sprint from the implemented Phase 3 Sprint 9 backend-plus-web baseline, not from older pre-Phase-3 narratives.
 - Treat transcript continuity, thread-linked workflow review, task-step timeline review, bounded explain-why embedding in `/chat`, deterministic resumption brief review, manual explicit-signal capture controls, the shipped review workspaces (`/memories`, `/entities`, `/artifacts`), the shipped connector workspaces (`/gmail`, `/calendar`), and bounded Calendar event discovery as baseline, not pending work.
-- Treat the deterministic validation matrix command (`python3 scripts/run_phase2_validation_matrix.py`) as the default release-candidate gate.
+- Treat the deterministic validation matrix command (`python3 scripts/run_phase3_validation_matrix.py`) as the default release-candidate gate, while keeping `python3 scripts/run_phase2_validation_matrix.py` as a compatibility check.
 - Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.
 - Reuse the existing continuity, response, approval, task, workspace-artifact, memory, entity, execution, and trace surfaces instead of introducing parallel contracts.
 

--- a/docs/runbooks/phase3-closeout-packet.md
+++ b/docs/runbooks/phase3-closeout-packet.md
@@ -1,0 +1,44 @@
+# Phase 3 Closeout Packet
+
+This runbook is the source-of-truth closeout packet for the accepted Phase 3 Sprint 9 baseline.
+
+## Required Phase 3 Go/No-Go Commands
+
+Run these commands from repo root in order and retain outputs verbatim in the evidence bundle:
+
+1. `python3 scripts/check_control_doc_truth.py`
+2. `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+3. `python3 scripts/run_phase3_validation_matrix.py`
+4. `python3 scripts/run_phase2_validation_matrix.py`
+
+Go decision rule:
+- `GO` only if all four commands pass in the same verification window.
+- `NO_GO` if any command fails, is skipped, or cannot produce deterministic output.
+
+## Required PASS Evidence Bundle
+
+Capture the following in one reviewable bundle:
+
+- command transcript for all required go/no-go commands
+- final statuses showing `Control-doc truth check: PASS`, unit test PASS, `Phase 3 validation matrix` PASS, and `Phase 2 validation matrix` PASS
+- timestamped operator note that canonical docs are aligned through Phase 3 Sprint 9
+- links to current sprint reports at repo root:
+  - `BUILD_REPORT.md`
+  - `REVIEW_REPORT.md`
+
+## Explicit Deferred Scope Entering Next Phase
+
+The following are deferred and must remain out of this closeout decision:
+
+- API/runtime feature expansion beyond accepted Phase 3 Sprint 9 behavior
+- schema and migration expansion
+- provider and connector capability broadening
+- orchestration/worker runtime implementation
+- profile CRUD expansion
+
+## Closeout Checklist
+
+- Canonical docs do not claim a baseline earlier than Phase 3 Sprint 9.
+- This closeout packet file exists and remains referenced by control-doc truth checks.
+- Control-doc truth guardrail and unit tests pass.
+- Phase 3 validation matrix and Phase 2 compatibility validation matrix remain PASS without gate semantic changes.

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -17,20 +17,20 @@ class ControlDocTruthRule:
 CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
     ControlDocTruthRule(
         relative_path="ARCHITECTURE.md",
-        required_markers=("through Phase 2 Sprint 14",),
+        required_markers=("through Phase 3 Sprint 9",),
     ),
     ControlDocTruthRule(
         relative_path="ROADMAP.md",
         required_markers=(
-            "through Phase 2 Sprint 14",
-            "canonical Phase 2 gate ownership",
+            "through Phase 3 Sprint 9",
+            "canonical Phase 3 gate entrypoints",
         ),
     ),
     ControlDocTruthRule(
         relative_path="README.md",
         required_markers=(
-            "through Phase 2 Sprint 14",
-            "Canonical gate ownership: `scripts/run_phase2_*.py` are implementation source",
+            "through Phase 3 Sprint 9",
+            "Canonical gate entrypoints: `scripts/run_phase3_*.py` are the control-plane entrypoint wrappers",
         ),
     ),
     ControlDocTruthRule(
@@ -44,15 +44,15 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
     ControlDocTruthRule(
         relative_path=".ai/handoff/CURRENT_STATE.md",
         required_markers=(
-            "through Phase 2 Sprint 14",
-            "Gate ownership is canonicalized to Phase 2 runner scripts",
+            "through Phase 3 Sprint 9",
+            "Gate entrypoints are canonicalized to Phase 3 runner script names",
         ),
     ),
     ControlDocTruthRule(
-        relative_path="docs/runbooks/phase2-closeout-packet.md",
+        relative_path="docs/runbooks/phase3-closeout-packet.md",
         required_markers=(
-            "accepted Phase 2 Sprint 14 baseline",
-            "Required Phase 2 Go/No-Go Commands",
+            "accepted Phase 3 Sprint 9 baseline",
+            "Required Phase 3 Go/No-Go Commands",
             "Required PASS Evidence Bundle",
             "Explicit Deferred Scope Entering Next Phase",
         ),
@@ -60,6 +60,11 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
 )
 
 DISALLOWED_MARKERS: tuple[str, ...] = (
+    "through Phase 2 Sprint 14",
+    "current through Phase 2 Sprint 14",
+    "accepted Phase 2 Sprint 14 baseline",
+    "canonical Phase 2 gate ownership",
+    "Gate ownership is canonicalized to Phase 2 runner scripts",
     "through Phase 2 Sprint 11",
     "current through Phase 2 Sprint 11",
     "Phase 2 Sprint 7",

--- a/scripts/run_phase3_acceptance.py
+++ b/scripts/run_phase3_acceptance.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+TARGET_SCRIPT = ROOT_DIR / "scripts" / "run_phase2_acceptance.py"
+
+
+def _resolve_python_executable() -> str:
+    venv_python = ROOT_DIR / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    return sys.executable
+
+
+def main() -> int:
+    command = [_resolve_python_executable(), str(TARGET_SCRIPT), *sys.argv[1:]]
+    print("Phase 3 acceptance entrypoint -> scripts/run_phase2_acceptance.py", flush=True)
+    print(shlex.join(command), flush=True)
+    completed = subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        check=False,
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_phase3_readiness_gates.py
+++ b/scripts/run_phase3_readiness_gates.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+TARGET_SCRIPT = ROOT_DIR / "scripts" / "run_phase2_readiness_gates.py"
+
+
+def _resolve_python_executable() -> str:
+    venv_python = ROOT_DIR / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    return sys.executable
+
+
+def main() -> int:
+    command = [_resolve_python_executable(), str(TARGET_SCRIPT), *sys.argv[1:]]
+    print("Phase 3 readiness entrypoint -> scripts/run_phase2_readiness_gates.py", flush=True)
+    print(shlex.join(command), flush=True)
+    completed = subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        check=False,
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_phase3_validation_matrix.py
+++ b/scripts/run_phase3_validation_matrix.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+TARGET_SCRIPT = ROOT_DIR / "scripts" / "run_phase2_validation_matrix.py"
+
+
+def _resolve_python_executable() -> str:
+    venv_python = ROOT_DIR / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    return sys.executable
+
+
+def main() -> int:
+    command = [_resolve_python_executable(), str(TARGET_SCRIPT), *sys.argv[1:]]
+    print("Phase 3 validation matrix entrypoint -> scripts/run_phase2_validation_matrix.py", flush=True)
+    print(shlex.join(command), flush=True)
+    completed = subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        check=False,
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_control_doc_truth.py
+++ b/tests/unit/test_control_doc_truth.py
@@ -39,14 +39,15 @@ def test_control_doc_truth_fails_when_disallowed_marker_is_present(tmp_path: Pat
     target_rule = control_doc_truth.CONTROL_DOC_TRUTH_RULES[1]
     target_path = tmp_path / target_rule.relative_path
     target_path.write_text(
-        target_path.read_text(encoding="utf-8") + "\nThe accepted repo state is current through Phase 2 Sprint 7.\n",
+        target_path.read_text(encoding="utf-8")
+        + "\nThe accepted repo state is current through Phase 2 Sprint 14.\n",
         encoding="utf-8",
     )
 
     issues = control_doc_truth.run_control_doc_truth_check(root_dir=tmp_path)
 
     assert any(
-        issue == f"{target_rule.relative_path}: contains disallowed marker 'Phase 2 Sprint 7'"
+        issue == f"{target_rule.relative_path}: contains disallowed marker 'through Phase 2 Sprint 14'"
         for issue in issues
     )
 
@@ -56,7 +57,7 @@ def test_control_doc_truth_fails_when_closeout_packet_is_missing(tmp_path: Path)
     closeout_rule = next(
         rule
         for rule in control_doc_truth.CONTROL_DOC_TRUTH_RULES
-        if rule.relative_path == "docs/runbooks/phase2-closeout-packet.md"
+        if rule.relative_path == "docs/runbooks/phase3-closeout-packet.md"
     )
     (tmp_path / closeout_rule.relative_path).unlink()
 


### PR DESCRIPTION
## Summary
This PR completes Phase 3 Sprint 10 by re-anchoring control-plane truth and gate entrypoints to the accepted Phase 3 Sprint 9 baseline, without changing product runtime behavior.

### What changed
- Updated canonical docs to align baseline truth with Phase 3 Sprint 9:
  - `ARCHITECTURE.md`
  - `ROADMAP.md`
  - `README.md`
  - `.ai/handoff/CURRENT_STATE.md`
- Updated control-doc truth checks (`scripts/check_control_doc_truth.py`) to:
  - require Phase 3 baseline markers
  - require Phase 3 closeout packet path
  - reject stale Phase 2 Sprint 14 ownership/baseline markers
- Updated control-doc truth unit tests (`tests/unit/test_control_doc_truth.py`) for new markers/rules.
- Added Phase 3 gate wrapper entrypoints:
  - `scripts/run_phase3_acceptance.py`
  - `scripts/run_phase3_readiness_gates.py`
  - `scripts/run_phase3_validation_matrix.py`
  These delegate to existing Phase 2 deterministic runners to preserve compatibility semantics.
- Added closeout runbook: `docs/runbooks/phase3-closeout-packet.md`.

## Scope Guardrails
- No runtime API logic changes
- No web behavior changes
- No schema/migration changes
- No provider/connector/orchestration expansion

## Verification
From sprint reports:
- `python3 scripts/check_control_doc_truth.py` -> `PASS`
- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q` -> `5 passed`
- `python3 scripts/run_phase3_validation_matrix.py` -> `PASS`
- `python3 scripts/run_phase2_validation_matrix.py` -> `PASS`

## Control Tower
- Review verdict: `PASS`
- Integration decision: `MERGE_APPROVED`
