### PR TITLE
Phase 5 Sprint 20: Open loops and daily review

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 5 Sprint 19 (P5-S19): Memory Review, Correction, and Freshness
+Phase 5 Sprint 20 (P5-S20): Open Loops and Daily Review
 
 ## Sprint Type
 
@@ -10,24 +10,24 @@ feature
 
 ## Sprint Reason
 
-P5-S18 shipped deterministic recall/resumption, but trust still depends on explicit correction. The next non-redundant step is a continuity review/correction path that updates retrieval behavior immediately and preserves historical truth.
+P5-S19 shipped review/correction/freshness, but continuity still needs a deterministic executive-function surface. The next non-redundant step is open-loop review and deterministic daily/weekly briefing built on shipped continuity and correction contracts.
 
 ## Sprint Intent
 
-Ship continuity review queue and correction-event workflows (confirm/edit/delete/supersede/mark_stale) with immediate recall/resumption impact, explicit freshness metadata, and preserved supersession history.
+Ship continuity open-loop dashboard plus deterministic daily/weekly review briefs with review actions (`done`, `deferred`, `still_blocked`) that immediately update resumption behavior.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase5-sprint-19-memory-review-correction-freshness`
+- Branch Name: `codex/phase5-sprint-20-open-loops-daily-review`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint
 
-- It closes the trust loop: corrections now change future retrieval deterministically.
-- It is the planned Phase 5 step after P5-S18 recall/resumption.
-- It avoids redundant scope by not reopening capture or recall/resumption implementation.
+- It turns continuity into daily execution support, not just memory correctness.
+- It is the planned final Phase 5 step after P5-S19 correction/freshness.
+- It avoids redundant scope by not reopening capture, recall/resumption, or correction architecture.
 
 ## Redundancy Guard
 
@@ -40,52 +40,64 @@ Ship continuity review queue and correction-event workflows (confirm/edit/delete
   - provenance-backed recall (`GET /v0/continuity/recall`)
   - deterministic resumption briefs (`GET /v0/continuity/resumption-brief`)
   - `/continuity` recall/resumption panels
-- Required now (P5-S19):
-  - review queue for correction-ready continuity objects
-  - correction event ledger + lifecycle transitions
-  - retrieval/resumption behavior that reflects corrections immediately
-  - superseded-chain visibility and freshness posture
-- Explicitly out of P5-S19:
-  - daily/weekly open-loop dashboard (P5-S20)
-  - channel/connector/platform expansion
+- Already shipped in P5-S19:
+  - continuity review queue (`GET /v0/continuity/review-queue`)
+  - review detail + correction actions
+  - append-only correction event ledger
+  - immediate correction impact on recall/resumption
+- Required now (P5-S20):
+  - open-loop dashboard for waiting-for/blocker/stale/next-action posture
+  - deterministic daily brief and weekly review endpoints
+  - review-action workflow (`done`, `deferred`, `still_blocked`)
+  - immediate resumption refresh after review actions
+- Explicitly out of P5-S20:
+  - connector/channel/platform expansion
+  - new memory backbone or recall ranking redesign
 
 ## Design Truth
 
-- Corrections are append-only events; no silent overwrite of history.
-- Corrected objects must affect next recall/resumption output immediately.
-- Supersession must preserve chain links (`supersedes`/`superseded_by`) for auditability.
-- Freshness posture must be explicit (`last_confirmed_at` and stale status behavior).
-- Confirmed/unconfirmed/stale/superseded posture must remain visible in API/UI.
+- Daily/weekly briefs must be deterministic for fixed input state.
+- Open-loop posture must be explicit and auditable:
+  - waiting_for
+  - blocker
+  - stale
+  - next_action
+- Review actions must map to deterministic lifecycle transitions.
+- Resumption must reflect review actions immediately.
+- Empty brief sections must be explicit empty states.
 
 ## Exact Surfaces In Scope
 
-- continuity review queue API and correction-action API
-- correction event persistence + continuity object lifecycle transitions
-- recall/resumption integration for corrected/superseded/stale objects
-- continuity workspace review/correction UI
-- tests for deterministic correction and supersession behavior
+- continuity open-loop dashboard API
+- deterministic daily brief API
+- deterministic weekly review API
+- review-action mutation API for open loops
+- continuity workspace open-loop/brief UI
+- tests for deterministic brief composition and action transitions
 
 ## Exact Files In Scope
 
-- `apps/api/alembic/versions/20260330_0042_phase5_continuity_corrections.py`
 - `apps/api/src/alicebot_api/contracts.py`
 - `apps/api/src/alicebot_api/store.py`
 - `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/continuity_open_loops.py`
 - `apps/api/src/alicebot_api/continuity_review.py`
-- `apps/api/src/alicebot_api/continuity_recall.py`
 - `apps/api/src/alicebot_api/continuity_resumption.py`
+- `apps/api/src/alicebot_api/memory.py`
 - `apps/web/lib/api.ts`
 - `apps/web/lib/api.test.ts`
 - `apps/web/app/continuity/page.tsx`
 - `apps/web/app/continuity/page.test.tsx`
-- `apps/web/components/continuity-review-queue.tsx`
-- `apps/web/components/continuity-review-queue.test.tsx`
-- `apps/web/components/continuity-correction-form.tsx`
-- `apps/web/components/continuity-correction-form.test.tsx`
-- `tests/unit/test_20260330_0042_phase5_continuity_corrections.py`
+- `apps/web/components/continuity-open-loops-panel.tsx`
+- `apps/web/components/continuity-open-loops-panel.test.tsx`
+- `apps/web/components/continuity-daily-brief.tsx`
+- `apps/web/components/continuity-daily-brief.test.tsx`
+- `apps/web/components/continuity-weekly-review.tsx`
+- `apps/web/components/continuity-weekly-review.test.tsx`
+- `tests/unit/test_continuity_open_loops.py`
+- `tests/integration/test_continuity_open_loops_api.py`
+- `tests/integration/test_continuity_daily_weekly_review_api.py`
 - `tests/unit/test_continuity_review.py`
-- `tests/integration/test_continuity_review_api.py`
-- `tests/unit/test_continuity_recall.py`
 - `tests/unit/test_continuity_resumption.py`
 - `docs/phase5-product-spec.md`
 - `docs/phase5-sprint-17-20-plan.md`
@@ -98,87 +110,93 @@ Ship continuity review queue and correction-event workflows (confirm/edit/delete
 
 ## In Scope
 
-- Add correction-event model and persistence for:
-  - confirm
-  - edit
-  - delete
-  - supersede
-  - mark_stale
-- Add review queue endpoint for correction-ready continuity objects.
-- Add correction action endpoint(s) on continuity objects.
-- Add object-lifecycle fields required for correction/freshness semantics.
-- Ensure recall/resumption treat superseded/deleted/stale posture deterministically.
+- Add open-loop dashboard endpoint with deterministic grouping and ordering.
+- Add daily brief endpoint that composes:
+  - waiting_for highlights
+  - blocker highlights
+  - stale items
+  - one next suggested action
+- Add weekly review endpoint with deterministic rollup for open-loop posture.
+- Add review-action endpoint for open-loop workflow:
+  - done
+  - deferred
+  - still_blocked
+- Ensure review actions update continuity resumption output immediately.
 - Add continuity UI surfaces for:
-  - review queue list/filter
-  - correction action submit/feedback
-  - superseded-chain visibility on reviewed object detail
+  - open-loop dashboard list/group review
+  - daily brief panel
+  - weekly review panel
+  - review-action controls with explicit outcome feedback
 
 ## Out of Scope
 
-- daily/weekly open-loop dashboard and briefing generation
-- broad cross-connector memory normalization
-- broad `/memories` redesign outside continuity workspace
+- reimplementation of P5-S17 capture backbone
+- reimplementation of P5-S18 recall/resumption ranking contracts
+- reimplementation of P5-S19 correction-event architecture
+- broad `/memories` or `/tasks` redesign outside continuity workspace
 - connector breadth changes
 - broad runtime architecture changes
 
 ## Required Deliverables
 
-- continuity correction event schema + store contracts
-- continuity review queue + correction action APIs
-- recall/resumption correction-awareness updates
-- continuity review/correction UI surfaces
-- unit/integration/web tests for deterministic correction/supersession behavior
+- continuity open-loop dashboard API + deterministic ordering behavior
+- deterministic daily brief and weekly review APIs
+- open-loop review-action mutation API
+- continuity open-loop/daily/weekly UI surfaces
+- unit/integration/web tests for deterministic brief/action behavior
 - synced docs and sprint reports
 
 ## Acceptance Criteria
 
-- correction actions append correction events before lifecycle state mutation.
-- confirm/edit/delete/supersede/mark_stale actions are deterministic for fixed input state.
-- recall and resumption reflect corrections immediately after action commit.
-- superseded chain is queryable and visible in continuity review detail.
-- freshness posture is explicit in API responses (`last_confirmed_at`, status transitions).
-- `./.venv/bin/python -m pytest tests/unit/test_20260330_0042_phase5_continuity_corrections.py tests/unit/test_continuity_review.py tests/integration/test_continuity_review_api.py tests/unit/test_continuity_recall.py tests/unit/test_continuity_resumption.py -q` passes.
-- `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-review-queue.test.tsx components/continuity-correction-form.test.tsx lib/api.test.ts` passes.
+- open-loop dashboard returns deterministic grouped ordering for waiting_for/blocker/stale/next_action posture.
+- daily brief and weekly review endpoints are deterministic for fixed input state and emit explicit empty states when sections are empty.
+- `done`/`deferred`/`still_blocked` actions are deterministic and auditable.
+- continuity resumption reflects review-action outcomes immediately.
+- `./.venv/bin/python -m pytest tests/unit/test_continuity_open_loops.py tests/integration/test_continuity_open_loops_api.py tests/integration/test_continuity_daily_weekly_review_api.py tests/unit/test_continuity_review.py tests/unit/test_continuity_resumption.py -q` passes.
+- `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-open-loops-panel.test.tsx components/continuity-daily-brief.test.tsx components/continuity-weekly-review.test.tsx lib/api.test.ts` passes.
 - `python3 scripts/run_phase4_validation_matrix.py` remains PASS (no Phase 4 regression).
-- `README.md`, `ROADMAP.md`, and `.ai/handoff/CURRENT_STATE.md` reflect active P5-S19 scope.
+- `README.md`, `ROADMAP.md`, and `.ai/handoff/CURRENT_STATE.md` reflect active P5-S20 scope.
 
 ## Implementation Constraints
 
 - do not introduce new dependencies
 - preserve P5-S17 capture/backbone semantics
 - preserve P5-S18 recall/resumption contracts
-- keep correction events append-only and machine-auditable
+- preserve P5-S19 correction-event semantics
+- keep brief composition deterministic and machine-auditable
 - keep docs machine-independent
 
 ## Control Tower Task Cards
 
-### Task 1: Schema + Store Corrections
+### Task 1: Open-Loop Backend
 
 Owner: tooling operative
 
 Write scope:
 
-- `apps/api/alembic/versions/20260330_0042_phase5_continuity_corrections.py`
+- `apps/api/src/alicebot_api/continuity_open_loops.py`
 - `apps/api/src/alicebot_api/store.py`
-- `tests/unit/test_20260330_0042_phase5_continuity_corrections.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `tests/unit/test_continuity_open_loops.py`
+- `tests/integration/test_continuity_open_loops_api.py`
 
-### Task 2: Review + Correction API
+### Task 2: Daily/Weekly Brief + Actions API
 
 Owner: tooling operative
 
 Write scope:
 
+- `apps/api/src/alicebot_api/continuity_open_loops.py`
 - `apps/api/src/alicebot_api/continuity_review.py`
 - `apps/api/src/alicebot_api/main.py`
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/continuity_recall.py`
 - `apps/api/src/alicebot_api/continuity_resumption.py`
+- `apps/api/src/alicebot_api/memory.py`
+- `tests/integration/test_continuity_daily_weekly_review_api.py`
 - `tests/unit/test_continuity_review.py`
-- `tests/integration/test_continuity_review_api.py`
-- `tests/unit/test_continuity_recall.py`
 - `tests/unit/test_continuity_resumption.py`
 
-### Task 3: Continuity Review UI
+### Task 3: Open-Loop/Daily/Weekly UI
 
 Owner: tooling operative
 
@@ -188,10 +206,12 @@ Write scope:
 - `apps/web/lib/api.test.ts`
 - `apps/web/app/continuity/page.tsx`
 - `apps/web/app/continuity/page.test.tsx`
-- `apps/web/components/continuity-review-queue.tsx`
-- `apps/web/components/continuity-review-queue.test.tsx`
-- `apps/web/components/continuity-correction-form.tsx`
-- `apps/web/components/continuity-correction-form.test.tsx`
+- `apps/web/components/continuity-open-loops-panel.tsx`
+- `apps/web/components/continuity-open-loops-panel.test.tsx`
+- `apps/web/components/continuity-daily-brief.tsx`
+- `apps/web/components/continuity-daily-brief.test.tsx`
+- `apps/web/components/continuity-weekly-review.tsx`
+- `apps/web/components/continuity-weekly-review.test.tsx`
 
 ### Task 4: Docs + Integration Review
 
@@ -209,31 +229,31 @@ Write scope:
 
 Responsibilities:
 
-- verify no capture or recall/resumption reimplementation
-- verify no P5-S20 dashboard scope creep
-- verify deterministic correction behavior and supersession chain visibility
+- verify no capture/recall/correction reimplementation
+- verify no connector breadth or orchestration scope creep
+- verify deterministic brief composition and review-action transitions
 - verify no Phase 4 regression
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
 
-- exact correction/freshness delta
-- exact correction-event and lifecycle transition behavior
+- exact open-loop/daily/weekly delta
+- exact brief composition and review-action behavior
 - exact verification command outcomes
-- explicit deferred Phase 5 scope (P5-S20 work)
+- explicit post-Phase-5 deferred scope (if any)
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
 
-- sprint stayed P5-S19 scoped
-- correction events are append-only and audit-safe
-- recall/resumption behavior reflects correction/supersession immediately
-- superseded/freshness posture is visible and deterministic
+- sprint stayed P5-S20 scoped
+- open-loop dashboard and daily/weekly briefs are deterministic
+- review actions map to deterministic lifecycle outcomes
+- resumption reflects review-action updates immediately
 - no hidden scope expansion
 - Phase 4 validation remains green
 
 ## Exit Condition
 
-This sprint is complete when continuity review and correction flows (confirm/edit/delete/supersede/mark_stale) are shipped with immediate recall/resumption impact, explicit freshness/supersession posture, and no Phase 4 regression.
+This sprint is complete when continuity open-loop dashboard plus deterministic daily/weekly review flows are shipped with deterministic review-action outcomes and no Phase 4 regression.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -4,7 +4,7 @@
 
 - The canonical baseline remains through Phase 3 Sprint 9.
 - Earlier Phase 4 work is already delivered: task-run linkage to approvals/executions, idempotent proxy execution replay guards, approval pause/resume continuity for linked runs, run transition observability, explicit stop reasons, bounded retries with persisted posture, explicit failure classes, and deterministic Phase 4 gate runners.
-- Active Sprint focus is Phase 4 Sprint 14 release-control ownership as canonical baseline. Current delivery has advanced through Phase 5 Sprint 19 continuity review/correction/freshness on top of completed Phase 5 Sprint 17 capture backbone, completed Phase 5 Sprint 18 recall/resumption, and completed Phase 4 Sprint 14-19 release-control/sign-off delivery.
+- Active Sprint focus is Phase 4 Sprint 14 release-control ownership as canonical baseline. Current delivery has advanced through Phase 5 Sprint 20 open-loop daily/weekly continuity delivery on top of completed Phase 5 Sprint 17 capture backbone, completed Phase 5 Sprint 18 recall/resumption, completed Phase 5 Sprint 19 review/correction/freshness, and completed Phase 4 Sprint 14-19 release-control/sign-off delivery.
 - The accepted baseline includes deterministic Phase 3 gate entrypoints: `python3 scripts/run_phase3_acceptance.py`, `python3 scripts/run_phase3_readiness_gates.py`, and `python3 scripts/run_phase3_validation_matrix.py` (default go/no-go command).
 - Phase 4 gate entrypoints are `python3 scripts/run_phase4_acceptance.py`, `python3 scripts/run_phase4_readiness_gates.py`, and `python3 scripts/run_phase4_validation_matrix.py`.
 - Phase 4 release-candidate rehearsal entrypoint is `python3 scripts/run_phase4_release_candidate.py`, which writes latest summary evidence at `artifacts/release/phase4_rc_summary.json` and appends retained archive/index evidence under `artifacts/release/archive/` for repeated-run audit, with deterministic archive index lock path `artifacts/release/archive/index.lock`, bounded lock-timeout failure contract, and atomic index replace writes.
@@ -31,14 +31,23 @@
   - `POST /v0/continuity/review-queue/{continuity_object_id}/corrections` applies deterministic `confirm`/`edit`/`delete`/`supersede`/`mark_stale` actions.
   - correction events are append-only and persisted before lifecycle mutation.
   - continuity recall/resumption now reflects correction posture immediately, including freshness/supersession metadata (`last_confirmed_at`, `supersedes_object_id`, `superseded_by_object_id`) and deleted-object exclusion from recall payloads.
+- Phase 5 Sprint 20 adds deterministic open-loop review and briefing seams:
+  - `GET /v0/continuity/open-loops` returns grouped posture sections (`waiting_for`, `blocker`, `stale`, `next_action`) with deterministic ordering metadata.
+  - `GET /v0/continuity/daily-brief` returns deterministic daily sections (`waiting_for_highlights`, `blocker_highlights`, `stale_items`, `next_suggested_action`) with explicit empty states.
+  - `GET /v0/continuity/weekly-review` returns deterministic grouped sections plus posture rollup counts.
+  - `POST /v0/continuity/open-loops/{continuity_object_id}/review-action` applies deterministic `done`/`deferred`/`still_blocked` actions with auditable correction-event payload mapping.
+  - continuity resumption reflects open-loop review-action outcomes immediately.
 - `apps/web` is also a shipped surface now. The operator shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live reads when API config is present and explicit fixture fallback when it is not.
 - `/chat` now ships assistant-response mode, governed-request mode, visible thread selection, compact thread creation, selected-thread transcript continuity, deterministic resumption brief review, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, manual explicit-signal capture controls for selected `message.user` events, and bounded supporting continuity review over thread sessions and events.
-- `/continuity` now ships the Phase 5 Sprint 17 + Sprint 18 + Sprint 19 continuity workspace:
+- `/continuity` now ships the Phase 5 Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 continuity workspace:
   - capture submit (optional explicit signal), recent capture list, and capture detail with posture/provenance
   - recall query/results panel with scoped filters and provenance-backed result cards
   - deterministic resumption-brief panel with always-present required sections
   - review queue list/filter panel
   - selected-object correction form with correction-event history and supersession chain visibility
+  - open-loop dashboard grouped by waiting-for/blocker/stale/next-action posture
+  - daily brief panel and weekly review panel with explicit empty-state rendering
+  - open-loop review-action controls (`done`, `deferred`, `still_blocked`) with immediate page refresh feedback
 - `/gmail` ships a bounded Gmail operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-message ingestion into one selected task workspace.
 - `/calendar` ships a bounded Calendar operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-event ingestion into one selected task workspace. The shipped API baseline now also includes bounded read-only event discovery for one selected account (`GET /v0/calendar-accounts/{calendar_account_id}/events`) with deterministic ordering metadata and bounded limits.
 - `/memories` ships a bounded memory review workspace: active/queue list posture, selected memory detail, revision review, and memory-label review/submit seams with explicit live/fixture/unavailable states.
@@ -61,7 +70,7 @@
 - Auth is still incomplete beyond database user context.
 - Connector breadth, richer parsing, and orchestration are still deferred; docs must stay synchronized with the shipped API-plus-web baseline, including `/gmail` and `/calendar`, so planning does not drift again.
 - Phase 5 remaining scope:
-  - Sprint 20 open-loop daily/weekly review dashboards remains deferred.
+  - none from Sprint 17-20 continuity plan; post-Phase-5 scope should be opened explicitly in a new packet.
 
 ## Repo Evidence To Trust
 
@@ -70,7 +79,7 @@
 - Web `/chat` continuity + workflow/timeline/explainability adoption: `apps/web/app/chat/page.tsx`, `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`, `apps/web/components/thread-event-list.tsx`, `apps/web/components/response-composer.tsx`, `apps/web/components/thread-workflow-panel.tsx`, `apps/web/components/task-step-list.tsx`, `apps/web/components/response-history.tsx`, `apps/web/components/thread-trace-panel.tsx`, and matching component tests.
 - Web review workspaces added through the accepted Sprint 6P/6Q/6R sequence: `apps/web/app/memories/page.tsx`, `apps/web/app/memories/page.test.tsx`, `apps/web/app/entities/page.tsx`, `apps/web/app/entities/page.test.tsx`, `apps/web/app/artifacts/page.tsx`, `apps/web/app/artifacts/page.test.tsx`.
 - Web Gmail and Calendar workspaces: `apps/web/app/gmail/page.tsx`, `apps/web/app/calendar/page.tsx`, `apps/web/lib/api.ts`, `apps/web/lib/api.test.ts`, `apps/web/components/gmail-account-list.test.tsx`, `apps/web/components/calendar-account-list.test.tsx`, `apps/web/components/calendar-event-ingest-form.test.tsx`
-- Web continuity workspace + retrieval/resumption/review surfaces: `apps/web/app/continuity/page.tsx`, `apps/web/app/continuity/page.test.tsx`, `apps/web/components/continuity-recall-panel.tsx`, `apps/web/components/continuity-recall-panel.test.tsx`, `apps/web/components/resumption-brief.tsx`, `apps/web/components/resumption-brief.test.tsx`, `apps/web/components/continuity-review-queue.tsx`, `apps/web/components/continuity-review-queue.test.tsx`, `apps/web/components/continuity-correction-form.tsx`, `apps/web/components/continuity-correction-form.test.tsx`
+- Web continuity workspace + retrieval/resumption/review/open-loop briefing surfaces: `apps/web/app/continuity/page.tsx`, `apps/web/app/continuity/page.test.tsx`, `apps/web/components/continuity-recall-panel.tsx`, `apps/web/components/continuity-recall-panel.test.tsx`, `apps/web/components/resumption-brief.tsx`, `apps/web/components/resumption-brief.test.tsx`, `apps/web/components/continuity-review-queue.tsx`, `apps/web/components/continuity-review-queue.test.tsx`, `apps/web/components/continuity-correction-form.tsx`, `apps/web/components/continuity-correction-form.test.tsx`, `apps/web/components/continuity-open-loops-panel.tsx`, `apps/web/components/continuity-open-loops-panel.test.tsx`, `apps/web/components/continuity-daily-brief.tsx`, `apps/web/components/continuity-daily-brief.test.tsx`, `apps/web/components/continuity-weekly-review.tsx`, `apps/web/components/continuity-weekly-review.test.tsx`
 - Shell route inventory and discoverability: `apps/web/components/app-shell.tsx`, `apps/web/app/page.tsx`
 
 ## Planning Guardrails

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,140 +1,103 @@
 # BUILD_REPORT.md
 
 ## Sprint Objective
-Implement Phase 5 Sprint 19 (P5-S19): ship continuity memory review/correction flows (`confirm`, `edit`, `delete`, `supersede`, `mark_stale`) with explicit freshness/supersession posture and immediate recall/resumption impact.
+Implement Phase 5 Sprint 20 (P5-S20): ship continuity open-loop dashboard, deterministic daily/weekly review briefs, and deterministic open-loop review actions (`done`, `deferred`, `still_blocked`) that update continuity resumption behavior immediately.
 
 ## Completed Work
-- Added migration `20260330_0042_phase5_continuity_corrections.py`:
-  - lifecycle/freshness columns on `continuity_objects`:
-    - `last_confirmed_at`
-    - `supersedes_object_id`
-    - `superseded_by_object_id`
-  - status check expansion to include `deleted`
-  - append-only `continuity_correction_events` table
-  - append-only trigger for correction-event immutability
-  - RLS policies and indexes for review/correction reads.
-- Added review/correction contracts and constants in `apps/api/src/alicebot_api/contracts.py`:
-  - correction actions and review status filters
-  - review queue/detail/correction response records
-  - recall ordering metadata includes lifecycle posture rank
-  - recall records include freshness/supersession fields.
-- Added review/correction store seams in `apps/api/src/alicebot_api/store.py`:
-  - list/count review queue
-  - get/update continuity object
-  - append/list correction events.
-- Added review/correction backend compiler in `apps/api/src/alicebot_api/continuity_review.py`:
-  - queue list/detail behavior
-  - deterministic correction transitions
-  - supersession-chain lookup
-  - correction-event append before lifecycle mutation.
-- Added API routes in `apps/api/src/alicebot_api/main.py`:
-  - `GET /v0/continuity/review-queue`
-  - `GET /v0/continuity/review-queue/{continuity_object_id}`
-  - `POST /v0/continuity/review-queue/{continuity_object_id}/corrections`.
-- Updated recall/resumption behavior:
-  - `apps/api/src/alicebot_api/continuity_recall.py`:
-    - excludes `deleted` from recall output
-    - lifecycle rank added to deterministic ordering metadata
-    - emits `last_confirmed_at` / supersession linkage fields.
-  - `apps/api/src/alicebot_api/continuity_resumption.py`:
-    - primary sections keep active truth
-    - recent changes preserve lifecycle posture visibility.
-- Added/updated backend tests:
-  - `tests/unit/test_20260330_0042_phase5_continuity_corrections.py`
-  - `tests/unit/test_continuity_review.py`
-  - `tests/integration/test_continuity_review_api.py`
-  - `tests/unit/test_continuity_recall.py`
-  - `tests/unit/test_continuity_resumption.py`.
-- Added/updated web continuity review surfaces:
-  - `apps/web/components/continuity-review-queue.tsx`
-  - `apps/web/components/continuity-correction-form.tsx`
-  - `apps/web/app/continuity/page.tsx`
+- Added P5-S20 continuity contracts in `apps/api/src/alicebot_api/contracts.py`:
+  - open-loop posture/action literals
+  - request/response types for dashboard, daily brief, weekly review, and review-action mutation
+  - deterministic ordering constants and limit defaults.
+- Added new backend compiler/mutation module `apps/api/src/alicebot_api/continuity_open_loops.py` with deterministic behavior:
+  - open-loop posture grouping: `waiting_for`, `blocker`, `stale`, `next_action`
+  - deterministic item ordering: `created_at_desc`, `id_desc`
+  - explicit empty-state payloads in all sections
+  - deterministic daily brief composition:
+    - `waiting_for_highlights`
+    - `blocker_highlights`
+    - `stale_items`
+    - `next_suggested_action`
+  - deterministic weekly review composition with posture rollup counts
+  - open-loop review-action transitions with auditable correction-event payload mapping:
+    - `done` -> lifecycle `completed`
+    - `deferred` -> lifecycle `stale`
+    - `still_blocked` -> lifecycle `active` with refreshed confirmation timestamp.
+- Added P5-S20 API routes in `apps/api/src/alicebot_api/main.py`:
+  - `GET /v0/continuity/open-loops`
+  - `GET /v0/continuity/daily-brief`
+  - `GET /v0/continuity/weekly-review`
+  - `POST /v0/continuity/open-loops/{continuity_object_id}/review-action`.
+- Added backend tests:
+  - `tests/unit/test_continuity_open_loops.py`
+  - `tests/integration/test_continuity_open_loops_api.py`
+  - `tests/integration/test_continuity_daily_weekly_review_api.py`
+  - updated `tests/unit/test_continuity_resumption.py` with open-loop lifecycle filtering coverage after action outcomes.
+- Extended web API client and tests:
   - `apps/web/lib/api.ts`
-  - matching tests in `app/continuity/page.test.tsx`, `components/continuity-review-queue.test.tsx`, `components/continuity-correction-form.test.tsx`, and `lib/api.test.ts`.
-- Updated existing continuity web tests impacted by recall contract expansion:
-  - `apps/web/components/continuity-recall-panel.test.tsx`
-  - `apps/web/components/resumption-brief.test.tsx`.
-- Synced sprint-scoped docs:
+  - `apps/web/lib/api.test.ts`.
+- Added continuity UI surfaces and tests:
+  - `apps/web/components/continuity-open-loops-panel.tsx`
+  - `apps/web/components/continuity-open-loops-panel.test.tsx`
+  - `apps/web/components/continuity-daily-brief.tsx`
+  - `apps/web/components/continuity-daily-brief.test.tsx`
+  - `apps/web/components/continuity-weekly-review.tsx`
+  - `apps/web/components/continuity-weekly-review.test.tsx`.
+- Integrated new surfaces into continuity workspace page and tests:
+  - `apps/web/app/continuity/page.tsx`
+  - `apps/web/app/continuity/page.test.tsx`.
+- Synced sprint-listed docs for shipped P5-S20 state:
   - `docs/phase5-product-spec.md`
   - `docs/phase5-sprint-17-20-plan.md`
   - `README.md`
   - `ROADMAP.md`
   - `.ai/handoff/CURRENT_STATE.md`
-  - `BUILD_REPORT.md`
-  - `REVIEW_REPORT.md`.
-
-## Exact Correction/Freshness Delta
-- New continuity review queue and detail reads expose correction posture and supersession chain.
-- New correction actions mutate lifecycle deterministically:
-  - `confirm` sets status `active` and stamps `last_confirmed_at`
-  - `edit` updates selected mutable fields and confirms freshness
-  - `delete` marks object as `deleted` (history preserved)
-  - `mark_stale` marks object as `stale`
-  - `supersede` creates replacement object, links both objects, and marks prior object `superseded`.
-- Freshness/supersession fields are now first-class API contract elements:
-  - `last_confirmed_at`
-  - `supersedes_object_id`
-  - `superseded_by_object_id`.
-
-## Exact Correction-Event And Lifecycle Transition Behavior
-- Each correction action appends one immutable `continuity_correction_events` row before lifecycle mutation.
-- Correction events are append-only at the DB layer (trigger blocks update/delete).
-- Lifecycle mutations are deterministic by action and current state; invalid action/state pairs return deterministic validation errors.
-- Supersession preserves historical truth with explicit two-way links and correction history.
-- Recall/resumption hot path reflects committed correction state immediately:
-  - deleted items excluded from recall
-  - lifecycle posture retained in ordering metadata and recent-change visibility.
+  - `REVIEW_REPORT.md`
+  - `BUILD_REPORT.md`.
 
 ## Incomplete Work
-- None within P5-S19 packet scope.
+- None within P5-S20 packet scope.
 
 ## Files Changed
-- `apps/api/alembic/versions/20260330_0042_phase5_continuity_corrections.py`
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/store.py`
 - `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/continuity_review.py`
-- `apps/api/src/alicebot_api/continuity_recall.py`
-- `apps/api/src/alicebot_api/continuity_resumption.py`
+- `apps/api/src/alicebot_api/continuity_open_loops.py`
 - `apps/web/lib/api.ts`
 - `apps/web/lib/api.test.ts`
 - `apps/web/app/continuity/page.tsx`
 - `apps/web/app/continuity/page.test.tsx`
-- `apps/web/components/continuity-review-queue.tsx`
-- `apps/web/components/continuity-review-queue.test.tsx`
-- `apps/web/components/continuity-correction-form.tsx`
-- `apps/web/components/continuity-correction-form.test.tsx`
-- `apps/web/components/continuity-recall-panel.test.tsx`
-- `apps/web/components/resumption-brief.test.tsx`
-- `tests/unit/test_20260330_0042_phase5_continuity_corrections.py`
-- `tests/unit/test_continuity_review.py`
-- `tests/integration/test_continuity_review_api.py`
-- `tests/unit/test_continuity_recall.py`
+- `apps/web/components/continuity-open-loops-panel.tsx`
+- `apps/web/components/continuity-open-loops-panel.test.tsx`
+- `apps/web/components/continuity-daily-brief.tsx`
+- `apps/web/components/continuity-daily-brief.test.tsx`
+- `apps/web/components/continuity-weekly-review.tsx`
+- `apps/web/components/continuity-weekly-review.test.tsx`
+- `tests/unit/test_continuity_open_loops.py`
+- `tests/integration/test_continuity_open_loops_api.py`
+- `tests/integration/test_continuity_daily_weekly_review_api.py`
 - `tests/unit/test_continuity_resumption.py`
 - `docs/phase5-product-spec.md`
 - `docs/phase5-sprint-17-20-plan.md`
 - `README.md`
 - `ROADMAP.md`
 - `.ai/handoff/CURRENT_STATE.md`
-- `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
+- `BUILD_REPORT.md`
 
 ## Tests Run
-- `./.venv/bin/python -m pytest tests/unit/test_20260330_0042_phase5_continuity_corrections.py tests/unit/test_continuity_review.py tests/integration/test_continuity_review_api.py tests/unit/test_continuity_recall.py tests/unit/test_continuity_resumption.py -q`
-  - PASS (`20 passed`)
-- `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-review-queue.test.tsx components/continuity-correction-form.test.tsx lib/api.test.ts`
-  - PASS (`4 passed` files, `35 passed` tests)
+- `./.venv/bin/python -m pytest tests/unit/test_continuity_open_loops.py tests/integration/test_continuity_open_loops_api.py tests/integration/test_continuity_daily_weekly_review_api.py tests/unit/test_continuity_review.py tests/unit/test_continuity_resumption.py -q`
+  - PASS (`19 passed in 2.14s`).
+- `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-open-loops-panel.test.tsx components/continuity-daily-brief.test.tsx components/continuity-weekly-review.test.tsx lib/api.test.ts`
+  - PASS (`5 files`, `38 tests`).
 - `python3 scripts/run_phase4_validation_matrix.py`
-  - PASS (`Phase 4 validation matrix result: PASS`)
-  - all reported gate groups PASS, including Phase 4, Phase 3 compatibility, Phase 2 compatibility, and MVP compatibility.
+  - PASS (`Phase 4 validation matrix result: PASS`).
 
 ## Blockers/Issues
-- DB-backed integration commands required elevated local network permissions to reach Postgres on `localhost:5432` in this runtime.
-- An intermediate run produced `NO_GO` while `.ai/handoff/CURRENT_STATE.md` lacked the exact required control-doc marker phrase; after restoring the marker text and stabilizing the flaky review-queue unit assertion, the full Phase 4 matrix rerun returned PASS.
-- After elevated rerun, all required verification commands passed.
+- Integration and matrix commands required elevated local permissions in this runtime to connect to Postgres on `localhost:5432`; reruns with elevated permissions passed.
+- No unresolved code or scope blockers remain for P5-S20.
 
-## Explicit Deferred Phase 5 Scope
-- P5-S20 open-loop daily/weekly review dashboards remain deferred and were not implemented in this sprint.
+## Explicit Post-Phase-5 Deferred Scope
+- No additional Sprint 17-20 continuity scope is deferred.
+- Any post-Phase-5 expansion (connector breadth, orchestration changes, broader memory architecture changes) should be opened as a new packet.
 
 ## Recommended Next Step
-Open P5-S20 packet execution focused only on open-loop daily/weekly review surfaces, reusing shipped P5-S17/18/19 continuity contracts without reopening correction or recall architecture.
+Open a new post-Phase-5 packet that selects one narrow next objective while keeping P5-S17..P5-S20 continuity contracts stable.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AliceBot
 
-AliceBot is a private, permissioned personal AI operating system. The canonical baseline remains through Phase 3 Sprint 9, with earlier Phase 4 work already delivering run linkage/idempotent replay safety and run observability/retry-failure discipline, Phase 4 Sprint 14 establishing canonical MVP release-gate ownership in Phase 4 gate scripts, Phase 4 Sprint 15 adding deterministic release-candidate rehearsal evidence packaging, Phase 4 Sprint 16 adding durable archive/index evidence retention for repeated RC rehearsal runs, Phase 4 Sprint 17 hardening archive index writes with deterministic locking and atomic replace behavior under contention, Phase 4 Sprint 18 adding deterministic MVP exit manifest generation/verification for formal phase closeout, and Phase 4 Sprint 19 adding deterministic MVP qualification orchestration plus a formal GO/NO_GO sign-off record/verifier. Phase 5 Sprint 17 shipped the typed continuity capture backbone, Phase 5 Sprint 18 shipped provenance-backed recall plus deterministic continuity resumption briefs, and Phase 5 Sprint 19 now ships continuity review/correction with explicit freshness and supersession posture.
+AliceBot is a private, permissioned personal AI operating system. The canonical baseline remains through Phase 3 Sprint 9, with earlier Phase 4 work already delivering run linkage/idempotent replay safety and run observability/retry-failure discipline, Phase 4 Sprint 14 establishing canonical MVP release-gate ownership in Phase 4 gate scripts, Phase 4 Sprint 15 adding deterministic release-candidate rehearsal evidence packaging, Phase 4 Sprint 16 adding durable archive/index evidence retention for repeated RC rehearsal runs, Phase 4 Sprint 17 hardening archive index writes with deterministic locking and atomic replace behavior under contention, Phase 4 Sprint 18 adding deterministic MVP exit manifest generation/verification for formal phase closeout, and Phase 4 Sprint 19 adding deterministic MVP qualification orchestration plus a formal GO/NO_GO sign-off record/verifier. Phase 5 Sprint 17 shipped the typed continuity capture backbone, Phase 5 Sprint 18 shipped provenance-backed recall plus deterministic continuity resumption briefs, Phase 5 Sprint 19 shipped continuity review/correction with explicit freshness and supersession posture, and Phase 5 Sprint 20 shipped open-loop dashboard plus deterministic daily/weekly review flows.
 
 ## Current Implemented Slice
 
@@ -17,14 +17,22 @@ AliceBot is a private, permissioned personal AI operating system. The canonical 
     - `GET /v0/continuity/review-queue`
     - `GET /v0/continuity/review-queue/{continuity_object_id}`
     - `POST /v0/continuity/review-queue/{continuity_object_id}/corrections`
+  - Sprint 20 open-loop and review briefing endpoints:
+    - `GET /v0/continuity/open-loops`
+    - `GET /v0/continuity/daily-brief`
+    - `GET /v0/continuity/weekly-review`
+    - `POST /v0/continuity/open-loops/{continuity_object_id}/review-action`
   - recall/resumption responses expose scoped filters, deterministic ordering metadata, confirmation/admission posture, and provenance references.
   - correction flows append immutable correction events before lifecycle mutation and expose freshness/supersession metadata (`last_confirmed_at`, `supersedes_object_id`, `superseded_by_object_id`).
+  - open-loop review actions (`done`, `deferred`, `still_blocked`) are deterministic, auditable, and reflected immediately in continuity resumption output.
 - `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
 - `apps/web` now also includes `/continuity` as the Phase 5 continuity workspace with:
   - Sprint 17 fast-capture inbox submit/list/detail
   - Sprint 18 recall query/results panel with provenance-backed cards
   - Sprint 18 deterministic resumption-brief panel with required explicit sections
   - Sprint 19 review queue and correction form with correction history and supersession chain visibility
+  - Sprint 20 open-loop dashboard with grouped posture sections and review-action controls
+  - Sprint 20 deterministic daily brief and weekly review panels with explicit empty states
 - `/chat` supports both assistant and governed-request modes, selected-thread continuity, compact thread creation, deterministic resumption brief review, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, manual explicit-signal capture controls for selected `message.user` events, and bounded supporting continuity review.
 - `/gmail` and `/calendar` are shipped bounded connector workspaces for account review, selected-account detail, explicit account connection, and explicit single-item ingestion into one selected task workspace.
 - `/artifacts`, `/memories`, and `/entities` are shipped bounded operator review workspaces for artifact, memory, and entity evidence.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,45 +4,39 @@
 PASS
 
 ## criteria met
-- P5-S19 scope stayed focused on continuity review/correction/freshness with no P5-S20 dashboard expansion.
-- Correction events remain append-only and audit-safe:
-  - persisted in `continuity_correction_events`
-  - update/delete blocked by append-only trigger
-  - correction event appended before lifecycle mutation.
-- Recall/resumption reflects corrections immediately:
-  - recall excludes `deleted`
-  - recall exposes lifecycle/freshness metadata (`last_confirmed_at`, supersession links, `lifecycle_rank`)
-  - resumption preserves active-truth primaries while keeping lifecycle posture in recent changes.
-- Supersession chain visibility is present in API and continuity UI review detail.
-- Required sprint verification commands are now PASS:
-  - `./.venv/bin/python -m pytest tests/unit/test_20260330_0042_phase5_continuity_corrections.py tests/unit/test_continuity_review.py tests/integration/test_continuity_review_api.py tests/unit/test_continuity_recall.py tests/unit/test_continuity_resumption.py -q` -> `20 passed`
-  - `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-review-queue.test.tsx components/continuity-correction-form.test.tsx lib/api.test.ts` -> `4 files / 35 tests passed`
-  - `python3 scripts/run_phase4_validation_matrix.py` -> `Phase 4 validation matrix result: PASS`.
+- Sprint scope stayed aligned to P5-S20 (open-loop dashboard, daily/weekly briefs, review-action workflow, continuity UI updates, and scoped docs updates).
+- Deterministic open-loop grouping/order is implemented for `waiting_for`, `blocker`, `stale`, `next_action` with explicit ordering metadata.
+- Daily brief and weekly review endpoints are deterministic for fixed input and emit explicit empty states for empty sections.
+- `done` / `deferred` / `still_blocked` actions map to deterministic lifecycle outcomes and persist auditable correction events.
+- Continuity resumption reflects open-loop review-action outcomes immediately.
+- Required verification commands passed in this review run:
+  - `./.venv/bin/python -m pytest tests/unit/test_continuity_open_loops.py tests/integration/test_continuity_open_loops_api.py tests/integration/test_continuity_daily_weekly_review_api.py tests/unit/test_continuity_review.py tests/unit/test_continuity_resumption.py -q` -> `22 passed`
+  - `pnpm --dir apps/web test -- app/continuity/page.test.tsx components/continuity-open-loops-panel.test.tsx components/continuity-daily-brief.test.tsx components/continuity-weekly-review.test.tsx lib/api.test.ts` -> `5 files / 38 tests passed`
+  - `python3 scripts/run_phase4_validation_matrix.py` -> `Phase 4 validation matrix result: PASS`
 
 ## criteria missed
-- None.
+- None strictly against packet acceptance checklist.
 
 ## quality issues
-- Resolved: control-doc marker mismatch in `.ai/handoff/CURRENT_STATE.md` line 7.
-  - Restored exact required phrase: `Active Sprint focus is Phase 4 Sprint 14`.
-- Resolved: flaky UUID tie-order assumption in `tests/unit/test_continuity_review.py`.
-  - Updated assertion to verify status membership independent of UUID tie-order.
-  - Stability check: target test passed `40/40` looped runs.
-- Build report accuracy issue is resolved because the Phase 4 matrix was rerun and is currently PASS.
+- Resolved in this fix:
+  - `apps/api/src/alicebot_api/continuity_open_loops.py` now validates mixed offset-naive/offset-aware windows and raises deterministic `ContinuityOpenLoopValidationError` instead of surfacing `TypeError`.
+  - Added regression coverage asserting HTTP 400 behavior for mixed window inputs on:
+    - `GET /v0/continuity/open-loops`
+    - `GET /v0/continuity/daily-brief`
+    - `GET /v0/continuity/weekly-review`.
 
 ## regression risks
-- Low immediate risk; coverage spans migration/unit/integration/web seams and full Phase 4 compatibility validation.
-- Future risk remains around control-doc marker drift if exact required phrases are reworded without checker updates.
+- Low: fix is narrow to time-window validation and now covered by unit + integration regression tests.
 
 ## docs issues
-- No remaining blocking docs mismatch after marker restoration and matrix rerun.
+- No documentation drift found for shipped P5-S20 scope.
 
 ## should anything be added to RULES.md?
-- Not required for this sprint acceptance.
+- Not required for this sprint.
 
 ## should anything update ARCHITECTURE.md?
-- Not required for this sprint acceptance.
+- No architecture change required; this is an endpoint-level input-validation defect.
 
 ## recommended next action
-1. Proceed to P5-S20 execution with open-loop daily/weekly review scope only.
-2. Keep P5-S19 correction and recall/resumption contracts stable while implementing P5-S20 UI/API additions.
+1. Keep datetime-window validation behavior unchanged unless paired tests are updated.
+2. Proceed with post-Phase-5 planning from the shipped P5-S20 baseline.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,7 @@
 - Phase 5 Sprint 17 adds the typed continuity capture backbone: immutable `continuity_capture_events`, typed `continuity_objects`, conservative admission posture (`DERIVED`/`TRIAGE`), and the fast capture inbox UI/API surface at `/continuity`.
 - Phase 5 Sprint 18 adds provenance-backed recall and deterministic continuity resumption surfaces: `GET /v0/continuity/recall`, `GET /v0/continuity/resumption-brief`, and `/continuity` recall/resumption panels with always-present required sections.
 - Phase 5 Sprint 19 adds continuity review/correction and freshness posture: `GET /v0/continuity/review-queue`, `GET /v0/continuity/review-queue/{continuity_object_id}`, `POST /v0/continuity/review-queue/{continuity_object_id}/corrections`, append-only correction events, and immediate recall/resumption correction impact with supersession-chain visibility.
+- Phase 5 Sprint 20 adds deterministic open-loop/daily/weekly executive-function seams: `GET /v0/continuity/open-loops`, `GET /v0/continuity/daily-brief`, `GET /v0/continuity/weekly-review`, `POST /v0/continuity/open-loops/{continuity_object_id}/review-action`, grouped posture ordering (`waiting_for`, `blocker`, `stale`, `next_action`), and immediate resumption refresh after `done`/`deferred`/`still_blocked` actions.
 - The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, typed memory and open-loop seams, deterministic thread resumption brief reads, unified explicit-signal capture seams, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, narrow read-only Gmail and Calendar seams with selected-item ingestion, bounded read-only Calendar event discovery for one connected account, and the no-tools assistant-response seam.
 - The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
 - `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, keeps bounded thread review and deterministic resumption brief review visible beside both assistant and governed-request composition, ships thread-linked governed workflow, ordered task-step timeline review, and bounded explain-why trace embedding, and includes manual explicit-signal capture controls for selected `message.user` events.
@@ -33,13 +34,17 @@
 - Treat `python3 scripts/run_phase4_mvp_qualification.py` and `python3 scripts/verify_phase4_mvp_signoff_record.py` as the canonical Sprint 19 MVP qualification/sign-off commands.
 - Treat archive index hardening as baseline behavior (deterministic lock and atomic index replace), not optional operational guidance.
 - Treat the deterministic validation matrix command (`python3 scripts/run_phase4_validation_matrix.py`) as the canonical Phase 4 validation step inside the RC rehearsal chain, while keeping Phase 3/Phase 2/MVP validation commands as compatibility checks.
-- Treat Phase 5 Sprint 17, Sprint 18, and Sprint 19 continuity surfaces as shipped baseline:
+- Treat Phase 5 Sprint 17 through Sprint 20 continuity surfaces as shipped baseline:
   - `/v0/continuity/captures*`
   - `/v0/continuity/recall`
   - `/v0/continuity/resumption-brief`
   - `/v0/continuity/review-queue*`
-  - `/continuity` capture/recall/resumption/review workspace
-- Do not relitigate continuity backbone, recall ordering contracts, correction-event append semantics, or required resumption-section contracts during Sprint 20 planning.
+  - `/v0/continuity/open-loops`
+  - `/v0/continuity/daily-brief`
+  - `/v0/continuity/weekly-review`
+  - `/v0/continuity/open-loops/{continuity_object_id}/review-action`
+  - `/continuity` capture/recall/resumption/review/open-loop/daily/weekly workspace
+- Do not relitigate continuity backbone, recall ordering contracts, correction-event append semantics, open-loop posture contracts, or required resumption/brief section contracts.
 - Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.
 - Reuse the existing continuity, response, approval, task, workspace-artifact, memory, entity, execution, and trace surfaces instead of introducing parallel contracts.
 
@@ -47,8 +52,9 @@
 
 - Do not bundle broader Gmail or Calendar breadth, auth expansion, richer document parsing, runner orchestration, or proxy breadth into the next sprint by default.
 - Do not reopen schema or API design unless the next sprint explicitly requires it.
-- Keep Phase 5 deferred scope explicit:
-  - Sprint 20 open-loop daily/weekly review dashboards
+- Keep Phase 5 follow-up scope explicit:
+  - no additional Sprint 17-20 continuity scope remains
+  - any post-Phase-5 work should be opened as a new packet, not folded into shipped Sprint 20 seams
 - Keep live docs synchronized with shipped reality so planning does not drift behind the repo again.
 
 ## Ongoing Risks

--- a/apps/api/src/alicebot_api/continuity_open_loops.py
+++ b/apps/api/src/alicebot_api/continuity_open_loops.py
@@ -1,0 +1,542 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+from alicebot_api.continuity_recall import query_continuity_recall
+from alicebot_api.contracts import (
+    CONTINUITY_DAILY_BRIEF_ASSEMBLY_VERSION_V0,
+    CONTINUITY_OPEN_LOOP_ITEM_ORDER,
+    CONTINUITY_OPEN_LOOP_POSTURE_ORDER,
+    CONTINUITY_OPEN_LOOP_POSTURES,
+    CONTINUITY_OPEN_LOOP_REVIEW_ACTIONS,
+    CONTINUITY_WEEKLY_REVIEW_ASSEMBLY_VERSION_V0,
+    MAX_CONTINUITY_DAILY_BRIEF_LIMIT,
+    MAX_CONTINUITY_OPEN_LOOP_LIMIT,
+    MAX_CONTINUITY_RECALL_LIMIT,
+    MAX_CONTINUITY_WEEKLY_REVIEW_LIMIT,
+    ContinuityDailyBriefRecord,
+    ContinuityDailyBriefRequestInput,
+    ContinuityDailyBriefResponse,
+    ContinuityOpenLoopDashboardQueryInput,
+    ContinuityOpenLoopDashboardRecord,
+    ContinuityOpenLoopDashboardResponse,
+    ContinuityOpenLoopPosture,
+    ContinuityOpenLoopReviewActionInput,
+    ContinuityOpenLoopReviewActionResponse,
+    ContinuityOpenLoopSection,
+    ContinuityRecallQueryInput,
+    ContinuityRecallResultRecord,
+    ContinuityResumptionEmptyState,
+    ContinuityResumptionSingleSection,
+    ContinuityReviewObjectRecord,
+    ContinuityWeeklyReviewRecord,
+    ContinuityWeeklyReviewRequestInput,
+    ContinuityWeeklyReviewResponse,
+    isoformat_or_none,
+)
+from alicebot_api.store import (
+    ContinuityCorrectionEventRow,
+    ContinuityObjectRow,
+    ContinuityStore,
+    JsonObject,
+)
+
+
+class ContinuityOpenLoopValidationError(ValueError):
+    """Raised when an open-loop continuity request is invalid."""
+
+
+class ContinuityOpenLoopNotFoundError(LookupError):
+    """Raised when the selected continuity object is not visible in scope."""
+
+
+@dataclass(frozen=True, slots=True)
+class _LifecycleTransition:
+    correction_action: str
+    lifecycle_outcome: str
+
+
+_OPEN_LOOP_OBJECT_TYPES = {"WaitingFor", "Blocker", "NextAction"}
+_EMPTY_MESSAGES: dict[ContinuityOpenLoopPosture, str] = {
+    "waiting_for": "No waiting-for items in the requested scope.",
+    "blocker": "No blocker items in the requested scope.",
+    "stale": "No stale items in the requested scope.",
+    "next_action": "No next-action items in the requested scope.",
+}
+_DAILY_WAITING_EMPTY = "No waiting-for highlights for today in the requested scope."
+_DAILY_BLOCKER_EMPTY = "No blocker highlights for today in the requested scope."
+_DAILY_STALE_EMPTY = "No stale items for today in the requested scope."
+_DAILY_NEXT_EMPTY = "No next suggested action in the requested scope."
+
+_REVIEW_ACTION_TRANSITIONS: dict[str, _LifecycleTransition] = {
+    "done": _LifecycleTransition(correction_action="edit", lifecycle_outcome="completed"),
+    "deferred": _LifecycleTransition(correction_action="mark_stale", lifecycle_outcome="stale"),
+    "still_blocked": _LifecycleTransition(correction_action="confirm", lifecycle_outcome="active"),
+}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _normalize_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = " ".join(value.split()).strip()
+    if not normalized:
+        return None
+    return normalized
+
+
+def _serialize_review_object(record: ContinuityObjectRow) -> ContinuityReviewObjectRecord:
+    return {
+        "id": str(record["id"]),
+        "capture_event_id": str(record["capture_event_id"]),
+        "object_type": record["object_type"],  # type: ignore[typeddict-item]
+        "status": record["status"],
+        "title": record["title"],
+        "body": record["body"],
+        "provenance": record["provenance"],
+        "confidence": float(record["confidence"]),
+        "last_confirmed_at": isoformat_or_none(record["last_confirmed_at"]),
+        "supersedes_object_id": (
+            None if record["supersedes_object_id"] is None else str(record["supersedes_object_id"])
+        ),
+        "superseded_by_object_id": (
+            None if record["superseded_by_object_id"] is None else str(record["superseded_by_object_id"])
+        ),
+        "created_at": record["created_at"].isoformat(),
+        "updated_at": record["updated_at"].isoformat(),
+    }
+
+
+def _serialize_correction_event(record: ContinuityCorrectionEventRow):
+    return {
+        "id": str(record["id"]),
+        "continuity_object_id": str(record["continuity_object_id"]),
+        "action": record["action"],
+        "reason": record["reason"],
+        "before_snapshot": record["before_snapshot"],
+        "after_snapshot": record["after_snapshot"],
+        "payload": record["payload"],
+        "created_at": record["created_at"].isoformat(),
+    }
+
+
+def _snapshot(record: ContinuityObjectRow) -> JsonObject:
+    return {
+        "id": str(record["id"]),
+        "capture_event_id": str(record["capture_event_id"]),
+        "object_type": record["object_type"],
+        "status": record["status"],
+        "title": record["title"],
+        "body": record["body"],
+        "provenance": record["provenance"],
+        "confidence": float(record["confidence"]),
+        "last_confirmed_at": isoformat_or_none(record["last_confirmed_at"]),
+        "supersedes_object_id": (
+            None if record["supersedes_object_id"] is None else str(record["supersedes_object_id"])
+        ),
+        "superseded_by_object_id": (
+            None if record["superseded_by_object_id"] is None else str(record["superseded_by_object_id"])
+        ),
+    }
+
+
+def _open_loop_posture(item: ContinuityRecallResultRecord) -> ContinuityOpenLoopPosture | None:
+    if item["object_type"] not in _OPEN_LOOP_OBJECT_TYPES:
+        return None
+
+    if item["status"] == "stale":
+        return "stale"
+
+    if item["status"] != "active":
+        return None
+
+    if item["object_type"] == "WaitingFor":
+        return "waiting_for"
+    if item["object_type"] == "Blocker":
+        return "blocker"
+    if item["object_type"] == "NextAction":
+        return "next_action"
+
+    return None
+
+
+def _recency_sort_key(item: ContinuityRecallResultRecord) -> tuple[str, str]:
+    return (item["created_at"], item["id"])
+
+
+def _empty_state(*, is_empty: bool, message: str) -> ContinuityResumptionEmptyState:
+    return {
+        "is_empty": is_empty,
+        "message": message,
+    }
+
+
+def _build_section(
+    *,
+    all_items: list[ContinuityRecallResultRecord],
+    limit: int,
+    empty_message: str,
+) -> ContinuityOpenLoopSection:
+    items = all_items[:limit] if limit > 0 else []
+    return {
+        "items": items,
+        "summary": {
+            "limit": limit,
+            "returned_count": len(items),
+            "total_count": len(all_items),
+            "order": list(CONTINUITY_OPEN_LOOP_ITEM_ORDER),
+        },
+        "empty_state": _empty_state(
+            is_empty=len(items) == 0,
+            message=empty_message,
+        ),
+    }
+
+
+def _validate_limit(limit: int, *, max_limit: int) -> None:
+    if limit < 0 or limit > max_limit:
+        raise ContinuityOpenLoopValidationError(f"limit must be between 0 and {max_limit}")
+
+
+def _is_offset_aware(value: datetime) -> bool:
+    return value.tzinfo is not None and value.utcoffset() is not None
+
+
+def _validate_time_window(*, since: datetime | None, until: datetime | None) -> None:
+    if since is None or until is None:
+        return
+
+    if _is_offset_aware(since) != _is_offset_aware(until):
+        raise ContinuityOpenLoopValidationError(
+            "since and until must both include timezone offsets or both omit timezone offsets"
+        )
+
+    try:
+        if until < since:
+            raise ContinuityOpenLoopValidationError("until must be greater than or equal to since")
+    except TypeError as exc:
+        raise ContinuityOpenLoopValidationError(
+            "since and until must both include timezone offsets or both omit timezone offsets"
+        ) from exc
+
+
+def _group_open_loops(
+    recall_items: list[ContinuityRecallResultRecord],
+) -> dict[ContinuityOpenLoopPosture, list[ContinuityRecallResultRecord]]:
+    grouped: dict[ContinuityOpenLoopPosture, list[ContinuityRecallResultRecord]] = {
+        "waiting_for": [],
+        "blocker": [],
+        "stale": [],
+        "next_action": [],
+    }
+
+    for item in recall_items:
+        posture = _open_loop_posture(item)
+        if posture is None:
+            continue
+        grouped[posture].append(item)
+
+    for posture in CONTINUITY_OPEN_LOOP_POSTURES:
+        grouped[posture].sort(key=_recency_sort_key, reverse=True)
+
+    return grouped
+
+
+def _load_grouped_open_loop_candidates(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    query: str | None,
+    thread_id: UUID | None,
+    task_id: UUID | None,
+    project: str | None,
+    person: str | None,
+    since: datetime | None,
+    until: datetime | None,
+) -> tuple[dict[str, str | None], dict[ContinuityOpenLoopPosture, list[ContinuityRecallResultRecord]]]:
+    recall_payload = query_continuity_recall(
+        store,
+        user_id=user_id,
+        request=ContinuityRecallQueryInput(
+            query=query,
+            thread_id=thread_id,
+            task_id=task_id,
+            project=project,
+            person=person,
+            since=since,
+            until=until,
+            limit=MAX_CONTINUITY_RECALL_LIMIT,
+        ),
+        apply_limit=False,
+    )
+
+    return recall_payload["summary"]["filters"], _group_open_loops(recall_payload["items"])
+
+
+def compile_continuity_open_loop_dashboard(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: ContinuityOpenLoopDashboardQueryInput,
+) -> ContinuityOpenLoopDashboardResponse:
+    _validate_limit(request.limit, max_limit=MAX_CONTINUITY_OPEN_LOOP_LIMIT)
+    _validate_time_window(since=request.since, until=request.until)
+
+    scope, grouped = _load_grouped_open_loop_candidates(
+        store,
+        user_id=user_id,
+        query=request.query,
+        thread_id=request.thread_id,
+        task_id=request.task_id,
+        project=request.project,
+        person=request.person,
+        since=request.since,
+        until=request.until,
+    )
+
+    dashboard: ContinuityOpenLoopDashboardRecord = {
+        "scope": scope,
+        "waiting_for": _build_section(
+            all_items=grouped["waiting_for"],
+            limit=request.limit,
+            empty_message=_EMPTY_MESSAGES["waiting_for"],
+        ),
+        "blocker": _build_section(
+            all_items=grouped["blocker"],
+            limit=request.limit,
+            empty_message=_EMPTY_MESSAGES["blocker"],
+        ),
+        "stale": _build_section(
+            all_items=grouped["stale"],
+            limit=request.limit,
+            empty_message=_EMPTY_MESSAGES["stale"],
+        ),
+        "next_action": _build_section(
+            all_items=grouped["next_action"],
+            limit=request.limit,
+            empty_message=_EMPTY_MESSAGES["next_action"],
+        ),
+        "summary": {
+            "limit": request.limit,
+            "total_count": sum(len(grouped[posture]) for posture in CONTINUITY_OPEN_LOOP_POSTURES),
+            "posture_order": list(CONTINUITY_OPEN_LOOP_POSTURE_ORDER),
+            "item_order": list(CONTINUITY_OPEN_LOOP_ITEM_ORDER),
+        },
+        "sources": ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+    }
+
+    return {"dashboard": dashboard}
+
+
+def compile_continuity_daily_brief(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: ContinuityDailyBriefRequestInput,
+) -> ContinuityDailyBriefResponse:
+    _validate_limit(request.limit, max_limit=MAX_CONTINUITY_DAILY_BRIEF_LIMIT)
+    _validate_time_window(since=request.since, until=request.until)
+
+    scope, grouped = _load_grouped_open_loop_candidates(
+        store,
+        user_id=user_id,
+        query=request.query,
+        thread_id=request.thread_id,
+        task_id=request.task_id,
+        project=request.project,
+        person=request.person,
+        since=request.since,
+        until=request.until,
+    )
+
+    next_item = grouped["next_action"][0] if request.limit > 0 and grouped["next_action"] else None
+    next_section: ContinuityResumptionSingleSection = {
+        "item": next_item,
+        "empty_state": _empty_state(
+            is_empty=next_item is None,
+            message=_DAILY_NEXT_EMPTY,
+        ),
+    }
+
+    brief: ContinuityDailyBriefRecord = {
+        "assembly_version": CONTINUITY_DAILY_BRIEF_ASSEMBLY_VERSION_V0,
+        "scope": scope,
+        "waiting_for_highlights": _build_section(
+            all_items=grouped["waiting_for"],
+            limit=request.limit,
+            empty_message=_DAILY_WAITING_EMPTY,
+        ),
+        "blocker_highlights": _build_section(
+            all_items=grouped["blocker"],
+            limit=request.limit,
+            empty_message=_DAILY_BLOCKER_EMPTY,
+        ),
+        "stale_items": _build_section(
+            all_items=grouped["stale"],
+            limit=request.limit,
+            empty_message=_DAILY_STALE_EMPTY,
+        ),
+        "next_suggested_action": next_section,
+        "sources": ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+    }
+
+    return {"brief": brief}
+
+
+def compile_continuity_weekly_review(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: ContinuityWeeklyReviewRequestInput,
+) -> ContinuityWeeklyReviewResponse:
+    _validate_limit(request.limit, max_limit=MAX_CONTINUITY_WEEKLY_REVIEW_LIMIT)
+    _validate_time_window(since=request.since, until=request.until)
+
+    scope, grouped = _load_grouped_open_loop_candidates(
+        store,
+        user_id=user_id,
+        query=request.query,
+        thread_id=request.thread_id,
+        task_id=request.task_id,
+        project=request.project,
+        person=request.person,
+        since=request.since,
+        until=request.until,
+    )
+
+    review: ContinuityWeeklyReviewRecord = {
+        "assembly_version": CONTINUITY_WEEKLY_REVIEW_ASSEMBLY_VERSION_V0,
+        "scope": scope,
+        "rollup": {
+            "total_count": sum(len(grouped[posture]) for posture in CONTINUITY_OPEN_LOOP_POSTURES),
+            "waiting_for_count": len(grouped["waiting_for"]),
+            "blocker_count": len(grouped["blocker"]),
+            "stale_count": len(grouped["stale"]),
+            "next_action_count": len(grouped["next_action"]),
+            "posture_order": list(CONTINUITY_OPEN_LOOP_POSTURE_ORDER),
+        },
+        "waiting_for": _build_section(
+            all_items=grouped["waiting_for"],
+            limit=request.limit,
+            empty_message=_EMPTY_MESSAGES["waiting_for"],
+        ),
+        "blocker": _build_section(
+            all_items=grouped["blocker"],
+            limit=request.limit,
+            empty_message=_EMPTY_MESSAGES["blocker"],
+        ),
+        "stale": _build_section(
+            all_items=grouped["stale"],
+            limit=request.limit,
+            empty_message=_EMPTY_MESSAGES["stale"],
+        ),
+        "next_action": _build_section(
+            all_items=grouped["next_action"],
+            limit=request.limit,
+            empty_message=_EMPTY_MESSAGES["next_action"],
+        ),
+        "sources": ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+    }
+
+    return {"review": review}
+
+
+def apply_continuity_open_loop_review_action(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    continuity_object_id: UUID,
+    request: ContinuityOpenLoopReviewActionInput,
+) -> ContinuityOpenLoopReviewActionResponse:
+    del user_id
+
+    action = request.action
+    if action not in CONTINUITY_OPEN_LOOP_REVIEW_ACTIONS:
+        allowed = ", ".join(CONTINUITY_OPEN_LOOP_REVIEW_ACTIONS)
+        raise ContinuityOpenLoopValidationError(f"action must be one of: {allowed}")
+
+    note = _normalize_optional_text(request.note)
+    if note is not None and len(note) > 500:
+        raise ContinuityOpenLoopValidationError("note must be 500 characters or fewer")
+
+    current = store.get_continuity_object_optional(continuity_object_id)
+    if current is None:
+        raise ContinuityOpenLoopNotFoundError(f"continuity object {continuity_object_id} was not found")
+
+    if current["object_type"] not in _OPEN_LOOP_OBJECT_TYPES:
+        allowed_types = ", ".join(sorted(_OPEN_LOOP_OBJECT_TYPES))
+        raise ContinuityOpenLoopValidationError(
+            f"review action requires one of object types: {allowed_types}"
+        )
+
+    if current["status"] in {"superseded", "deleted", "cancelled"}:
+        raise ContinuityOpenLoopValidationError(
+            f"review action cannot be applied when status is {current['status']}"
+        )
+
+    transition = _REVIEW_ACTION_TRANSITIONS[action]
+    next_last_confirmed_at = current["last_confirmed_at"]
+    if action == "still_blocked":
+        next_last_confirmed_at = _utcnow()
+
+    before_snapshot = _snapshot(current)
+    after_snapshot: JsonObject = {
+        **before_snapshot,
+        "status": transition.lifecycle_outcome,
+        "last_confirmed_at": isoformat_or_none(next_last_confirmed_at),
+    }
+
+    correction_event = store.create_continuity_correction_event(
+        continuity_object_id=continuity_object_id,
+        action=transition.correction_action,
+        reason=note,
+        before_snapshot=before_snapshot,
+        after_snapshot=after_snapshot,
+        payload={
+            "review_action": action,
+            "note": note,
+            "mapped_correction_action": transition.correction_action,
+            "lifecycle_outcome": transition.lifecycle_outcome,
+        },
+    )
+
+    updated = store.update_continuity_object_optional(
+        continuity_object_id=continuity_object_id,
+        status=transition.lifecycle_outcome,
+        title=current["title"],
+        body=current["body"],
+        provenance=current["provenance"],
+        confidence=float(current["confidence"]),
+        last_confirmed_at=next_last_confirmed_at,
+        supersedes_object_id=current["supersedes_object_id"],
+        superseded_by_object_id=current["superseded_by_object_id"],
+    )
+    if updated is None:
+        raise ContinuityOpenLoopNotFoundError(f"continuity object {continuity_object_id} was not found")
+
+    return {
+        "continuity_object": _serialize_review_object(updated),
+        "correction_event": _serialize_correction_event(correction_event),
+        "review_action": action,
+        "lifecycle_outcome": transition.lifecycle_outcome,
+    }
+
+
+def build_default_continuity_open_loop_query() -> ContinuityOpenLoopDashboardQueryInput:
+    return ContinuityOpenLoopDashboardQueryInput()
+
+
+__all__ = [
+    "ContinuityOpenLoopNotFoundError",
+    "ContinuityOpenLoopValidationError",
+    "apply_continuity_open_loop_review_action",
+    "build_default_continuity_open_loop_query",
+    "compile_continuity_daily_brief",
+    "compile_continuity_open_loop_dashboard",
+    "compile_continuity_weekly_review",
+]

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -161,6 +161,8 @@ ContinuityRecallScopeKind = Literal["thread", "task", "project", "person"]
 ContinuityCorrectionAction = Literal["confirm", "edit", "delete", "supersede", "mark_stale"]
 ContinuityReviewStatus = Literal["active", "stale", "superseded", "deleted"]
 ContinuityReviewStatusFilter = Literal["correction_ready", "active", "stale", "superseded", "deleted", "all"]
+ContinuityOpenLoopPosture = Literal["waiting_for", "blocker", "stale", "next_action"]
+ContinuityOpenLoopReviewAction = Literal["done", "deferred", "still_blocked"]
 ExplicitCommitmentOpenLoopDecision = Literal[
     "CREATED",
     "NOOP_ACTIVE_EXISTS",
@@ -198,6 +200,12 @@ DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT = 5
 MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT = 20
 DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT = 5
 MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT = 20
+DEFAULT_CONTINUITY_OPEN_LOOP_LIMIT = 20
+MAX_CONTINUITY_OPEN_LOOP_LIMIT = 100
+DEFAULT_CONTINUITY_DAILY_BRIEF_LIMIT = 3
+MAX_CONTINUITY_DAILY_BRIEF_LIMIT = 20
+DEFAULT_CONTINUITY_WEEKLY_REVIEW_LIMIT = 5
+MAX_CONTINUITY_WEEKLY_REVIEW_LIMIT = 50
 DEFAULT_CALENDAR_EVENT_LIST_LIMIT = 20
 MAX_CALENDAR_EVENT_LIST_LIMIT = 50
 COMPILER_VERSION_V0 = "continuity_v0"
@@ -214,6 +222,8 @@ THREAD_EVENT_LIST_ORDER = ["sequence_no_asc"]
 DEFAULT_AGENT_PROFILE_ID = "assistant_default"
 RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0 = "resumption_brief_v0"
 CONTINUITY_RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0 = "continuity_resumption_brief_v0"
+CONTINUITY_DAILY_BRIEF_ASSEMBLY_VERSION_V0 = "continuity_daily_brief_v0"
+CONTINUITY_WEEKLY_REVIEW_ASSEMBLY_VERSION_V0 = "continuity_weekly_review_v0"
 RESUMPTION_BRIEF_CONVERSATION_EVENT_KINDS = ["message.user", "message.assistant"]
 RESUMPTION_BRIEF_CONVERSATION_ORDER = ["sequence_no_asc"]
 RESUMPTION_BRIEF_MEMORY_ORDER = ["updated_at_asc", "created_at_asc", "id_asc"]
@@ -348,6 +358,8 @@ CONTINUITY_CORRECTION_EVENT_ORDER = ["created_at_desc", "id_desc"]
 CONTINUITY_RECALL_LIST_ORDER = ["relevance_desc", "created_at_desc", "id_desc"]
 CONTINUITY_RESUMPTION_RECENT_CHANGE_ORDER = ["created_at_desc", "id_desc"]
 CONTINUITY_RESUMPTION_OPEN_LOOP_ORDER = ["created_at_desc", "id_desc"]
+CONTINUITY_OPEN_LOOP_POSTURE_ORDER = ["waiting_for", "blocker", "stale", "next_action"]
+CONTINUITY_OPEN_LOOP_ITEM_ORDER = ["created_at_desc", "id_desc"]
 TASK_WORKSPACE_STATUSES = ["active"]
 TASK_ARTIFACT_STATUSES = ["registered"]
 TASK_ARTIFACT_INGESTION_STATUSES = ["pending", "ingested"]
@@ -408,6 +420,17 @@ CONTINUITY_REVIEW_STATUSES = [
     "stale",
     "superseded",
     "deleted",
+]
+CONTINUITY_OPEN_LOOP_POSTURES = [
+    "waiting_for",
+    "blocker",
+    "stale",
+    "next_action",
+]
+CONTINUITY_OPEN_LOOP_REVIEW_ACTIONS = [
+    "done",
+    "deferred",
+    "still_blocked",
 ]
 
 
@@ -1336,6 +1359,93 @@ class ContinuityResumptionBriefRequestInput:
 
 
 @dataclass(frozen=True, slots=True)
+class ContinuityOpenLoopDashboardQueryInput:
+    query: str | None = None
+    thread_id: UUID | None = None
+    task_id: UUID | None = None
+    project: str | None = None
+    person: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    limit: int = DEFAULT_CONTINUITY_OPEN_LOOP_LIMIT
+
+    def as_payload(self) -> JsonObject:
+        payload: JsonObject = {
+            "query": self.query,
+            "thread_id": None if self.thread_id is None else str(self.thread_id),
+            "task_id": None if self.task_id is None else str(self.task_id),
+            "project": self.project,
+            "person": self.person,
+            "limit": self.limit,
+        }
+        payload["since"] = isoformat_or_none(self.since)
+        payload["until"] = isoformat_or_none(self.until)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuityDailyBriefRequestInput:
+    query: str | None = None
+    thread_id: UUID | None = None
+    task_id: UUID | None = None
+    project: str | None = None
+    person: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    limit: int = DEFAULT_CONTINUITY_DAILY_BRIEF_LIMIT
+
+    def as_payload(self) -> JsonObject:
+        payload: JsonObject = {
+            "query": self.query,
+            "thread_id": None if self.thread_id is None else str(self.thread_id),
+            "task_id": None if self.task_id is None else str(self.task_id),
+            "project": self.project,
+            "person": self.person,
+            "limit": self.limit,
+        }
+        payload["since"] = isoformat_or_none(self.since)
+        payload["until"] = isoformat_or_none(self.until)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuityWeeklyReviewRequestInput:
+    query: str | None = None
+    thread_id: UUID | None = None
+    task_id: UUID | None = None
+    project: str | None = None
+    person: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    limit: int = DEFAULT_CONTINUITY_WEEKLY_REVIEW_LIMIT
+
+    def as_payload(self) -> JsonObject:
+        payload: JsonObject = {
+            "query": self.query,
+            "thread_id": None if self.thread_id is None else str(self.thread_id),
+            "task_id": None if self.task_id is None else str(self.task_id),
+            "project": self.project,
+            "person": self.person,
+            "limit": self.limit,
+        }
+        payload["since"] = isoformat_or_none(self.since)
+        payload["until"] = isoformat_or_none(self.until)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuityOpenLoopReviewActionInput:
+    action: ContinuityOpenLoopReviewAction
+    note: str | None = None
+
+    def as_payload(self) -> JsonObject:
+        return {
+            "action": self.action,
+            "note": self.note,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class OpenLoopCreateInput:
     title: str
     memory_id: UUID | None = None
@@ -2032,6 +2142,85 @@ class ContinuityResumptionBriefRecord(TypedDict):
 
 class ContinuityResumptionBriefResponse(TypedDict):
     brief: ContinuityResumptionBriefRecord
+
+
+class ContinuityOpenLoopSectionSummary(TypedDict):
+    limit: int
+    returned_count: int
+    total_count: int
+    order: list[str]
+
+
+class ContinuityOpenLoopSection(TypedDict):
+    items: list[ContinuityRecallResultRecord]
+    summary: ContinuityOpenLoopSectionSummary
+    empty_state: ContinuityResumptionEmptyState
+
+
+class ContinuityOpenLoopDashboardSummary(TypedDict):
+    limit: int
+    total_count: int
+    posture_order: list[ContinuityOpenLoopPosture]
+    item_order: list[str]
+
+
+class ContinuityOpenLoopDashboardRecord(TypedDict):
+    scope: ContinuityRecallScopeFilters
+    waiting_for: ContinuityOpenLoopSection
+    blocker: ContinuityOpenLoopSection
+    stale: ContinuityOpenLoopSection
+    next_action: ContinuityOpenLoopSection
+    summary: ContinuityOpenLoopDashboardSummary
+    sources: list[str]
+
+
+class ContinuityOpenLoopDashboardResponse(TypedDict):
+    dashboard: ContinuityOpenLoopDashboardRecord
+
+
+class ContinuityDailyBriefRecord(TypedDict):
+    assembly_version: str
+    scope: ContinuityRecallScopeFilters
+    waiting_for_highlights: ContinuityOpenLoopSection
+    blocker_highlights: ContinuityOpenLoopSection
+    stale_items: ContinuityOpenLoopSection
+    next_suggested_action: ContinuityResumptionSingleSection
+    sources: list[str]
+
+
+class ContinuityDailyBriefResponse(TypedDict):
+    brief: ContinuityDailyBriefRecord
+
+
+class ContinuityWeeklyReviewRollup(TypedDict):
+    total_count: int
+    waiting_for_count: int
+    blocker_count: int
+    stale_count: int
+    next_action_count: int
+    posture_order: list[ContinuityOpenLoopPosture]
+
+
+class ContinuityWeeklyReviewRecord(TypedDict):
+    assembly_version: str
+    scope: ContinuityRecallScopeFilters
+    rollup: ContinuityWeeklyReviewRollup
+    waiting_for: ContinuityOpenLoopSection
+    blocker: ContinuityOpenLoopSection
+    stale: ContinuityOpenLoopSection
+    next_action: ContinuityOpenLoopSection
+    sources: list[str]
+
+
+class ContinuityWeeklyReviewResponse(TypedDict):
+    review: ContinuityWeeklyReviewRecord
+
+
+class ContinuityOpenLoopReviewActionResponse(TypedDict):
+    continuity_object: ContinuityReviewObjectRecord
+    correction_event: ContinuityCorrectionEventRecord
+    review_action: ContinuityOpenLoopReviewAction
+    lifecycle_outcome: str
 
 
 class ContinuityCorrectionApplyResponse(TypedDict):

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -35,6 +35,9 @@ from alicebot_api.contracts import (
     DEFAULT_CONTINUITY_CAPTURE_LIMIT,
     DEFAULT_CONTINUITY_REVIEW_LIMIT,
     DEFAULT_CONTINUITY_RECALL_LIMIT,
+    DEFAULT_CONTINUITY_OPEN_LOOP_LIMIT,
+    DEFAULT_CONTINUITY_DAILY_BRIEF_LIMIT,
+    DEFAULT_CONTINUITY_WEEKLY_REVIEW_LIMIT,
     DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
     DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
     DEFAULT_MAX_EVENTS,
@@ -58,11 +61,20 @@ from alicebot_api.contracts import (
     MAX_CONTINUITY_CAPTURE_LIMIT,
     MAX_CONTINUITY_REVIEW_LIMIT,
     MAX_CONTINUITY_RECALL_LIMIT,
+    MAX_CONTINUITY_OPEN_LOOP_LIMIT,
+    MAX_CONTINUITY_DAILY_BRIEF_LIMIT,
+    MAX_CONTINUITY_WEEKLY_REVIEW_LIMIT,
     MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
     MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
     MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
     ContextCompilerLimits,
     ContinuityCaptureCreateInput,
+    ContinuityDailyBriefRequestInput,
+    ContinuityDailyBriefResponse,
+    ContinuityOpenLoopDashboardQueryInput,
+    ContinuityOpenLoopDashboardResponse,
+    ContinuityOpenLoopReviewActionInput,
+    ContinuityOpenLoopReviewActionResponse,
     ContinuityCorrectionInput,
     ContinuityRecallQueryInput,
     ContinuityRecallResponse,
@@ -71,6 +83,8 @@ from alicebot_api.contracts import (
     ContinuityReviewQueueResponse,
     ContinuityResumptionBriefRequestInput,
     ContinuityResumptionBriefResponse,
+    ContinuityWeeklyReviewRequestInput,
+    ContinuityWeeklyReviewResponse,
     EmbeddingConfigStatus,
     EmbeddingConfigCreateInput,
     ExecutionBudgetCreateInput,
@@ -318,6 +332,14 @@ from alicebot_api.continuity_review import (
 from alicebot_api.continuity_resumption import (
     ContinuityResumptionValidationError,
     compile_continuity_resumption_brief,
+)
+from alicebot_api.continuity_open_loops import (
+    ContinuityOpenLoopNotFoundError,
+    ContinuityOpenLoopValidationError,
+    apply_continuity_open_loop_review_action,
+    compile_continuity_daily_brief,
+    compile_continuity_open_loop_dashboard,
+    compile_continuity_weekly_review,
 )
 from alicebot_api.continuity_objects import ContinuityObjectValidationError
 from alicebot_api.memory import (
@@ -594,6 +616,12 @@ class ContinuityCorrectionRequest(BaseModel):
     replacement_body: dict[str, object] | None = None
     replacement_provenance: dict[str, object] | None = None
     replacement_confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class ContinuityOpenLoopReviewActionRequest(BaseModel):
+    user_id: UUID
+    action: str = Field(min_length=1, max_length=40)
+    note: str | None = Field(default=None, min_length=1, max_length=500)
 
 
 class CreateMemoryReviewLabelRequest(BaseModel):
@@ -3250,6 +3278,170 @@ def apply_continuity_correction_endpoint(
     except ContinuityReviewValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
     except ContinuityReviewNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/continuity/open-loops")
+def get_continuity_open_loop_dashboard(
+    user_id: UUID,
+    query_text: str | None = Query(default=None, alias="query", min_length=1, max_length=4000),
+    thread_id: UUID | None = None,
+    task_id: UUID | None = None,
+    project: str | None = Query(default=None, min_length=1, max_length=200),
+    person: str | None = Query(default=None, min_length=1, max_length=200),
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = Query(
+        default=DEFAULT_CONTINUITY_OPEN_LOOP_LIMIT,
+        ge=0,
+        le=MAX_CONTINUITY_OPEN_LOOP_LIMIT,
+    ),
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: ContinuityOpenLoopDashboardResponse = compile_continuity_open_loop_dashboard(
+                ContinuityStore(conn),
+                user_id=user_id,
+                request=ContinuityOpenLoopDashboardQueryInput(
+                    query=query_text,
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    project=project,
+                    person=person,
+                    since=since,
+                    until=until,
+                    limit=limit,
+                ),
+            )
+    except ContinuityOpenLoopValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except ContinuityRecallValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/continuity/daily-brief")
+def get_continuity_daily_brief(
+    user_id: UUID,
+    query_text: str | None = Query(default=None, alias="query", min_length=1, max_length=4000),
+    thread_id: UUID | None = None,
+    task_id: UUID | None = None,
+    project: str | None = Query(default=None, min_length=1, max_length=200),
+    person: str | None = Query(default=None, min_length=1, max_length=200),
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = Query(
+        default=DEFAULT_CONTINUITY_DAILY_BRIEF_LIMIT,
+        ge=0,
+        le=MAX_CONTINUITY_DAILY_BRIEF_LIMIT,
+    ),
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: ContinuityDailyBriefResponse = compile_continuity_daily_brief(
+                ContinuityStore(conn),
+                user_id=user_id,
+                request=ContinuityDailyBriefRequestInput(
+                    query=query_text,
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    project=project,
+                    person=person,
+                    since=since,
+                    until=until,
+                    limit=limit,
+                ),
+            )
+    except ContinuityOpenLoopValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except ContinuityRecallValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/continuity/weekly-review")
+def get_continuity_weekly_review(
+    user_id: UUID,
+    query_text: str | None = Query(default=None, alias="query", min_length=1, max_length=4000),
+    thread_id: UUID | None = None,
+    task_id: UUID | None = None,
+    project: str | None = Query(default=None, min_length=1, max_length=200),
+    person: str | None = Query(default=None, min_length=1, max_length=200),
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = Query(
+        default=DEFAULT_CONTINUITY_WEEKLY_REVIEW_LIMIT,
+        ge=0,
+        le=MAX_CONTINUITY_WEEKLY_REVIEW_LIMIT,
+    ),
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: ContinuityWeeklyReviewResponse = compile_continuity_weekly_review(
+                ContinuityStore(conn),
+                user_id=user_id,
+                request=ContinuityWeeklyReviewRequestInput(
+                    query=query_text,
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    project=project,
+                    person=person,
+                    since=since,
+                    until=until,
+                    limit=limit,
+                ),
+            )
+    except ContinuityOpenLoopValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except ContinuityRecallValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.post("/v0/continuity/open-loops/{continuity_object_id}/review-action")
+def apply_continuity_open_loop_review_action_endpoint(
+    continuity_object_id: UUID,
+    request: ContinuityOpenLoopReviewActionRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            payload: ContinuityOpenLoopReviewActionResponse = apply_continuity_open_loop_review_action(
+                ContinuityStore(conn),
+                user_id=request.user_id,
+                continuity_object_id=continuity_object_id,
+                request=ContinuityOpenLoopReviewActionInput(
+                    action=request.action,  # type: ignore[arg-type]
+                    note=request.note,
+                ),
+            )
+    except ContinuityOpenLoopValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except ContinuityOpenLoopNotFoundError as exc:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
 
     return JSONResponse(

--- a/apps/web/app/continuity/page.test.tsx
+++ b/apps/web/app/continuity/page.test.tsx
@@ -6,9 +6,12 @@ import ContinuityPage from "./page";
 
 const {
   getApiConfigMock,
+  getContinuityDailyBriefMock,
+  getContinuityOpenLoopDashboardMock,
   getContinuityCaptureDetailMock,
   getContinuityReviewDetailMock,
   getContinuityResumptionBriefMock,
+  getContinuityWeeklyReviewMock,
   hasLiveApiConfigMock,
   listContinuityReviewQueueMock,
   listContinuityCapturesMock,
@@ -16,9 +19,12 @@ const {
   refreshMock,
 } = vi.hoisted(() => ({
   getApiConfigMock: vi.fn(),
+  getContinuityDailyBriefMock: vi.fn(),
+  getContinuityOpenLoopDashboardMock: vi.fn(),
   getContinuityCaptureDetailMock: vi.fn(),
   getContinuityReviewDetailMock: vi.fn(),
   getContinuityResumptionBriefMock: vi.fn(),
+  getContinuityWeeklyReviewMock: vi.fn(),
   hasLiveApiConfigMock: vi.fn(),
   listContinuityReviewQueueMock: vi.fn(),
   listContinuityCapturesMock: vi.fn(),
@@ -55,9 +61,12 @@ vi.mock("../../lib/api", async () => {
   return {
     ...actual,
     getApiConfig: getApiConfigMock,
+    getContinuityDailyBrief: getContinuityDailyBriefMock,
+    getContinuityOpenLoopDashboard: getContinuityOpenLoopDashboardMock,
     getContinuityCaptureDetail: getContinuityCaptureDetailMock,
     getContinuityReviewDetail: getContinuityReviewDetailMock,
     getContinuityResumptionBrief: getContinuityResumptionBriefMock,
+    getContinuityWeeklyReview: getContinuityWeeklyReviewMock,
     hasLiveApiConfig: hasLiveApiConfigMock,
     listContinuityReviewQueue: listContinuityReviewQueueMock,
     listContinuityCaptures: listContinuityCapturesMock,
@@ -68,9 +77,12 @@ vi.mock("../../lib/api", async () => {
 describe("ContinuityPage", () => {
   beforeEach(() => {
     getApiConfigMock.mockReset();
+    getContinuityDailyBriefMock.mockReset();
+    getContinuityOpenLoopDashboardMock.mockReset();
     getContinuityCaptureDetailMock.mockReset();
     getContinuityReviewDetailMock.mockReset();
     getContinuityResumptionBriefMock.mockReset();
+    getContinuityWeeklyReviewMock.mockReset();
     hasLiveApiConfigMock.mockReset();
     listContinuityReviewQueueMock.mockReset();
     listContinuityCapturesMock.mockReset();
@@ -97,12 +109,18 @@ describe("ContinuityPage", () => {
     expect(screen.getByText("Fixture inbox")).toBeInTheDocument();
     expect(screen.getByText("Fixture recall")).toBeInTheDocument();
     expect(screen.getByText("Fixture brief")).toBeInTheDocument();
+    expect(screen.getByText("Fixture open loops")).toBeInTheDocument();
+    expect(screen.getByText("Fixture daily brief")).toBeInTheDocument();
+    expect(screen.getByText("Fixture weekly review")).toBeInTheDocument();
     expect(screen.getByText("Fixture review queue")).toBeInTheDocument();
     expect(screen.getByText("Continuity recall")).toBeInTheDocument();
     expect(screen.getAllByText("Correction actions").length).toBeGreaterThan(0);
     expect(listContinuityCapturesMock).not.toHaveBeenCalled();
     expect(queryContinuityRecallMock).not.toHaveBeenCalled();
     expect(getContinuityResumptionBriefMock).not.toHaveBeenCalled();
+    expect(getContinuityOpenLoopDashboardMock).not.toHaveBeenCalled();
+    expect(getContinuityDailyBriefMock).not.toHaveBeenCalled();
+    expect(getContinuityWeeklyReviewMock).not.toHaveBeenCalled();
     expect(listContinuityReviewQueueMock).not.toHaveBeenCalled();
   });
 
@@ -278,6 +296,99 @@ describe("ContinuityPage", () => {
         sources: ["continuity_capture_events", "continuity_objects"],
       },
     });
+    getContinuityOpenLoopDashboardMock.mockResolvedValue({
+      dashboard: {
+        scope: { thread_id: "thread-1", since: null, until: null },
+        waiting_for: {
+          items: [],
+          summary: { limit: 20, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No waiting-for items in the requested scope." },
+        },
+        blocker: {
+          items: [],
+          summary: { limit: 20, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No blocker items in the requested scope." },
+        },
+        stale: {
+          items: [],
+          summary: { limit: 20, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No stale items in the requested scope." },
+        },
+        next_action: {
+          items: [],
+          summary: { limit: 20, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No next-action items in the requested scope." },
+        },
+        summary: {
+          limit: 20,
+          total_count: 0,
+          posture_order: ["waiting_for", "blocker", "stale", "next_action"],
+          item_order: ["created_at_desc", "id_desc"],
+        },
+        sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+      },
+    });
+    getContinuityDailyBriefMock.mockResolvedValue({
+      brief: {
+        assembly_version: "continuity_daily_brief_v0",
+        scope: { thread_id: "thread-1", since: null, until: null },
+        waiting_for_highlights: {
+          items: [],
+          summary: { limit: 3, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No waiting-for highlights for today in the requested scope." },
+        },
+        blocker_highlights: {
+          items: [],
+          summary: { limit: 3, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No blocker highlights for today in the requested scope." },
+        },
+        stale_items: {
+          items: [],
+          summary: { limit: 3, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No stale items for today in the requested scope." },
+        },
+        next_suggested_action: {
+          item: null,
+          empty_state: { is_empty: true, message: "No next suggested action in the requested scope." },
+        },
+        sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+      },
+    });
+    getContinuityWeeklyReviewMock.mockResolvedValue({
+      review: {
+        assembly_version: "continuity_weekly_review_v0",
+        scope: { thread_id: "thread-1", since: null, until: null },
+        rollup: {
+          total_count: 0,
+          waiting_for_count: 0,
+          blocker_count: 0,
+          stale_count: 0,
+          next_action_count: 0,
+          posture_order: ["waiting_for", "blocker", "stale", "next_action"],
+        },
+        waiting_for: {
+          items: [],
+          summary: { limit: 5, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No waiting-for items in the requested scope." },
+        },
+        blocker: {
+          items: [],
+          summary: { limit: 5, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No blocker items in the requested scope." },
+        },
+        stale: {
+          items: [],
+          summary: { limit: 5, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No stale items in the requested scope." },
+        },
+        next_action: {
+          items: [],
+          summary: { limit: 5, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+          empty_state: { is_empty: true, message: "No next-action items in the requested scope." },
+        },
+        sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+      },
+    });
     listContinuityReviewQueueMock.mockResolvedValue({
       items: [
         {
@@ -339,6 +450,9 @@ describe("ContinuityPage", () => {
     expect(screen.getByText("Live inbox")).toBeInTheDocument();
     expect(screen.getByText("Live recall")).toBeInTheDocument();
     expect(screen.getByText("Live brief")).toBeInTheDocument();
+    expect(screen.getByText("Live open loops")).toBeInTheDocument();
+    expect(screen.getByText("Live daily brief")).toBeInTheDocument();
+    expect(screen.getByText("Live weekly review")).toBeInTheDocument();
     expect(screen.getByText("Live review queue")).toBeInTheDocument();
     expect(screen.getAllByText("Decision: Keep admission conservative").length).toBeGreaterThan(0);
 
@@ -379,6 +493,40 @@ describe("ContinuityPage", () => {
       until: "",
       maxRecentChanges: 5,
       maxOpenLoops: 5,
+    });
+    expect(getContinuityOpenLoopDashboardMock).toHaveBeenCalledWith(
+      "https://api.example.com",
+      "user-1",
+      {
+        query: "decision",
+        threadId: "",
+        taskId: "",
+        project: "",
+        person: "",
+        since: "",
+        until: "",
+        limit: 20,
+      },
+    );
+    expect(getContinuityDailyBriefMock).toHaveBeenCalledWith("https://api.example.com", "user-1", {
+      query: "decision",
+      threadId: "",
+      taskId: "",
+      project: "",
+      person: "",
+      since: "",
+      until: "",
+      limit: 3,
+    });
+    expect(getContinuityWeeklyReviewMock).toHaveBeenCalledWith("https://api.example.com", "user-1", {
+      query: "decision",
+      threadId: "",
+      taskId: "",
+      project: "",
+      person: "",
+      since: "",
+      until: "",
+      limit: 5,
     });
   });
 });

--- a/apps/web/app/continuity/page.tsx
+++ b/apps/web/app/continuity/page.tsx
@@ -1,8 +1,11 @@
 import { ContinuityCaptureForm } from "../../components/continuity-capture-form";
 import { ContinuityCorrectionForm } from "../../components/continuity-correction-form";
+import { ContinuityDailyBriefPanel } from "../../components/continuity-daily-brief";
 import { ContinuityInboxList } from "../../components/continuity-inbox-list";
+import { ContinuityOpenLoopsPanel } from "../../components/continuity-open-loops-panel";
 import { ContinuityRecallPanel } from "../../components/continuity-recall-panel";
 import { ContinuityReviewQueue } from "../../components/continuity-review-queue";
+import { ContinuityWeeklyReviewPanel } from "../../components/continuity-weekly-review";
 import { EmptyState } from "../../components/empty-state";
 import { PageHeader } from "../../components/page-header";
 import { ResumptionBrief } from "../../components/resumption-brief";
@@ -12,6 +15,8 @@ import type {
   ApiSource,
   ContinuityCaptureInboxItem,
   ContinuityCaptureInboxSummary,
+  ContinuityDailyBrief,
+  ContinuityOpenLoopDashboard,
   ContinuityRecallResult,
   ContinuityRecallSummary,
   ContinuityReviewDetail,
@@ -19,13 +24,17 @@ import type {
   ContinuityReviewQueueSummary,
   ContinuityReviewStatusFilter,
   ContinuityResumptionBrief,
+  ContinuityWeeklyReview,
 } from "../../lib/api";
 import {
   getContinuityReviewDetail,
   combinePageModes,
   getApiConfig,
   getContinuityCaptureDetail,
+  getContinuityDailyBrief,
+  getContinuityOpenLoopDashboard,
   getContinuityResumptionBrief,
+  getContinuityWeeklyReview,
   hasLiveApiConfig,
   listContinuityReviewQueue,
   listContinuityCaptures,
@@ -257,6 +266,214 @@ const continuityResumptionFixture: ContinuityResumptionBrief = {
   sources: ["continuity_capture_events", "continuity_objects"],
 };
 
+const continuityOpenLoopWaitingFixture: ContinuityRecallResult = {
+  id: "open-loop-waiting-1",
+  capture_event_id: "capture-open-loop-waiting-1",
+  object_type: "WaitingFor",
+  status: "active",
+  title: "Waiting For: Vendor quote",
+  body: {
+    waiting_for_text: "Vendor quote",
+  },
+  provenance: {
+    thread_id: "thread-fixture-1",
+    project: "Launch Project",
+  },
+  confirmation_status: "unconfirmed",
+  admission_posture: "DERIVED",
+  confidence: 1,
+  relevance: 96,
+  last_confirmed_at: null,
+  supersedes_object_id: null,
+  superseded_by_object_id: null,
+  scope_matches: [],
+  provenance_references: [{ source_kind: "continuity_capture_event", source_id: "capture-open-loop-waiting-1" }],
+  ordering: {
+    scope_match_count: 0,
+    query_term_match_count: 0,
+    confirmation_rank: 2,
+    posture_rank: 2,
+    lifecycle_rank: 4,
+    confidence: 1,
+  },
+  created_at: "2026-03-29T09:30:00Z",
+  updated_at: "2026-03-29T09:30:00Z",
+};
+
+const continuityOpenLoopBlockerFixture: ContinuityRecallResult = {
+  id: "open-loop-blocker-1",
+  capture_event_id: "capture-open-loop-blocker-1",
+  object_type: "Blocker",
+  status: "active",
+  title: "Blocker: Await security approval",
+  body: {
+    blocking_reason: "Await security approval",
+  },
+  provenance: {
+    thread_id: "thread-fixture-1",
+    project: "Launch Project",
+  },
+  confirmation_status: "unconfirmed",
+  admission_posture: "DERIVED",
+  confidence: 1,
+  relevance: 95,
+  last_confirmed_at: null,
+  supersedes_object_id: null,
+  superseded_by_object_id: null,
+  scope_matches: [],
+  provenance_references: [{ source_kind: "continuity_capture_event", source_id: "capture-open-loop-blocker-1" }],
+  ordering: {
+    scope_match_count: 0,
+    query_term_match_count: 0,
+    confirmation_rank: 2,
+    posture_rank: 2,
+    lifecycle_rank: 4,
+    confidence: 1,
+  },
+  created_at: "2026-03-29T09:35:00Z",
+  updated_at: "2026-03-29T09:35:00Z",
+};
+
+const continuityOpenLoopStaleFixture: ContinuityRecallResult = {
+  id: "open-loop-stale-1",
+  capture_event_id: "capture-open-loop-stale-1",
+  object_type: "WaitingFor",
+  status: "stale",
+  title: "Waiting For: Stale finance response",
+  body: {
+    waiting_for_text: "Stale finance response",
+  },
+  provenance: {
+    thread_id: "thread-fixture-1",
+    project: "Launch Project",
+  },
+  confirmation_status: "unconfirmed",
+  admission_posture: "DERIVED",
+  confidence: 1,
+  relevance: 90,
+  last_confirmed_at: null,
+  supersedes_object_id: null,
+  superseded_by_object_id: null,
+  scope_matches: [],
+  provenance_references: [{ source_kind: "continuity_capture_event", source_id: "capture-open-loop-stale-1" }],
+  ordering: {
+    scope_match_count: 0,
+    query_term_match_count: 0,
+    confirmation_rank: 2,
+    posture_rank: 2,
+    lifecycle_rank: 3,
+    confidence: 1,
+  },
+  created_at: "2026-03-29T09:40:00Z",
+  updated_at: "2026-03-29T09:40:00Z",
+};
+
+const continuityOpenLoopDashboardFixture: ContinuityOpenLoopDashboard = {
+  scope: {
+    since: null,
+    until: null,
+  },
+  waiting_for: {
+    items: [continuityOpenLoopWaitingFixture],
+    summary: {
+      limit: 20,
+      returned_count: 1,
+      total_count: 1,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No waiting-for items in the requested scope.",
+    },
+  },
+  blocker: {
+    items: [continuityOpenLoopBlockerFixture],
+    summary: {
+      limit: 20,
+      returned_count: 1,
+      total_count: 1,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No blocker items in the requested scope.",
+    },
+  },
+  stale: {
+    items: [continuityOpenLoopStaleFixture],
+    summary: {
+      limit: 20,
+      returned_count: 1,
+      total_count: 1,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No stale items in the requested scope.",
+    },
+  },
+  next_action: {
+    items: [continuityRecallFixtures[0]],
+    summary: {
+      limit: 20,
+      returned_count: 1,
+      total_count: 1,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No next-action items in the requested scope.",
+    },
+  },
+  summary: {
+    limit: 20,
+    total_count: 4,
+    posture_order: ["waiting_for", "blocker", "stale", "next_action"],
+    item_order: ["created_at_desc", "id_desc"],
+  },
+  sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+};
+
+const continuityDailyBriefFixture: ContinuityDailyBrief = {
+  assembly_version: "continuity_daily_brief_v0",
+  scope: {
+    since: null,
+    until: null,
+  },
+  waiting_for_highlights: continuityOpenLoopDashboardFixture.waiting_for,
+  blocker_highlights: continuityOpenLoopDashboardFixture.blocker,
+  stale_items: continuityOpenLoopDashboardFixture.stale,
+  next_suggested_action: {
+    item: continuityRecallFixtures[0],
+    empty_state: {
+      is_empty: false,
+      message: "No next suggested action in the requested scope.",
+    },
+  },
+  sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+};
+
+const continuityWeeklyReviewFixture: ContinuityWeeklyReview = {
+  assembly_version: "continuity_weekly_review_v0",
+  scope: {
+    since: null,
+    until: null,
+  },
+  rollup: {
+    total_count: 4,
+    waiting_for_count: 1,
+    blocker_count: 1,
+    stale_count: 1,
+    next_action_count: 1,
+    posture_order: ["waiting_for", "blocker", "stale", "next_action"],
+  },
+  waiting_for: continuityOpenLoopDashboardFixture.waiting_for,
+  blocker: continuityOpenLoopDashboardFixture.blocker,
+  stale: continuityOpenLoopDashboardFixture.stale,
+  next_action: continuityOpenLoopDashboardFixture.next_action,
+  sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+};
+
 const continuityReviewFixtures: ContinuityReviewObject[] = [
   {
     id: "review-fixture-1",
@@ -411,6 +628,9 @@ export default async function ContinuityPage({
   const recallLimit = parsePositiveInt(normalizeParam(params.recall_limit), 20);
   const reviewStatus = parseReviewStatus(normalizeParam(params.review_status));
   const reviewLimit = parsePositiveInt(normalizeParam(params.review_limit), 20);
+  const openLoopLimit = parseNonNegativeInt(normalizeParam(params.open_loop_limit), 20);
+  const dailyBriefLimit = parseNonNegativeInt(normalizeParam(params.daily_limit), 3);
+  const weeklyReviewLimit = parseNonNegativeInt(normalizeParam(params.weekly_limit), 5);
   const resumptionRecentChanges = parseNonNegativeInt(normalizeParam(params.resumption_recent), 5);
   const resumptionOpenLoops = parseNonNegativeInt(normalizeParam(params.resumption_open), 5);
 
@@ -517,6 +737,84 @@ export default async function ContinuityPage({
     }
   }
 
+  let openLoopDashboard = continuityOpenLoopDashboardFixture;
+  let openLoopSource: ApiSource = "fixture";
+  let openLoopUnavailableReason: string | undefined;
+
+  if (liveModeReady) {
+    try {
+      const payload = await getContinuityOpenLoopDashboard(apiConfig.apiBaseUrl, apiConfig.userId, {
+        query: recallQuery,
+        threadId: recallThreadId,
+        taskId: recallTaskId,
+        project: recallProject,
+        person: recallPerson,
+        since: recallSince,
+        until: recallUntil,
+        limit: openLoopLimit,
+      });
+      openLoopDashboard = payload.dashboard;
+      openLoopSource = "live";
+    } catch (error) {
+      openLoopUnavailableReason =
+        error instanceof Error
+          ? error.message
+          : "Continuity open-loop dashboard could not be loaded.";
+    }
+  }
+
+  let dailyBrief = continuityDailyBriefFixture;
+  let dailyBriefSource: ApiSource = "fixture";
+  let dailyBriefUnavailableReason: string | undefined;
+
+  if (liveModeReady) {
+    try {
+      const payload = await getContinuityDailyBrief(apiConfig.apiBaseUrl, apiConfig.userId, {
+        query: recallQuery,
+        threadId: recallThreadId,
+        taskId: recallTaskId,
+        project: recallProject,
+        person: recallPerson,
+        since: recallSince,
+        until: recallUntil,
+        limit: dailyBriefLimit,
+      });
+      dailyBrief = payload.brief;
+      dailyBriefSource = "live";
+    } catch (error) {
+      dailyBriefUnavailableReason =
+        error instanceof Error
+          ? error.message
+          : "Continuity daily brief could not be loaded.";
+    }
+  }
+
+  let weeklyReview = continuityWeeklyReviewFixture;
+  let weeklyReviewSource: ApiSource = "fixture";
+  let weeklyReviewUnavailableReason: string | undefined;
+
+  if (liveModeReady) {
+    try {
+      const payload = await getContinuityWeeklyReview(apiConfig.apiBaseUrl, apiConfig.userId, {
+        query: recallQuery,
+        threadId: recallThreadId,
+        taskId: recallTaskId,
+        project: recallProject,
+        person: recallPerson,
+        since: recallSince,
+        until: recallUntil,
+        limit: weeklyReviewLimit,
+      });
+      weeklyReview = payload.review;
+      weeklyReviewSource = "live";
+    } catch (error) {
+      weeklyReviewUnavailableReason =
+        error instanceof Error
+          ? error.message
+          : "Continuity weekly review could not be loaded.";
+    }
+  }
+
   let reviewItems = continuityReviewFixtures;
   let reviewSummary = continuityReviewSummaryFixture;
   let reviewSource: ApiSource = "fixture";
@@ -570,6 +868,9 @@ export default async function ContinuityPage({
     selectedSource,
     recallSource,
     resumptionSource,
+    openLoopSource,
+    dailyBriefSource,
+    weeklyReviewSource,
     reviewSource,
     correctionSource,
   );
@@ -623,6 +924,27 @@ export default async function ContinuityPage({
           unavailableReason={resumptionUnavailableReason}
         />
       </div>
+
+      <div className="grid grid--two">
+        <ContinuityOpenLoopsPanel
+          apiBaseUrl={apiConfig.apiBaseUrl}
+          userId={apiConfig.userId}
+          dashboard={openLoopDashboard}
+          source={openLoopSource}
+          unavailableReason={openLoopUnavailableReason}
+        />
+        <ContinuityDailyBriefPanel
+          brief={dailyBrief}
+          source={dailyBriefSource}
+          unavailableReason={dailyBriefUnavailableReason}
+        />
+      </div>
+
+      <ContinuityWeeklyReviewPanel
+        review={weeklyReview}
+        source={weeklyReviewSource}
+        unavailableReason={weeklyReviewUnavailableReason}
+      />
 
       <div className="grid grid--two">
         <ContinuityReviewQueue

--- a/apps/web/components/continuity-daily-brief.test.tsx
+++ b/apps/web/components/continuity-daily-brief.test.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ContinuityDailyBriefPanel } from "./continuity-daily-brief";
+
+const briefFixture = {
+  assembly_version: "continuity_daily_brief_v0",
+  scope: {
+    since: null,
+    until: null,
+  },
+  waiting_for_highlights: {
+    items: [
+      {
+        id: "waiting-1",
+        capture_event_id: "capture-1",
+        object_type: "WaitingFor" as const,
+        status: "active",
+        title: "Waiting For: Vendor quote",
+        body: { waiting_for_text: "Vendor quote" },
+        provenance: {},
+        confirmation_status: "unconfirmed" as const,
+        admission_posture: "DERIVED" as const,
+        confidence: 1,
+        relevance: 100,
+        last_confirmed_at: null,
+        supersedes_object_id: null,
+        superseded_by_object_id: null,
+        scope_matches: [],
+        provenance_references: [],
+        ordering: {
+          scope_match_count: 0,
+          query_term_match_count: 0,
+          confirmation_rank: 2,
+          posture_rank: 2,
+          lifecycle_rank: 4,
+          confidence: 1,
+        },
+        created_at: "2026-03-30T09:00:00Z",
+        updated_at: "2026-03-30T09:00:00Z",
+      },
+    ],
+    summary: {
+      limit: 3,
+      returned_count: 1,
+      total_count: 1,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No waiting-for highlights for today in the requested scope.",
+    },
+  },
+  blocker_highlights: {
+    items: [],
+    summary: {
+      limit: 3,
+      returned_count: 0,
+      total_count: 0,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: true,
+      message: "No blocker highlights for today in the requested scope.",
+    },
+  },
+  stale_items: {
+    items: [],
+    summary: {
+      limit: 3,
+      returned_count: 0,
+      total_count: 0,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: true,
+      message: "No stale items for today in the requested scope.",
+    },
+  },
+  next_suggested_action: {
+    item: {
+      id: "next-1",
+      capture_event_id: "capture-2",
+      object_type: "NextAction" as const,
+      status: "active",
+      title: "Next Action: Send follow-up",
+      body: { action_text: "Send follow-up" },
+      provenance: {},
+      confirmation_status: "unconfirmed" as const,
+      admission_posture: "DERIVED" as const,
+      confidence: 1,
+      relevance: 99,
+      last_confirmed_at: null,
+      supersedes_object_id: null,
+      superseded_by_object_id: null,
+      scope_matches: [],
+      provenance_references: [],
+      ordering: {
+        scope_match_count: 0,
+        query_term_match_count: 0,
+        confirmation_rank: 2,
+        posture_rank: 2,
+        lifecycle_rank: 4,
+        confidence: 1,
+      },
+      created_at: "2026-03-30T09:05:00Z",
+      updated_at: "2026-03-30T09:05:00Z",
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No next suggested action in the requested scope.",
+    },
+  },
+  sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+};
+
+describe("ContinuityDailyBriefPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders daily brief sections with explicit empty states", () => {
+    render(<ContinuityDailyBriefPanel brief={briefFixture} source="live" />);
+
+    expect(screen.getByText("Live daily brief")).toBeInTheDocument();
+    expect(screen.getByText("continuity_daily_brief_v0")).toBeInTheDocument();
+    expect(screen.getByText("Waiting For: Vendor quote")).toBeInTheDocument();
+    expect(screen.getByText("No blocker highlights for today in the requested scope.")).toBeInTheDocument();
+    expect(screen.getByText("No stale items for today in the requested scope.")).toBeInTheDocument();
+    expect(screen.getByText("Next Action: Send follow-up")).toBeInTheDocument();
+  });
+
+  it("renders fallback empty state when payload is absent", () => {
+    render(<ContinuityDailyBriefPanel brief={null} source="fixture" />);
+
+    expect(screen.getByText("Daily brief unavailable")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/continuity-daily-brief.tsx
+++ b/apps/web/components/continuity-daily-brief.tsx
@@ -1,0 +1,97 @@
+import type { ApiSource, ContinuityDailyBrief } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type ContinuityDailyBriefProps = {
+  brief: ContinuityDailyBrief | null;
+  source: ApiSource | "unavailable";
+  unavailableReason?: string;
+};
+
+function renderListSection(
+  heading: string,
+  section:
+    | ContinuityDailyBrief["waiting_for_highlights"]
+    | ContinuityDailyBrief["blocker_highlights"]
+    | ContinuityDailyBrief["stale_items"],
+) {
+  return (
+    <div className="detail-group">
+      <h3>{heading}</h3>
+      {section.items.length === 0 ? (
+        <p className="muted-copy">{section.empty_state.message}</p>
+      ) : (
+        <ul className="detail-stack">
+          {section.items.map((item) => (
+            <li key={item.id} className="cluster">
+              <span className="meta-pill">{item.object_type}</span>
+              <span>{item.title}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export function ContinuityDailyBriefPanel({ brief, source, unavailableReason }: ContinuityDailyBriefProps) {
+  if (brief === null) {
+    return (
+      <SectionCard
+        eyebrow="Daily"
+        title="Daily brief"
+        description="Compose deterministic waiting-for, blocker, stale, and next-action sections for daily continuity review."
+      >
+        <EmptyState
+          title="Daily brief unavailable"
+          description="Daily brief is not available in this mode yet."
+        />
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard
+      eyebrow="Daily"
+      title="Daily brief"
+      description="Daily review composes deterministic open-loop highlights and one next suggested action with explicit empty states."
+    >
+      <div className="detail-stack">
+        <div className="cluster">
+          <StatusBadge
+            status={source}
+            label={
+              source === "live"
+                ? "Live daily brief"
+                : source === "fixture"
+                  ? "Fixture daily brief"
+                  : "Daily brief unavailable"
+            }
+          />
+          <span className="meta-pill mono">{brief.assembly_version}</span>
+        </div>
+
+        {unavailableReason ? (
+          <p className="responsive-note">Live daily brief read failed: {unavailableReason}</p>
+        ) : null}
+
+        {renderListSection("Waiting for", brief.waiting_for_highlights)}
+        {renderListSection("Blockers", brief.blocker_highlights)}
+        {renderListSection("Stale", brief.stale_items)}
+
+        <div className="detail-group">
+          <h3>Next suggested action</h3>
+          {brief.next_suggested_action.item ? (
+            <div className="cluster">
+              <span className="meta-pill">{brief.next_suggested_action.item.object_type}</span>
+              <span>{brief.next_suggested_action.item.title}</span>
+            </div>
+          ) : (
+            <p className="muted-copy">{brief.next_suggested_action.empty_state.message}</p>
+          )}
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/components/continuity-open-loops-panel.test.tsx
+++ b/apps/web/components/continuity-open-loops-panel.test.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ContinuityOpenLoopsPanel } from "./continuity-open-loops-panel";
+
+const { applyContinuityOpenLoopReviewActionMock, refreshMock } = vi.hoisted(() => ({
+  applyContinuityOpenLoopReviewActionMock: vi.fn(),
+  refreshMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual("../lib/api");
+  return {
+    ...actual,
+    applyContinuityOpenLoopReviewAction: applyContinuityOpenLoopReviewActionMock,
+  };
+});
+
+const dashboardFixture = {
+  scope: {
+    since: null,
+    until: null,
+  },
+  waiting_for: {
+    items: [
+      {
+        id: "object-1",
+        capture_event_id: "capture-1",
+        object_type: "WaitingFor" as const,
+        status: "active",
+        title: "Waiting For: Vendor quote",
+        body: { waiting_for_text: "Vendor quote" },
+        provenance: {},
+        confirmation_status: "unconfirmed" as const,
+        admission_posture: "DERIVED" as const,
+        confidence: 1,
+        relevance: 100,
+        last_confirmed_at: null,
+        supersedes_object_id: null,
+        superseded_by_object_id: null,
+        scope_matches: [],
+        provenance_references: [],
+        ordering: {
+          scope_match_count: 0,
+          query_term_match_count: 0,
+          confirmation_rank: 2,
+          posture_rank: 2,
+          lifecycle_rank: 4,
+          confidence: 1,
+        },
+        created_at: "2026-03-30T10:00:00Z",
+        updated_at: "2026-03-30T10:00:00Z",
+      },
+    ],
+    summary: {
+      limit: 10,
+      returned_count: 1,
+      total_count: 1,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: false,
+      message: "none",
+    },
+  },
+  blocker: {
+    items: [],
+    summary: {
+      limit: 10,
+      returned_count: 0,
+      total_count: 0,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: true,
+      message: "No blocker items in the requested scope.",
+    },
+  },
+  stale: {
+    items: [],
+    summary: {
+      limit: 10,
+      returned_count: 0,
+      total_count: 0,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: true,
+      message: "No stale items in the requested scope.",
+    },
+  },
+  next_action: {
+    items: [],
+    summary: {
+      limit: 10,
+      returned_count: 0,
+      total_count: 0,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: true,
+      message: "No next-action items in the requested scope.",
+    },
+  },
+  summary: {
+    limit: 10,
+    total_count: 1,
+    posture_order: ["waiting_for", "blocker", "stale", "next_action"] as const,
+    item_order: ["created_at_desc", "id_desc"],
+  },
+  sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+};
+
+describe("ContinuityOpenLoopsPanel", () => {
+  beforeEach(() => {
+    applyContinuityOpenLoopReviewActionMock.mockReset();
+    refreshMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders posture groups and submits review actions", async () => {
+    applyContinuityOpenLoopReviewActionMock.mockResolvedValue({
+      continuity_object: {
+        id: "object-1",
+        capture_event_id: "capture-1",
+        object_type: "WaitingFor",
+        status: "completed",
+        title: "Waiting For: Vendor quote",
+        body: { waiting_for_text: "Vendor quote" },
+        provenance: {},
+        confidence: 1,
+        last_confirmed_at: null,
+        supersedes_object_id: null,
+        superseded_by_object_id: null,
+        created_at: "2026-03-30T10:00:00Z",
+        updated_at: "2026-03-30T10:01:00Z",
+      },
+      correction_event: {
+        id: "event-1",
+        continuity_object_id: "object-1",
+        action: "edit",
+        reason: null,
+        before_snapshot: {},
+        after_snapshot: {},
+        payload: { review_action: "done" },
+        created_at: "2026-03-30T10:01:00Z",
+      },
+      review_action: "done",
+      lifecycle_outcome: "completed",
+    });
+
+    render(
+      <ContinuityOpenLoopsPanel
+        apiBaseUrl="https://api.example.com"
+        userId="user-1"
+        dashboard={dashboardFixture}
+        source="live"
+      />,
+    );
+
+    expect(screen.getByText("Live open loops")).toBeInTheDocument();
+    expect(screen.getByText("Waiting For: Vendor quote")).toBeInTheDocument();
+    expect(screen.getByText("No blocker items in the requested scope.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    await waitFor(() => {
+      expect(applyContinuityOpenLoopReviewActionMock).toHaveBeenCalledWith(
+        "https://api.example.com",
+        "object-1",
+        {
+          user_id: "user-1",
+          action: "done",
+        },
+      );
+    });
+
+    expect(refreshMock).toHaveBeenCalled();
+    expect(screen.getByText(/Lifecycle is now completed/i)).toBeInTheDocument();
+  });
+
+  it("renders explicit fallback when dashboard payload is absent", () => {
+    render(<ContinuityOpenLoopsPanel dashboard={null} source="fixture" />);
+
+    expect(screen.getByText("Open-loop dashboard unavailable")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/continuity-open-loops-panel.tsx
+++ b/apps/web/components/continuity-open-loops-panel.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState } from "react";
+
+import { useRouter } from "next/navigation";
+
+import type {
+  ApiSource,
+  ContinuityOpenLoopDashboard,
+  ContinuityOpenLoopPosture,
+  ContinuityOpenLoopReviewAction,
+} from "../lib/api";
+import { applyContinuityOpenLoopReviewAction } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type ContinuityOpenLoopsPanelProps = {
+  apiBaseUrl?: string;
+  userId?: string;
+  dashboard: ContinuityOpenLoopDashboard | null;
+  source: ApiSource | "unavailable";
+  unavailableReason?: string;
+};
+
+const GROUPS: Array<{ key: ContinuityOpenLoopPosture; label: string }> = [
+  { key: "waiting_for", label: "Waiting for" },
+  { key: "blocker", label: "Blockers" },
+  { key: "stale", label: "Stale" },
+  { key: "next_action", label: "Next action" },
+];
+
+const ACTION_LABELS: Array<{ action: ContinuityOpenLoopReviewAction; label: string }> = [
+  { action: "done", label: "Done" },
+  { action: "deferred", label: "Deferred" },
+  { action: "still_blocked", label: "Still blocked" },
+];
+
+export function ContinuityOpenLoopsPanel({
+  apiBaseUrl,
+  userId,
+  dashboard,
+  source,
+  unavailableReason,
+}: ContinuityOpenLoopsPanelProps) {
+  const router = useRouter();
+  const liveModeReady = Boolean(apiBaseUrl && userId && source === "live");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusTone, setStatusTone] = useState<"info" | "success" | "danger">("info");
+  const [statusText, setStatusText] = useState(
+    "Review one open-loop item and apply done/deferred/still_blocked actions.",
+  );
+
+  async function handleAction(
+    continuityObjectId: string,
+    action: ContinuityOpenLoopReviewAction,
+    title: string,
+  ) {
+    if (!liveModeReady || !apiBaseUrl || !userId) {
+      setStatusTone("info");
+      setStatusText("Review actions are available only when live continuity API access is configured.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusTone("info");
+    setStatusText(`Applying ${action}...`);
+
+    try {
+      const payload = await applyContinuityOpenLoopReviewAction(apiBaseUrl, continuityObjectId, {
+        user_id: userId,
+        action,
+      });
+      setStatusTone("success");
+      setStatusText(
+        `${action} applied to "${title}". Lifecycle is now ${payload.lifecycle_outcome}. Resumption has been refreshed.`,
+      );
+      router.refresh();
+    } catch (error) {
+      setStatusTone("danger");
+      setStatusText(
+        `Unable to apply review action: ${error instanceof Error ? error.message : "Request failed"}`,
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (dashboard === null) {
+    return (
+      <SectionCard
+        eyebrow="Open loops"
+        title="Open-loop dashboard"
+        description="Review waiting-for, blocker, stale, and next-action posture with deterministic grouping and ordering."
+      >
+        <EmptyState
+          title="Open-loop dashboard unavailable"
+          description="Open-loop dashboard is not available in this mode yet."
+        />
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard
+      eyebrow="Open loops"
+      title="Open-loop dashboard"
+      description="Deterministic posture groups support daily continuity review and explicit action handling."
+    >
+      <div className="detail-stack">
+        <div className="cluster">
+          <StatusBadge
+            status={source}
+            label={
+              source === "live"
+                ? "Live open loops"
+                : source === "fixture"
+                  ? "Fixture open loops"
+                  : "Open-loop dashboard unavailable"
+            }
+          />
+          <span className="meta-pill">{dashboard.summary.total_count} total</span>
+        </div>
+
+        {unavailableReason ? (
+          <p className="responsive-note">Live open-loop dashboard read failed: {unavailableReason}</p>
+        ) : null}
+
+        <div className="composer-status" aria-live="polite">
+          <StatusBadge
+            status={
+              isSubmitting
+                ? "submitting"
+                : statusTone === "success"
+                  ? "success"
+                  : statusTone === "danger"
+                    ? "error"
+                    : liveModeReady
+                      ? "ready"
+                      : "unavailable"
+            }
+            label={
+              isSubmitting
+                ? "Submitting"
+                : statusTone === "success"
+                  ? "Applied"
+                  : statusTone === "danger"
+                    ? "Attention"
+                    : liveModeReady
+                      ? "Ready"
+                      : "Unavailable"
+            }
+          />
+          <span>{statusText}</span>
+        </div>
+
+        {GROUPS.map((group) => {
+          const section = dashboard[group.key];
+          return (
+            <div key={group.key} className="detail-group">
+              <h3>{group.label}</h3>
+              {section.items.length === 0 ? (
+                <p className="muted-copy">{section.empty_state.message}</p>
+              ) : (
+                <ul className="detail-stack">
+                  {section.items.map((item) => (
+                    <li key={item.id} className="list-row">
+                      <div className="list-row__topline">
+                        <div className="detail-stack">
+                          <span className="list-row__eyebrow mono">{item.id}</span>
+                          <span className="list-row__title">{item.title}</span>
+                        </div>
+                        <div className="cluster">
+                          <span className="meta-pill">{item.object_type}</span>
+                          <StatusBadge status={item.status} label={item.status} />
+                        </div>
+                      </div>
+
+                      <div className="composer-actions">
+                        {ACTION_LABELS.map((option) => (
+                          <button
+                            key={option.action}
+                            type="button"
+                            className="button button--ghost"
+                            onClick={() => handleAction(item.id, option.action, item.title)}
+                            disabled={!liveModeReady || isSubmitting}
+                          >
+                            {option.label}
+                          </button>
+                        ))}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/components/continuity-weekly-review.test.tsx
+++ b/apps/web/components/continuity-weekly-review.test.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ContinuityWeeklyReviewPanel } from "./continuity-weekly-review";
+
+const reviewFixture = {
+  assembly_version: "continuity_weekly_review_v0",
+  scope: {
+    since: null,
+    until: null,
+  },
+  rollup: {
+    total_count: 2,
+    waiting_for_count: 1,
+    blocker_count: 0,
+    stale_count: 1,
+    next_action_count: 0,
+    posture_order: ["waiting_for", "blocker", "stale", "next_action"] as const,
+  },
+  waiting_for: {
+    items: [
+      {
+        id: "waiting-1",
+        capture_event_id: "capture-1",
+        object_type: "WaitingFor" as const,
+        status: "active",
+        title: "Waiting For: Vendor quote",
+        body: { waiting_for_text: "Vendor quote" },
+        provenance: {},
+        confirmation_status: "unconfirmed" as const,
+        admission_posture: "DERIVED" as const,
+        confidence: 1,
+        relevance: 100,
+        last_confirmed_at: null,
+        supersedes_object_id: null,
+        superseded_by_object_id: null,
+        scope_matches: [],
+        provenance_references: [],
+        ordering: {
+          scope_match_count: 0,
+          query_term_match_count: 0,
+          confirmation_rank: 2,
+          posture_rank: 2,
+          lifecycle_rank: 4,
+          confidence: 1,
+        },
+        created_at: "2026-03-30T09:00:00Z",
+        updated_at: "2026-03-30T09:00:00Z",
+      },
+    ],
+    summary: {
+      limit: 5,
+      returned_count: 1,
+      total_count: 1,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No waiting-for items in the requested scope.",
+    },
+  },
+  blocker: {
+    items: [],
+    summary: {
+      limit: 5,
+      returned_count: 0,
+      total_count: 0,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: true,
+      message: "No blocker items in the requested scope.",
+    },
+  },
+  stale: {
+    items: [
+      {
+        id: "stale-1",
+        capture_event_id: "capture-2",
+        object_type: "WaitingFor" as const,
+        status: "stale",
+        title: "Waiting For: Stale invoice response",
+        body: { waiting_for_text: "Stale invoice response" },
+        provenance: {},
+        confirmation_status: "unconfirmed" as const,
+        admission_posture: "DERIVED" as const,
+        confidence: 1,
+        relevance: 90,
+        last_confirmed_at: null,
+        supersedes_object_id: null,
+        superseded_by_object_id: null,
+        scope_matches: [],
+        provenance_references: [],
+        ordering: {
+          scope_match_count: 0,
+          query_term_match_count: 0,
+          confirmation_rank: 2,
+          posture_rank: 2,
+          lifecycle_rank: 3,
+          confidence: 1,
+        },
+        created_at: "2026-03-30T09:05:00Z",
+        updated_at: "2026-03-30T09:05:00Z",
+      },
+    ],
+    summary: {
+      limit: 5,
+      returned_count: 1,
+      total_count: 1,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: false,
+      message: "No stale items in the requested scope.",
+    },
+  },
+  next_action: {
+    items: [],
+    summary: {
+      limit: 5,
+      returned_count: 0,
+      total_count: 0,
+      order: ["created_at_desc", "id_desc"],
+    },
+    empty_state: {
+      is_empty: true,
+      message: "No next-action items in the requested scope.",
+    },
+  },
+  sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+};
+
+describe("ContinuityWeeklyReviewPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders weekly rollup and grouped posture sections", () => {
+    render(<ContinuityWeeklyReviewPanel review={reviewFixture} source="live" />);
+
+    expect(screen.getByText("Live weekly review")).toBeInTheDocument();
+    expect(screen.getByText("continuity_weekly_review_v0")).toBeInTheDocument();
+    expect(screen.getByText("2 total")).toBeInTheDocument();
+    expect(screen.getByText("Waiting For: Vendor quote")).toBeInTheDocument();
+    expect(screen.getByText("Waiting For: Stale invoice response")).toBeInTheDocument();
+    expect(screen.getByText("No blocker items in the requested scope.")).toBeInTheDocument();
+    expect(screen.getByText("No next-action items in the requested scope.")).toBeInTheDocument();
+  });
+
+  it("renders fallback empty state when payload is absent", () => {
+    render(<ContinuityWeeklyReviewPanel review={null} source="fixture" />);
+
+    expect(screen.getByText("Weekly review unavailable")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/continuity-weekly-review.tsx
+++ b/apps/web/components/continuity-weekly-review.tsx
@@ -1,0 +1,103 @@
+import type { ApiSource, ContinuityWeeklyReview } from "../lib/api";
+import { EmptyState } from "./empty-state";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type ContinuityWeeklyReviewProps = {
+  review: ContinuityWeeklyReview | null;
+  source: ApiSource | "unavailable";
+  unavailableReason?: string;
+};
+
+function renderSection(
+  heading: string,
+  section: ContinuityWeeklyReview["waiting_for"] | ContinuityWeeklyReview["blocker"] | ContinuityWeeklyReview["stale"] | ContinuityWeeklyReview["next_action"],
+) {
+  return (
+    <div className="detail-group">
+      <h3>{heading}</h3>
+      {section.items.length === 0 ? (
+        <p className="muted-copy">{section.empty_state.message}</p>
+      ) : (
+        <ul className="detail-stack">
+          {section.items.map((item) => (
+            <li key={item.id} className="cluster">
+              <span className="meta-pill">{item.status}</span>
+              <span>{item.title}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export function ContinuityWeeklyReviewPanel({ review, source, unavailableReason }: ContinuityWeeklyReviewProps) {
+  if (review === null) {
+    return (
+      <SectionCard
+        eyebrow="Weekly"
+        title="Weekly review"
+        description="Compile deterministic weekly posture rollups over waiting, blocker, stale, and next-action continuity seams."
+      >
+        <EmptyState
+          title="Weekly review unavailable"
+          description="Weekly review is not available in this mode yet."
+        />
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard
+      eyebrow="Weekly"
+      title="Weekly review"
+      description="Weekly review keeps posture counts and grouped continuity sections deterministic and auditable."
+    >
+      <div className="detail-stack">
+        <div className="cluster">
+          <StatusBadge
+            status={source}
+            label={
+              source === "live"
+                ? "Live weekly review"
+                : source === "fixture"
+                  ? "Fixture weekly review"
+                  : "Weekly review unavailable"
+            }
+          />
+          <span className="meta-pill mono">{review.assembly_version}</span>
+          <span className="meta-pill">{review.rollup.total_count} total</span>
+        </div>
+
+        {unavailableReason ? (
+          <p className="responsive-note">Live weekly review read failed: {unavailableReason}</p>
+        ) : null}
+
+        <dl className="key-value-grid key-value-grid--compact">
+          <div>
+            <dt>Waiting for</dt>
+            <dd>{review.rollup.waiting_for_count}</dd>
+          </div>
+          <div>
+            <dt>Blockers</dt>
+            <dd>{review.rollup.blocker_count}</dd>
+          </div>
+          <div>
+            <dt>Stale</dt>
+            <dd>{review.rollup.stale_count}</dd>
+          </div>
+          <div>
+            <dt>Next action</dt>
+            <dd>{review.rollup.next_action_count}</dd>
+          </div>
+        </dl>
+
+        {renderSection("Waiting for", review.waiting_for)}
+        {renderSection("Blockers", review.blocker)}
+        {renderSection("Stale", review.stale)}
+        {renderSection("Next action", review.next_action)}
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -19,6 +19,9 @@ import {
   getEntityDetail,
   getContinuityCaptureDetail,
   getContinuityReviewDetail,
+  getContinuityOpenLoopDashboard,
+  getContinuityDailyBrief,
+  getContinuityWeeklyReview,
   getMemoryDetail,
   getMemoryEvaluationSummary,
   getMemoryRevisions,
@@ -60,6 +63,7 @@ import {
   submitApprovalRequest,
   captureExplicitSignals,
   extractExplicitCommitments,
+  applyContinuityOpenLoopReviewAction,
   submitMemoryLabel,
   updateOpenLoopStatus,
 } from "./api";
@@ -2576,6 +2580,194 @@ describe("api helpers", () => {
       user_id: "user-1",
       action: "confirm",
       reason: "Reviewed",
+    });
+  });
+
+  it("uses continuity open-loop dashboard, daily/weekly brief, and review-action endpoints", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            dashboard: {
+              scope: { thread_id: "thread-1", since: null, until: null },
+              waiting_for: {
+                items: [],
+                summary: { limit: 10, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              blocker: {
+                items: [],
+                summary: { limit: 10, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              stale: {
+                items: [],
+                summary: { limit: 10, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              next_action: {
+                items: [],
+                summary: { limit: 10, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              summary: {
+                limit: 10,
+                total_count: 0,
+                posture_order: ["waiting_for", "blocker", "stale", "next_action"],
+                item_order: ["created_at_desc", "id_desc"],
+              },
+              sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            brief: {
+              assembly_version: "continuity_daily_brief_v0",
+              scope: { thread_id: "thread-1", since: null, until: null },
+              waiting_for_highlights: {
+                items: [],
+                summary: { limit: 3, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              blocker_highlights: {
+                items: [],
+                summary: { limit: 3, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              stale_items: {
+                items: [],
+                summary: { limit: 3, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              next_suggested_action: { item: null, empty_state: { is_empty: true, message: "none" } },
+              sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            review: {
+              assembly_version: "continuity_weekly_review_v0",
+              scope: { thread_id: "thread-1", since: null, until: null },
+              rollup: {
+                total_count: 0,
+                waiting_for_count: 0,
+                blocker_count: 0,
+                stale_count: 0,
+                next_action_count: 0,
+                posture_order: ["waiting_for", "blocker", "stale", "next_action"],
+              },
+              waiting_for: {
+                items: [],
+                summary: { limit: 5, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              blocker: {
+                items: [],
+                summary: { limit: 5, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              stale: {
+                items: [],
+                summary: { limit: 5, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              next_action: {
+                items: [],
+                summary: { limit: 5, returned_count: 0, total_count: 0, order: ["created_at_desc", "id_desc"] },
+                empty_state: { is_empty: true, message: "none" },
+              },
+              sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            continuity_object: {
+              id: "object-1",
+              capture_event_id: "capture-1",
+              object_type: "WaitingFor",
+              status: "completed",
+              title: "Waiting For: Vendor quote",
+              body: { waiting_for_text: "Vendor quote" },
+              provenance: {},
+              confidence: 0.9,
+              last_confirmed_at: null,
+              supersedes_object_id: null,
+              superseded_by_object_id: null,
+              created_at: "2026-03-30T10:00:00Z",
+              updated_at: "2026-03-30T10:01:00Z",
+            },
+            correction_event: {
+              id: "event-1",
+              continuity_object_id: "object-1",
+              action: "edit",
+              reason: "done in standup",
+              before_snapshot: {},
+              after_snapshot: {},
+              payload: { review_action: "done" },
+              created_at: "2026-03-30T10:01:00Z",
+            },
+            review_action: "done",
+            lifecycle_outcome: "completed",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    await getContinuityOpenLoopDashboard("https://api.example.com", "user-1", {
+      threadId: "thread-1",
+      limit: 10,
+    });
+    await getContinuityDailyBrief("https://api.example.com", "user-1", {
+      threadId: "thread-1",
+      limit: 3,
+    });
+    await getContinuityWeeklyReview("https://api.example.com", "user-1", {
+      threadId: "thread-1",
+      limit: 5,
+    });
+    await applyContinuityOpenLoopReviewAction("https://api.example.com", "object-1", {
+      user_id: "user-1",
+      action: "done",
+      note: "done in standup",
+    });
+
+    expect(fetchMock.mock.calls).toEqual([
+      [
+        "https://api.example.com/v0/continuity/open-loops?user_id=user-1&thread_id=thread-1&limit=10",
+        expect.objectContaining({ cache: "no-store" }),
+      ],
+      [
+        "https://api.example.com/v0/continuity/daily-brief?user_id=user-1&thread_id=thread-1&limit=3",
+        expect.objectContaining({ cache: "no-store" }),
+      ],
+      [
+        "https://api.example.com/v0/continuity/weekly-review?user_id=user-1&thread_id=thread-1&limit=5",
+        expect.objectContaining({ cache: "no-store" }),
+      ],
+      [
+        "https://api.example.com/v0/continuity/open-loops/object-1/review-action",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "Content-Type": "application/json" }),
+        }),
+      ],
+    ]);
+    expect(JSON.parse(String(fetchMock.mock.calls[3]?.[1]?.body))).toEqual({
+      user_id: "user-1",
+      action: "done",
+      note: "done in standup",
     });
   });
 });

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1082,6 +1082,79 @@ export type ContinuityResumptionBrief = {
   sources: string[];
 };
 
+export type ContinuityOpenLoopPosture = "waiting_for" | "blocker" | "stale" | "next_action";
+
+export type ContinuityOpenLoopReviewAction = "done" | "deferred" | "still_blocked";
+
+export type ContinuityOpenLoopSectionSummary = {
+  limit: number;
+  returned_count: number;
+  total_count: number;
+  order: string[];
+};
+
+export type ContinuityOpenLoopSection = {
+  items: ContinuityRecallResult[];
+  summary: ContinuityOpenLoopSectionSummary;
+  empty_state: ContinuityResumptionEmptyState;
+};
+
+export type ContinuityOpenLoopDashboard = {
+  scope: ContinuityRecallSummary["filters"];
+  waiting_for: ContinuityOpenLoopSection;
+  blocker: ContinuityOpenLoopSection;
+  stale: ContinuityOpenLoopSection;
+  next_action: ContinuityOpenLoopSection;
+  summary: {
+    limit: number;
+    total_count: number;
+    posture_order: ContinuityOpenLoopPosture[];
+    item_order: string[];
+  };
+  sources: string[];
+};
+
+export type ContinuityDailyBrief = {
+  assembly_version: string;
+  scope: ContinuityRecallSummary["filters"];
+  waiting_for_highlights: ContinuityOpenLoopSection;
+  blocker_highlights: ContinuityOpenLoopSection;
+  stale_items: ContinuityOpenLoopSection;
+  next_suggested_action: ContinuityResumptionSingleSection;
+  sources: string[];
+};
+
+export type ContinuityWeeklyReview = {
+  assembly_version: string;
+  scope: ContinuityRecallSummary["filters"];
+  rollup: {
+    total_count: number;
+    waiting_for_count: number;
+    blocker_count: number;
+    stale_count: number;
+    next_action_count: number;
+    posture_order: ContinuityOpenLoopPosture[];
+  };
+  waiting_for: ContinuityOpenLoopSection;
+  blocker: ContinuityOpenLoopSection;
+  stale: ContinuityOpenLoopSection;
+  next_action: ContinuityOpenLoopSection;
+  sources: string[];
+};
+
+export type ContinuityOpenLoopReviewActionPayload = {
+  user_id: string;
+  action: ContinuityOpenLoopReviewAction;
+  note?: string | null;
+};
+
+export type ContinuityOpenLoopReviewActionResult = {
+  continuity_object: ContinuityReviewObject;
+  correction_event: ContinuityCorrectionEvent;
+  review_action: ContinuityOpenLoopReviewAction;
+  lifecycle_outcome: string;
+};
+
 export type OpenLoopCreatePayload = {
   user_id: string;
   memory_id?: string | null;
@@ -1630,6 +1703,153 @@ export function getContinuityResumptionBrief(
       until: until || undefined,
       max_recent_changes: maxRecentChanges,
       max_open_loops: maxOpenLoops,
+    },
+  );
+}
+
+export function getContinuityOpenLoopDashboard(
+  apiBaseUrl: string,
+  userId: string,
+  options?: {
+    query?: string;
+    threadId?: string;
+    taskId?: string;
+    project?: string;
+    person?: string;
+    since?: string;
+    until?: string;
+    limit?: number;
+  },
+) {
+  const query = options?.query?.trim();
+  const threadId = options?.threadId?.trim();
+  const taskId = options?.taskId?.trim();
+  const project = options?.project?.trim();
+  const person = options?.person?.trim();
+  const since = options?.since?.trim();
+  const until = options?.until?.trim();
+  const limit =
+    typeof options?.limit === "number" && Number.isFinite(options.limit) && options.limit >= 0
+      ? String(Math.trunc(options.limit))
+      : undefined;
+
+  return requestJson<{ dashboard: ContinuityOpenLoopDashboard }>(
+    apiBaseUrl,
+    "/v0/continuity/open-loops",
+    undefined,
+    {
+      user_id: userId,
+      query: query || undefined,
+      thread_id: threadId || undefined,
+      task_id: taskId || undefined,
+      project: project || undefined,
+      person: person || undefined,
+      since: since || undefined,
+      until: until || undefined,
+      limit,
+    },
+  );
+}
+
+export function getContinuityDailyBrief(
+  apiBaseUrl: string,
+  userId: string,
+  options?: {
+    query?: string;
+    threadId?: string;
+    taskId?: string;
+    project?: string;
+    person?: string;
+    since?: string;
+    until?: string;
+    limit?: number;
+  },
+) {
+  const query = options?.query?.trim();
+  const threadId = options?.threadId?.trim();
+  const taskId = options?.taskId?.trim();
+  const project = options?.project?.trim();
+  const person = options?.person?.trim();
+  const since = options?.since?.trim();
+  const until = options?.until?.trim();
+  const limit =
+    typeof options?.limit === "number" && Number.isFinite(options.limit) && options.limit >= 0
+      ? String(Math.trunc(options.limit))
+      : undefined;
+
+  return requestJson<{ brief: ContinuityDailyBrief }>(
+    apiBaseUrl,
+    "/v0/continuity/daily-brief",
+    undefined,
+    {
+      user_id: userId,
+      query: query || undefined,
+      thread_id: threadId || undefined,
+      task_id: taskId || undefined,
+      project: project || undefined,
+      person: person || undefined,
+      since: since || undefined,
+      until: until || undefined,
+      limit,
+    },
+  );
+}
+
+export function getContinuityWeeklyReview(
+  apiBaseUrl: string,
+  userId: string,
+  options?: {
+    query?: string;
+    threadId?: string;
+    taskId?: string;
+    project?: string;
+    person?: string;
+    since?: string;
+    until?: string;
+    limit?: number;
+  },
+) {
+  const query = options?.query?.trim();
+  const threadId = options?.threadId?.trim();
+  const taskId = options?.taskId?.trim();
+  const project = options?.project?.trim();
+  const person = options?.person?.trim();
+  const since = options?.since?.trim();
+  const until = options?.until?.trim();
+  const limit =
+    typeof options?.limit === "number" && Number.isFinite(options.limit) && options.limit >= 0
+      ? String(Math.trunc(options.limit))
+      : undefined;
+
+  return requestJson<{ review: ContinuityWeeklyReview }>(
+    apiBaseUrl,
+    "/v0/continuity/weekly-review",
+    undefined,
+    {
+      user_id: userId,
+      query: query || undefined,
+      thread_id: threadId || undefined,
+      task_id: taskId || undefined,
+      project: project || undefined,
+      person: person || undefined,
+      since: since || undefined,
+      until: until || undefined,
+      limit,
+    },
+  );
+}
+
+export function applyContinuityOpenLoopReviewAction(
+  apiBaseUrl: string,
+  continuityObjectId: string,
+  payload: ContinuityOpenLoopReviewActionPayload,
+) {
+  return requestJson<ContinuityOpenLoopReviewActionResult>(
+    apiBaseUrl,
+    `/v0/continuity/open-loops/${continuityObjectId}/review-action`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
     },
   );
 }

--- a/docs/phase5-product-spec.md
+++ b/docs/phase5-product-spec.md
@@ -297,10 +297,27 @@ Required metrics:
   - selected object correction form with supersession chain visibility
   - correction event history review
 
-## Explicitly Deferred After P5-S19
+## Shipped In P5-S20 (March 29, 2026)
 
-- P5-S20: daily/weekly open-loop review dashboards
-- keep docs and control-tower planning aligned with shipped behavior
+- continuity open-loop/daily/weekly API surfaces:
+  - `GET /v0/continuity/open-loops`
+  - `GET /v0/continuity/daily-brief`
+  - `GET /v0/continuity/weekly-review`
+  - `POST /v0/continuity/open-loops/{continuity_object_id}/review-action`
+- deterministic open-loop posture grouping and ordering:
+  - explicit posture groups: `waiting_for`, `blocker`, `stale`, `next_action`
+  - deterministic item ordering metadata: `created_at_desc`, `id_desc`
+  - explicit empty-state payloads for all sections
+- deterministic review-action workflow for open loops:
+  - `done` -> completed lifecycle outcome
+  - `deferred` -> stale lifecycle outcome
+  - `still_blocked` -> active lifecycle outcome with freshness confirmation
+  - each action appends an auditable correction event payload before lifecycle mutation
+- continuity resumption reflects review-action outcomes immediately in open-loop and recent-change sections
+- `/continuity` workspace expansion for:
+  - open-loop dashboard review panel with per-item action controls
+  - deterministic daily brief panel
+  - deterministic weekly review panel with posture rollup
 
 ## Acceptance Criteria
 

--- a/docs/phase5-sprint-17-20-plan.md
+++ b/docs/phase5-sprint-17-20-plan.md
@@ -201,7 +201,7 @@ Open Loops and Daily Review
 
 ### Status
 
-Deferred (not started in P5-S17).
+Shipped on March 29, 2026.
 
 ### Objective
 
@@ -214,21 +214,45 @@ Convert continuity into executive-function support by surfacing what is waiting,
 - stale-item review
 - daily brief
 - weekly review
+- open-loop review actions with deterministic lifecycle outcomes
 
 ### Deliverables
 
 - open-loop dashboard
 - deterministic daily brief
 - weekly review surface
-- done/defer/dismiss actions
+- done/deferred/still_blocked actions
 - immediate resumption updates after review actions
+
+### Implementation Snapshot
+
+- API:
+  - `GET /v0/continuity/open-loops`
+  - `GET /v0/continuity/daily-brief`
+  - `GET /v0/continuity/weekly-review`
+  - `POST /v0/continuity/open-loops/{continuity_object_id}/review-action`
+- Open-loop dashboard behavior:
+  - explicit posture groups: `waiting_for`, `blocker`, `stale`, `next_action`
+  - deterministic item ordering: `created_at_desc`, `id_desc`
+  - explicit empty-state payloads per section
+- Daily/weekly brief behavior:
+  - daily sections: `waiting_for_highlights`, `blocker_highlights`, `stale_items`, `next_suggested_action`
+  - weekly review includes deterministic posture rollup counts with grouped sections
+- Review-action behavior:
+  - `done` -> `completed`
+  - `deferred` -> `stale`
+  - `still_blocked` -> `active` with refreshed confirmation timestamp
+  - mapped correction event appended before lifecycle mutation
+- Web:
+  - `/continuity` now includes open-loop dashboard, daily brief, weekly review, and open-loop action controls
 
 ### Acceptance Criteria
 
-- daily brief is generated deterministically from continuity objects and task state
-- users can mark items done, deferred, or still blocked
-- review actions improve later resumption output
-- stale and waiting items are surfaced before they disappear from active attention
+- open-loop dashboard returns deterministic grouped ordering for waiting_for/blocker/stale/next_action posture
+- daily brief and weekly review endpoints are deterministic for fixed input state and emit explicit empty states for empty sections
+- users can mark open-loop items done, deferred, or still blocked
+- review-action lifecycle outcomes are deterministic and auditable
+- continuity resumption reflects review-action outcomes immediately
 
 ### Out Of Scope
 

--- a/tests/integration/test_continuity_daily_weekly_review_api.py
+++ b/tests/integration/test_continuity_daily_weekly_review_api.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from typing import Any
+from urllib.parse import urlencode
+from uuid import UUID, uuid4
+
+import anyio
+import psycopg
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+from alicebot_api.db import user_connection
+from alicebot_api.store import ContinuityStore
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+
+        request_received = True
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def seed_user(database_url: str, *, email: str) -> UUID:
+    user_id = uuid4()
+    with user_connection(database_url, user_id) as conn:
+        ContinuityStore(conn).create_user(user_id, email, email.split("@", 1)[0].title())
+    return user_id
+
+
+def set_continuity_timestamps(
+    admin_database_url: str,
+    *,
+    continuity_object_id: UUID,
+    created_at: datetime,
+) -> None:
+    with psycopg.connect(admin_database_url, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE continuity_objects SET created_at = %s, updated_at = %s WHERE id = %s",
+                (created_at, created_at, continuity_object_id),
+            )
+
+
+def test_daily_and_weekly_review_endpoints_are_deterministic(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="daily-weekly@example.com")
+    thread_id = UUID("cccccccc-cccc-4ccc-8ccc-cccccccccccc")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+
+        waiting_capture = store.create_continuity_capture_event(
+            raw_content="Waiting For: Vendor quote",
+            explicit_signal="waiting_for",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_waiting_for",
+        )
+        waiting_object = store.create_continuity_object(
+            capture_event_id=waiting_capture["id"],
+            object_type="WaitingFor",
+            status="active",
+            title="Waiting For: Vendor quote",
+            body={"waiting_for_text": "Vendor quote"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+        blocker_capture = store.create_continuity_capture_event(
+            raw_content="Blocker: Missing API key",
+            explicit_signal="blocker",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_blocker",
+        )
+        blocker_object = store.create_continuity_object(
+            capture_event_id=blocker_capture["id"],
+            object_type="Blocker",
+            status="active",
+            title="Blocker: Missing API key",
+            body={"blocking_reason": "Missing API key"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+        stale_capture = store.create_continuity_capture_event(
+            raw_content="Waiting For: Stale finance reply",
+            explicit_signal="waiting_for",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_waiting_for",
+        )
+        stale_object = store.create_continuity_object(
+            capture_event_id=stale_capture["id"],
+            object_type="WaitingFor",
+            status="stale",
+            title="Waiting For: Stale finance reply",
+            body={"waiting_for_text": "Stale finance reply"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+        next_capture = store.create_continuity_capture_event(
+            raw_content="Next Action: Send follow-up",
+            explicit_signal="next_action",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_next_action",
+        )
+        next_object = store.create_continuity_object(
+            capture_event_id=next_capture["id"],
+            object_type="NextAction",
+            status="active",
+            title="Next Action: Send follow-up",
+            body={"action_text": "Send follow-up"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=waiting_object["id"],
+        created_at=datetime(2026, 3, 30, 8, 0, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=blocker_object["id"],
+        created_at=datetime(2026, 3, 30, 8, 5, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=stale_object["id"],
+        created_at=datetime(2026, 3, 30, 8, 10, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=next_object["id"],
+        created_at=datetime(2026, 3, 30, 8, 15, tzinfo=UTC),
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    first_daily_status, first_daily = invoke_request(
+        "GET",
+        "/v0/continuity/daily-brief",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "limit": "3",
+        },
+    )
+    second_daily_status, second_daily = invoke_request(
+        "GET",
+        "/v0/continuity/daily-brief",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "limit": "3",
+        },
+    )
+
+    assert first_daily_status == 200
+    assert second_daily_status == 200
+    assert first_daily == second_daily
+    assert [item["title"] for item in first_daily["brief"]["waiting_for_highlights"]["items"]] == [
+        "Waiting For: Vendor quote",
+    ]
+    assert [item["title"] for item in first_daily["brief"]["blocker_highlights"]["items"]] == [
+        "Blocker: Missing API key",
+    ]
+    assert [item["title"] for item in first_daily["brief"]["stale_items"]["items"]] == [
+        "Waiting For: Stale finance reply",
+    ]
+    assert first_daily["brief"]["next_suggested_action"]["item"]["title"] == "Next Action: Send follow-up"
+
+    first_weekly_status, first_weekly = invoke_request(
+        "GET",
+        "/v0/continuity/weekly-review",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "limit": "5",
+        },
+    )
+    second_weekly_status, second_weekly = invoke_request(
+        "GET",
+        "/v0/continuity/weekly-review",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "limit": "5",
+        },
+    )
+
+    assert first_weekly_status == 200
+    assert second_weekly_status == 200
+    assert first_weekly == second_weekly
+    assert first_weekly["review"]["rollup"] == {
+        "total_count": 4,
+        "waiting_for_count": 1,
+        "blocker_count": 1,
+        "stale_count": 1,
+        "next_action_count": 1,
+        "posture_order": ["waiting_for", "blocker", "stale", "next_action"],
+    }
+
+
+def test_daily_and_weekly_review_endpoints_emit_explicit_empty_states(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="daily-weekly-empty@example.com")
+    thread_id = UUID("dddddddd-dddd-4ddd-8ddd-dddddddddddd")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        note_capture = store.create_continuity_capture_event(
+            raw_content="Note: context only",
+            explicit_signal="note",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_note",
+        )
+        note_object = store.create_continuity_object(
+            capture_event_id=note_capture["id"],
+            object_type="Note",
+            status="active",
+            title="Note: context only",
+            body={"body": "context only"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=note_object["id"],
+        created_at=datetime(2026, 3, 30, 9, 0, tzinfo=UTC),
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    daily_status, daily_payload = invoke_request(
+        "GET",
+        "/v0/continuity/daily-brief",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "limit": "3",
+        },
+    )
+    weekly_status, weekly_payload = invoke_request(
+        "GET",
+        "/v0/continuity/weekly-review",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "limit": "3",
+        },
+    )
+
+    assert daily_status == 200
+    assert daily_payload["brief"]["waiting_for_highlights"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No waiting-for highlights for today in the requested scope.",
+    }
+    assert daily_payload["brief"]["blocker_highlights"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No blocker highlights for today in the requested scope.",
+    }
+    assert daily_payload["brief"]["stale_items"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No stale items for today in the requested scope.",
+    }
+    assert daily_payload["brief"]["next_suggested_action"] == {
+        "item": None,
+        "empty_state": {
+            "is_empty": True,
+            "message": "No next suggested action in the requested scope.",
+        },
+    }
+
+    assert weekly_status == 200
+    assert weekly_payload["review"]["rollup"]["total_count"] == 0
+    assert weekly_payload["review"]["waiting_for"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No waiting-for items in the requested scope.",
+    }
+    assert weekly_payload["review"]["blocker"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No blocker items in the requested scope.",
+    }
+    assert weekly_payload["review"]["stale"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No stale items in the requested scope.",
+    }
+    assert weekly_payload["review"]["next_action"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No next-action items in the requested scope.",
+    }
+
+
+def test_daily_and_weekly_review_endpoints_reject_mixed_naive_and_offset_aware_time_window(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="daily-weekly-window-validation@example.com")
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    for path in ("/v0/continuity/daily-brief", "/v0/continuity/weekly-review"):
+        status, payload = invoke_request(
+            "GET",
+            path,
+            query_params={
+                "user_id": str(user_id),
+                "since": "2026-03-30T10:00:00Z",
+                "until": "2026-03-30T10:01:00",
+            },
+        )
+        assert status == 400
+        assert (
+            payload["detail"]
+            == "since and until must both include timezone offsets or both omit timezone offsets"
+        )

--- a/tests/integration/test_continuity_open_loops_api.py
+++ b/tests/integration/test_continuity_open_loops_api.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from typing import Any
+from urllib.parse import urlencode
+from uuid import UUID, uuid4
+
+import anyio
+import psycopg
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+from alicebot_api.db import user_connection
+from alicebot_api.store import ContinuityStore
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+
+        request_received = True
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def seed_user(database_url: str, *, email: str) -> UUID:
+    user_id = uuid4()
+    with user_connection(database_url, user_id) as conn:
+        ContinuityStore(conn).create_user(user_id, email, email.split("@", 1)[0].title())
+    return user_id
+
+
+def set_continuity_timestamps(
+    admin_database_url: str,
+    *,
+    continuity_object_id: UUID,
+    created_at: datetime,
+) -> None:
+    with psycopg.connect(admin_database_url, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE continuity_objects SET created_at = %s, updated_at = %s WHERE id = %s",
+                (created_at, created_at, continuity_object_id),
+            )
+
+
+def test_continuity_open_loop_dashboard_groups_posture_and_order(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="dashboard@example.com")
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+
+        waiting_capture = store.create_continuity_capture_event(
+            raw_content="Waiting For: Vendor quote",
+            explicit_signal="waiting_for",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_waiting_for",
+        )
+        waiting_object = store.create_continuity_object(
+            capture_event_id=waiting_capture["id"],
+            object_type="WaitingFor",
+            status="active",
+            title="Waiting For: Vendor quote",
+            body={"waiting_for_text": "Vendor quote"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+        blocker_capture = store.create_continuity_capture_event(
+            raw_content="Blocker: Missing API key",
+            explicit_signal="blocker",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_blocker",
+        )
+        blocker_object = store.create_continuity_object(
+            capture_event_id=blocker_capture["id"],
+            object_type="Blocker",
+            status="active",
+            title="Blocker: Missing API key",
+            body={"blocking_reason": "Missing API key"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+        next_capture = store.create_continuity_capture_event(
+            raw_content="Next Action: Send follow-up",
+            explicit_signal="next_action",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_next_action",
+        )
+        next_object = store.create_continuity_object(
+            capture_event_id=next_capture["id"],
+            object_type="NextAction",
+            status="active",
+            title="Next Action: Send follow-up",
+            body={"action_text": "Send follow-up"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+        stale_capture = store.create_continuity_capture_event(
+            raw_content="Waiting For: Stale finance reply",
+            explicit_signal="waiting_for",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_waiting_for",
+        )
+        stale_object = store.create_continuity_object(
+            capture_event_id=stale_capture["id"],
+            object_type="WaitingFor",
+            status="stale",
+            title="Waiting For: Stale finance reply",
+            body={"waiting_for_text": "Stale finance reply"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=waiting_object["id"],
+        created_at=datetime(2026, 3, 30, 10, 0, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=blocker_object["id"],
+        created_at=datetime(2026, 3, 30, 10, 5, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=next_object["id"],
+        created_at=datetime(2026, 3, 30, 10, 10, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=stale_object["id"],
+        created_at=datetime(2026, 3, 30, 10, 15, tzinfo=UTC),
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v0/continuity/open-loops",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "limit": "20",
+        },
+    )
+
+    assert status == 200
+    dashboard = payload["dashboard"]
+    assert dashboard["summary"] == {
+        "limit": 20,
+        "total_count": 4,
+        "posture_order": ["waiting_for", "blocker", "stale", "next_action"],
+        "item_order": ["created_at_desc", "id_desc"],
+    }
+    assert [item["title"] for item in dashboard["waiting_for"]["items"]] == [
+        "Waiting For: Vendor quote",
+    ]
+    assert [item["title"] for item in dashboard["blocker"]["items"]] == [
+        "Blocker: Missing API key",
+    ]
+    assert [item["title"] for item in dashboard["stale"]["items"]] == [
+        "Waiting For: Stale finance reply",
+    ]
+    assert [item["title"] for item in dashboard["next_action"]["items"]] == [
+        "Next Action: Send follow-up",
+    ]
+
+
+def test_open_loop_review_actions_update_resumption_immediately(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="review-actions@example.com")
+    thread_id = UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+
+        waiting_capture = store.create_continuity_capture_event(
+            raw_content="Waiting For: Vendor quote",
+            explicit_signal="waiting_for",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_waiting_for",
+        )
+        waiting_object = store.create_continuity_object(
+            capture_event_id=waiting_capture["id"],
+            object_type="WaitingFor",
+            status="active",
+            title="Waiting For: Vendor quote",
+            body={"waiting_for_text": "Vendor quote"},
+            provenance={"thread_id": str(thread_id)},
+            confidence=1.0,
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=waiting_object["id"],
+        created_at=datetime(2026, 3, 30, 12, 0, tzinfo=UTC),
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    done_status, done_payload = invoke_request(
+        "POST",
+        f"/v0/continuity/open-loops/{waiting_object['id']}/review-action",
+        payload={
+            "user_id": str(user_id),
+            "action": "done",
+            "note": "Closed after follow-up",
+        },
+    )
+    assert done_status == 200
+    assert done_payload["review_action"] == "done"
+    assert done_payload["lifecycle_outcome"] == "completed"
+    assert done_payload["continuity_object"]["status"] == "completed"
+
+    resumption_after_done_status, resumption_after_done = invoke_request(
+        "GET",
+        "/v0/continuity/resumption-brief",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "max_open_loops": "5",
+            "max_recent_changes": "5",
+        },
+    )
+    assert resumption_after_done_status == 200
+    assert resumption_after_done["brief"]["open_loops"]["items"] == []
+
+    still_blocked_status, still_blocked_payload = invoke_request(
+        "POST",
+        f"/v0/continuity/open-loops/{waiting_object['id']}/review-action",
+        payload={
+            "user_id": str(user_id),
+            "action": "still_blocked",
+        },
+    )
+    assert still_blocked_status == 200
+    assert still_blocked_payload["lifecycle_outcome"] == "active"
+    assert still_blocked_payload["continuity_object"]["status"] == "active"
+
+    resumption_after_still_blocked_status, resumption_after_still_blocked = invoke_request(
+        "GET",
+        "/v0/continuity/resumption-brief",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "max_open_loops": "5",
+            "max_recent_changes": "5",
+        },
+    )
+    assert resumption_after_still_blocked_status == 200
+    assert [item["id"] for item in resumption_after_still_blocked["brief"]["open_loops"]["items"]] == [
+        str(waiting_object["id"]),
+    ]
+
+    deferred_status, deferred_payload = invoke_request(
+        "POST",
+        f"/v0/continuity/open-loops/{waiting_object['id']}/review-action",
+        payload={
+            "user_id": str(user_id),
+            "action": "deferred",
+        },
+    )
+    assert deferred_status == 200
+    assert deferred_payload["lifecycle_outcome"] == "stale"
+    assert deferred_payload["continuity_object"]["status"] == "stale"
+
+    resumption_after_deferred_status, resumption_after_deferred = invoke_request(
+        "GET",
+        "/v0/continuity/resumption-brief",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "max_open_loops": "5",
+            "max_recent_changes": "5",
+        },
+    )
+    assert resumption_after_deferred_status == 200
+    assert resumption_after_deferred["brief"]["open_loops"]["items"] == []
+    assert [item["status"] for item in resumption_after_deferred["brief"]["recent_changes"]["items"]][:1] == [
+        "stale",
+    ]
+
+
+def test_open_loop_dashboard_rejects_mixed_naive_and_offset_aware_time_window(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="open-loop-window-validation@example.com")
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v0/continuity/open-loops",
+        query_params={
+            "user_id": str(user_id),
+            "since": "2026-03-30T10:00:00Z",
+            "until": "2026-03-30T10:01:00",
+        },
+    )
+
+    assert status == 400
+    assert (
+        payload["detail"]
+        == "since and until must both include timezone offsets or both omit timezone offsets"
+    )

--- a/tests/unit/test_continuity_open_loops.py
+++ b/tests/unit/test_continuity_open_loops.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+
+from alicebot_api.continuity_open_loops import (
+    ContinuityOpenLoopValidationError,
+    apply_continuity_open_loop_review_action,
+    compile_continuity_daily_brief,
+    compile_continuity_open_loop_dashboard,
+    compile_continuity_weekly_review,
+)
+from alicebot_api.contracts import (
+    ContinuityDailyBriefRequestInput,
+    ContinuityOpenLoopDashboardQueryInput,
+    ContinuityOpenLoopReviewActionInput,
+    ContinuityWeeklyReviewRequestInput,
+)
+
+
+class ContinuityOpenLoopsStoreStub:
+    def __init__(self, rows: list[dict[str, object]] | None = None) -> None:
+        self.base_time = datetime(2026, 3, 30, 9, 0, tzinfo=UTC)
+        self._recall_rows = list(rows or [])
+        self.objects: dict[UUID, dict[str, object]] = {}
+        self.events: list[dict[str, object]] = []
+
+    def list_continuity_recall_candidates(self):
+        return list(self._recall_rows)
+
+    def add_object(
+        self,
+        *,
+        object_type: str,
+        status: str = "active",
+        title: str,
+        created_at: datetime | None = None,
+        last_confirmed_at: datetime | None = None,
+    ) -> dict[str, object]:
+        object_id = uuid4()
+        capture_event_id = uuid4()
+        row = {
+            "id": object_id,
+            "user_id": UUID("11111111-1111-4111-8111-111111111111"),
+            "capture_event_id": capture_event_id,
+            "object_type": object_type,
+            "status": status,
+            "title": title,
+            "body": {"text": title},
+            "provenance": {"thread_id": "thread-1"},
+            "confidence": 0.91,
+            "last_confirmed_at": last_confirmed_at,
+            "supersedes_object_id": None,
+            "superseded_by_object_id": None,
+            "created_at": created_at or self.base_time,
+            "updated_at": created_at or self.base_time,
+        }
+        self.objects[object_id] = row
+        return dict(row)
+
+    def get_continuity_object_optional(self, continuity_object_id: UUID):
+        row = self.objects.get(continuity_object_id)
+        if row is None:
+            return None
+        return dict(row)
+
+    def create_continuity_correction_event(
+        self,
+        *,
+        continuity_object_id: UUID,
+        action: str,
+        reason: str | None,
+        before_snapshot,
+        after_snapshot,
+        payload,
+    ):
+        event = {
+            "id": uuid4(),
+            "user_id": UUID("11111111-1111-4111-8111-111111111111"),
+            "continuity_object_id": continuity_object_id,
+            "action": action,
+            "reason": reason,
+            "before_snapshot": before_snapshot,
+            "after_snapshot": after_snapshot,
+            "payload": payload,
+            "created_at": self.base_time + timedelta(minutes=len(self.events) + 1),
+        }
+        self.events.append(event)
+        return dict(event)
+
+    def update_continuity_object_optional(
+        self,
+        *,
+        continuity_object_id: UUID,
+        status: str,
+        title: str,
+        body,
+        provenance,
+        confidence: float,
+        last_confirmed_at: datetime | None,
+        supersedes_object_id: UUID | None,
+        superseded_by_object_id: UUID | None,
+    ):
+        row = self.objects.get(continuity_object_id)
+        if row is None:
+            return None
+
+        updated = {
+            **row,
+            "status": status,
+            "title": title,
+            "body": body,
+            "provenance": provenance,
+            "confidence": confidence,
+            "last_confirmed_at": last_confirmed_at,
+            "supersedes_object_id": supersedes_object_id,
+            "superseded_by_object_id": superseded_by_object_id,
+            "updated_at": self.base_time + timedelta(minutes=len(self.events) + 1),
+        }
+        self.objects[continuity_object_id] = updated
+        return dict(updated)
+
+
+def make_candidate_row(
+    *,
+    title: str,
+    object_type: str,
+    status: str,
+    created_at: datetime,
+) -> dict[str, object]:
+    return {
+        "id": uuid4(),
+        "user_id": UUID("11111111-1111-4111-8111-111111111111"),
+        "capture_event_id": uuid4(),
+        "object_type": object_type,
+        "status": status,
+        "title": title,
+        "body": {"text": title},
+        "provenance": {"thread_id": "thread-1"},
+        "confidence": 1.0,
+        "last_confirmed_at": None,
+        "supersedes_object_id": None,
+        "superseded_by_object_id": None,
+        "object_created_at": created_at,
+        "object_updated_at": created_at,
+        "admission_posture": "DERIVED",
+        "admission_reason": "seeded",
+        "explicit_signal": None,
+        "capture_created_at": created_at,
+    }
+
+
+def test_open_loop_dashboard_groups_and_orders_posture_deterministically() -> None:
+    rows = [
+        make_candidate_row(
+            title="Waiting For: Vendor quote",
+            object_type="WaitingFor",
+            status="active",
+            created_at=datetime(2026, 3, 30, 10, 1, tzinfo=UTC),
+        ),
+        make_candidate_row(
+            title="Waiting For: Legal signoff",
+            object_type="WaitingFor",
+            status="active",
+            created_at=datetime(2026, 3, 30, 10, 3, tzinfo=UTC),
+        ),
+        make_candidate_row(
+            title="Blocker: Missing API key",
+            object_type="Blocker",
+            status="active",
+            created_at=datetime(2026, 3, 30, 10, 4, tzinfo=UTC),
+        ),
+        make_candidate_row(
+            title="Next Action: Send follow-up",
+            object_type="NextAction",
+            status="active",
+            created_at=datetime(2026, 3, 30, 10, 5, tzinfo=UTC),
+        ),
+        make_candidate_row(
+            title="Waiting For: Stale invoice response",
+            object_type="WaitingFor",
+            status="stale",
+            created_at=datetime(2026, 3, 30, 10, 6, tzinfo=UTC),
+        ),
+        make_candidate_row(
+            title="Note: not part of open-loop posture",
+            object_type="Note",
+            status="active",
+            created_at=datetime(2026, 3, 30, 10, 7, tzinfo=UTC),
+        ),
+    ]
+
+    payload = compile_continuity_open_loop_dashboard(
+        ContinuityOpenLoopsStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityOpenLoopDashboardQueryInput(limit=10),
+    )
+
+    dashboard = payload["dashboard"]
+    assert dashboard["summary"] == {
+        "limit": 10,
+        "total_count": 5,
+        "posture_order": ["waiting_for", "blocker", "stale", "next_action"],
+        "item_order": ["created_at_desc", "id_desc"],
+    }
+    assert [item["title"] for item in dashboard["waiting_for"]["items"]] == [
+        "Waiting For: Legal signoff",
+        "Waiting For: Vendor quote",
+    ]
+    assert [item["title"] for item in dashboard["blocker"]["items"]] == [
+        "Blocker: Missing API key",
+    ]
+    assert [item["title"] for item in dashboard["stale"]["items"]] == [
+        "Waiting For: Stale invoice response",
+    ]
+    assert [item["title"] for item in dashboard["next_action"]["items"]] == [
+        "Next Action: Send follow-up",
+    ]
+
+
+def test_daily_and_weekly_briefs_emit_explicit_empty_states() -> None:
+    rows = [
+        make_candidate_row(
+            title="Decision: Keep rollout phased",
+            object_type="Decision",
+            status="active",
+            created_at=datetime(2026, 3, 30, 11, 0, tzinfo=UTC),
+        ),
+    ]
+
+    daily = compile_continuity_daily_brief(
+        ContinuityOpenLoopsStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityDailyBriefRequestInput(limit=3),
+    )["brief"]
+    weekly = compile_continuity_weekly_review(
+        ContinuityOpenLoopsStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityWeeklyReviewRequestInput(limit=3),
+    )["review"]
+
+    assert daily["waiting_for_highlights"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No waiting-for highlights for today in the requested scope.",
+    }
+    assert daily["blocker_highlights"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No blocker highlights for today in the requested scope.",
+    }
+    assert daily["stale_items"]["empty_state"] == {
+        "is_empty": True,
+        "message": "No stale items for today in the requested scope.",
+    }
+    assert daily["next_suggested_action"] == {
+        "item": None,
+        "empty_state": {
+            "is_empty": True,
+            "message": "No next suggested action in the requested scope.",
+        },
+    }
+
+    assert weekly["rollup"] == {
+        "total_count": 0,
+        "waiting_for_count": 0,
+        "blocker_count": 0,
+        "stale_count": 0,
+        "next_action_count": 0,
+        "posture_order": ["waiting_for", "blocker", "stale", "next_action"],
+    }
+
+
+def test_open_loop_dashboard_rejects_mixed_naive_and_offset_aware_time_window() -> None:
+    with pytest.raises(
+        ContinuityOpenLoopValidationError,
+        match="since and until must both include timezone offsets or both omit timezone offsets",
+    ):
+        compile_continuity_open_loop_dashboard(
+            ContinuityOpenLoopsStoreStub(),  # type: ignore[arg-type]
+            user_id=UUID("11111111-1111-4111-8111-111111111111"),
+            request=ContinuityOpenLoopDashboardQueryInput(
+                since=datetime(2026, 3, 30, 10, 0, tzinfo=UTC),
+                until=datetime(2026, 3, 30, 10, 1),
+            ),
+        )
+
+
+def test_review_actions_transition_deterministically_and_emit_audit_rows() -> None:
+    store = ContinuityOpenLoopsStoreStub()
+    row = store.add_object(
+        object_type="WaitingFor",
+        status="active",
+        title="Waiting For: Vendor quote",
+    )
+
+    done = apply_continuity_open_loop_review_action(
+        store,  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        continuity_object_id=row["id"],
+        request=ContinuityOpenLoopReviewActionInput(action="done", note="Closed in standup"),
+    )
+    assert done["review_action"] == "done"
+    assert done["lifecycle_outcome"] == "completed"
+    assert done["continuity_object"]["status"] == "completed"
+    assert done["correction_event"]["action"] == "edit"
+    assert done["correction_event"]["payload"]["review_action"] == "done"
+
+    deferred = apply_continuity_open_loop_review_action(
+        store,  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        continuity_object_id=row["id"],
+        request=ContinuityOpenLoopReviewActionInput(action="deferred"),
+    )
+    assert deferred["lifecycle_outcome"] == "stale"
+    assert deferred["continuity_object"]["status"] == "stale"
+    assert deferred["correction_event"]["action"] == "mark_stale"
+
+    still_blocked = apply_continuity_open_loop_review_action(
+        store,  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        continuity_object_id=row["id"],
+        request=ContinuityOpenLoopReviewActionInput(action="still_blocked"),
+    )
+    assert still_blocked["lifecycle_outcome"] == "active"
+    assert still_blocked["continuity_object"]["status"] == "active"
+    assert still_blocked["continuity_object"]["last_confirmed_at"] is not None
+    assert still_blocked["correction_event"]["action"] == "confirm"
+
+
+def test_review_action_rejects_unsupported_status() -> None:
+    store = ContinuityOpenLoopsStoreStub()
+    row = store.add_object(
+        object_type="Blocker",
+        status="deleted",
+        title="Blocker: Deprecated",
+    )
+
+    with pytest.raises(
+        ContinuityOpenLoopValidationError,
+        match="review action cannot be applied when status is deleted",
+    ):
+        apply_continuity_open_loop_review_action(
+            store,  # type: ignore[arg-type]
+            user_id=UUID("11111111-1111-4111-8111-111111111111"),
+            continuity_object_id=row["id"],
+            request=ContinuityOpenLoopReviewActionInput(action="still_blocked"),
+        )

--- a/tests/unit/test_continuity_resumption.py
+++ b/tests/unit/test_continuity_resumption.py
@@ -243,3 +243,59 @@ def test_resumption_brief_ignores_superseded_for_primary_sections_but_keeps_rece
         "Decision: active latest decision",
         "Decision: superseded old decision",
     ]
+
+
+def test_resumption_brief_excludes_completed_and_stale_from_primary_open_loop_sections() -> None:
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    rows = [
+        make_candidate_row(
+            title="Waiting For: completed item",
+            object_type="WaitingFor",
+            capture_created_at=datetime(2026, 3, 29, 10, 0, tzinfo=UTC),
+            provenance={"thread_id": str(thread_id)},
+            status="completed",
+        ),
+        make_candidate_row(
+            title="Waiting For: deferred stale item",
+            object_type="WaitingFor",
+            capture_created_at=datetime(2026, 3, 29, 10, 1, tzinfo=UTC),
+            provenance={"thread_id": str(thread_id)},
+            status="stale",
+        ),
+        make_candidate_row(
+            title="Waiting For: still blocked active item",
+            object_type="WaitingFor",
+            capture_created_at=datetime(2026, 3, 29, 10, 2, tzinfo=UTC),
+            provenance={"thread_id": str(thread_id)},
+            status="active",
+        ),
+        make_candidate_row(
+            title="Next Action: done item",
+            object_type="NextAction",
+            capture_created_at=datetime(2026, 3, 29, 10, 3, tzinfo=UTC),
+            provenance={"thread_id": str(thread_id)},
+            status="completed",
+        ),
+    ]
+
+    payload = compile_continuity_resumption_brief(
+        ContinuityResumptionStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityResumptionBriefRequestInput(
+            thread_id=thread_id,
+            max_recent_changes=5,
+            max_open_loops=5,
+        ),
+    )
+
+    brief = payload["brief"]
+    assert [item["title"] for item in brief["open_loops"]["items"]] == [
+        "Waiting For: still blocked active item",
+    ]
+    assert brief["next_action"]["item"] is None
+    assert [item["title"] for item in brief["recent_changes"]["items"]] == [
+        "Next Action: done item",
+        "Waiting For: still blocked active item",
+        "Waiting For: deferred stale item",
+        "Waiting For: completed item",
+    ]


### PR DESCRIPTION
## Summary
- add continuity open-loop dashboard, daily brief, weekly review, and review-action APIs with deterministic composition/order
- add continuity open-loop/daily/weekly UI panels and API wiring
- add backend/web tests plus sprint doc/report synchronization for P5-S20

## Verification
- Review verdict: PASS (REVIEW_REPORT.md)
- Backend acceptance checks: PASS
- Web acceptance checks: PASS
- Phase 4 regression matrix: PASS
- Control Tower decision: MERGE_APPROVED