### PR TITLE
Phase 5 Sprint 18: Recall and resumption

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 5 Sprint 17 (P5-S17): Continuity Backbone and Fast Capture
+Phase 5 Sprint 18 (P5-S18): Recall and Resumption
 
 ## Sprint Type
 
@@ -10,76 +10,80 @@ feature
 
 ## Sprint Reason
 
-Phase 4 MVP qualification/sign-off is complete. The first Phase 5 non-redundant delivery is the typed continuity backbone and one fast capture flow, because all later Phase 5 recall/resumption/review work depends on it.
+P5-S17 shipped typed continuity capture/backbone. The next non-redundant dependency is retrieval and deterministic resumption so captured continuity becomes usable without transcript reconstruction.
 
 ## Sprint Intent
 
-Ship a deterministic typed continuity object backbone plus fast capture inbox flow that always preserves immutable capture events and only promotes durable objects when signals are explicit or high-confidence.
+Ship provenance-backed recall queries and deterministic resumption briefs for thread/task/project/person scope using the continuity object backbone from P5-S17.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase5-sprint-17-continuity-backbone-fast-capture`
+- Branch Name: `codex/phase5-sprint-18-recall-resumption`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- It starts Phase 5 with the minimum shared data model required by all later sprints.
-- It creates immediate user value (capture without loss) while keeping admission conservative.
-- It avoids redundant work by not touching recall/resumption/review dashboards yet.
+- It turns stored continuity into practical product value.
+- It is the planned Phase 5 step after capture/backbone.
+- It avoids redundant scope by not reopening capture architecture or correction/open-loop dashboards.
 
 ## Redundancy Guard
 
-- Already shipped in Phase 4:
-  - release-control, RC rehearsal, archive/index, sign-off tooling
-- Required now (P5-S17):
-  - continuity object contracts
-  - fast capture API/UI
-  - triage posture for ambiguous captures
-- Explicitly out of P5-S17:
-  - broad recall UX
+- Already shipped in P5-S17:
+  - immutable capture events
+  - typed continuity objects
+  - conservative admission posture (`DERIVED`/`TRIAGE`)
+  - `/continuity` capture inbox
+- Required now (P5-S18):
+  - recall query surfaces with provenance and confirmation posture
   - deterministic resumption briefs
-  - memory correction queues
-  - daily/weekly review dashboards
+  - recent-change and open-loop summary sections in resumption output
+- Explicitly out of P5-S18:
+  - memory correction queue/supersession UX (P5-S19)
+  - daily/weekly open-loop dashboard (P5-S20)
+  - channel/connector/platform expansion
 
 ## Design Truth
 
-- Every capture produces an immutable capture event.
-- Durable continuity objects are typed and provenance-backed.
-- Admission defaults to conservative behavior (`NOOP`/triage) for ambiguous inputs.
-- Raw capture events and derived continuity objects remain distinct.
+- Recall results must be provenance-backed and scoped.
+- Resumption briefs must be deterministic for fixed input state.
+- Required resumption sections:
+  - last decision
+  - open loops
+  - recent changes
+  - next action
+- Missing sections must be explicit empty states, not silent omission.
 
 ## Exact Surfaces In Scope
 
-- typed continuity object contracts and persistence seams
-- capture intake endpoint(s) with explicit signal typing
-- capture inbox review surface (list/detail)
-- triage posture visibility for uncertain captures
+- continuity recall API + ranking/filter behavior
+- continuity resumption brief API/compiler behavior
+- recall/resumption UI in continuity workspace
+- tests for deterministic output contracts
 
 ## Exact Files In Scope
 
-- `apps/api/alembic/versions/20260329_0041_phase5_continuity_backbone.py`
 - `apps/api/src/alicebot_api/contracts.py`
 - `apps/api/src/alicebot_api/store.py`
 - `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/continuity_capture.py`
-- `apps/api/src/alicebot_api/continuity_objects.py`
+- `apps/api/src/alicebot_api/continuity_recall.py`
+- `apps/api/src/alicebot_api/continuity_resumption.py`
 - `apps/web/lib/api.ts`
 - `apps/web/lib/api.test.ts`
 - `apps/web/app/continuity/page.tsx`
 - `apps/web/app/continuity/page.test.tsx`
-- `apps/web/components/continuity-capture-form.tsx`
-- `apps/web/components/continuity-capture-form.test.tsx`
-- `apps/web/components/continuity-inbox-list.tsx`
-- `apps/web/components/continuity-inbox-list.test.tsx`
-- `tests/unit/test_20260329_0041_phase5_continuity_backbone.py`
-- `tests/unit/test_continuity_capture.py`
-- `tests/unit/test_continuity_objects.py`
-- `tests/integration/test_continuity_capture_api.py`
+- `apps/web/components/continuity-recall-panel.tsx`
+- `apps/web/components/continuity-recall-panel.test.tsx`
+- `apps/web/components/resumption-brief.tsx`
+- `apps/web/components/resumption-brief.test.tsx`
+- `tests/unit/test_continuity_recall.py`
+- `tests/unit/test_continuity_resumption.py`
+- `tests/integration/test_continuity_recall_api.py`
+- `tests/integration/test_continuity_resumption_api.py`
 - `docs/phase5-product-spec.md`
 - `docs/phase5-sprint-17-20-plan.md`
-- `docs/phase5-continuity-object-model.md`
 - `README.md`
 - `ROADMAP.md`
 - `.ai/handoff/CURRENT_STATE.md`
@@ -89,86 +93,84 @@ Ship a deterministic typed continuity object backbone plus fast capture inbox fl
 
 ## In Scope
 
-- Add minimal typed object model for:
-  - `Note`
-  - `MemoryFact`
-  - `Decision`
-  - `Commitment`
-  - `WaitingFor`
-  - `Blocker`
-  - `NextAction`
-- Implement capture endpoint that:
-  - always writes capture event
-  - accepts optional explicit signal (`remember_this`, `task`, `decision`, etc.)
-  - creates typed continuity object when explicit/high-confidence
-  - records triage posture when ambiguous
-- Implement capture inbox UI:
-  - submit capture
-  - list recent captures with posture
-  - view derived object/provenance summary
-- Keep provenance visible for all derived objects.
+- Add recall query endpoints with scoped filters:
+  - thread
+  - task
+  - project
+  - person
+  - time window
+- Return recall results with:
+  - object type
+  - confirmation/posture
+  - provenance references
+  - relevance/ordering metadata
+- Add deterministic resumption brief endpoint(s) for scoped contexts.
+- Ensure resumption briefs always include required sections with explicit empty states.
+- Add continuity UI panels for:
+  - recall query + results
+  - resumption brief view
 
 ## Out of Scope
 
-- recall query and ranking UX
-- deterministic resumption brief generation
-- correction queue and supersession flows
-- daily/weekly open-loop review dashboard
-- connector/channel/platform expansion
+- correction/confirm/edit/delete queue work
+- contradiction/superseded-chain editing UX
+- daily/weekly review dashboard
+- connector breadth changes
+- broad runtime architecture changes
 
 ## Required Deliverables
 
-- migration + persistence seam for typed continuity backbone
-- capture API and conservative admission behavior
-- capture inbox UI surface
-- unit/integration/web tests for deterministic capture + triage behavior
-- synced phase/control docs
+- recall API + deterministic filter/ranking behavior
+- deterministic resumption brief compiler/API
+- recall/resumption continuity UI surfaces
+- unit/integration/web tests for contract behavior
+- synced docs and sprint reports
 
 ## Acceptance Criteria
 
-- capture API always persists an immutable capture event.
-- explicit signals deterministically map to correct typed continuity object.
-- ambiguous captures are persisted and marked triage instead of creating unsafe durable objects.
-- provenance references are present for every derived continuity object.
-- `./.venv/bin/python -m pytest tests/unit/test_20260329_0041_phase5_continuity_backbone.py tests/unit/test_continuity_capture.py tests/unit/test_continuity_objects.py tests/integration/test_continuity_capture_api.py -q` passes.
-- `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-capture-form.test.tsx components/continuity-inbox-list.test.tsx lib/api.test.ts` passes.
+- recall query returns provenance-backed results for scoped filters.
+- recall results expose confirmation/posture and deterministic ordering for fixed input state.
+- resumption briefs include `last_decision`, `open_loops`, `recent_changes`, `next_action` sections deterministically.
+- missing sections are explicit empty states.
+- `./.venv/bin/python -m pytest tests/unit/test_continuity_recall.py tests/unit/test_continuity_resumption.py tests/integration/test_continuity_recall_api.py tests/integration/test_continuity_resumption_api.py -q` passes.
+- `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-recall-panel.test.tsx components/resumption-brief.test.tsx lib/api.test.ts` passes.
 - `python3 scripts/run_phase4_validation_matrix.py` remains PASS (no Phase 4 regression).
-- `README.md`, `ROADMAP.md`, and `.ai/handoff/CURRENT_STATE.md` reflect active P5-S17 scope.
+- `README.md`, `ROADMAP.md`, and `.ai/handoff/CURRENT_STATE.md` reflect active P5-S18 scope.
 
 ## Implementation Constraints
 
 - do not introduce new dependencies
-- preserve Phase 4 release-control commands and artifacts
-- keep admission conservative by default
-- keep machine-independent docs/paths
+- preserve P5-S17 capture/backbone semantics
+- keep deterministic output for recall/resumption contracts
+- keep docs machine-independent
 
 ## Control Tower Task Cards
 
-### Task 1: Backbone Schema + Store
+### Task 1: Recall Backend
 
 Owner: tooling operative
 
 Write scope:
 
-- `apps/api/alembic/versions/20260329_0041_phase5_continuity_backbone.py`
+- `apps/api/src/alicebot_api/continuity_recall.py`
 - `apps/api/src/alicebot_api/store.py`
-- `apps/api/src/alicebot_api/continuity_objects.py`
-- `tests/unit/test_20260329_0041_phase5_continuity_backbone.py`
-- `tests/unit/test_continuity_objects.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `tests/unit/test_continuity_recall.py`
+- `tests/integration/test_continuity_recall_api.py`
 
-### Task 2: Capture API + Admission
+### Task 2: Resumption Backend
 
 Owner: tooling operative
 
 Write scope:
 
-- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/continuity_resumption.py`
 - `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/continuity_capture.py`
-- `tests/unit/test_continuity_capture.py`
-- `tests/integration/test_continuity_capture_api.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `tests/unit/test_continuity_resumption.py`
+- `tests/integration/test_continuity_resumption_api.py`
 
-### Task 3: Capture Inbox UI
+### Task 3: Recall/Resumption UI
 
 Owner: tooling operative
 
@@ -178,10 +180,10 @@ Write scope:
 - `apps/web/lib/api.test.ts`
 - `apps/web/app/continuity/page.tsx`
 - `apps/web/app/continuity/page.test.tsx`
-- `apps/web/components/continuity-capture-form.tsx`
-- `apps/web/components/continuity-capture-form.test.tsx`
-- `apps/web/components/continuity-inbox-list.tsx`
-- `apps/web/components/continuity-inbox-list.test.tsx`
+- `apps/web/components/continuity-recall-panel.tsx`
+- `apps/web/components/continuity-recall-panel.test.tsx`
+- `apps/web/components/resumption-brief.tsx`
+- `apps/web/components/resumption-brief.test.tsx`
 
 ### Task 4: Docs + Integration Review
 
@@ -191,7 +193,6 @@ Write scope:
 
 - `docs/phase5-product-spec.md`
 - `docs/phase5-sprint-17-20-plan.md`
-- `docs/phase5-continuity-object-model.md`
 - `README.md`
 - `ROADMAP.md`
 - `.ai/handoff/CURRENT_STATE.md`
@@ -200,30 +201,30 @@ Write scope:
 
 Responsibilities:
 
-- verify sprint stayed P5-S17 scoped
-- verify no recall/resumption/review-dashboard scope creep
-- verify conservative admission posture and provenance guarantees
+- verify no capture-backbone reimplementation
+- verify no correction/dashboard scope creep
+- verify deterministic recall/resumption behavior
 - verify no Phase 4 regression
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
 
-- exact capture/backbone delta
-- exact triage/admission behavior
+- exact recall/resumption delta
+- exact deterministic output behavior
 - exact verification command outcomes
-- explicit deferred Phase 5 scope (P5-S18/19/20 work)
+- explicit deferred Phase 5 scope (P5-S19/P5-S20 work)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
 
-- sprint stayed in capture/backbone scope
-- typed object mapping and triage behavior are deterministic
-- provenance is visible and consistent
+- sprint stayed P5-S18 scoped
+- recall results and resumption briefs are deterministic and provenance-backed
+- required resumption sections are always present
 - no hidden scope expansion
 - Phase 4 validation remains green
 
 ## Exit Condition
 
-This sprint is complete when typed continuity backbone + fast capture inbox are shipped with deterministic admission/triage behavior, provenance visibility, and no Phase 4 regression.
+This sprint is complete when provenance-backed recall and deterministic resumption are shipped on top of the Phase 5 backbone with no Phase 4 regression.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -4,7 +4,7 @@
 
 - The canonical baseline remains through Phase 3 Sprint 9.
 - Earlier Phase 4 work is already delivered: task-run linkage to approvals/executions, idempotent proxy execution replay guards, approval pause/resume continuity for linked runs, run transition observability, explicit stop reasons, bounded retries with persisted posture, explicit failure classes, and deterministic Phase 4 gate runners.
-- Active Sprint focus is Phase 4 Sprint 14 release-control ownership as canonical baseline, while current delivery work is Phase 5 Sprint 17 continuity backbone + fast capture after completed Phase 4 Sprint 14-19 release-control/sign-off delivery.
+- Active Sprint focus is Phase 4 Sprint 14 release-control ownership as canonical baseline. Current delivery has advanced through Phase 5 Sprint 18 continuity recall/resumption on top of completed Phase 5 Sprint 17 capture backbone and completed Phase 4 Sprint 14-19 release-control/sign-off delivery.
 - The accepted baseline includes deterministic Phase 3 gate entrypoints: `python3 scripts/run_phase3_acceptance.py`, `python3 scripts/run_phase3_readiness_gates.py`, and `python3 scripts/run_phase3_validation_matrix.py` (default go/no-go command).
 - Phase 4 gate entrypoints are `python3 scripts/run_phase4_acceptance.py`, `python3 scripts/run_phase4_readiness_gates.py`, and `python3 scripts/run_phase4_validation_matrix.py`.
 - Phase 4 release-candidate rehearsal entrypoint is `python3 scripts/run_phase4_release_candidate.py`, which writes latest summary evidence at `artifacts/release/phase4_rc_summary.json` and appends retained archive/index evidence under `artifacts/release/archive/` for repeated-run audit, with deterministic archive index lock path `artifacts/release/archive/index.lock`, bounded lock-timeout failure contract, and atomic index replace writes.
@@ -22,9 +22,15 @@
   - `POST /v0/continuity/captures` always appends an immutable capture event and conservatively admits typed durable objects.
   - `GET /v0/continuity/captures` returns inbox rows with admission posture (`DERIVED`/`TRIAGE`) and optional derived object summary.
   - `GET /v0/continuity/captures/{capture_event_id}` returns capture detail with derived object and provenance when admitted.
+- Phase 5 Sprint 18 adds continuity recall/resumption seams:
+  - `GET /v0/continuity/recall` returns provenance-backed scoped recall results with deterministic ordering metadata, confirmation status, and admission posture.
+  - `GET /v0/continuity/resumption-brief` compiles deterministic brief sections (`last_decision`, `open_loops`, `recent_changes`, `next_action`) with explicit empty states.
 - `apps/web` is also a shipped surface now. The operator shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live reads when API config is present and explicit fixture fallback when it is not.
 - `/chat` now ships assistant-response mode, governed-request mode, visible thread selection, compact thread creation, selected-thread transcript continuity, deterministic resumption brief review, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, manual explicit-signal capture controls for selected `message.user` events, and bounded supporting continuity review over thread sessions and events.
-- `/continuity` now ships the Phase 5 Sprint 17 fast capture inbox surface: capture submit (optional explicit signal), recent capture list with posture, and capture detail with derived object/provenance or triage state.
+- `/continuity` now ships the Phase 5 Sprint 17 + Sprint 18 continuity workspace:
+  - capture submit (optional explicit signal), recent capture list, and capture detail with posture/provenance
+  - recall query/results panel with scoped filters and provenance-backed result cards
+  - deterministic resumption-brief panel with always-present required sections
 - `/gmail` ships a bounded Gmail operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-message ingestion into one selected task workspace.
 - `/calendar` ships a bounded Calendar operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-event ingestion into one selected task workspace. The shipped API baseline now also includes bounded read-only event discovery for one selected account (`GET /v0/calendar-accounts/{calendar_account_id}/events`) with deterministic ordering metadata and bounded limits.
 - `/memories` ships a bounded memory review workspace: active/queue list posture, selected memory detail, revision review, and memory-label review/submit seams with explicit live/fixture/unavailable states.
@@ -47,7 +53,6 @@
 - Auth is still incomplete beyond database user context.
 - Connector breadth, richer parsing, and orchestration are still deferred; docs must stay synchronized with the shipped API-plus-web baseline, including `/gmail` and `/calendar`, so planning does not drift again.
 - Phase 5 deferred scope remains open:
-  - Sprint 18 recall and deterministic resumption brief UX.
   - Sprint 19 memory correction/freshness queue.
   - Sprint 20 open-loop daily/weekly review dashboards.
 
@@ -58,6 +63,7 @@
 - Web `/chat` continuity + workflow/timeline/explainability adoption: `apps/web/app/chat/page.tsx`, `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`, `apps/web/components/thread-event-list.tsx`, `apps/web/components/response-composer.tsx`, `apps/web/components/thread-workflow-panel.tsx`, `apps/web/components/task-step-list.tsx`, `apps/web/components/response-history.tsx`, `apps/web/components/thread-trace-panel.tsx`, and matching component tests.
 - Web review workspaces added through the accepted Sprint 6P/6Q/6R sequence: `apps/web/app/memories/page.tsx`, `apps/web/app/memories/page.test.tsx`, `apps/web/app/entities/page.tsx`, `apps/web/app/entities/page.test.tsx`, `apps/web/app/artifacts/page.tsx`, `apps/web/app/artifacts/page.test.tsx`.
 - Web Gmail and Calendar workspaces: `apps/web/app/gmail/page.tsx`, `apps/web/app/calendar/page.tsx`, `apps/web/lib/api.ts`, `apps/web/lib/api.test.ts`, `apps/web/components/gmail-account-list.test.tsx`, `apps/web/components/calendar-account-list.test.tsx`, `apps/web/components/calendar-event-ingest-form.test.tsx`
+- Web continuity workspace + retrieval/resumption surfaces: `apps/web/app/continuity/page.tsx`, `apps/web/app/continuity/page.test.tsx`, `apps/web/components/continuity-recall-panel.tsx`, `apps/web/components/continuity-recall-panel.test.tsx`, `apps/web/components/resumption-brief.tsx`, `apps/web/components/resumption-brief.test.tsx`
 - Shell route inventory and discoverability: `apps/web/components/app-shell.tsx`, `apps/web/app/page.tsx`
 
 ## Planning Guardrails

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,81 +1,94 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Phase 5 Sprint 17: ship typed continuity backbone plus fast capture inbox with conservative admission and provenance visibility.
+Implement Phase 5 Sprint 18 (P5-S18): ship provenance-backed continuity recall and deterministic continuity resumption briefs on top of the shipped P5-S17 capture backbone.
 
 ## Completed Work
-- Added migration `20260329_0041_phase5_continuity_backbone` with:
-  - immutable `continuity_capture_events`
-  - typed `continuity_objects`
-  - deterministic constraints for object types, explicit signals, posture, confidence bounds
-  - RLS/policies/grants and inbox/object indexes
-- Added backend continuity contracts and persistence seams:
-  - typed literals/records for capture create/list/detail and continuity objects
-  - store methods for capture event create/list/count/detail and object create/list/detail
-- Added continuity admission logic:
-  - always persist capture event
-  - explicit signal mapping:
-    - `remember_this -> MemoryFact`
-    - `task/next_action -> NextAction`
-    - `decision -> Decision`
-    - `commitment -> Commitment`
-    - `waiting_for -> WaitingFor`
-    - `blocker -> Blocker`
-    - `note -> Note`
-  - high-confidence prefix mapping for deterministic no-signal capture (`decision:`, `task:`, `todo:`, `next:`, `commitment:`, `waiting for:`, `blocker:`, `remember:`, `fact:`, `note:`)
-  - ambiguous capture posture: `TRIAGE`
-  - provenance on every derived object (`capture_event_id`, `source_kind`, `admission_reason`)
-- Added API routes:
-  - `POST /v0/continuity/captures`
-  - `GET /v0/continuity/captures`
-  - `GET /v0/continuity/captures/{capture_event_id}`
-- Added web fast-capture inbox surface:
-  - `apps/web/app/continuity/page.tsx`
-  - submit capture with optional explicit signal
-  - list recent captures with `DERIVED`/`TRIAGE` posture
-  - detail panel with derived object/provenance or triage posture
-  - live API + fixture fallback behavior
-- Added/updated tests for migration, capture/object services, API integration, and web page/components.
-- Synced phase/control docs for active P5-S17 scope and deferred P5-S18/19/20 scope.
+- Added recall contracts, limits, ordering constants, request inputs, and response typed records in `apps/api/src/alicebot_api/contracts.py`.
+- Added recall candidate persistence seam in `apps/api/src/alicebot_api/store.py`:
+  - `ContinuityRecallCandidateRow`
+  - `LIST_CONTINUITY_RECALL_CANDIDATES_SQL`
+  - `list_continuity_recall_candidates()`
+- Added recall compiler in `apps/api/src/alicebot_api/continuity_recall.py` with:
+  - scoped filters (`thread`, `task`, `project`, `person`, `since`, `until`)
+  - provenance reference extraction
+  - confirmation/admission posture exposure
+  - deterministic ranking and ordering metadata
+  - request validation.
+- Added resumption compiler in `apps/api/src/alicebot_api/continuity_resumption.py` with required sections:
+  - `last_decision`
+  - `open_loops`
+  - `recent_changes`
+  - `next_action`
+  - explicit empty states for missing sections.
+- Patched resumption assembly to avoid relevance-truncated preselection:
+  - resumption sections now derive from full scoped recall candidates (`apply_limit=False`) before recency section extraction.
+  - added >100-record correctness coverage in unit/integration tests.
+- Wired new API routes in `apps/api/src/alicebot_api/main.py`:
+  - `GET /v0/continuity/recall`
+  - `GET /v0/continuity/resumption-brief`
+- Added backend tests:
+  - `tests/unit/test_continuity_recall.py`
+  - `tests/unit/test_continuity_resumption.py`
+  - `tests/integration/test_continuity_recall_api.py`
+  - `tests/integration/test_continuity_resumption_api.py`
+- Added web API client contracts and calls in `apps/web/lib/api.ts` + tests in `apps/web/lib/api.test.ts`.
+- Expanded `/continuity` page (`apps/web/app/continuity/page.tsx`) to include:
+  - recall query/results panel
+  - resumption brief panel
+  - live/fixture fallback handling.
+- Added web components and tests:
+  - `apps/web/components/continuity-recall-panel.tsx`
+  - `apps/web/components/continuity-recall-panel.test.tsx`
+  - `apps/web/components/resumption-brief.tsx`
+  - `apps/web/components/resumption-brief.test.tsx`
+- Synced sprint/docs artifacts for P5-S18 in:
+  - `docs/phase5-product-spec.md`
+  - `docs/phase5-sprint-17-20-plan.md`
+  - `README.md`
+  - `ROADMAP.md`
+  - `.ai/handoff/CURRENT_STATE.md`
+  - `BUILD_REPORT.md`
+  - `REVIEW_REPORT.md`
 
-## Exact Capture/Backbone Delta
-- New immutable capture backbone table and typed continuity object table.
-- Capture and durable object flows are now distinct.
-- Durable object admission is conservative and deterministic, with explicit triage for ambiguity.
-- Capture detail and inbox expose provenance/posture directly.
+## Exact Recall/Resumption Delta
+- New recall read surface (`/v0/continuity/recall`) now returns typed continuity objects filtered by scope/time/query with provenance and posture metadata.
+- New continuity resumption surface (`/v0/continuity/resumption-brief`) now compiles deterministic brief sections from recall candidates and always emits required sections.
+- `/continuity` UI now supports capture inbox/detail plus recall query and resumption brief review in one workspace.
 
-## Exact Triage/Admission Behavior
-- Admission default: `TRIAGE` with reason `ambiguous_capture_requires_triage`.
-- Admission upgrades to `DERIVED` only when:
-  - explicit signal is supplied, or
-  - deterministic high-confidence prefix rule matches.
-- Every capture persists even when no durable object is created.
+## Exact Deterministic Output Behavior
+- Recall ordering is deterministic for fixed input state:
+  - sorted by scope-match count, query-term matches, confirmation rank, posture rank, confidence, `created_at`, and `id` (descending for tie-break stability).
+  - response `summary.order` contract is `["relevance_desc", "created_at_desc", "id_desc"]`.
+- Resumption brief assembly is deterministic for fixed input state:
+  - compiles from recall payload constrained by request scope.
+  - always includes `last_decision`, `open_loops`, `recent_changes`, and `next_action`.
+  - each missing section returns explicit `empty_state` object instead of omission.
+  - open loops and recent changes include deterministic summary order metadata (`["created_at_desc", "id_desc"]`).
 
 ## Incomplete Work
-- No implementation gaps inside P5-S17 code scope.
+- None inside P5-S18 sprint scope.
 
 ## Files Changed
-- `apps/api/alembic/versions/20260329_0041_phase5_continuity_backbone.py`
 - `apps/api/src/alicebot_api/contracts.py`
 - `apps/api/src/alicebot_api/store.py`
 - `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/continuity_capture.py`
-- `apps/api/src/alicebot_api/continuity_objects.py`
+- `apps/api/src/alicebot_api/continuity_recall.py`
+- `apps/api/src/alicebot_api/continuity_resumption.py`
+- `tests/unit/test_continuity_recall.py`
+- `tests/unit/test_continuity_resumption.py`
+- `tests/integration/test_continuity_recall_api.py`
+- `tests/integration/test_continuity_resumption_api.py`
 - `apps/web/lib/api.ts`
 - `apps/web/lib/api.test.ts`
 - `apps/web/app/continuity/page.tsx`
 - `apps/web/app/continuity/page.test.tsx`
-- `apps/web/components/continuity-capture-form.tsx`
-- `apps/web/components/continuity-capture-form.test.tsx`
-- `apps/web/components/continuity-inbox-list.tsx`
-- `apps/web/components/continuity-inbox-list.test.tsx`
-- `tests/unit/test_20260329_0041_phase5_continuity_backbone.py`
-- `tests/unit/test_continuity_capture.py`
-- `tests/unit/test_continuity_objects.py`
-- `tests/integration/test_continuity_capture_api.py`
+- `apps/web/components/continuity-recall-panel.tsx`
+- `apps/web/components/continuity-recall-panel.test.tsx`
+- `apps/web/components/resumption-brief.tsx`
+- `apps/web/components/resumption-brief.test.tsx`
 - `docs/phase5-product-spec.md`
 - `docs/phase5-sprint-17-20-plan.md`
-- `docs/phase5-continuity-object-model.md`
 - `README.md`
 - `ROADMAP.md`
 - `.ai/handoff/CURRENT_STATE.md`
@@ -83,22 +96,21 @@ Implement Phase 5 Sprint 17: ship typed continuity backbone plus fast capture in
 - `REVIEW_REPORT.md`
 
 ## Tests Run
-- `./.venv/bin/python -m pytest tests/unit/test_20260329_0041_phase5_continuity_backbone.py tests/unit/test_continuity_capture.py tests/unit/test_continuity_objects.py tests/integration/test_continuity_capture_api.py -q`
-  - PASS (`15 passed in 1.51s`, elevated run)
-- `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-capture-form.test.tsx components/continuity-inbox-list.test.tsx lib/api.test.ts`
-  - PASS (`32 passed`)
+- `./.venv/bin/python -m pytest tests/unit/test_continuity_recall.py tests/unit/test_continuity_resumption.py tests/integration/test_continuity_recall_api.py tests/integration/test_continuity_resumption_api.py -q`
+  - PASS (`11 passed`)
+- `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-recall-panel.test.tsx components/resumption-brief.test.tsx lib/api.test.ts`
+  - PASS (`4 passed` files, `34 passed` tests)
 - `python3 scripts/run_phase4_validation_matrix.py`
-  - PASS (`Phase 4 validation matrix result: PASS`, elevated run)
+  - PASS (`Phase 4 validation matrix result: PASS`)
+  - Key gate outcomes: `phase4_acceptance`, `phase4_readiness_gates`, `phase4_magnesium_ship_gate`, `phase4_scenarios`, `phase4_web_diagnostics`, `phase3_compat_validation`, `phase2_compat_validation`, `mvp_compat_validation` all PASS.
 
 ## Blockers/Issues
-- Sandbox-localhost restriction blocks DB-backed integration tests and matrix runs in non-elevated mode.
-  - resolved by re-running with elevated execution
+- Non-elevated sandbox runs cannot access local DB-backed checks in this environment.
+  - Resolved by running required DB-backed verification commands with elevated permissions.
 
-## Explicit Deferred Phase 5 Scope (P5-S18/P5-S19/P5-S20)
-- broad recall query UX and ranking surface
-- deterministic resumption brief product surface
-- memory correction queue and supersession workflows
-- daily/weekly open-loop review dashboards
+## Explicit Deferred Phase 5 Scope (P5-S19/P5-S20)
+- P5-S19: memory correction queue, supersession workflow, freshness controls.
+- P5-S20: daily/weekly open-loop review dashboards.
 
 ## Recommended Next Step
-Open the sprint PR for Control Tower review; acceptance commands now run in repo-compatible form and Phase 4 compatibility remains PASS.
+Proceed to Control Tower review for P5-S18 and open the next sprint packet for P5-S19 (memory review/correction) without reopening recall/resumption contracts.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The canonical baseline remains through Phase 3 Sprint 9, with earlier Phase 4 work already delivering run linkage/idempotent replay safety and run observability/retry-failure discipline, Phase 4 Sprint 14 establishing canonical MVP release-gate ownership in Phase 4 gate scripts, Phase 4 Sprint 15 adding deterministic release-candidate rehearsal evidence packaging, Phase 4 Sprint 16 adding durable archive/index evidence retention for repeated RC rehearsal runs, Phase 4 Sprint 17 hardening archive index writes with deterministic locking and atomic replace behavior under contention, Phase 4 Sprint 18 adding deterministic MVP exit manifest generation/verification for formal phase closeout, and Phase 4 Sprint 19 adding deterministic MVP qualification orchestration plus a formal GO/NO_GO sign-off record/verifier. Phase 5 Sprint 17 now adds the typed continuity backbone and fast capture inbox surfaces.
+AliceBot is a private, permissioned personal AI operating system. The canonical baseline remains through Phase 3 Sprint 9, with earlier Phase 4 work already delivering run linkage/idempotent replay safety and run observability/retry-failure discipline, Phase 4 Sprint 14 establishing canonical MVP release-gate ownership in Phase 4 gate scripts, Phase 4 Sprint 15 adding deterministic release-candidate rehearsal evidence packaging, Phase 4 Sprint 16 adding durable archive/index evidence retention for repeated RC rehearsal runs, Phase 4 Sprint 17 hardening archive index writes with deterministic locking and atomic replace behavior under contention, Phase 4 Sprint 18 adding deterministic MVP exit manifest generation/verification for formal phase closeout, and Phase 4 Sprint 19 adding deterministic MVP qualification orchestration plus a formal GO/NO_GO sign-off record/verifier. Phase 5 Sprint 17 shipped the typed continuity capture backbone, and Phase 5 Sprint 18 now ships provenance-backed recall plus deterministic continuity resumption briefs.
 
 ## Current Implemented Slice
 
 - `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, typed memory admission/review and open-loop lifecycle seams, deterministic thread resumption brief reads, explicit-signal capture, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and narrow read-only Gmail and Calendar seams with bounded event discovery plus selected-item ingestion.
-- `apps/api` now also ships Phase 5 Sprint 17 continuity-capture endpoints: `POST /v0/continuity/captures`, `GET /v0/continuity/captures`, and `GET /v0/continuity/captures/{capture_event_id}` with conservative admission (`DERIVED` or `TRIAGE`) and immutable capture-event persistence.
+- `apps/api` now also ships Phase 5 continuity retrieval/resumption seams:
+  - capture backbone endpoints from Sprint 17:
+    - `POST /v0/continuity/captures`
+    - `GET /v0/continuity/captures`
+    - `GET /v0/continuity/captures/{capture_event_id}`
+  - Sprint 18 retrieval/resumption endpoints:
+    - `GET /v0/continuity/recall`
+    - `GET /v0/continuity/resumption-brief`
+  - recall/resumption responses expose scoped filters, deterministic ordering metadata, confirmation/admission posture, and provenance references.
 - `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
-- `apps/web` now also includes `/continuity` as the Phase 5 Sprint 17 fast-capture inbox surface for submit/list/detail with visible admission posture and provenance.
+- `apps/web` now also includes `/continuity` as the Phase 5 continuity workspace with:
+  - Sprint 17 fast-capture inbox submit/list/detail
+  - Sprint 18 recall query/results panel with provenance-backed cards
+  - Sprint 18 deterministic resumption-brief panel with required explicit sections
 - `/chat` supports both assistant and governed-request modes, selected-thread continuity, compact thread creation, deterministic resumption brief review, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, manual explicit-signal capture controls for selected `message.user` events, and bounded supporting continuity review.
 - `/gmail` and `/calendar` are shipped bounded connector workspaces for account review, selected-account detail, explicit account connection, and explicit single-item ingestion into one selected task workspace.
 - `/artifacts`, `/memories`, and `/entities` are shipped bounded operator review workspaces for artifact, memory, and entity evidence.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,38 +4,41 @@
 PASS
 
 ## criteria met
-- Sprint stayed within P5-S17 scope: typed continuity backbone, fast capture API/UI, and required docs/control sync.
-- Capture API behavior is deterministic and conservative:
-  - immutable capture event is always persisted
-  - explicit signals map deterministically to typed continuity objects
-  - ambiguous captures are persisted with `TRIAGE` posture
-- Provenance references are present and visible for derived objects in API and `/continuity` detail surface.
-- Required backend acceptance command passes:
-  - `./.venv/bin/python -m pytest tests/unit/test_20260329_0041_phase5_continuity_backbone.py tests/unit/test_continuity_capture.py tests/unit/test_continuity_objects.py tests/integration/test_continuity_capture_api.py -q` -> `15 passed`
-- Required web acceptance command (Vitest-compatible packet form) passes:
-  - `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-capture-form.test.tsx components/continuity-inbox-list.test.tsx lib/api.test.ts` -> `32 passed`
-- Required regression gate passes:
-  - `python3 scripts/run_phase4_validation_matrix.py` -> `Phase 4 validation matrix result: PASS`
-- `README.md`, `ROADMAP.md`, and `.ai/handoff/CURRENT_STATE.md` now satisfy control-doc truth markers while reflecting active P5-S17 scope.
+- Sprint stayed within declared P5-S18 scope and touched only in-scope files for recall/resumption API, UI, tests, and docs.
+- Recall API is implemented and contract-complete for scoped filters, provenance references, confirmation/admission posture, and deterministic ordering metadata.
+- Resumption brief API is implemented and always returns required sections (`last_decision`, `open_loops`, `recent_changes`, `next_action`) with explicit empty-state envelopes.
+- `/continuity` UI now includes recall query/results and resumption brief panels with fixture/live fallback behavior.
+- Acceptance verification commands were executed and passed:
+- `./.venv/bin/python -m pytest tests/unit/test_continuity_recall.py tests/unit/test_continuity_resumption.py tests/integration/test_continuity_recall_api.py tests/integration/test_continuity_resumption_api.py -q` -> PASS (`11 passed`)
+- `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-recall-panel.test.tsx components/resumption-brief.test.tsx lib/api.test.ts` -> PASS (`4 files`, `34 tests`)
+- `python3 scripts/run_phase4_validation_matrix.py` -> PASS (`Phase 4 validation matrix result: PASS`)
 
 ## criteria missed
-- None.
+- None strictly against packet acceptance wording.
 
 ## quality issues
-- No blocking implementation quality issues found in P5-S17 surfaces.
+- The previously identified resumption truncation risk is fixed:
+  - `apps/api/src/alicebot_api/continuity_resumption.py` now compiles sections from the full scoped recall candidate set (no relevance-limit truncation before recency selection).
+  - `apps/api/src/alicebot_api/continuity_recall.py` now supports unbounded internal recall candidate ordering reuse for deterministic section compilers.
+- Remaining non-blocking note:
+  - `apps/api/src/alicebot_api/store.py` + `apps/api/src/alicebot_api/continuity_recall.py` still do scope/time filtering in Python after row fetch (acceptable for current scale, potential future performance hotspot).
 
 ## regression risks
-- Admission no-signal promotion currently depends on deterministic prefix heuristics; keep this conservative in follow-on sprints to avoid unsafe durable-object creation.
-- DB-backed validation commands require local Postgres access; non-elevated sandbox execution can produce environment-only false negatives.
+- Added coverage now protects the >100-record edge case for resumption selection:
+  - `tests/unit/test_continuity_resumption.py::test_resumption_brief_uses_full_scoped_set_instead_of_recall_limit`
+  - `tests/integration/test_continuity_resumption_api.py::test_continuity_resumption_api_selects_latest_sections_beyond_recall_limit`
+- Recall scope matching depends on provenance/body key naming (`thread_id`, `task_id`, `project`, `person` aliases); schema drift will reduce match quality without hard failures.
 
 ## docs issues
-- None blocking after marker restoration and packet command correction.
+- Docs are generally in sync for shipped P5-S18 scope.
+- No blocking documentation gaps remain for this fix.
 
 ## should anything be added to RULES.md?
-- Not required for this sprint.
+- Not required for acceptance.
 
 ## should anything update ARCHITECTURE.md?
 - Not required for acceptance.
 
 ## recommended next action
-1. Proceed with Control Tower review and PR merge flow for P5-S17.
+1. Keep recall/resumption contracts stable and proceed with P5-S19 planning.
+2. If continuity volume grows significantly, consider SQL-side predicate pushdown for recall candidate prefiltering.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,7 @@
 - Phase 4 Sprint 18 adds formal closeout evidence tooling: deterministic MVP exit manifest generation (`python3 scripts/generate_phase4_mvp_exit_manifest.py`) and manifest verification (`python3 scripts/verify_phase4_mvp_exit_manifest.py`) from latest GO RC archive evidence.
 - Phase 4 Sprint 19 adds deterministic MVP qualification orchestration (`python3 scripts/run_phase4_mvp_qualification.py`) and formal sign-off record verification (`python3 scripts/verify_phase4_mvp_signoff_record.py`) with explicit GO/NO_GO blocker registry.
 - Phase 5 Sprint 17 adds the typed continuity capture backbone: immutable `continuity_capture_events`, typed `continuity_objects`, conservative admission posture (`DERIVED`/`TRIAGE`), and the fast capture inbox UI/API surface at `/continuity`.
+- Phase 5 Sprint 18 adds provenance-backed recall and deterministic continuity resumption surfaces: `GET /v0/continuity/recall`, `GET /v0/continuity/resumption-brief`, and `/continuity` recall/resumption panels with always-present required sections.
 - The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, typed memory and open-loop seams, deterministic thread resumption brief reads, unified explicit-signal capture seams, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, narrow read-only Gmail and Calendar seams with selected-item ingestion, bounded read-only Calendar event discovery for one connected account, and the no-tools assistant-response seam.
 - The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
 - `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, keeps bounded thread review and deterministic resumption brief review visible beside both assistant and governed-request composition, ships thread-linked governed workflow, ordered task-step timeline review, and bounded explain-why trace embedding, and includes manual explicit-signal capture controls for selected `message.user` events.
@@ -31,7 +32,12 @@
 - Treat `python3 scripts/run_phase4_mvp_qualification.py` and `python3 scripts/verify_phase4_mvp_signoff_record.py` as the canonical Sprint 19 MVP qualification/sign-off commands.
 - Treat archive index hardening as baseline behavior (deterministic lock and atomic index replace), not optional operational guidance.
 - Treat the deterministic validation matrix command (`python3 scripts/run_phase4_validation_matrix.py`) as the canonical Phase 4 validation step inside the RC rehearsal chain, while keeping Phase 3/Phase 2/MVP validation commands as compatibility checks.
-- Treat Phase 5 Sprint 17 continuity capture as shipped baseline (`/v0/continuity/captures*` and `/continuity`) and do not relitigate backbone contracts during Sprint 18 planning.
+- Treat Phase 5 Sprint 17 and Sprint 18 continuity surfaces as shipped baseline:
+  - `/v0/continuity/captures*`
+  - `/v0/continuity/recall`
+  - `/v0/continuity/resumption-brief`
+  - `/continuity` capture/recall/resumption workspace
+- Do not relitigate continuity backbone, recall ordering contracts, or required resumption-section contracts during Sprint 19 planning.
 - Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.
 - Reuse the existing continuity, response, approval, task, workspace-artifact, memory, entity, execution, and trace surfaces instead of introducing parallel contracts.
 
@@ -40,7 +46,6 @@
 - Do not bundle broader Gmail or Calendar breadth, auth expansion, richer document parsing, runner orchestration, or proxy breadth into the next sprint by default.
 - Do not reopen schema or API design unless the next sprint explicitly requires it.
 - Keep Phase 5 deferred scope explicit:
-  - Sprint 18 recall + deterministic resumption briefs
   - Sprint 19 memory correction/freshness queue
   - Sprint 20 open-loop daily/weekly review dashboards
 - Keep live docs synchronized with shipped reality so planning does not drift behind the repo again.

--- a/apps/api/src/alicebot_api/continuity_recall.py
+++ b/apps/api/src/alicebot_api/continuity_recall.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import cast
+from uuid import UUID
+
+from alicebot_api.contracts import (
+    CONTINUITY_RECALL_LIST_ORDER,
+    DEFAULT_CONTINUITY_RECALL_LIMIT,
+    MAX_CONTINUITY_RECALL_LIMIT,
+    MEMORY_CONFIRMATION_STATUSES,
+    ContinuityRecallOrderingMetadata,
+    ContinuityRecallProvenanceReference,
+    ContinuityRecallQueryInput,
+    ContinuityRecallResponse,
+    ContinuityRecallResultRecord,
+    ContinuityRecallScopeFilters,
+    ContinuityRecallScopeKind,
+    ContinuityRecallScopeMatch,
+    MemoryConfirmationStatus,
+    isoformat_or_none,
+)
+from alicebot_api.store import ContinuityRecallCandidateRow, ContinuityStore, JsonObject
+
+
+class ContinuityRecallValidationError(ValueError):
+    """Raised when a continuity recall query is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class RankedRecallCandidate:
+    row: ContinuityRecallCandidateRow
+    scope_matches: list[ContinuityRecallScopeMatch]
+    query_term_match_count: int
+    confirmation_status: MemoryConfirmationStatus
+    confirmation_rank: int
+    posture_rank: int
+    relevance: float
+
+
+_SCOPE_FILTER_KEYS: dict[ContinuityRecallScopeKind, set[str]] = {
+    "thread": {"thread_id", "thread"},
+    "task": {"task_id", "task"},
+    "project": {"project", "project_id", "project_name"},
+    "person": {"person", "person_id", "person_name", "owner", "assignee"},
+}
+_CONFIRMATION_RANK: dict[MemoryConfirmationStatus, int] = {
+    "confirmed": 3,
+    "unconfirmed": 2,
+    "contested": 1,
+}
+_POSTURE_RANK: dict[str, int] = {
+    "DERIVED": 2,
+    "TRIAGE": 1,
+}
+
+
+def _normalize_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = re.sub(r"\s+", " ", value).strip()
+    if not normalized:
+        return None
+    return normalized
+
+
+def _normalize_uuid_string(value: UUID | str | None) -> str | None:
+    if value is None:
+        return None
+    return str(value).strip().lower()
+
+
+def _collect_strings(payload: object, *, keys: set[str]) -> set[str]:
+    values: set[str] = set()
+
+    def visit(value: object) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                normalized_key = key.strip().casefold()
+                if normalized_key in keys:
+                    if isinstance(child, str):
+                        normalized = _normalize_optional_text(child)
+                        if normalized is not None:
+                            values.add(normalized)
+                    elif isinstance(child, list):
+                        for item in child:
+                            if isinstance(item, str):
+                                normalized = _normalize_optional_text(item)
+                                if normalized is not None:
+                                    values.add(normalized)
+                visit(child)
+            return
+
+        if isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(payload)
+    return values
+
+
+def _flatten_text(payload: object) -> str:
+    values: list[str] = []
+
+    def visit(value: object) -> None:
+        if isinstance(value, str):
+            normalized = _normalize_optional_text(value)
+            if normalized is not None:
+                values.append(normalized)
+            return
+
+        if isinstance(value, dict):
+            for child in value.values():
+                visit(child)
+            return
+
+        if isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(payload)
+    return " ".join(values)
+
+
+def _extract_confirmation_status(row: ContinuityRecallCandidateRow) -> MemoryConfirmationStatus:
+    for source in (row["provenance"], row["body"]):
+        values = _collect_strings(
+            source,
+            keys={"confirmation_status", "memory_confirmation_status"},
+        )
+        for value in values:
+            normalized = value.casefold()
+            if normalized in MEMORY_CONFIRMATION_STATUSES:
+                return cast(MemoryConfirmationStatus, normalized)
+
+    return "unconfirmed"
+
+
+def _compute_scope_matches(
+    row: ContinuityRecallCandidateRow,
+    *,
+    thread_filter: str | None,
+    task_filter: str | None,
+    project_filter: str | None,
+    person_filter: str | None,
+) -> list[ContinuityRecallScopeMatch]:
+    scope_matches: list[ContinuityRecallScopeMatch] = []
+
+    if thread_filter is not None:
+        candidate_values = {
+            value.casefold()
+            for value in _collect_strings(
+                row["provenance"],
+                keys=_SCOPE_FILTER_KEYS["thread"],
+            )
+            | _collect_strings(
+                row["body"],
+                keys=_SCOPE_FILTER_KEYS["thread"],
+            )
+        }
+        if thread_filter in candidate_values:
+            scope_matches.append({"kind": "thread", "value": thread_filter})
+
+    if task_filter is not None:
+        candidate_values = {
+            value.casefold()
+            for value in _collect_strings(
+                row["provenance"],
+                keys=_SCOPE_FILTER_KEYS["task"],
+            )
+            | _collect_strings(
+                row["body"],
+                keys=_SCOPE_FILTER_KEYS["task"],
+            )
+        }
+        if task_filter in candidate_values:
+            scope_matches.append({"kind": "task", "value": task_filter})
+
+    if project_filter is not None:
+        candidate_values = {
+            value.casefold()
+            for value in _collect_strings(
+                row["provenance"],
+                keys=_SCOPE_FILTER_KEYS["project"],
+            )
+            | _collect_strings(
+                row["body"],
+                keys=_SCOPE_FILTER_KEYS["project"],
+            )
+        }
+        if project_filter in candidate_values:
+            scope_matches.append({"kind": "project", "value": project_filter})
+
+    if person_filter is not None:
+        candidate_values = {
+            value.casefold()
+            for value in _collect_strings(
+                row["provenance"],
+                keys=_SCOPE_FILTER_KEYS["person"],
+            )
+            | _collect_strings(
+                row["body"],
+                keys=_SCOPE_FILTER_KEYS["person"],
+            )
+        }
+        if person_filter in candidate_values:
+            scope_matches.append({"kind": "person", "value": person_filter})
+
+    return scope_matches
+
+
+def _query_terms(query: str | None) -> list[str]:
+    if query is None:
+        return []
+    return [
+        term
+        for term in re.findall(r"[a-z0-9]+", query.casefold())
+        if term
+    ]
+
+
+def _count_query_term_matches(row: ContinuityRecallCandidateRow, terms: list[str]) -> int:
+    if not terms:
+        return 0
+
+    text = " ".join(
+        [
+            row["title"],
+            _flatten_text(row["body"]),
+            _flatten_text(row["provenance"]),
+        ]
+    ).casefold()
+    return sum(1 for term in terms if term in text)
+
+
+def _matches_time_window(
+    row: ContinuityRecallCandidateRow,
+    *,
+    since: datetime | None,
+    until: datetime | None,
+) -> bool:
+    created_at = row["object_created_at"]
+    if since is not None and created_at < since:
+        return False
+    if until is not None and created_at > until:
+        return False
+    return True
+
+
+def _provenance_reference_kind(key: str) -> str:
+    if key.endswith("_id"):
+        return key[: -len("_id")]
+    if key.endswith("_ids"):
+        return key[: -len("_ids")]
+    return key
+
+
+def _build_provenance_references(
+    capture_event_id: UUID,
+    provenance: JsonObject,
+) -> list[ContinuityRecallProvenanceReference]:
+    references: set[tuple[str, str]] = {
+        ("continuity_capture_event", str(capture_event_id)),
+    }
+
+    def visit(value: object) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                normalized_key = key.strip().casefold()
+                if normalized_key.endswith("_id"):
+                    if isinstance(child, (str, UUID)):
+                        references.add((_provenance_reference_kind(normalized_key), str(child)))
+                elif normalized_key.endswith("_ids") and isinstance(child, list):
+                    for item in child:
+                        if isinstance(item, (str, UUID)):
+                            references.add((_provenance_reference_kind(normalized_key), str(item)))
+                visit(child)
+            return
+
+        if isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(provenance)
+
+    return [
+        {"source_kind": source_kind, "source_id": source_id}
+        for source_kind, source_id in sorted(references)
+    ]
+
+
+def _serialize_recall_result(item: RankedRecallCandidate) -> ContinuityRecallResultRecord:
+    row = item.row
+
+    ordering: ContinuityRecallOrderingMetadata = {
+        "scope_match_count": len(item.scope_matches),
+        "query_term_match_count": item.query_term_match_count,
+        "confirmation_rank": item.confirmation_rank,
+        "posture_rank": item.posture_rank,
+        "confidence": float(row["confidence"]),
+    }
+
+    return {
+        "id": str(row["id"]),
+        "capture_event_id": str(row["capture_event_id"]),
+        "object_type": row["object_type"],  # type: ignore[typeddict-item]
+        "status": row["status"],
+        "title": row["title"],
+        "body": row["body"],
+        "provenance": row["provenance"],
+        "confirmation_status": item.confirmation_status,
+        "admission_posture": row["admission_posture"],  # type: ignore[typeddict-item]
+        "confidence": float(row["confidence"]),
+        "relevance": item.relevance,
+        "scope_matches": item.scope_matches,
+        "provenance_references": _build_provenance_references(
+            row["capture_event_id"],
+            row["provenance"],
+        ),
+        "ordering": ordering,
+        "created_at": row["object_created_at"].isoformat(),
+        "updated_at": row["object_updated_at"].isoformat(),
+    }
+
+
+def _scope_filters_payload(request: ContinuityRecallQueryInput) -> ContinuityRecallScopeFilters:
+    payload: ContinuityRecallScopeFilters = {
+        "since": isoformat_or_none(request.since),
+        "until": isoformat_or_none(request.until),
+    }
+    if request.thread_id is not None:
+        payload["thread_id"] = str(request.thread_id)
+    if request.task_id is not None:
+        payload["task_id"] = str(request.task_id)
+    if request.project is not None:
+        payload["project"] = request.project
+    if request.person is not None:
+        payload["person"] = request.person
+    return payload
+
+
+def _validate_request(request: ContinuityRecallQueryInput) -> None:
+    if request.limit < 1 or request.limit > MAX_CONTINUITY_RECALL_LIMIT:
+        raise ContinuityRecallValidationError(
+            f"limit must be between 1 and {MAX_CONTINUITY_RECALL_LIMIT}"
+        )
+
+    if request.since is not None and request.until is not None and request.until < request.since:
+        raise ContinuityRecallValidationError("until must be greater than or equal to since")
+
+
+def _ordered_recall_candidates(
+    store: ContinuityStore,
+    *,
+    request: ContinuityRecallQueryInput,
+) -> list[RankedRecallCandidate]:
+    thread_filter = _normalize_uuid_string(request.thread_id)
+    task_filter = _normalize_uuid_string(request.task_id)
+    project_filter = (
+        request.project.casefold()
+        if request.project is not None
+        else None
+    )
+    person_filter = (
+        request.person.casefold()
+        if request.person is not None
+        else None
+    )
+    query_terms = _query_terms(request.query)
+
+    ranked_candidates: list[RankedRecallCandidate] = []
+
+    for row in store.list_continuity_recall_candidates():
+        if not _matches_time_window(
+            row,
+            since=request.since,
+            until=request.until,
+        ):
+            continue
+
+        scope_matches = _compute_scope_matches(
+            row,
+            thread_filter=thread_filter,
+            task_filter=task_filter,
+            project_filter=project_filter,
+            person_filter=person_filter,
+        )
+
+        required_scope_count = sum(
+            value is not None
+            for value in (thread_filter, task_filter, project_filter, person_filter)
+        )
+        if len(scope_matches) != required_scope_count:
+            continue
+
+        query_term_match_count = _count_query_term_matches(row, query_terms)
+        if query_terms and query_term_match_count == 0:
+            continue
+
+        confirmation_status = _extract_confirmation_status(row)
+        confirmation_rank = _CONFIRMATION_RANK[confirmation_status]
+        posture_rank = _POSTURE_RANK.get(row["admission_posture"], 0)
+        relevance = (
+            float(len(scope_matches)) * 100.0
+            + float(query_term_match_count) * 10.0
+            + float(confirmation_rank) * 5.0
+            + float(posture_rank) * 2.0
+            + float(row["confidence"])
+        )
+
+        ranked_candidates.append(
+            RankedRecallCandidate(
+                row=row,
+                scope_matches=scope_matches,
+                query_term_match_count=query_term_match_count,
+                confirmation_status=confirmation_status,
+                confirmation_rank=confirmation_rank,
+                posture_rank=posture_rank,
+                relevance=relevance,
+            )
+        )
+
+    return sorted(
+        ranked_candidates,
+        key=lambda candidate: (
+            len(candidate.scope_matches),
+            candidate.query_term_match_count,
+            candidate.confirmation_rank,
+            candidate.posture_rank,
+            float(candidate.row["confidence"]),
+            candidate.row["object_created_at"],
+            str(candidate.row["id"]),
+        ),
+        reverse=True,
+    )
+
+
+def query_continuity_recall(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: ContinuityRecallQueryInput,
+    apply_limit: bool = True,
+) -> ContinuityRecallResponse:
+    del user_id
+
+    normalized_query = _normalize_optional_text(request.query)
+    normalized_project = _normalize_optional_text(request.project)
+    normalized_person = _normalize_optional_text(request.person)
+    normalized_request = ContinuityRecallQueryInput(
+        query=normalized_query,
+        thread_id=request.thread_id,
+        task_id=request.task_id,
+        project=normalized_project,
+        person=normalized_person,
+        since=request.since,
+        until=request.until,
+        limit=request.limit,
+    )
+
+    _validate_request(normalized_request)
+
+    ordered_candidates = _ordered_recall_candidates(
+        store,
+        request=normalized_request,
+    )
+
+    if apply_limit:
+        returned_candidates = ordered_candidates[: normalized_request.limit]
+    else:
+        returned_candidates = ordered_candidates
+    items = [_serialize_recall_result(item) for item in returned_candidates]
+
+    return {
+        "items": items,
+        "summary": {
+            "query": normalized_request.query,
+            "filters": _scope_filters_payload(normalized_request),
+            "limit": normalized_request.limit,
+            "returned_count": len(items),
+            "total_count": len(ordered_candidates),
+            "order": list(CONTINUITY_RECALL_LIST_ORDER),
+        },
+    }
+
+
+def build_default_recall_query_input() -> ContinuityRecallQueryInput:
+    return ContinuityRecallQueryInput(limit=DEFAULT_CONTINUITY_RECALL_LIMIT)

--- a/apps/api/src/alicebot_api/continuity_resumption.py
+++ b/apps/api/src/alicebot_api/continuity_resumption.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from alicebot_api.continuity_recall import query_continuity_recall
+from alicebot_api.contracts import (
+    CONTINUITY_RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0,
+    CONTINUITY_RESUMPTION_OPEN_LOOP_ORDER,
+    CONTINUITY_RESUMPTION_RECENT_CHANGE_ORDER,
+    DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    MAX_CONTINUITY_RECALL_LIMIT,
+    MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    ContinuityRecallQueryInput,
+    ContinuityRecallResultRecord,
+    ContinuityResumptionBriefRecord,
+    ContinuityResumptionBriefRequestInput,
+    ContinuityResumptionBriefResponse,
+    ContinuityResumptionEmptyState,
+    ContinuityResumptionListSection,
+    ContinuityResumptionSingleSection,
+    ResumptionBriefSectionSummary,
+)
+from alicebot_api.store import ContinuityStore
+
+
+class ContinuityResumptionValidationError(ValueError):
+    """Raised when a continuity resumption request is invalid."""
+
+
+def _build_empty_state(*, is_empty: bool, message: str) -> ContinuityResumptionEmptyState:
+    return {
+        "is_empty": is_empty,
+        "message": message,
+    }
+
+
+def _build_single_section(
+    item: ContinuityRecallResultRecord | None,
+    *,
+    empty_message: str,
+) -> ContinuityResumptionSingleSection:
+    return {
+        "item": item,
+        "empty_state": _build_empty_state(
+            is_empty=item is None,
+            message=empty_message,
+        ),
+    }
+
+
+def _build_list_section(
+    *,
+    items: list[ContinuityRecallResultRecord],
+    limit: int,
+    total_count: int,
+    order: list[str],
+    empty_message: str,
+) -> ContinuityResumptionListSection:
+    summary: ResumptionBriefSectionSummary = {
+        "limit": limit,
+        "returned_count": len(items),
+        "total_count": total_count,
+        "order": list(order),
+    }
+    return {
+        "items": items,
+        "summary": summary,
+        "empty_state": _build_empty_state(
+            is_empty=len(items) == 0,
+            message=empty_message,
+        ),
+    }
+
+
+def _validate_request(request: ContinuityResumptionBriefRequestInput) -> None:
+    if request.max_recent_changes < 0 or request.max_recent_changes > MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT:
+        raise ContinuityResumptionValidationError(
+            "max_recent_changes must be between "
+            f"0 and {MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT}"
+        )
+
+    if request.max_open_loops < 0 or request.max_open_loops > MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT:
+        raise ContinuityResumptionValidationError(
+            f"max_open_loops must be between 0 and {MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT}"
+        )
+
+    if request.since is not None and request.until is not None and request.until < request.since:
+        raise ContinuityResumptionValidationError("until must be greater than or equal to since")
+
+
+def _recency_sort_key(item: ContinuityRecallResultRecord) -> tuple[str, str]:
+    return (item["created_at"], item["id"])
+
+
+def compile_continuity_resumption_brief(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: ContinuityResumptionBriefRequestInput,
+) -> ContinuityResumptionBriefResponse:
+    _validate_request(request)
+
+    recall_payload = query_continuity_recall(
+        store,
+        user_id=user_id,
+        request=ContinuityRecallQueryInput(
+            query=request.query,
+            thread_id=request.thread_id,
+            task_id=request.task_id,
+            project=request.project,
+            person=request.person,
+            since=request.since,
+            until=request.until,
+            limit=MAX_CONTINUITY_RECALL_LIMIT,
+        ),
+        apply_limit=False,
+    )
+
+    recent_ordered_items = sorted(
+        recall_payload["items"],
+        key=_recency_sort_key,
+        reverse=True,
+    )
+
+    latest_decision = next(
+        (
+            item
+            for item in recent_ordered_items
+            if item["object_type"] == "Decision" and item["status"] == "active"
+        ),
+        None,
+    )
+    latest_next_action = next(
+        (
+            item
+            for item in recent_ordered_items
+            if item["object_type"] == "NextAction" and item["status"] == "active"
+        ),
+        None,
+    )
+
+    open_loop_candidates = [
+        item
+        for item in recent_ordered_items
+        if item["status"] == "active"
+        and item["object_type"] in {"Commitment", "WaitingFor", "Blocker"}
+    ]
+    open_loop_items = (
+        open_loop_candidates[: request.max_open_loops]
+        if request.max_open_loops > 0
+        else []
+    )
+
+    recent_change_items = (
+        recent_ordered_items[: request.max_recent_changes]
+        if request.max_recent_changes > 0
+        else []
+    )
+
+    brief: ContinuityResumptionBriefRecord = {
+        "assembly_version": CONTINUITY_RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0,
+        "scope": recall_payload["summary"]["filters"],
+        "last_decision": _build_single_section(
+            latest_decision,
+            empty_message="No decision found in the requested scope.",
+        ),
+        "open_loops": _build_list_section(
+            items=open_loop_items,
+            limit=request.max_open_loops,
+            total_count=len(open_loop_candidates),
+            order=list(CONTINUITY_RESUMPTION_OPEN_LOOP_ORDER),
+            empty_message="No open loops found in the requested scope.",
+        ),
+        "recent_changes": _build_list_section(
+            items=recent_change_items,
+            limit=request.max_recent_changes,
+            total_count=len(recent_ordered_items),
+            order=list(CONTINUITY_RESUMPTION_RECENT_CHANGE_ORDER),
+            empty_message="No recent changes found in the requested scope.",
+        ),
+        "next_action": _build_single_section(
+            latest_next_action,
+            empty_message="No next action found in the requested scope.",
+        ),
+        "sources": ["continuity_capture_events", "continuity_objects"],
+    }
+
+    return {"brief": brief}
+
+
+def build_default_resumption_request() -> ContinuityResumptionBriefRequestInput:
+    return ContinuityResumptionBriefRequestInput(
+        max_recent_changes=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        max_open_loops=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    )

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -157,6 +157,7 @@ ContinuityCaptureExplicitSignal = Literal[
     "note",
 ]
 ContinuityCaptureAdmissionPosture = Literal["DERIVED", "TRIAGE"]
+ContinuityRecallScopeKind = Literal["thread", "task", "project", "person"]
 ExplicitCommitmentOpenLoopDecision = Literal[
     "CREATED",
     "NOOP_ACTIVE_EXISTS",
@@ -186,6 +187,12 @@ DEFAULT_ARTIFACT_CHUNK_RETRIEVAL_LIMIT = 5
 MAX_ARTIFACT_CHUNK_RETRIEVAL_LIMIT = 50
 DEFAULT_CONTINUITY_CAPTURE_LIMIT = 20
 MAX_CONTINUITY_CAPTURE_LIMIT = 100
+DEFAULT_CONTINUITY_RECALL_LIMIT = 20
+MAX_CONTINUITY_RECALL_LIMIT = 100
+DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT = 5
+MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT = 20
+DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT = 5
+MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT = 20
 DEFAULT_CALENDAR_EVENT_LIST_LIMIT = 20
 MAX_CALENDAR_EVENT_LIST_LIMIT = 50
 COMPILER_VERSION_V0 = "continuity_v0"
@@ -201,6 +208,7 @@ THREAD_SESSION_LIST_ORDER = ["started_at_asc", "created_at_asc", "id_asc"]
 THREAD_EVENT_LIST_ORDER = ["sequence_no_asc"]
 DEFAULT_AGENT_PROFILE_ID = "assistant_default"
 RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0 = "resumption_brief_v0"
+CONTINUITY_RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0 = "continuity_resumption_brief_v0"
 RESUMPTION_BRIEF_CONVERSATION_EVENT_KINDS = ["message.user", "message.assistant"]
 RESUMPTION_BRIEF_CONVERSATION_ORDER = ["sequence_no_asc"]
 RESUMPTION_BRIEF_MEMORY_ORDER = ["updated_at_asc", "created_at_asc", "id_asc"]
@@ -330,6 +338,9 @@ TASK_RUN_RETRY_POSTURES = [
 TASK_RUN_LIST_ORDER = ["created_at_asc", "id_asc"]
 CONTINUITY_CAPTURE_LIST_ORDER = ["created_at_desc", "id_desc"]
 CONTINUITY_OBJECT_LIST_ORDER = ["created_at_desc", "id_desc"]
+CONTINUITY_RECALL_LIST_ORDER = ["relevance_desc", "created_at_desc", "id_desc"]
+CONTINUITY_RESUMPTION_RECENT_CHANGE_ORDER = ["created_at_desc", "id_desc"]
+CONTINUITY_RESUMPTION_OPEN_LOOP_ORDER = ["created_at_desc", "id_desc"]
 TASK_WORKSPACE_STATUSES = ["active"]
 TASK_ARTIFACT_STATUSES = ["registered"]
 TASK_ARTIFACT_INGESTION_STATUSES = ["pending", "ingested"]
@@ -1212,6 +1223,58 @@ class ContinuityCaptureCreateInput:
 
 
 @dataclass(frozen=True, slots=True)
+class ContinuityRecallQueryInput:
+    query: str | None = None
+    thread_id: UUID | None = None
+    task_id: UUID | None = None
+    project: str | None = None
+    person: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    limit: int = DEFAULT_CONTINUITY_RECALL_LIMIT
+
+    def as_payload(self) -> JsonObject:
+        payload: JsonObject = {
+            "query": self.query,
+            "thread_id": None if self.thread_id is None else str(self.thread_id),
+            "task_id": None if self.task_id is None else str(self.task_id),
+            "project": self.project,
+            "person": self.person,
+            "limit": self.limit,
+        }
+        payload["since"] = isoformat_or_none(self.since)
+        payload["until"] = isoformat_or_none(self.until)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuityResumptionBriefRequestInput:
+    query: str | None = None
+    thread_id: UUID | None = None
+    task_id: UUID | None = None
+    project: str | None = None
+    person: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    max_recent_changes: int = DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT
+    max_open_loops: int = DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT
+
+    def as_payload(self) -> JsonObject:
+        payload: JsonObject = {
+            "query": self.query,
+            "thread_id": None if self.thread_id is None else str(self.thread_id),
+            "task_id": None if self.task_id is None else str(self.task_id),
+            "project": self.project,
+            "person": self.person,
+            "max_recent_changes": self.max_recent_changes,
+            "max_open_loops": self.max_open_loops,
+        }
+        payload["since"] = isoformat_or_none(self.since)
+        payload["until"] = isoformat_or_none(self.until)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
 class OpenLoopCreateInput:
     title: str
     memory_id: UUID | None = None
@@ -1759,6 +1822,96 @@ class ContinuityCaptureInboxResponse(TypedDict):
 
 class ContinuityCaptureDetailResponse(TypedDict):
     capture: ContinuityCaptureInboxItem
+
+
+class ContinuityRecallScopeFilters(TypedDict):
+    thread_id: NotRequired[str]
+    task_id: NotRequired[str]
+    project: NotRequired[str]
+    person: NotRequired[str]
+    since: str | None
+    until: str | None
+
+
+class ContinuityRecallScopeMatch(TypedDict):
+    kind: ContinuityRecallScopeKind
+    value: str
+
+
+class ContinuityRecallProvenanceReference(TypedDict):
+    source_kind: str
+    source_id: str
+
+
+class ContinuityRecallOrderingMetadata(TypedDict):
+    scope_match_count: int
+    query_term_match_count: int
+    confirmation_rank: int
+    posture_rank: int
+    confidence: float
+
+
+class ContinuityRecallResultRecord(TypedDict):
+    id: str
+    capture_event_id: str
+    object_type: ContinuityObjectType
+    status: str
+    title: str
+    body: JsonObject
+    provenance: JsonObject
+    confirmation_status: MemoryConfirmationStatus
+    admission_posture: ContinuityCaptureAdmissionPosture
+    confidence: float
+    relevance: float
+    scope_matches: list[ContinuityRecallScopeMatch]
+    provenance_references: list[ContinuityRecallProvenanceReference]
+    ordering: ContinuityRecallOrderingMetadata
+    created_at: str
+    updated_at: str
+
+
+class ContinuityRecallSummary(TypedDict):
+    query: str | None
+    filters: ContinuityRecallScopeFilters
+    limit: int
+    returned_count: int
+    total_count: int
+    order: list[str]
+
+
+class ContinuityRecallResponse(TypedDict):
+    items: list[ContinuityRecallResultRecord]
+    summary: ContinuityRecallSummary
+
+
+class ContinuityResumptionEmptyState(TypedDict):
+    is_empty: bool
+    message: str
+
+
+class ContinuityResumptionSingleSection(TypedDict):
+    item: ContinuityRecallResultRecord | None
+    empty_state: ContinuityResumptionEmptyState
+
+
+class ContinuityResumptionListSection(TypedDict):
+    items: list[ContinuityRecallResultRecord]
+    summary: ResumptionBriefSectionSummary
+    empty_state: ContinuityResumptionEmptyState
+
+
+class ContinuityResumptionBriefRecord(TypedDict):
+    assembly_version: str
+    scope: ContinuityRecallScopeFilters
+    last_decision: ContinuityResumptionSingleSection
+    open_loops: ContinuityResumptionListSection
+    recent_changes: ContinuityResumptionListSection
+    next_action: ContinuityResumptionSingleSection
+    sources: list[str]
+
+
+class ContinuityResumptionBriefResponse(TypedDict):
+    brief: ContinuityResumptionBriefRecord
 
 
 class MemoryReviewRecord(TypedDict):

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -33,6 +33,9 @@ from alicebot_api.contracts import (
     DEFAULT_AGENT_PROFILE_ID,
     DEFAULT_CALENDAR_EVENT_LIST_LIMIT,
     DEFAULT_CONTINUITY_CAPTURE_LIMIT,
+    DEFAULT_CONTINUITY_RECALL_LIMIT,
+    DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
     DEFAULT_MAX_EVENTS,
     DEFAULT_MAX_ENTITY_EDGES,
     DEFAULT_MAX_ENTITIES,
@@ -52,9 +55,16 @@ from alicebot_api.contracts import (
     MAX_ARTIFACT_CHUNK_RETRIEVAL_LIMIT,
     MAX_CALENDAR_EVENT_LIST_LIMIT,
     MAX_CONTINUITY_CAPTURE_LIMIT,
+    MAX_CONTINUITY_RECALL_LIMIT,
+    MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
     MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
     ContextCompilerLimits,
     ContinuityCaptureCreateInput,
+    ContinuityRecallQueryInput,
+    ContinuityRecallResponse,
+    ContinuityResumptionBriefRequestInput,
+    ContinuityResumptionBriefResponse,
     EmbeddingConfigStatus,
     EmbeddingConfigCreateInput,
     ExecutionBudgetCreateInput,
@@ -287,6 +297,14 @@ from alicebot_api.continuity_capture import (
     capture_continuity_input,
     get_continuity_capture_detail,
     list_continuity_capture_inbox,
+)
+from alicebot_api.continuity_recall import (
+    ContinuityRecallValidationError,
+    query_continuity_recall,
+)
+from alicebot_api.continuity_resumption import (
+    ContinuityResumptionValidationError,
+    compile_continuity_resumption_brief,
 )
 from alicebot_api.continuity_objects import ContinuityObjectValidationError
 from alicebot_api.memory import (
@@ -3115,6 +3133,100 @@ def get_continuity_capture(capture_event_id: UUID, user_id: UUID) -> JSONRespons
             )
     except ContinuityCaptureNotFoundError as exc:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/continuity/recall")
+def list_continuity_recall(
+    user_id: UUID,
+    query_text: str | None = Query(default=None, alias="query", min_length=1, max_length=4000),
+    thread_id: UUID | None = None,
+    task_id: UUID | None = None,
+    project: str | None = Query(default=None, min_length=1, max_length=200),
+    person: str | None = Query(default=None, min_length=1, max_length=200),
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = Query(
+        default=DEFAULT_CONTINUITY_RECALL_LIMIT,
+        ge=1,
+        le=MAX_CONTINUITY_RECALL_LIMIT,
+    ),
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: ContinuityRecallResponse = query_continuity_recall(
+                ContinuityStore(conn),
+                user_id=user_id,
+                request=ContinuityRecallQueryInput(
+                    query=query_text,
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    project=project,
+                    person=person,
+                    since=since,
+                    until=until,
+                    limit=limit,
+                ),
+            )
+    except ContinuityRecallValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/continuity/resumption-brief")
+def get_continuity_resumption_brief(
+    user_id: UUID,
+    query_text: str | None = Query(default=None, alias="query", min_length=1, max_length=4000),
+    thread_id: UUID | None = None,
+    task_id: UUID | None = None,
+    project: str | None = Query(default=None, min_length=1, max_length=200),
+    person: str | None = Query(default=None, min_length=1, max_length=200),
+    since: datetime | None = None,
+    until: datetime | None = None,
+    max_recent_changes: int = Query(
+        default=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        ge=0,
+        le=MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    ),
+    max_open_loops: int = Query(
+        default=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+        ge=0,
+        le=MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    ),
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: ContinuityResumptionBriefResponse = compile_continuity_resumption_brief(
+                ContinuityStore(conn),
+                user_id=user_id,
+                request=ContinuityResumptionBriefRequestInput(
+                    query=query_text,
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    project=project,
+                    person=person,
+                    since=since,
+                    until=until,
+                    max_recent_changes=max_recent_changes,
+                    max_open_loops=max_open_loops,
+                ),
+            )
+    except ContinuityResumptionValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except ContinuityRecallValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
 
     return JSONResponse(
         status_code=200,

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -172,6 +172,24 @@ class ContinuityObjectRow(TypedDict):
     updated_at: datetime
 
 
+class ContinuityRecallCandidateRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    capture_event_id: UUID
+    object_type: str
+    status: str
+    title: str
+    body: JsonObject
+    provenance: JsonObject
+    confidence: float
+    object_created_at: datetime
+    object_updated_at: datetime
+    admission_posture: str
+    admission_reason: str
+    explicit_signal: str | None
+    capture_created_at: datetime
+
+
 class EmbeddingConfigRow(TypedDict):
     id: UUID
     user_id: UUID
@@ -3594,6 +3612,30 @@ LIST_CONTINUITY_OBJECTS_FOR_CAPTURE_EVENTS_SQL = """
                 ORDER BY created_at DESC, id DESC
                 """
 
+LIST_CONTINUITY_RECALL_CANDIDATES_SQL = """
+                SELECT
+                  continuity_objects.id,
+                  continuity_objects.user_id,
+                  continuity_objects.capture_event_id,
+                  continuity_objects.object_type,
+                  continuity_objects.status,
+                  continuity_objects.title,
+                  continuity_objects.body,
+                  continuity_objects.provenance,
+                  continuity_objects.confidence,
+                  continuity_objects.created_at AS object_created_at,
+                  continuity_objects.updated_at AS object_updated_at,
+                  continuity_capture_events.admission_posture,
+                  continuity_capture_events.admission_reason,
+                  continuity_capture_events.explicit_signal,
+                  continuity_capture_events.created_at AS capture_created_at
+                FROM continuity_objects
+                JOIN continuity_capture_events
+                  ON continuity_capture_events.id = continuity_objects.capture_event_id
+                 AND continuity_capture_events.user_id = continuity_objects.user_id
+                ORDER BY continuity_objects.created_at DESC, continuity_objects.id DESC
+                """
+
 UPDATE_EVENT_ERROR = "events are append-only and must be superseded by new records"
 DELETE_EVENT_ERROR = "events are append-only and must not be deleted in place"
 UPDATE_TRACE_EVENT_ERROR = "trace events are append-only and must be superseded by new records"
@@ -4117,6 +4159,9 @@ class ContinuityStore:
             LIST_CONTINUITY_OBJECTS_FOR_CAPTURE_EVENTS_SQL,
             (capture_event_ids,),
         )
+
+    def list_continuity_recall_candidates(self) -> list[ContinuityRecallCandidateRow]:
+        return self._fetch_all(LIST_CONTINUITY_RECALL_CANDIDATES_SQL)
 
     def create_embedding_config(
         self,

--- a/apps/web/app/continuity/page.test.tsx
+++ b/apps/web/app/continuity/page.test.tsx
@@ -7,14 +7,18 @@ import ContinuityPage from "./page";
 const {
   getApiConfigMock,
   getContinuityCaptureDetailMock,
+  getContinuityResumptionBriefMock,
   hasLiveApiConfigMock,
   listContinuityCapturesMock,
+  queryContinuityRecallMock,
   refreshMock,
 } = vi.hoisted(() => ({
   getApiConfigMock: vi.fn(),
   getContinuityCaptureDetailMock: vi.fn(),
+  getContinuityResumptionBriefMock: vi.fn(),
   hasLiveApiConfigMock: vi.fn(),
   listContinuityCapturesMock: vi.fn(),
+  queryContinuityRecallMock: vi.fn(),
   refreshMock: vi.fn(),
 }));
 
@@ -48,8 +52,10 @@ vi.mock("../../lib/api", async () => {
     ...actual,
     getApiConfig: getApiConfigMock,
     getContinuityCaptureDetail: getContinuityCaptureDetailMock,
+    getContinuityResumptionBrief: getContinuityResumptionBriefMock,
     hasLiveApiConfig: hasLiveApiConfigMock,
     listContinuityCaptures: listContinuityCapturesMock,
+    queryContinuityRecall: queryContinuityRecallMock,
   };
 });
 
@@ -57,8 +63,10 @@ describe("ContinuityPage", () => {
   beforeEach(() => {
     getApiConfigMock.mockReset();
     getContinuityCaptureDetailMock.mockReset();
+    getContinuityResumptionBriefMock.mockReset();
     hasLiveApiConfigMock.mockReset();
     listContinuityCapturesMock.mockReset();
+    queryContinuityRecallMock.mockReset();
     refreshMock.mockReset();
 
     getApiConfigMock.mockReturnValue({
@@ -79,13 +87,16 @@ describe("ContinuityPage", () => {
 
     expect(screen.getByText("Fixture-backed")).toBeInTheDocument();
     expect(screen.getByText("Fixture inbox")).toBeInTheDocument();
-    expect(screen.getAllByText("Finalize launch checklist").length).toBeGreaterThan(0);
-    expect(screen.getByText("Maybe revisit this next month")).toBeInTheDocument();
-    expect(screen.getByText("No durable object")).toBeInTheDocument();
+    expect(screen.getByText("Fixture recall")).toBeInTheDocument();
+    expect(screen.getByText("Fixture brief")).toBeInTheDocument();
+    expect(screen.getByText("Continuity recall")).toBeInTheDocument();
+    expect(screen.getByText("Resumption brief")).toBeInTheDocument();
     expect(listContinuityCapturesMock).not.toHaveBeenCalled();
+    expect(queryContinuityRecallMock).not.toHaveBeenCalled();
+    expect(getContinuityResumptionBriefMock).not.toHaveBeenCalled();
   });
 
-  it("renders live continuity inbox and detail when live reads succeed", async () => {
+  it("renders live continuity inbox, recall, and resumption when reads succeed", async () => {
     getApiConfigMock.mockReturnValue({
       apiBaseUrl: "https://api.example.com",
       userId: "user-1",
@@ -161,15 +172,102 @@ describe("ContinuityPage", () => {
         },
       },
     });
+    queryContinuityRecallMock.mockResolvedValue({
+      items: [
+        {
+          id: "recall-live-1",
+          capture_event_id: "capture-live-1",
+          object_type: "Decision",
+          status: "active",
+          title: "Decision: Keep admission conservative",
+          body: { decision_text: "Keep admission conservative" },
+          provenance: { thread_id: "thread-1" },
+          confirmation_status: "confirmed",
+          admission_posture: "DERIVED",
+          confidence: 0.95,
+          relevance: 130,
+          scope_matches: [{ kind: "thread", value: "thread-1" }],
+          provenance_references: [{ source_kind: "continuity_capture_event", source_id: "capture-live-1" }],
+          ordering: {
+            scope_match_count: 1,
+            query_term_match_count: 1,
+            confirmation_rank: 3,
+            posture_rank: 2,
+            confidence: 0.95,
+          },
+          created_at: "2026-03-29T09:20:00Z",
+          updated_at: "2026-03-29T09:20:00Z",
+        },
+      ],
+      summary: {
+        query: "decision",
+        filters: {
+          thread_id: "thread-1",
+          since: null,
+          until: null,
+        },
+        limit: 20,
+        returned_count: 1,
+        total_count: 1,
+        order: ["relevance_desc", "created_at_desc", "id_desc"],
+      },
+    });
+    getContinuityResumptionBriefMock.mockResolvedValue({
+      brief: {
+        assembly_version: "continuity_resumption_brief_v0",
+        scope: { thread_id: "thread-1", since: null, until: null },
+        last_decision: {
+          item: {
+            id: "recall-live-1",
+            capture_event_id: "capture-live-1",
+            object_type: "Decision",
+            status: "active",
+            title: "Decision: Keep admission conservative",
+            body: { decision_text: "Keep admission conservative" },
+            provenance: { thread_id: "thread-1" },
+            confirmation_status: "confirmed",
+            admission_posture: "DERIVED",
+            confidence: 0.95,
+            relevance: 130,
+            scope_matches: [{ kind: "thread", value: "thread-1" }],
+            provenance_references: [{ source_kind: "continuity_capture_event", source_id: "capture-live-1" }],
+            ordering: {
+              scope_match_count: 1,
+              query_term_match_count: 1,
+              confirmation_rank: 3,
+              posture_rank: 2,
+              confidence: 0.95,
+            },
+            created_at: "2026-03-29T09:20:00Z",
+            updated_at: "2026-03-29T09:20:00Z",
+          },
+          empty_state: { is_empty: false, message: "No decision found in the requested scope." },
+        },
+        open_loops: {
+          items: [],
+          summary: { limit: 5, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No open loops found in the requested scope." },
+        },
+        recent_changes: {
+          items: [],
+          summary: { limit: 5, returned_count: 0, total_count: 1, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No recent changes found in the requested scope." },
+        },
+        next_action: {
+          item: null,
+          empty_state: { is_empty: true, message: "No next action found in the requested scope." },
+        },
+        sources: ["continuity_capture_events", "continuity_objects"],
+      },
+    });
 
-    render(await ContinuityPage({ searchParams: Promise.resolve({ capture: "capture-live-1" }) }));
+    render(await ContinuityPage({ searchParams: Promise.resolve({ capture: "capture-live-1", recall_query: "decision" }) }));
 
     expect(screen.getByText("Live API")).toBeInTheDocument();
     expect(screen.getByText("Live inbox")).toBeInTheDocument();
-    expect(screen.getByText("Live detail")).toBeInTheDocument();
+    expect(screen.getByText("Live recall")).toBeInTheDocument();
+    expect(screen.getByText("Live brief")).toBeInTheDocument();
     expect(screen.getAllByText("Decision: Keep admission conservative").length).toBeGreaterThan(0);
-    expect(screen.getByText("Derived object")).toBeInTheDocument();
-    expect(screen.getByText("Provenance")).toBeInTheDocument();
 
     expect(listContinuityCapturesMock).toHaveBeenCalledWith("https://api.example.com", "user-1", {
       limit: 20,
@@ -179,5 +277,26 @@ describe("ContinuityPage", () => {
       "capture-live-1",
       "user-1",
     );
+    expect(queryContinuityRecallMock).toHaveBeenCalledWith("https://api.example.com", "user-1", {
+      query: "decision",
+      threadId: "",
+      taskId: "",
+      project: "",
+      person: "",
+      since: "",
+      until: "",
+      limit: 20,
+    });
+    expect(getContinuityResumptionBriefMock).toHaveBeenCalledWith("https://api.example.com", "user-1", {
+      query: "decision",
+      threadId: "",
+      taskId: "",
+      project: "",
+      person: "",
+      since: "",
+      until: "",
+      maxRecentChanges: 5,
+      maxOpenLoops: 5,
+    });
   });
 });

--- a/apps/web/app/continuity/page.tsx
+++ b/apps/web/app/continuity/page.tsx
@@ -1,17 +1,28 @@
 import { ContinuityCaptureForm } from "../../components/continuity-capture-form";
 import { ContinuityInboxList } from "../../components/continuity-inbox-list";
+import { ContinuityRecallPanel } from "../../components/continuity-recall-panel";
 import { EmptyState } from "../../components/empty-state";
 import { PageHeader } from "../../components/page-header";
+import { ResumptionBrief } from "../../components/resumption-brief";
 import { SectionCard } from "../../components/section-card";
 import { StatusBadge } from "../../components/status-badge";
-import type { ApiSource, ContinuityCaptureInboxItem, ContinuityCaptureInboxSummary } from "../../lib/api";
+import type {
+  ApiSource,
+  ContinuityCaptureInboxItem,
+  ContinuityCaptureInboxSummary,
+  ContinuityRecallResult,
+  ContinuityRecallSummary,
+  ContinuityResumptionBrief,
+} from "../../lib/api";
 import {
   combinePageModes,
   getApiConfig,
   getContinuityCaptureDetail,
+  getContinuityResumptionBrief,
   hasLiveApiConfig,
   listContinuityCaptures,
   pageModeLabel,
+  queryContinuityRecall,
 } from "../../lib/api";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
@@ -21,6 +32,22 @@ function normalizeParam(value: string | string[] | undefined) {
     return normalizeParam(value[0]);
   }
   return value?.trim() ?? "";
+}
+
+function parsePositiveInt(value: string, fallback: number) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function parseNonNegativeInt(value: string, fallback: number) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
 }
 
 function resolveSelectedCaptureId(requestedCaptureId: string, items: ContinuityCaptureInboxItem[]) {
@@ -89,6 +116,108 @@ const continuityCaptureSummaryFixture: ContinuityCaptureInboxSummary = {
   order: ["created_at_desc", "id_desc"],
 };
 
+const continuityRecallFixtures: ContinuityRecallResult[] = [
+  {
+    id: "recall-fixture-1",
+    capture_event_id: "capture-fixture-1",
+    object_type: "NextAction",
+    status: "active",
+    title: "Next Action: Finalize launch checklist",
+    body: {
+      action_text: "Finalize launch checklist",
+    },
+    provenance: {
+      thread_id: "thread-fixture-1",
+      project: "Launch Project",
+      person: "Alex",
+      source_event_ids: ["event-fixture-1"],
+    },
+    confirmation_status: "unconfirmed",
+    admission_posture: "DERIVED",
+    confidence: 1,
+    relevance: 121,
+    scope_matches: [
+      { kind: "project", value: "launch project" },
+      { kind: "person", value: "alex" },
+    ],
+    provenance_references: [
+      { source_kind: "continuity_capture_event", source_id: "capture-fixture-1" },
+      { source_kind: "event", source_id: "event-fixture-1" },
+      { source_kind: "thread", source_id: "thread-fixture-1" },
+    ],
+    ordering: {
+      scope_match_count: 2,
+      query_term_match_count: 1,
+      confirmation_rank: 2,
+      posture_rank: 2,
+      confidence: 1,
+    },
+    created_at: "2026-03-29T09:00:00Z",
+    updated_at: "2026-03-29T09:00:00Z",
+  },
+];
+
+const continuityRecallSummaryFixture: ContinuityRecallSummary = {
+  query: null,
+  filters: {
+    since: null,
+    until: null,
+  },
+  limit: 20,
+  returned_count: continuityRecallFixtures.length,
+  total_count: continuityRecallFixtures.length,
+  order: ["relevance_desc", "created_at_desc", "id_desc"],
+};
+
+const continuityResumptionFixture: ContinuityResumptionBrief = {
+  assembly_version: "continuity_resumption_brief_v0",
+  scope: {
+    since: null,
+    until: null,
+  },
+  last_decision: {
+    item: null,
+    empty_state: {
+      is_empty: true,
+      message: "No decision found in the requested scope.",
+    },
+  },
+  open_loops: {
+    items: [],
+    summary: {
+      limit: 5,
+      returned_count: 0,
+      total_count: 0,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: true,
+      message: "No open loops found in the requested scope.",
+    },
+  },
+  recent_changes: {
+    items: continuityRecallFixtures,
+    summary: {
+      limit: 5,
+      returned_count: continuityRecallFixtures.length,
+      total_count: continuityRecallFixtures.length,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No recent changes found in the requested scope.",
+    },
+  },
+  next_action: {
+    item: continuityRecallFixtures[0],
+    empty_state: {
+      is_empty: false,
+      message: "No next action found in the requested scope.",
+    },
+  },
+  sources: ["continuity_capture_events", "continuity_objects"],
+};
+
 function renderDetail(item: ContinuityCaptureInboxItem | null, source: ApiSource | "unavailable" | null, unavailableReason?: string) {
   if (!item) {
     return (
@@ -99,7 +228,7 @@ function renderDetail(item: ContinuityCaptureInboxItem | null, source: ApiSource
       >
         <EmptyState
           title="Detail panel is idle"
-          description="Choose one capture from the inbox to inspect posture and provenance." 
+          description="Choose one capture from the inbox to inspect posture and provenance."
         />
       </SectionCard>
     );
@@ -191,7 +320,19 @@ export default async function ContinuityPage({
     string,
     string | string[] | undefined
   >;
+
   const requestedCaptureId = normalizeParam(params.capture);
+  const recallQuery = normalizeParam(params.recall_query);
+  const recallThreadId = normalizeParam(params.recall_thread);
+  const recallTaskId = normalizeParam(params.recall_task);
+  const recallProject = normalizeParam(params.recall_project);
+  const recallPerson = normalizeParam(params.recall_person);
+  const recallSince = normalizeParam(params.recall_since);
+  const recallUntil = normalizeParam(params.recall_until);
+  const recallLimit = parsePositiveInt(normalizeParam(params.recall_limit), 20);
+  const resumptionRecentChanges = parseNonNegativeInt(normalizeParam(params.resumption_recent), 5);
+  const resumptionOpenLoops = parseNonNegativeInt(normalizeParam(params.resumption_open), 5);
+
   const apiConfig = getApiConfig();
   const liveModeReady = hasLiveApiConfig(apiConfig);
 
@@ -240,14 +381,69 @@ export default async function ContinuityPage({
     }
   }
 
-  const pageMode = combinePageModes(listSource, selectedSource);
+  let recallResults = continuityRecallFixtures;
+  let recallSummary = continuityRecallSummaryFixture;
+  let recallSource: ApiSource = "fixture";
+  let recallUnavailableReason: string | undefined;
+
+  if (liveModeReady) {
+    try {
+      const payload = await queryContinuityRecall(apiConfig.apiBaseUrl, apiConfig.userId, {
+        query: recallQuery,
+        threadId: recallThreadId,
+        taskId: recallTaskId,
+        project: recallProject,
+        person: recallPerson,
+        since: recallSince,
+        until: recallUntil,
+        limit: recallLimit,
+      });
+      recallResults = payload.items;
+      recallSummary = payload.summary;
+      recallSource = "live";
+    } catch (error) {
+      recallUnavailableReason =
+        error instanceof Error
+          ? error.message
+          : "Continuity recall query could not be loaded.";
+    }
+  }
+
+  let brief = continuityResumptionFixture;
+  let resumptionSource: ApiSource = "fixture";
+  let resumptionUnavailableReason: string | undefined;
+
+  if (liveModeReady) {
+    try {
+      const payload = await getContinuityResumptionBrief(apiConfig.apiBaseUrl, apiConfig.userId, {
+        query: recallQuery,
+        threadId: recallThreadId,
+        taskId: recallTaskId,
+        project: recallProject,
+        person: recallPerson,
+        since: recallSince,
+        until: recallUntil,
+        maxRecentChanges: resumptionRecentChanges,
+        maxOpenLoops: resumptionOpenLoops,
+      });
+      brief = payload.brief;
+      resumptionSource = "live";
+    } catch (error) {
+      resumptionUnavailableReason =
+        error instanceof Error
+          ? error.message
+          : "Continuity resumption brief could not be loaded.";
+    }
+  }
+
+  const pageMode = combinePageModes(listSource, selectedSource, recallSource, resumptionSource);
 
   return (
     <main className="stack">
       <PageHeader
         eyebrow="Continuity"
-        title="Fast Capture Inbox"
-        description="Capture quickly, preserve immutable events, and promote durable continuity objects only with explicit or high-confidence signals."
+        title="Continuity workspace"
+        description="Capture quickly, query continuity with provenance-backed recall, and compile deterministic resumption sections."
         meta={<StatusBadge status={pageMode} label={pageModeLabel(pageMode)} />}
       />
 
@@ -266,6 +462,30 @@ export default async function ContinuityPage({
           unavailableReason={listUnavailableReason}
         />
         {renderDetail(selectedItem, selectedSource, selectedUnavailableReason)}
+      </div>
+
+      <div className="grid grid--two">
+        <ContinuityRecallPanel
+          results={recallResults}
+          summary={recallSummary}
+          source={recallSource}
+          unavailableReason={recallUnavailableReason}
+          filters={{
+            query: recallQuery,
+            threadId: recallThreadId,
+            taskId: recallTaskId,
+            project: recallProject,
+            person: recallPerson,
+            since: recallSince,
+            until: recallUntil,
+            limit: recallLimit,
+          }}
+        />
+        <ResumptionBrief
+          brief={brief}
+          source={resumptionSource}
+          unavailableReason={resumptionUnavailableReason}
+        />
       </div>
     </main>
   );

--- a/apps/web/components/continuity-recall-panel.test.tsx
+++ b/apps/web/components/continuity-recall-panel.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ContinuityRecallPanel } from "./continuity-recall-panel";
+
+const recallItems = [
+  {
+    id: "recall-1",
+    capture_event_id: "capture-1",
+    object_type: "Decision" as const,
+    status: "active",
+    title: "Decision: Keep rollout phased",
+    body: { decision_text: "Keep rollout phased" },
+    provenance: { thread_id: "thread-1" },
+    confirmation_status: "confirmed" as const,
+    admission_posture: "DERIVED" as const,
+    confidence: 0.95,
+    relevance: 130,
+    scope_matches: [{ kind: "thread" as const, value: "thread-1" }],
+    provenance_references: [{ source_kind: "continuity_capture_event", source_id: "capture-1" }],
+    ordering: {
+      scope_match_count: 1,
+      query_term_match_count: 1,
+      confirmation_rank: 3,
+      posture_rank: 2,
+      confidence: 0.95,
+    },
+    created_at: "2026-03-29T10:00:00Z",
+    updated_at: "2026-03-29T10:00:00Z",
+  },
+];
+
+describe("ContinuityRecallPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders recall filters and provenance-backed result cards", () => {
+    render(
+      <ContinuityRecallPanel
+        results={recallItems}
+        summary={{
+          query: "rollout",
+          filters: {
+            thread_id: "thread-1",
+            since: null,
+            until: null,
+          },
+          limit: 20,
+          returned_count: 1,
+          total_count: 1,
+          order: ["relevance_desc", "created_at_desc", "id_desc"],
+        }}
+        source="live"
+        filters={{
+          query: "rollout",
+          threadId: "thread-1",
+          taskId: "",
+          project: "",
+          person: "",
+          since: "",
+          until: "",
+          limit: 20,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Live recall")).toBeInTheDocument();
+    expect(screen.getByText("1 matched")).toBeInTheDocument();
+    expect(screen.getByLabelText("Query")).toHaveValue("rollout");
+    expect(screen.getByLabelText("Thread ID")).toHaveValue("thread-1");
+    expect(screen.getByText("Decision: Keep rollout phased")).toBeInTheDocument();
+    expect(screen.getByText("1 provenance refs")).toBeInTheDocument();
+    expect(screen.getByText("1 scope matches")).toBeInTheDocument();
+  });
+
+  it("renders explicit empty state when no recall results exist", () => {
+    render(
+      <ContinuityRecallPanel
+        results={[]}
+        summary={{
+          query: null,
+          filters: {
+            since: null,
+            until: null,
+          },
+          limit: 20,
+          returned_count: 0,
+          total_count: 0,
+          order: ["relevance_desc", "created_at_desc", "id_desc"],
+        }}
+        source="fixture"
+        filters={{
+          query: "",
+          threadId: "",
+          taskId: "",
+          project: "",
+          person: "",
+          since: "",
+          until: "",
+          limit: 20,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("No recall hits")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/continuity-recall-panel.tsx
+++ b/apps/web/components/continuity-recall-panel.tsx
@@ -1,0 +1,151 @@
+import type { ApiSource, ContinuityRecallResult, ContinuityRecallSummary } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type ContinuityRecallPanelProps = {
+  results: ContinuityRecallResult[];
+  summary: ContinuityRecallSummary | null;
+  source: ApiSource | "unavailable";
+  unavailableReason?: string;
+  filters: {
+    query: string;
+    threadId: string;
+    taskId: string;
+    project: string;
+    person: string;
+    since: string;
+    until: string;
+    limit: number;
+  };
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function toFixedRelevance(value: number) {
+  if (!Number.isFinite(value)) {
+    return "0.00";
+  }
+  return value.toFixed(2);
+}
+
+export function ContinuityRecallPanel({
+  results,
+  summary,
+  source,
+  unavailableReason,
+  filters,
+}: ContinuityRecallPanelProps) {
+  return (
+    <SectionCard
+      eyebrow="Recall"
+      title="Continuity recall"
+      description="Query typed continuity objects with scoped filters and provenance-backed ranking."
+    >
+      <div className="detail-stack">
+        <form method="get" className="detail-stack">
+          <div className="cluster">
+            <StatusBadge
+              status={source}
+              label={
+                source === "live"
+                  ? "Live recall"
+                  : source === "fixture"
+                    ? "Fixture recall"
+                    : "Recall unavailable"
+              }
+            />
+            {summary ? <span className="meta-pill">{summary.total_count} matched</span> : null}
+          </div>
+
+          {unavailableReason ? (
+            <p className="responsive-note">Live recall read failed: {unavailableReason}</p>
+          ) : null}
+
+          <div className="grid grid--two">
+            <div className="form-field">
+              <label htmlFor="continuity-recall-query">Query</label>
+              <input id="continuity-recall-query" name="recall_query" defaultValue={filters.query} maxLength={4000} />
+            </div>
+            <div className="form-field">
+              <label htmlFor="continuity-recall-limit">Limit</label>
+              <input
+                id="continuity-recall-limit"
+                name="recall_limit"
+                type="number"
+                min={1}
+                max={100}
+                defaultValue={String(filters.limit)}
+              />
+            </div>
+            <div className="form-field">
+              <label htmlFor="continuity-recall-thread">Thread ID</label>
+              <input id="continuity-recall-thread" name="recall_thread" defaultValue={filters.threadId} />
+            </div>
+            <div className="form-field">
+              <label htmlFor="continuity-recall-task">Task ID</label>
+              <input id="continuity-recall-task" name="recall_task" defaultValue={filters.taskId} />
+            </div>
+            <div className="form-field">
+              <label htmlFor="continuity-recall-project">Project</label>
+              <input id="continuity-recall-project" name="recall_project" defaultValue={filters.project} />
+            </div>
+            <div className="form-field">
+              <label htmlFor="continuity-recall-person">Person</label>
+              <input id="continuity-recall-person" name="recall_person" defaultValue={filters.person} />
+            </div>
+            <div className="form-field">
+              <label htmlFor="continuity-recall-since">Since (ISO datetime)</label>
+              <input id="continuity-recall-since" name="recall_since" defaultValue={filters.since} />
+            </div>
+            <div className="form-field">
+              <label htmlFor="continuity-recall-until">Until (ISO datetime)</label>
+              <input id="continuity-recall-until" name="recall_until" defaultValue={filters.until} />
+            </div>
+          </div>
+
+          <div className="composer-actions">
+            <button type="submit" className="button">Run recall</button>
+          </div>
+        </form>
+
+        {results.length === 0 ? (
+          <EmptyState
+            title="No recall hits"
+            description="Try broader filters or a less specific query to retrieve continuity evidence."
+          />
+        ) : (
+          <div className="list-rows">
+            {results.map((item) => (
+              <article key={item.id} className="list-row">
+                <div className="list-row__topline">
+                  <div className="detail-stack">
+                    <span className="list-row__eyebrow">{formatDate(item.created_at)}</span>
+                    <h3 className="list-row__title">{item.title}</h3>
+                  </div>
+                  <div className="cluster">
+                    <StatusBadge status={item.admission_posture} label={item.admission_posture} />
+                    <span className="meta-pill">{item.object_type}</span>
+                    <span className="meta-pill">{item.confirmation_status}</span>
+                  </div>
+                </div>
+                <div className="list-row__meta">
+                  <span className="meta-pill mono">score {toFixedRelevance(item.relevance)}</span>
+                  <span className="meta-pill">{item.provenance_references.length} provenance refs</span>
+                  <span className="meta-pill">{item.scope_matches.length} scope matches</span>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/components/resumption-brief.test.tsx
+++ b/apps/web/components/resumption-brief.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ResumptionBrief } from "./resumption-brief";
+
+const briefFixture = {
+  assembly_version: "continuity_resumption_brief_v0",
+  scope: {
+    since: null,
+    until: null,
+  },
+  last_decision: {
+    item: {
+      id: "decision-1",
+      capture_event_id: "capture-1",
+      object_type: "Decision" as const,
+      status: "active",
+      title: "Decision: Keep rollout phased",
+      body: { decision_text: "Keep rollout phased" },
+      provenance: {},
+      confirmation_status: "confirmed" as const,
+      admission_posture: "DERIVED" as const,
+      confidence: 1,
+      relevance: 100,
+      scope_matches: [],
+      provenance_references: [],
+      ordering: {
+        scope_match_count: 0,
+        query_term_match_count: 0,
+        confirmation_rank: 3,
+        posture_rank: 2,
+        confidence: 1,
+      },
+      created_at: "2026-03-29T10:00:00Z",
+      updated_at: "2026-03-29T10:00:00Z",
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No decision found in the requested scope.",
+    },
+  },
+  open_loops: {
+    items: [
+      {
+        id: "loop-1",
+        capture_event_id: "capture-2",
+        object_type: "WaitingFor" as const,
+        status: "active",
+        title: "Waiting For: Vendor quote",
+        body: { waiting_for_text: "Vendor quote" },
+        provenance: {},
+        confirmation_status: "unconfirmed" as const,
+        admission_posture: "DERIVED" as const,
+        confidence: 1,
+        relevance: 95,
+        scope_matches: [],
+        provenance_references: [],
+        ordering: {
+          scope_match_count: 0,
+          query_term_match_count: 0,
+          confirmation_rank: 2,
+          posture_rank: 2,
+          confidence: 1,
+        },
+        created_at: "2026-03-29T10:10:00Z",
+        updated_at: "2026-03-29T10:10:00Z",
+      },
+    ],
+    summary: {
+      limit: 5,
+      returned_count: 1,
+      total_count: 1,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No open loops found in the requested scope.",
+    },
+  },
+  recent_changes: {
+    items: [],
+    summary: {
+      limit: 5,
+      returned_count: 0,
+      total_count: 1,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: true,
+      message: "No recent changes found in the requested scope.",
+    },
+  },
+  next_action: {
+    item: null,
+    empty_state: {
+      is_empty: true,
+      message: "No next action found in the requested scope.",
+    },
+  },
+  sources: ["continuity_capture_events", "continuity_objects"],
+};
+
+describe("ResumptionBrief", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders deterministic resumption sections with explicit empty states", () => {
+    render(<ResumptionBrief brief={briefFixture} source="live" />);
+
+    expect(screen.getByText("Live brief")).toBeInTheDocument();
+    expect(screen.getByText("continuity_resumption_brief_v0")).toBeInTheDocument();
+    expect(screen.getByText("Decision: Keep rollout phased")).toBeInTheDocument();
+    expect(screen.getByText("Waiting For: Vendor quote")).toBeInTheDocument();
+    expect(screen.getByText("No recent changes found in the requested scope.")).toBeInTheDocument();
+    expect(screen.getByText("No next action found in the requested scope.")).toBeInTheDocument();
+  });
+
+  it("renders fallback empty state when brief payload is absent", () => {
+    render(<ResumptionBrief brief={null} source="fixture" />);
+
+    expect(screen.getByText("Resumption unavailable")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/resumption-brief.tsx
+++ b/apps/web/components/resumption-brief.tsx
@@ -1,0 +1,119 @@
+import type { ApiSource, ContinuityResumptionBrief } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type ResumptionBriefProps = {
+  brief: ContinuityResumptionBrief | null;
+  source: ApiSource | "unavailable";
+  unavailableReason?: string;
+};
+
+function renderSingleSection(
+  heading: string,
+  section: {
+    item: ContinuityResumptionBrief["last_decision"]["item"];
+    empty_state: ContinuityResumptionBrief["last_decision"]["empty_state"];
+  },
+) {
+  if (section.item) {
+    return (
+      <div className="detail-group">
+        <h3>{heading}</h3>
+        <p className="list-row__title">{section.item.title}</p>
+        <div className="cluster">
+          <span className="meta-pill">{section.item.object_type}</span>
+          <StatusBadge status={section.item.confirmation_status} label={section.item.confirmation_status} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="detail-group detail-group--muted">
+      <h3>{heading}</h3>
+      <p className="muted-copy">{section.empty_state.message}</p>
+    </div>
+  );
+}
+
+export function ResumptionBrief({ brief, source, unavailableReason }: ResumptionBriefProps) {
+  if (brief === null) {
+    return (
+      <SectionCard
+        eyebrow="Resumption"
+        title="Resumption brief"
+        description="Compile deterministic resume artifacts from continuity objects."
+      >
+        <EmptyState
+          title="Resumption unavailable"
+          description="Resumption brief is not available in this mode yet."
+        />
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard
+      eyebrow="Resumption"
+      title="Resumption brief"
+      description="Deterministic sections are compiled for last decision, open loops, recent changes, and next action."
+    >
+      <div className="detail-stack">
+        <div className="cluster">
+          <StatusBadge
+            status={source}
+            label={
+              source === "live"
+                ? "Live brief"
+                : source === "fixture"
+                  ? "Fixture brief"
+                  : "Brief unavailable"
+            }
+          />
+          <span className="meta-pill mono">{brief.assembly_version}</span>
+        </div>
+
+        {unavailableReason ? (
+          <p className="responsive-note">Live brief read failed: {unavailableReason}</p>
+        ) : null}
+
+        {renderSingleSection("Last decision", brief.last_decision)}
+
+        <div className="detail-group">
+          <h3>Open loops</h3>
+          {brief.open_loops.items.length === 0 ? (
+            <p className="muted-copy">{brief.open_loops.empty_state.message}</p>
+          ) : (
+            <ul className="detail-stack">
+              {brief.open_loops.items.map((item) => (
+                <li key={item.id} className="cluster">
+                  <span className="meta-pill">{item.object_type}</span>
+                  <span>{item.title}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="detail-group">
+          <h3>Recent changes</h3>
+          {brief.recent_changes.items.length === 0 ? (
+            <p className="muted-copy">{brief.recent_changes.empty_state.message}</p>
+          ) : (
+            <ul className="detail-stack">
+              {brief.recent_changes.items.map((item) => (
+                <li key={item.id} className="cluster">
+                  <span className="meta-pill">{item.object_type}</span>
+                  <span>{item.title}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {renderSingleSection("Next action", brief.next_action)}
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -24,6 +24,7 @@ import {
   getThreadDetail,
   getThreadEvents,
   getThreadResumptionBrief,
+  getContinuityResumptionBrief,
   getThreadSessions,
   executeApproval,
   ingestCalendarEvent,
@@ -48,6 +49,7 @@ import {
   getTraceEvents,
   listThreads,
   listTraces,
+  queryContinuityRecall,
   pageModeLabel,
   resolveApproval,
   shouldExpectThreadExecutionReview,
@@ -2389,6 +2391,76 @@ describe("api helpers", () => {
         message: "task task-1 was not found",
         status: 404,
       }),
+    );
+  });
+
+  it("queries continuity recall with scoped filter parameters", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          items: [],
+          summary: {
+            query: "rollout",
+            filters: { thread_id: "thread-1", since: null, until: null },
+            limit: 20,
+            returned_count: 0,
+            total_count: 0,
+            order: ["relevance_desc", "created_at_desc", "id_desc"],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await queryContinuityRecall("https://api.example.com", "user-1", {
+      query: "rollout",
+      threadId: "thread-1",
+      project: "Project Phoenix",
+      person: "Alex",
+      limit: 20,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v0/continuity/recall?user_id=user-1&query=rollout&thread_id=thread-1&project=Project+Phoenix&person=Alex&limit=20",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
+  it("reads continuity resumption briefs with deterministic section limits", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          brief: {
+            assembly_version: "continuity_resumption_brief_v0",
+            scope: { thread_id: "thread-1", since: null, until: null },
+            last_decision: { item: null, empty_state: { is_empty: true, message: "none" } },
+            open_loops: {
+              items: [],
+              summary: { limit: 3, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+              empty_state: { is_empty: true, message: "none" },
+            },
+            recent_changes: {
+              items: [],
+              summary: { limit: 4, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+              empty_state: { is_empty: true, message: "none" },
+            },
+            next_action: { item: null, empty_state: { is_empty: true, message: "none" } },
+            sources: ["continuity_capture_events", "continuity_objects"],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await getContinuityResumptionBrief("https://api.example.com", "user-1", {
+      threadId: "thread-1",
+      maxRecentChanges: 4,
+      maxOpenLoops: 3,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v0/continuity/resumption-brief?user_id=user-1&thread_id=thread-1&max_recent_changes=4&max_open_loops=3",
+      expect.objectContaining({ cache: "no-store" }),
     );
   });
 });

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -929,6 +929,87 @@ export type ContinuityCaptureCreatePayload = {
   explicit_signal?: ContinuityCaptureExplicitSignal | null;
 };
 
+export type ContinuityRecallScopeKind = "thread" | "task" | "project" | "person";
+
+export type ContinuityRecallScopeMatch = {
+  kind: ContinuityRecallScopeKind;
+  value: string;
+};
+
+export type ContinuityRecallProvenanceReference = {
+  source_kind: string;
+  source_id: string;
+};
+
+export type ContinuityRecallOrdering = {
+  scope_match_count: number;
+  query_term_match_count: number;
+  confirmation_rank: number;
+  posture_rank: number;
+  confidence: number;
+};
+
+export type ContinuityRecallResult = {
+  id: string;
+  capture_event_id: string;
+  object_type: ContinuityObjectType;
+  status: string;
+  title: string;
+  body: JsonObject;
+  provenance: JsonObject;
+  confirmation_status: MemoryConfirmationStatus;
+  admission_posture: ContinuityCaptureAdmissionPosture;
+  confidence: number;
+  relevance: number;
+  scope_matches: ContinuityRecallScopeMatch[];
+  provenance_references: ContinuityRecallProvenanceReference[];
+  ordering: ContinuityRecallOrdering;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ContinuityRecallSummary = {
+  query: string | null;
+  filters: {
+    thread_id?: string;
+    task_id?: string;
+    project?: string;
+    person?: string;
+    since: string | null;
+    until: string | null;
+  };
+  limit: number;
+  returned_count: number;
+  total_count: number;
+  order: string[];
+};
+
+export type ContinuityResumptionEmptyState = {
+  is_empty: boolean;
+  message: string;
+};
+
+export type ContinuityResumptionSingleSection = {
+  item: ContinuityRecallResult | null;
+  empty_state: ContinuityResumptionEmptyState;
+};
+
+export type ContinuityResumptionListSection = {
+  items: ContinuityRecallResult[];
+  summary: ResumptionBriefSectionSummary;
+  empty_state: ContinuityResumptionEmptyState;
+};
+
+export type ContinuityResumptionBrief = {
+  assembly_version: string;
+  scope: ContinuityRecallSummary["filters"];
+  last_decision: ContinuityResumptionSingleSection;
+  open_loops: ContinuityResumptionListSection;
+  recent_changes: ContinuityResumptionListSection;
+  next_action: ContinuityResumptionSingleSection;
+  sources: string[];
+};
+
 export type OpenLoopCreatePayload = {
   user_id: string;
   memory_id?: string | null;
@@ -1379,6 +1460,104 @@ export function getThreadResumptionBrief(
           : undefined,
       max_memories:
         typeof options?.maxMemories === "number" ? String(Math.max(0, options.maxMemories)) : undefined,
+    },
+  );
+}
+
+export function queryContinuityRecall(
+  apiBaseUrl: string,
+  userId: string,
+  options?: {
+    query?: string;
+    threadId?: string;
+    taskId?: string;
+    project?: string;
+    person?: string;
+    since?: string;
+    until?: string;
+    limit?: number;
+  },
+) {
+  const query = options?.query?.trim();
+  const threadId = options?.threadId?.trim();
+  const taskId = options?.taskId?.trim();
+  const project = options?.project?.trim();
+  const person = options?.person?.trim();
+  const since = options?.since?.trim();
+  const until = options?.until?.trim();
+  const limit =
+    typeof options?.limit === "number" && Number.isFinite(options.limit) && options.limit > 0
+      ? String(Math.trunc(options.limit))
+      : undefined;
+
+  return requestJson<{ items: ContinuityRecallResult[]; summary: ContinuityRecallSummary }>(
+    apiBaseUrl,
+    "/v0/continuity/recall",
+    undefined,
+    {
+      user_id: userId,
+      query: query || undefined,
+      thread_id: threadId || undefined,
+      task_id: taskId || undefined,
+      project: project || undefined,
+      person: person || undefined,
+      since: since || undefined,
+      until: until || undefined,
+      limit,
+    },
+  );
+}
+
+export function getContinuityResumptionBrief(
+  apiBaseUrl: string,
+  userId: string,
+  options?: {
+    query?: string;
+    threadId?: string;
+    taskId?: string;
+    project?: string;
+    person?: string;
+    since?: string;
+    until?: string;
+    maxRecentChanges?: number;
+    maxOpenLoops?: number;
+  },
+) {
+  const query = options?.query?.trim();
+  const threadId = options?.threadId?.trim();
+  const taskId = options?.taskId?.trim();
+  const project = options?.project?.trim();
+  const person = options?.person?.trim();
+  const since = options?.since?.trim();
+  const until = options?.until?.trim();
+  const maxRecentChanges =
+    typeof options?.maxRecentChanges === "number" &&
+    Number.isFinite(options.maxRecentChanges) &&
+    options.maxRecentChanges >= 0
+      ? String(Math.trunc(options.maxRecentChanges))
+      : undefined;
+  const maxOpenLoops =
+    typeof options?.maxOpenLoops === "number" &&
+    Number.isFinite(options.maxOpenLoops) &&
+    options.maxOpenLoops >= 0
+      ? String(Math.trunc(options.maxOpenLoops))
+      : undefined;
+
+  return requestJson<{ brief: ContinuityResumptionBrief }>(
+    apiBaseUrl,
+    "/v0/continuity/resumption-brief",
+    undefined,
+    {
+      user_id: userId,
+      query: query || undefined,
+      thread_id: threadId || undefined,
+      task_id: taskId || undefined,
+      project: project || undefined,
+      person: person || undefined,
+      since: since || undefined,
+      until: until || undefined,
+      max_recent_changes: maxRecentChanges,
+      max_open_loops: maxOpenLoops,
     },
   );
 }

--- a/docs/phase5-product-spec.md
+++ b/docs/phase5-product-spec.md
@@ -249,9 +249,27 @@ Required metrics:
 - provenance-backed derived object visibility in capture detail
 - fast capture inbox surface (`/continuity`) with submit/list/detail
 
-## Explicitly Deferred After P5-S17
+## Shipped In P5-S18 (March 29, 2026)
 
-- P5-S18: broad recall UX and deterministic resumption-brief surfaces
+- provenance-backed recall API surface:
+  - `GET /v0/continuity/recall`
+  - scoped filters (`thread`, `task`, `project`, `person`, `since`, `until`)
+  - deterministic ordering metadata and confirmation/posture exposure
+- deterministic continuity resumption-brief API surface:
+  - `GET /v0/continuity/resumption-brief`
+  - always-present sections:
+    - `last_decision`
+    - `open_loops`
+    - `recent_changes`
+    - `next_action`
+  - explicit empty-state payloads for missing sections
+- `/continuity` workspace expansion for:
+  - recall query and results panel
+  - resumption-brief panel
+  - preserved capture inbox/detail behavior from P5-S17
+
+## Explicitly Deferred After P5-S18
+
 - P5-S19: memory correction queue, supersession workflow, freshness controls
 - P5-S20: daily/weekly open-loop review dashboards
 - keep docs and control-tower planning aligned with shipped behavior

--- a/docs/phase5-sprint-17-20-plan.md
+++ b/docs/phase5-sprint-17-20-plan.md
@@ -76,7 +76,7 @@ Recall and Resumption
 
 ### Status
 
-Deferred (not started in P5-S17).
+Shipped on March 29, 2026.
 
 ### Objective
 
@@ -95,6 +95,25 @@ Turn stored continuity into useful retrieval and deterministic resume artifacts.
 - provenance-backed result cards
 - resumption brief generator
 - what-changed view for scoped contexts
+
+### Implementation Snapshot
+
+- API:
+  - `GET /v0/continuity/recall`
+  - `GET /v0/continuity/resumption-brief`
+- Recall behavior:
+  - scoped filters (`thread`, `task`, `project`, `person`, time window)
+  - deterministic ordering (`relevance_desc`, `created_at_desc`, `id_desc`)
+  - provenance references and confirmation/admission posture in each result
+- Resumption behavior:
+  - deterministic section compiler over recall candidates
+  - always-present sections with explicit empty states
+    - `last_decision`
+    - `open_loops`
+    - `recent_changes`
+    - `next_action`
+- Web:
+  - `/continuity` now includes capture inbox/detail plus recall + resumption panels
 
 ### Acceptance Criteria
 

--- a/tests/integration/test_continuity_recall_api.py
+++ b/tests/integration/test_continuity_recall_api.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from typing import Any
+from urllib.parse import urlencode
+from uuid import UUID, uuid4
+
+import anyio
+import psycopg
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+from alicebot_api.db import user_connection
+from alicebot_api.store import ContinuityStore
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+
+        request_received = True
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def seed_user(database_url: str, *, email: str) -> UUID:
+    user_id = uuid4()
+    with user_connection(database_url, user_id) as conn:
+        ContinuityStore(conn).create_user(user_id, email, email.split("@", 1)[0].title())
+    return user_id
+
+
+def set_continuity_timestamps(
+    admin_database_url: str,
+    *,
+    continuity_object_id: UUID,
+    created_at: datetime,
+) -> None:
+    with psycopg.connect(admin_database_url, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE continuity_objects SET created_at = %s, updated_at = %s WHERE id = %s",
+                (created_at, created_at, continuity_object_id),
+            )
+
+
+def test_continuity_recall_api_returns_provenance_backed_scoped_results(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="owner@example.com")
+    intruder_id = seed_user(migrated_database_urls["app"], email="intruder@example.com")
+
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    task_id = UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+
+        capture_primary = store.create_continuity_capture_event(
+            raw_content="Decision: Keep rollout phased",
+            explicit_signal="decision",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_decision",
+        )
+        primary_object = store.create_continuity_object(
+            capture_event_id=capture_primary["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: Keep rollout phased",
+            body={"decision_text": "Keep rollout phased"},
+            provenance={
+                "thread_id": str(thread_id),
+                "task_id": str(task_id),
+                "project": "Project Phoenix",
+                "person": "Alex",
+                "confirmation_status": "confirmed",
+                "source_event_ids": ["event-1"],
+            },
+            confidence=0.95,
+        )
+
+        capture_other = store.create_continuity_capture_event(
+            raw_content="Decision: unrelated",
+            explicit_signal="decision",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_decision",
+        )
+        other_object = store.create_continuity_object(
+            capture_event_id=capture_other["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: unrelated",
+            body={"decision_text": "unrelated"},
+            provenance={
+                "thread_id": str(uuid4()),
+                "task_id": str(uuid4()),
+                "project": "Project Atlas",
+                "person": "Taylor",
+                "confirmation_status": "unconfirmed",
+                "source_event_ids": ["event-2"],
+            },
+            confidence=0.9,
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=primary_object["id"],
+        created_at=datetime(2026, 3, 29, 10, 0, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=other_object["id"],
+        created_at=datetime(2026, 3, 29, 9, 0, tzinfo=UTC),
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v0/continuity/recall",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "task_id": str(task_id),
+            "project": "Project Phoenix",
+            "person": "Alex",
+            "query": "rollout",
+            "since": "2026-03-29T09:30:00+00:00",
+            "until": "2026-03-29T11:00:00+00:00",
+            "limit": "20",
+        },
+    )
+
+    assert status == 200
+    assert payload["summary"] == {
+        "query": "rollout",
+        "filters": {
+            "thread_id": str(thread_id),
+            "task_id": str(task_id),
+            "project": "Project Phoenix",
+            "person": "Alex",
+            "since": "2026-03-29T09:30:00+00:00",
+            "until": "2026-03-29T11:00:00+00:00",
+        },
+        "limit": 20,
+        "returned_count": 1,
+        "total_count": 1,
+        "order": ["relevance_desc", "created_at_desc", "id_desc"],
+    }
+    assert payload["items"][0]["title"] == "Decision: Keep rollout phased"
+    assert payload["items"][0]["confirmation_status"] == "confirmed"
+    assert payload["items"][0]["admission_posture"] == "DERIVED"
+    assert payload["items"][0]["provenance_references"] == [
+        {"source_kind": "continuity_capture_event", "source_id": payload["items"][0]["capture_event_id"]},
+        {"source_kind": "source_event", "source_id": "event-1"},
+        {"source_kind": "task", "source_id": str(task_id)},
+        {"source_kind": "thread", "source_id": str(thread_id)},
+    ]
+
+    intruder_status, intruder_payload = invoke_request(
+        "GET",
+        "/v0/continuity/recall",
+        query_params={"user_id": str(intruder_id), "limit": "20"},
+    )
+    assert intruder_status == 200
+    assert intruder_payload == {
+        "items": [],
+        "summary": {
+            "query": None,
+            "filters": {"since": None, "until": None},
+            "limit": 20,
+            "returned_count": 0,
+            "total_count": 0,
+            "order": ["relevance_desc", "created_at_desc", "id_desc"],
+        },
+    }
+
+
+def test_continuity_recall_api_rejects_invalid_time_window(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="owner2@example.com")
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v0/continuity/recall",
+        query_params={
+            "user_id": str(user_id),
+            "since": "2026-03-29T11:00:00+00:00",
+            "until": "2026-03-29T10:00:00+00:00",
+            "limit": "20",
+        },
+    )
+
+    assert status == 400
+    assert payload == {"detail": "until must be greater than or equal to since"}

--- a/tests/integration/test_continuity_resumption_api.py
+++ b/tests/integration/test_continuity_resumption_api.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+from typing import Any
+from urllib.parse import urlencode
+from uuid import UUID, uuid4
+
+import anyio
+import psycopg
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+from alicebot_api.db import user_connection
+from alicebot_api.store import ContinuityStore
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+
+        request_received = True
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def seed_user(database_url: str, *, email: str) -> UUID:
+    user_id = uuid4()
+    with user_connection(database_url, user_id) as conn:
+        ContinuityStore(conn).create_user(user_id, email, email.split("@", 1)[0].title())
+    return user_id
+
+
+def set_continuity_timestamps(
+    admin_database_url: str,
+    *,
+    continuity_object_id: UUID,
+    created_at: datetime,
+) -> None:
+    with psycopg.connect(admin_database_url, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE continuity_objects SET created_at = %s, updated_at = %s WHERE id = %s",
+                (created_at, created_at, continuity_object_id),
+            )
+
+
+def test_continuity_resumption_api_returns_required_sections(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="owner@example.com")
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+
+        decision_capture = store.create_continuity_capture_event(
+            raw_content="Decision: Freeze API contract",
+            explicit_signal="decision",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_decision",
+        )
+        decision_object = store.create_continuity_object(
+            capture_event_id=decision_capture["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: Freeze API contract",
+            body={"decision_text": "Freeze API contract"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+        waiting_capture = store.create_continuity_capture_event(
+            raw_content="Waiting For: Vendor quote",
+            explicit_signal="waiting_for",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_waiting_for",
+        )
+        waiting_object = store.create_continuity_object(
+            capture_event_id=waiting_capture["id"],
+            object_type="WaitingFor",
+            status="active",
+            title="Waiting For: Vendor quote",
+            body={"waiting_for_text": "Vendor quote"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+        next_capture = store.create_continuity_capture_event(
+            raw_content="Next Action: Send approval email",
+            explicit_signal="next_action",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_next_action",
+        )
+        next_object = store.create_continuity_object(
+            capture_event_id=next_capture["id"],
+            object_type="NextAction",
+            status="active",
+            title="Next Action: Send approval email",
+            body={"action_text": "Send approval email"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+        latest_decision_capture = store.create_continuity_capture_event(
+            raw_content="Decision: Keep rollout phased",
+            explicit_signal="decision",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_decision",
+        )
+        latest_decision_object = store.create_continuity_object(
+            capture_event_id=latest_decision_capture["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: Keep rollout phased",
+            body={"decision_text": "Keep rollout phased"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=decision_object["id"],
+        created_at=datetime(2026, 3, 29, 9, 0, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=waiting_object["id"],
+        created_at=datetime(2026, 3, 29, 10, 0, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=next_object["id"],
+        created_at=datetime(2026, 3, 29, 10, 5, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=latest_decision_object["id"],
+        created_at=datetime(2026, 3, 29, 10, 10, tzinfo=UTC),
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v0/continuity/resumption-brief",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "max_recent_changes": "3",
+            "max_open_loops": "2",
+        },
+    )
+
+    assert status == 200
+    brief = payload["brief"]
+    assert brief["assembly_version"] == "continuity_resumption_brief_v0"
+    assert brief["last_decision"]["item"]["title"] == "Decision: Keep rollout phased"
+    assert brief["open_loops"]["summary"] == {
+        "limit": 2,
+        "returned_count": 1,
+        "total_count": 1,
+        "order": ["created_at_desc", "id_desc"],
+    }
+    assert [item["title"] for item in brief["recent_changes"]["items"]] == [
+        "Decision: Keep rollout phased",
+        "Next Action: Send approval email",
+        "Waiting For: Vendor quote",
+    ]
+    assert brief["next_action"]["item"]["title"] == "Next Action: Send approval email"
+
+
+def test_continuity_resumption_api_returns_explicit_empty_states(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="owner2@example.com")
+    task_id = UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        capture = store.create_continuity_capture_event(
+            raw_content="Note: context only",
+            explicit_signal="note",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_note",
+        )
+        continuity_object = store.create_continuity_object(
+            capture_event_id=capture["id"],
+            object_type="Note",
+            status="active",
+            title="Note: context only",
+            body={"body": "context only"},
+            provenance={"task_id": str(task_id)},
+            confidence=1.0,
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=continuity_object["id"],
+        created_at=datetime(2026, 3, 29, 9, 0, tzinfo=UTC),
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v0/continuity/resumption-brief",
+        query_params={
+            "user_id": str(user_id),
+            "task_id": str(task_id),
+            "max_recent_changes": "2",
+            "max_open_loops": "2",
+        },
+    )
+
+    assert status == 200
+    assert payload["brief"]["last_decision"] == {
+        "item": None,
+        "empty_state": {
+            "is_empty": True,
+            "message": "No decision found in the requested scope.",
+        },
+    }
+    assert payload["brief"]["open_loops"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No open loops found in the requested scope.",
+    }
+    assert payload["brief"]["next_action"] == {
+        "item": None,
+        "empty_state": {
+            "is_empty": True,
+            "message": "No next action found in the requested scope.",
+        },
+    }
+
+
+def test_continuity_resumption_api_selects_latest_sections_beyond_recall_limit(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="owner3@example.com")
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    base_time = datetime(2026, 3, 29, 8, 0, tzinfo=UTC)
+
+    historical_object_ids: list[UUID] = []
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+
+        for index in range(110):
+            capture = store.create_continuity_capture_event(
+                raw_content=f"Decision: historical {index}",
+                explicit_signal="decision",
+                admission_posture="DERIVED",
+                admission_reason="explicit_signal_decision",
+            )
+            continuity_object = store.create_continuity_object(
+                capture_event_id=capture["id"],
+                object_type="Decision",
+                status="active",
+                title=f"Decision: historical {index}",
+                body={"decision_text": f"historical {index}"},
+                provenance={"thread_id": str(thread_id)},
+                confidence=1.0,
+            )
+            historical_object_ids.append(continuity_object["id"])
+
+        latest_decision_capture = store.create_continuity_capture_event(
+            raw_content="Decision: newest low confidence",
+            explicit_signal="decision",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_decision",
+        )
+        latest_decision_object = store.create_continuity_object(
+            capture_event_id=latest_decision_capture["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: newest low confidence",
+            body={"decision_text": "newest low confidence"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=0.01,
+        )
+
+        latest_next_action_capture = store.create_continuity_capture_event(
+            raw_content="Next Action: newest low confidence",
+            explicit_signal="next_action",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_next_action",
+        )
+        latest_next_action_object = store.create_continuity_object(
+            capture_event_id=latest_next_action_capture["id"],
+            object_type="NextAction",
+            status="active",
+            title="Next Action: newest low confidence",
+            body={"action_text": "newest low confidence"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=0.01,
+        )
+
+    for index, continuity_object_id in enumerate(historical_object_ids):
+        set_continuity_timestamps(
+            migrated_database_urls["admin"],
+            continuity_object_id=continuity_object_id,
+            created_at=base_time + timedelta(minutes=index),
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=latest_decision_object["id"],
+        created_at=base_time + timedelta(minutes=200),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=latest_next_action_object["id"],
+        created_at=base_time + timedelta(minutes=201),
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v0/continuity/resumption-brief",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "max_recent_changes": "2",
+            "max_open_loops": "1",
+        },
+    )
+
+    assert status == 200
+    brief = payload["brief"]
+    assert brief["last_decision"]["item"]["title"] == "Decision: newest low confidence"
+    assert brief["next_action"]["item"]["title"] == "Next Action: newest low confidence"
+    assert [item["title"] for item in brief["recent_changes"]["items"]] == [
+        "Next Action: newest low confidence",
+        "Decision: newest low confidence",
+    ]

--- a/tests/unit/test_continuity_recall.py
+++ b/tests/unit/test_continuity_recall.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from alicebot_api.continuity_recall import ContinuityRecallValidationError, query_continuity_recall
+from alicebot_api.contracts import ContinuityRecallQueryInput
+
+
+class ContinuityRecallStoreStub:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+
+    def list_continuity_recall_candidates(self):
+        return list(self._rows)
+
+
+def make_candidate_row(
+    *,
+    title: str,
+    object_type: str,
+    capture_created_at: datetime,
+    confidence: float,
+    admission_posture: str = "DERIVED",
+    provenance: dict[str, object] | None = None,
+    body: dict[str, object] | None = None,
+) -> dict[str, object]:
+    object_id = uuid4()
+    capture_event_id = uuid4()
+    created_at = capture_created_at
+    updated_at = capture_created_at
+    return {
+        "id": object_id,
+        "user_id": UUID("11111111-1111-4111-8111-111111111111"),
+        "capture_event_id": capture_event_id,
+        "object_type": object_type,
+        "status": "active",
+        "title": title,
+        "body": body or {},
+        "provenance": provenance or {},
+        "confidence": confidence,
+        "object_created_at": created_at,
+        "object_updated_at": updated_at,
+        "admission_posture": admission_posture,
+        "admission_reason": "seeded",
+        "explicit_signal": None,
+        "capture_created_at": capture_created_at,
+    }
+
+
+def test_recall_returns_deterministic_order_and_provenance_fields() -> None:
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    task_id = UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    rows = [
+        make_candidate_row(
+            title="Decision: Keep conservative posture",
+            object_type="Decision",
+            capture_created_at=datetime(2026, 3, 29, 10, 5, tzinfo=UTC),
+            confidence=0.8,
+            provenance={
+                "thread_id": str(thread_id),
+                "task_id": str(task_id),
+                "confirmation_status": "confirmed",
+                "source_event_ids": ["event-1"],
+            },
+            body={"decision_text": "Keep conservative posture"},
+        ),
+        make_candidate_row(
+            title="Decision: Revisit tomorrow",
+            object_type="Decision",
+            capture_created_at=datetime(2026, 3, 29, 10, 10, tzinfo=UTC),
+            confidence=0.9,
+            provenance={
+                "thread_id": str(thread_id),
+                "task_id": str(task_id),
+                "confirmation_status": "unconfirmed",
+                "source_event_ids": ["event-2"],
+            },
+            body={"decision_text": "Revisit tomorrow"},
+        ),
+    ]
+
+    payload = query_continuity_recall(
+        ContinuityRecallStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityRecallQueryInput(
+            thread_id=thread_id,
+            task_id=task_id,
+            limit=20,
+        ),
+    )
+
+    assert payload["summary"] == {
+        "query": None,
+        "filters": {
+            "thread_id": str(thread_id),
+            "task_id": str(task_id),
+            "since": None,
+            "until": None,
+        },
+        "limit": 20,
+        "returned_count": 2,
+        "total_count": 2,
+        "order": ["relevance_desc", "created_at_desc", "id_desc"],
+    }
+    assert payload["items"][0]["title"] == "Decision: Keep conservative posture"
+    assert payload["items"][0]["confirmation_status"] == "confirmed"
+    assert payload["items"][0]["admission_posture"] == "DERIVED"
+    assert payload["items"][0]["scope_matches"] == [
+        {"kind": "thread", "value": str(thread_id).lower()},
+        {"kind": "task", "value": str(task_id).lower()},
+    ]
+    assert payload["items"][0]["provenance_references"] == [
+        {"source_kind": "continuity_capture_event", "source_id": payload["items"][0]["capture_event_id"]},
+        {"source_kind": "source_event", "source_id": "event-1"},
+        {"source_kind": "task", "source_id": str(task_id)},
+        {"source_kind": "thread", "source_id": str(thread_id)},
+    ]
+
+
+def test_recall_filters_project_person_query_and_time_window() -> None:
+    rows = [
+        make_candidate_row(
+            title="Next Action: Follow up with Alex on Phoenix",
+            object_type="NextAction",
+            capture_created_at=datetime(2026, 3, 29, 10, 30, tzinfo=UTC),
+            confidence=1.0,
+            provenance={"project": "Project Phoenix", "person": "Alex"},
+            body={"action_text": "Follow up with Alex"},
+        ),
+        make_candidate_row(
+            title="Next Action: Draft runway notes",
+            object_type="NextAction",
+            capture_created_at=datetime(2026, 3, 29, 8, 0, tzinfo=UTC),
+            confidence=1.0,
+            provenance={"project": "Project Atlas", "person": "Sam"},
+            body={"action_text": "Draft notes"},
+        ),
+    ]
+
+    payload = query_continuity_recall(
+        ContinuityRecallStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityRecallQueryInput(
+            query="follow up",
+            project="Project Phoenix",
+            person="Alex",
+            since=datetime(2026, 3, 29, 9, 0, tzinfo=UTC),
+            until=datetime(2026, 3, 29, 11, 0, tzinfo=UTC),
+            limit=20,
+        ),
+    )
+
+    assert [item["title"] for item in payload["items"]] == [
+        "Next Action: Follow up with Alex on Phoenix",
+    ]
+
+
+def test_recall_rejects_invalid_limits_and_time_window() -> None:
+    store = ContinuityRecallStoreStub([])
+
+    with pytest.raises(ContinuityRecallValidationError, match="limit must be between 1 and"):
+        query_continuity_recall(
+            store,  # type: ignore[arg-type]
+            user_id=UUID("11111111-1111-4111-8111-111111111111"),
+            request=ContinuityRecallQueryInput(limit=0),
+        )
+
+    with pytest.raises(ContinuityRecallValidationError, match="until must be greater than or equal to since"):
+        query_continuity_recall(
+            store,  # type: ignore[arg-type]
+            user_id=UUID("11111111-1111-4111-8111-111111111111"),
+            request=ContinuityRecallQueryInput(
+                since=datetime(2026, 3, 29, 12, 0, tzinfo=UTC),
+                until=datetime(2026, 3, 29, 11, 0, tzinfo=UTC),
+            ),
+        )

--- a/tests/unit/test_continuity_resumption.py
+++ b/tests/unit/test_continuity_resumption.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+from alicebot_api.continuity_resumption import compile_continuity_resumption_brief
+from alicebot_api.contracts import ContinuityResumptionBriefRequestInput
+
+
+class ContinuityResumptionStoreStub:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+
+    def list_continuity_recall_candidates(self):
+        return list(self._rows)
+
+
+def make_candidate_row(
+    *,
+    title: str,
+    object_type: str,
+    capture_created_at: datetime,
+    provenance: dict[str, object] | None = None,
+    confidence: float = 1.0,
+) -> dict[str, object]:
+    return {
+        "id": uuid4(),
+        "user_id": UUID("11111111-1111-4111-8111-111111111111"),
+        "capture_event_id": uuid4(),
+        "object_type": object_type,
+        "status": "active",
+        "title": title,
+        "body": {"text": title},
+        "provenance": provenance or {},
+        "confidence": confidence,
+        "object_created_at": capture_created_at,
+        "object_updated_at": capture_created_at,
+        "admission_posture": "DERIVED",
+        "admission_reason": "seeded",
+        "explicit_signal": None,
+        "capture_created_at": capture_created_at,
+    }
+
+
+def test_resumption_brief_includes_required_sections_deterministically() -> None:
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    rows = [
+        make_candidate_row(
+            title="Decision: Freeze API contract",
+            object_type="Decision",
+            capture_created_at=datetime(2026, 3, 29, 10, 0, tzinfo=UTC),
+            provenance={"thread_id": str(thread_id)},
+        ),
+        make_candidate_row(
+            title="Waiting For: Vendor quote",
+            object_type="WaitingFor",
+            capture_created_at=datetime(2026, 3, 29, 10, 5, tzinfo=UTC),
+            provenance={"thread_id": str(thread_id)},
+        ),
+        make_candidate_row(
+            title="Next Action: Send approval email",
+            object_type="NextAction",
+            capture_created_at=datetime(2026, 3, 29, 10, 6, tzinfo=UTC),
+            provenance={"thread_id": str(thread_id)},
+        ),
+        make_candidate_row(
+            title="Decision: Keep rollout phased",
+            object_type="Decision",
+            capture_created_at=datetime(2026, 3, 29, 10, 10, tzinfo=UTC),
+            provenance={"thread_id": str(thread_id)},
+        ),
+    ]
+
+    payload = compile_continuity_resumption_brief(
+        ContinuityResumptionStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityResumptionBriefRequestInput(
+            thread_id=thread_id,
+            max_recent_changes=3,
+            max_open_loops=2,
+        ),
+    )
+
+    brief = payload["brief"]
+
+    assert brief["last_decision"]["item"] is not None
+    assert brief["last_decision"]["item"]["title"] == "Decision: Keep rollout phased"
+    assert brief["open_loops"]["summary"] == {
+        "limit": 2,
+        "returned_count": 1,
+        "total_count": 1,
+        "order": ["created_at_desc", "id_desc"],
+    }
+    assert [item["title"] for item in brief["open_loops"]["items"]] == [
+        "Waiting For: Vendor quote",
+    ]
+    assert [item["title"] for item in brief["recent_changes"]["items"]] == [
+        "Decision: Keep rollout phased",
+        "Next Action: Send approval email",
+        "Waiting For: Vendor quote",
+    ]
+    assert brief["next_action"]["item"] is not None
+    assert brief["next_action"]["item"]["title"] == "Next Action: Send approval email"
+
+
+def test_resumption_brief_uses_explicit_empty_states_when_sections_are_missing() -> None:
+    task_id = UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    rows = [
+        make_candidate_row(
+            title="Note: Context only",
+            object_type="Note",
+            capture_created_at=datetime(2026, 3, 29, 9, 0, tzinfo=UTC),
+            provenance={"task_id": str(task_id)},
+        ),
+    ]
+
+    payload = compile_continuity_resumption_brief(
+        ContinuityResumptionStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityResumptionBriefRequestInput(
+            task_id=task_id,
+            max_recent_changes=2,
+            max_open_loops=2,
+        ),
+    )
+
+    brief = payload["brief"]
+
+    assert brief["last_decision"] == {
+        "item": None,
+        "empty_state": {
+            "is_empty": True,
+            "message": "No decision found in the requested scope.",
+        },
+    }
+    assert brief["open_loops"]["items"] == []
+    assert brief["open_loops"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No open loops found in the requested scope.",
+    }
+    assert brief["next_action"] == {
+        "item": None,
+        "empty_state": {
+            "is_empty": True,
+            "message": "No next action found in the requested scope.",
+        },
+    }
+
+
+def test_resumption_brief_uses_full_scoped_set_instead_of_recall_limit() -> None:
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    base_time = datetime(2026, 3, 29, 8, 0, tzinfo=UTC)
+    rows: list[dict[str, object]] = []
+
+    for index in range(110):
+        rows.append(
+            make_candidate_row(
+                title=f"Decision: historical {index}",
+                object_type="Decision",
+                capture_created_at=base_time + timedelta(minutes=index),
+                provenance={"thread_id": str(thread_id)},
+                confidence=1.0,
+            )
+        )
+
+    rows.append(
+        make_candidate_row(
+            title="Decision: newest low confidence",
+            object_type="Decision",
+            capture_created_at=base_time + timedelta(minutes=200),
+            provenance={"thread_id": str(thread_id)},
+            confidence=0.01,
+        )
+    )
+    rows.append(
+        make_candidate_row(
+            title="Next Action: newest low confidence",
+            object_type="NextAction",
+            capture_created_at=base_time + timedelta(minutes=201),
+            provenance={"thread_id": str(thread_id)},
+            confidence=0.01,
+        )
+    )
+
+    payload = compile_continuity_resumption_brief(
+        ContinuityResumptionStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityResumptionBriefRequestInput(
+            thread_id=thread_id,
+            max_recent_changes=2,
+            max_open_loops=1,
+        ),
+    )
+
+    brief = payload["brief"]
+    assert brief["last_decision"]["item"] is not None
+    assert brief["last_decision"]["item"]["title"] == "Decision: newest low confidence"
+    assert brief["next_action"]["item"] is not None
+    assert brief["next_action"]["item"]["title"] == "Next Action: newest low confidence"
+    assert [item["title"] for item in brief["recent_changes"]["items"]] == [
+        "Next Action: newest low confidence",
+        "Decision: newest low confidence",
+    ]


### PR DESCRIPTION
## Summary
- add continuity recall API/contracts/store/compiler with deterministic scoped ordering and provenance exposure
- add deterministic continuity resumption brief compiler/API and required section empty-state behavior
- add continuity recall/resumption UI panels, tests, and synced sprint docs/reports

## Verification
- Review verdict: PASS (REVIEW_REPORT.md)
- Backend acceptance command: PASS
- Web acceptance command: PASS
- Phase 4 regression matrix: PASS
- Control Tower decision: MERGE_APPROVED