### PR TITLE
Side sprint: pentest hardening safeguards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 APP_ENV=development
 APP_HOST=127.0.0.1
 APP_PORT=8000
+# Development-only local credentials. Override for any shared or remote environment.
 DATABASE_URL=postgresql://alicebot_app:alicebot_app@localhost:5432/alicebot
 DATABASE_ADMIN_URL=postgresql://alicebot_admin:alicebot_admin@localhost:5432/alicebot
 REDIS_URL=redis://localhost:6379/0
@@ -10,3 +11,8 @@ S3_SECRET_KEY=alicebot-secret
 S3_BUCKET=alicebot-local
 HEALTHCHECK_TIMEOUT_SECONDS=2
 TASK_WORKSPACE_ROOT=/tmp/alicebot/task-workspaces
+# Server-side authenticated user binding for /v0 requests.
+ALICEBOT_AUTH_USER_ID=00000000-0000-0000-0000-000000000001
+# Per-user response generation throttle (POST /v0/responses).
+RESPONSE_RATE_LIMIT_WINDOW_SECONDS=60
+RESPONSE_RATE_LIMIT_MAX_REQUESTS=20

--- a/apps/api/src/alicebot_api/calendar_secret_manager.py
+++ b/apps/api/src/alicebot_api/calendar_secret_manager.py
@@ -8,6 +8,8 @@ from urllib.parse import unquote, urlparse
 from alicebot_api.store import JsonObject
 
 CALENDAR_SECRET_MANAGER_KIND_FILE_V1 = "file_v1"
+SECRET_DIRECTORY_MODE = 0o700
+SECRET_FILE_MODE = 0o600
 
 
 class CalendarSecretManagerError(RuntimeError):
@@ -32,6 +34,11 @@ class FileCalendarSecretManager(CalendarSecretManager):
 
     def __init__(self, *, root: Path) -> None:
         self._root = root.expanduser().resolve()
+        try:
+            self._root.mkdir(parents=True, exist_ok=True, mode=SECRET_DIRECTORY_MODE)
+            self._root.chmod(SECRET_DIRECTORY_MODE)
+        except OSError as exc:
+            raise CalendarSecretManagerError("calendar secret manager root is not writable") from exc
 
     def load_secret(self, *, secret_ref: str) -> JsonObject:
         path = self._resolve_secret_path(secret_ref)
@@ -47,11 +54,18 @@ class FileCalendarSecretManager(CalendarSecretManager):
 
     def write_secret(self, *, secret_ref: str, payload: JsonObject) -> None:
         path = self._resolve_secret_path(secret_ref)
-        path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_private_directory(path.parent)
         temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
         try:
-            temp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+            with os.fdopen(
+                os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, SECRET_FILE_MODE),
+                "w",
+                encoding="utf-8",
+            ) as secret_file:
+                secret_file.write(json.dumps(payload, sort_keys=True))
+            temp_path.chmod(SECRET_FILE_MODE)
             temp_path.replace(path)
+            path.chmod(SECRET_FILE_MODE)
         except OSError as exc:
             try:
                 temp_path.unlink(missing_ok=True)
@@ -75,6 +89,15 @@ class FileCalendarSecretManager(CalendarSecretManager):
                 f"calendar secret {secret_ref} is outside the configured root"
             ) from exc
         return candidate
+
+    def _ensure_private_directory(self, directory: Path) -> None:
+        try:
+            directory.mkdir(parents=True, exist_ok=True, mode=SECRET_DIRECTORY_MODE)
+            directory.chmod(SECRET_DIRECTORY_MODE)
+        except OSError as exc:
+            raise CalendarSecretManagerError(
+                "calendar secret directory permissions could not be secured"
+            ) from exc
 
 
 def build_calendar_secret_manager(secret_manager_url: str) -> CalendarSecretManager:

--- a/apps/api/src/alicebot_api/config.py
+++ b/apps/api/src/alicebot_api/config.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import lru_cache
 import os
+from uuid import UUID
 
 DEFAULT_APP_ENV = "development"
 DEFAULT_APP_HOST = "127.0.0.1"
@@ -33,6 +34,9 @@ DEFAULT_MODEL_TIMEOUT_SECONDS = 30
 DEFAULT_TASK_WORKSPACE_ROOT = "/tmp/alicebot/task-workspaces"
 DEFAULT_GMAIL_SECRET_MANAGER_URL = ""
 DEFAULT_CALENDAR_SECRET_MANAGER_URL = ""
+DEFAULT_AUTH_USER_ID = ""
+DEFAULT_RESPONSE_RATE_LIMIT_WINDOW_SECONDS = 60
+DEFAULT_RESPONSE_RATE_LIMIT_MAX_REQUESTS = 20
 
 Environment = Mapping[str, str]
 
@@ -73,11 +77,14 @@ class Settings:
     task_workspace_root: str = DEFAULT_TASK_WORKSPACE_ROOT
     gmail_secret_manager_url: str = DEFAULT_GMAIL_SECRET_MANAGER_URL
     calendar_secret_manager_url: str = DEFAULT_CALENDAR_SECRET_MANAGER_URL
+    auth_user_id: str = DEFAULT_AUTH_USER_ID
+    response_rate_limit_window_seconds: int = DEFAULT_RESPONSE_RATE_LIMIT_WINDOW_SECONDS
+    response_rate_limit_max_requests: int = DEFAULT_RESPONSE_RATE_LIMIT_MAX_REQUESTS
 
     @classmethod
     def from_env(cls, env: Environment | None = None) -> "Settings":
         current_env = os.environ if env is None else env
-        return cls(
+        settings = cls(
             app_env=_get_env_value(current_env, "APP_ENV", cls.app_env),
             app_host=_get_env_value(current_env, "APP_HOST", cls.app_host),
             app_port=_get_env_int(current_env, "APP_PORT", cls.app_port),
@@ -125,7 +132,50 @@ class Settings:
                 "CALENDAR_SECRET_MANAGER_URL",
                 cls.calendar_secret_manager_url,
             ),
+            auth_user_id=_get_env_value(current_env, "ALICEBOT_AUTH_USER_ID", cls.auth_user_id).strip(),
+            response_rate_limit_window_seconds=_get_env_int(
+                current_env,
+                "RESPONSE_RATE_LIMIT_WINDOW_SECONDS",
+                cls.response_rate_limit_window_seconds,
+            ),
+            response_rate_limit_max_requests=_get_env_int(
+                current_env,
+                "RESPONSE_RATE_LIMIT_MAX_REQUESTS",
+                cls.response_rate_limit_max_requests,
+            ),
         )
+        return _validate_settings(settings)
+
+
+def _validate_settings(settings: Settings) -> Settings:
+    if settings.auth_user_id != "":
+        try:
+            UUID(settings.auth_user_id)
+        except ValueError as exc:
+            raise ValueError("ALICEBOT_AUTH_USER_ID must be a valid UUID") from exc
+
+    if settings.response_rate_limit_window_seconds <= 0:
+        raise ValueError("RESPONSE_RATE_LIMIT_WINDOW_SECONDS must be a positive integer")
+    if settings.response_rate_limit_max_requests <= 0:
+        raise ValueError("RESPONSE_RATE_LIMIT_MAX_REQUESTS must be a positive integer")
+
+    if settings.app_env not in {"development", "test"}:
+        if settings.auth_user_id == "":
+            raise ValueError(
+                "ALICEBOT_AUTH_USER_ID must be configured outside development/test environments"
+            )
+        if settings.database_url == DEFAULT_DATABASE_URL:
+            raise ValueError("DATABASE_URL must be overridden outside development/test environments")
+        if settings.database_admin_url == DEFAULT_DATABASE_ADMIN_URL:
+            raise ValueError(
+                "DATABASE_ADMIN_URL must be overridden outside development/test environments"
+            )
+        if settings.s3_access_key == DEFAULT_S3_ACCESS_KEY:
+            raise ValueError("S3_ACCESS_KEY must be overridden outside development/test environments")
+        if settings.s3_secret_key == DEFAULT_S3_SECRET_KEY:
+            raise ValueError("S3_SECRET_KEY must be overridden outside development/test environments")
+
+    return settings
 
 
 @lru_cache(maxsize=1)

--- a/apps/api/src/alicebot_api/gmail_secret_manager.py
+++ b/apps/api/src/alicebot_api/gmail_secret_manager.py
@@ -9,6 +9,8 @@ from urllib.parse import unquote, urlparse
 from alicebot_api.store import JsonObject
 
 GMAIL_SECRET_MANAGER_KIND_FILE_V1 = "file_v1"
+SECRET_DIRECTORY_MODE = 0o700
+SECRET_FILE_MODE = 0o600
 
 
 class GmailSecretManagerError(RuntimeError):
@@ -39,6 +41,11 @@ class FileGmailSecretManager(GmailSecretManager):
 
     def __init__(self, *, root: Path) -> None:
         self._root = root.expanduser().resolve()
+        try:
+            self._root.mkdir(parents=True, exist_ok=True, mode=SECRET_DIRECTORY_MODE)
+            self._root.chmod(SECRET_DIRECTORY_MODE)
+        except OSError as exc:
+            raise GmailSecretManagerError("gmail secret manager root is not writable") from exc
 
     def load_secret(self, *, secret_ref: str) -> JsonObject:
         path = self._resolve_secret_path(secret_ref)
@@ -54,11 +61,18 @@ class FileGmailSecretManager(GmailSecretManager):
 
     def write_secret(self, *, secret_ref: str, payload: JsonObject) -> None:
         path = self._resolve_secret_path(secret_ref)
-        path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_private_directory(path.parent)
         temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
         try:
-            temp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+            with os.fdopen(
+                os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, SECRET_FILE_MODE),
+                "w",
+                encoding="utf-8",
+            ) as secret_file:
+                secret_file.write(json.dumps(payload, sort_keys=True))
+            temp_path.chmod(SECRET_FILE_MODE)
             temp_path.replace(path)
+            path.chmod(SECRET_FILE_MODE)
         except OSError as exc:
             try:
                 temp_path.unlink(missing_ok=True)
@@ -80,6 +94,13 @@ class FileGmailSecretManager(GmailSecretManager):
         except ValueError as exc:
             raise GmailSecretManagerError(f"gmail secret {secret_ref} is outside the configured root") from exc
         return candidate
+
+    def _ensure_private_directory(self, directory: Path) -> None:
+        try:
+            directory.mkdir(parents=True, exist_ok=True, mode=SECRET_DIRECTORY_MODE)
+            directory.chmod(SECRET_DIRECTORY_MODE)
+        except OSError as exc:
+            raise GmailSecretManagerError("gmail secret directory permissions could not be secured") from exc
 
 
 def build_gmail_secret_manager(secret_manager_url: str) -> GmailSecretManager:

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+from collections import defaultdict, deque
 from datetime import datetime
-from typing import Annotated, Callable, Literal, TypedDict
+import json
+import threading
+import time
+from typing import Annotated, Awaitable, Callable, Literal, TypedDict
 from uuid import UUID
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Query, Request
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from fastapi.responses import JSONResponse
 import psycopg
 from psycopg.rows import dict_row
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from alicebot_api.compiler import compile_and_persist_trace, compile_resumption_brief
 from alicebot_api.config import Settings, get_settings
@@ -470,6 +474,106 @@ class HealthcheckPayload(TypedDict):
     status: HealthStatus
     environment: str
     services: HealthServicesPayload
+
+
+AUTH_USER_HEADER = "X-AliceBot-User-Id"
+
+
+class ResponseRateLimiter:
+    def __init__(self) -> None:
+        self._events_by_key: dict[str, deque[float]] = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    def allow(self, *, key: str, max_requests: int, window_seconds: int) -> tuple[bool, int]:
+        now = time.monotonic()
+
+        with self._lock:
+            events = self._events_by_key[key]
+            cutoff = now - window_seconds
+            while events and events[0] <= cutoff:
+                events.popleft()
+
+            if len(events) >= max_requests:
+                retry_after_seconds = max(1, int(events[0] + window_seconds - now))
+                return False, retry_after_seconds
+
+            events.append(now)
+            return True, 0
+
+    def reset(self) -> None:
+        with self._lock:
+            self._events_by_key.clear()
+
+
+response_rate_limiter = ResponseRateLimiter()
+
+
+def _resolve_authenticated_user_id(settings: Settings, request: Request) -> UUID | None:
+    if settings.auth_user_id != "":
+        return UUID(settings.auth_user_id)
+
+    header_value = request.headers.get(AUTH_USER_HEADER)
+    if header_value is None or header_value.strip() == "":
+        if settings.app_env in {"development", "test"}:
+            return None
+        raise ValueError(
+            "request authentication is not configured; set ALICEBOT_AUTH_USER_ID "
+            "or provide X-AliceBot-User-Id"
+        )
+
+    try:
+        return UUID(header_value)
+    except ValueError as exc:
+        raise ValueError("X-AliceBot-User-Id must be a valid UUID") from exc
+
+
+def _rewrite_user_id_query_param(request: Request, authenticated_user_id: UUID) -> None:
+    raw_query = request.scope.get("query_string", b"")
+    query_items = parse_qsl(raw_query.decode("utf-8"), keep_blank_values=True)
+    expected_user_id = str(authenticated_user_id)
+    for key, value in query_items:
+        if key == "user_id" and value != expected_user_id:
+            raise ValueError("query user_id does not match authenticated user")
+    rewritten_items = [(key, value) for key, value in query_items if key != "user_id"]
+    rewritten_items.append(("user_id", expected_user_id))
+    request.scope["query_string"] = urlencode(rewritten_items, doseq=True).encode("utf-8")
+
+
+async def _rewrite_user_id_json_body(request: Request, authenticated_user_id: UUID) -> Request:
+    if request.method.upper() not in {"POST", "PUT", "PATCH", "DELETE"}:
+        return request
+
+    content_type = request.headers.get("content-type", "").lower()
+    if "application/json" not in content_type:
+        return request
+
+    raw_body = await request.body()
+    if raw_body == b"":
+        return request
+
+    try:
+        parsed_body = json.loads(raw_body)
+    except json.JSONDecodeError:
+        return request
+
+    if not isinstance(parsed_body, dict):
+        return request
+
+    expected_user_id = str(authenticated_user_id)
+    existing_user_id = parsed_body.get("user_id")
+    if existing_user_id is not None and str(existing_user_id) != expected_user_id:
+        raise ValueError("request user_id does not match authenticated user")
+    parsed_body["user_id"] = expected_user_id
+    rewritten_body = json.dumps(parsed_body, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+    async def receive() -> dict[str, object]:
+        return {
+            "type": "http.request",
+            "body": rewritten_body,
+            "more_body": False,
+        }
+
+    return Request(request.scope, receive)
 
 
 class CompileContextSemanticRequest(BaseModel):
@@ -1083,6 +1187,65 @@ def build_healthcheck_payload(settings: Settings, database_ok: bool) -> Healthch
     }
 
 
+def _response_rate_limit_error(
+    *,
+    max_requests: int,
+    window_seconds: int,
+    retry_after_seconds: int,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=429,
+        headers={"Retry-After": str(retry_after_seconds)},
+        content={
+            "detail": {
+                "code": "response_rate_limit_exceeded",
+                "message": (
+                    "response generation rate limit exceeded; "
+                    f"max {max_requests} requests per {window_seconds} seconds"
+                ),
+                "retry_after_seconds": retry_after_seconds,
+            }
+        },
+    )
+
+
+def _enforce_response_rate_limit(settings: Settings, user_id: UUID) -> JSONResponse | None:
+    allowed, retry_after_seconds = response_rate_limiter.allow(
+        key=f"responses:{user_id}",
+        max_requests=settings.response_rate_limit_max_requests,
+        window_seconds=settings.response_rate_limit_window_seconds,
+    )
+    if allowed:
+        return None
+    return _response_rate_limit_error(
+        max_requests=settings.response_rate_limit_max_requests,
+        window_seconds=settings.response_rate_limit_window_seconds,
+        retry_after_seconds=retry_after_seconds,
+    )
+
+
+@app.middleware("http")
+async def enforce_authenticated_user_identity(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[JSONResponse]],
+):
+    if not request.url.path.startswith("/v0/"):
+        return await call_next(request)
+
+    settings = get_settings()
+
+    try:
+        authenticated_user_id = _resolve_authenticated_user_id(settings, request)
+        if authenticated_user_id is not None:
+            request.scope.setdefault("state", {})["authenticated_user_id"] = str(authenticated_user_id)
+            _rewrite_user_id_query_param(request, authenticated_user_id)
+            request = await _rewrite_user_id_json_body(request, authenticated_user_id)
+    except ValueError as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+
+    return await call_next(request)
+
+
 @app.get("/healthz")
 def healthcheck() -> JSONResponse:
     settings = get_settings()
@@ -1214,6 +1377,9 @@ def compile_context(request: CompileContextRequest) -> JSONResponse:
 @app.post("/v0/responses")
 def generate_assistant_response(request: GenerateResponseRequest) -> JSONResponse:
     settings = get_settings()
+    rate_limit_error = _enforce_response_rate_limit(settings, request.user_id)
+    if rate_limit_error is not None:
+        return rate_limit_error
 
     try:
         with user_connection(settings.database_url, request.user_id) as conn:

--- a/docs/runbooks/mvp-ship-gate-magnesium-reorder.md
+++ b/docs/runbooks/mvp-ship-gate-magnesium-reorder.md
@@ -17,7 +17,8 @@ This scenario is first-class in Phase 4 gates via:
 ## Preconditions
 
 - API is running and reachable by `apps/web`.
-- `NEXT_PUBLIC_ALICEBOT_API_BASE_URL` and `NEXT_PUBLIC_ALICEBOT_USER_ID` are set.
+- `NEXT_PUBLIC_ALICEBOT_API_BASE_URL` is set for `apps/web`.
+- API is configured with `ALICEBOT_AUTH_USER_ID` so `/v0/*` requests are server-bound to one authenticated user identity.
 - One tool/policy path exists that routes magnesium reorder requests through approval and `proxy.echo` execution.
 
 ## Manual Verification: `/approvals`

--- a/tests/unit/test_calendar_secret_manager.py
+++ b/tests/unit/test_calendar_secret_manager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import stat
+
 import pytest
 
 from alicebot_api.calendar_secret_manager import (
@@ -29,6 +31,9 @@ def test_file_calendar_secret_manager_round_trips_secret_payload(tmp_path) -> No
     manager.write_secret(secret_ref=secret_ref, payload=payload)
 
     assert manager.load_secret(secret_ref=secret_ref) == payload
+    secret_path = tmp_path / secret_ref
+    assert stat.S_IMODE(secret_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(secret_path.parent.stat().st_mode) == 0o700
 
 
 def test_file_calendar_secret_manager_rejects_missing_or_escaped_refs(tmp_path) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -26,6 +26,9 @@ def test_settings_defaults(monkeypatch):
         "TASK_WORKSPACE_ROOT",
         "GMAIL_SECRET_MANAGER_URL",
         "CALENDAR_SECRET_MANAGER_URL",
+        "ALICEBOT_AUTH_USER_ID",
+        "RESPONSE_RATE_LIMIT_WINDOW_SECONDS",
+        "RESPONSE_RATE_LIMIT_MAX_REQUESTS",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -43,6 +46,9 @@ def test_settings_defaults(monkeypatch):
     assert settings.task_workspace_root == "/tmp/alicebot/task-workspaces"
     assert settings.gmail_secret_manager_url == ""
     assert settings.calendar_secret_manager_url == ""
+    assert settings.auth_user_id == ""
+    assert settings.response_rate_limit_window_seconds == 60
+    assert settings.response_rate_limit_max_requests == 20
 
 
 def test_settings_honor_environment_overrides(monkeypatch):
@@ -56,6 +62,9 @@ def test_settings_honor_environment_overrides(monkeypatch):
     monkeypatch.setenv("TASK_WORKSPACE_ROOT", "/tmp/custom-workspaces")
     monkeypatch.setenv("GMAIL_SECRET_MANAGER_URL", "file:///tmp/custom-gmail-secrets")
     monkeypatch.setenv("CALENDAR_SECRET_MANAGER_URL", "file:///tmp/custom-calendar-secrets")
+    monkeypatch.setenv("ALICEBOT_AUTH_USER_ID", "00000000-0000-0000-0000-000000000001")
+    monkeypatch.setenv("RESPONSE_RATE_LIMIT_WINDOW_SECONDS", "120")
+    monkeypatch.setenv("RESPONSE_RATE_LIMIT_MAX_REQUESTS", "30")
 
     settings = Settings.from_env()
 
@@ -69,6 +78,9 @@ def test_settings_honor_environment_overrides(monkeypatch):
     assert settings.task_workspace_root == "/tmp/custom-workspaces"
     assert settings.gmail_secret_manager_url == "file:///tmp/custom-gmail-secrets"
     assert settings.calendar_secret_manager_url == "file:///tmp/custom-calendar-secrets"
+    assert settings.auth_user_id == "00000000-0000-0000-0000-000000000001"
+    assert settings.response_rate_limit_window_seconds == 120
+    assert settings.response_rate_limit_max_requests == 30
 
 
 def test_settings_can_be_loaded_from_an_explicit_environment_mapping() -> None:
@@ -82,6 +94,9 @@ def test_settings_can_be_loaded_from_an_explicit_environment_mapping() -> None:
             "TASK_WORKSPACE_ROOT": "/tmp/mapped-workspaces",
             "GMAIL_SECRET_MANAGER_URL": "file:///tmp/mapped-gmail-secrets",
             "CALENDAR_SECRET_MANAGER_URL": "file:///tmp/mapped-calendar-secrets",
+            "ALICEBOT_AUTH_USER_ID": "00000000-0000-0000-0000-000000000001",
+            "RESPONSE_RATE_LIMIT_WINDOW_SECONDS": "75",
+            "RESPONSE_RATE_LIMIT_MAX_REQUESTS": "10",
         }
     )
 
@@ -93,6 +108,9 @@ def test_settings_can_be_loaded_from_an_explicit_environment_mapping() -> None:
     assert settings.task_workspace_root == "/tmp/mapped-workspaces"
     assert settings.gmail_secret_manager_url == "file:///tmp/mapped-gmail-secrets"
     assert settings.calendar_secret_manager_url == "file:///tmp/mapped-calendar-secrets"
+    assert settings.auth_user_id == "00000000-0000-0000-0000-000000000001"
+    assert settings.response_rate_limit_window_seconds == 75
+    assert settings.response_rate_limit_max_requests == 10
 
 
 def test_settings_raise_clear_error_for_invalid_integer_values() -> None:
@@ -101,3 +119,41 @@ def test_settings_raise_clear_error_for_invalid_integer_values() -> None:
 
     with pytest.raises(ValueError, match="MODEL_TIMEOUT_SECONDS must be an integer"):
         Settings.from_env({"MODEL_TIMEOUT_SECONDS": "not-an-integer"})
+
+    with pytest.raises(ValueError, match="RESPONSE_RATE_LIMIT_MAX_REQUESTS must be an integer"):
+        Settings.from_env({"RESPONSE_RATE_LIMIT_MAX_REQUESTS": "not-an-integer"})
+
+
+def test_settings_reject_invalid_auth_user_id() -> None:
+    with pytest.raises(ValueError, match="ALICEBOT_AUTH_USER_ID must be a valid UUID"):
+        Settings.from_env({"ALICEBOT_AUTH_USER_ID": "not-a-uuid"})
+
+
+def test_settings_reject_non_positive_rate_limit_values() -> None:
+    with pytest.raises(
+        ValueError,
+        match="RESPONSE_RATE_LIMIT_WINDOW_SECONDS must be a positive integer",
+    ):
+        Settings.from_env({"RESPONSE_RATE_LIMIT_WINDOW_SECONDS": "0"})
+
+    with pytest.raises(
+        ValueError,
+        match="RESPONSE_RATE_LIMIT_MAX_REQUESTS must be a positive integer",
+    ):
+        Settings.from_env({"RESPONSE_RATE_LIMIT_MAX_REQUESTS": "0"})
+
+
+def test_settings_require_hardened_non_dev_configuration() -> None:
+    with pytest.raises(
+        ValueError,
+        match="ALICEBOT_AUTH_USER_ID must be configured outside development/test environments",
+    ):
+        Settings.from_env({"APP_ENV": "staging"})
+
+    with pytest.raises(ValueError, match="DATABASE_URL must be overridden outside development/test environments"):
+        Settings.from_env(
+            {
+                "APP_ENV": "staging",
+                "ALICEBOT_AUTH_USER_ID": "00000000-0000-0000-0000-000000000001",
+            }
+        )

--- a/tests/unit/test_gmail_secret_manager.py
+++ b/tests/unit/test_gmail_secret_manager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import stat
+
 import pytest
 
 from alicebot_api.gmail_secret_manager import (
@@ -29,6 +31,9 @@ def test_file_gmail_secret_manager_round_trips_secret_payload(tmp_path) -> None:
     manager.write_secret(secret_ref=secret_ref, payload=payload)
 
     assert manager.load_secret(secret_ref=secret_ref) == payload
+    secret_path = tmp_path / secret_ref
+    assert stat.S_IMODE(secret_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(secret_path.parent.stat().st_mode) == 0o700
 
 
 def test_file_gmail_secret_manager_rejects_missing_or_escaped_refs(tmp_path) -> None:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from contextlib import contextmanager
 from datetime import datetime
 from uuid import uuid4
 
 import pytest
+from fastapi import Request
 import apps.api.src.alicebot_api.main as main_module
 from apps.api.src.alicebot_api.config import Settings
 from alicebot_api.artifacts import TaskArtifactNotFoundError
@@ -192,6 +194,121 @@ def test_build_healthcheck_payload_keeps_boundary_statuses_consistent() -> None:
     assert main_module.build_healthcheck_payload(settings, database_ok=False)["services"][
         "database"
     ] == {"status": "unreachable"}
+
+
+def _build_request(
+    *,
+    method: str,
+    path: str,
+    query_string: str = "",
+    body: bytes = b"",
+    headers: dict[str, str] | None = None,
+) -> Request:
+    encoded_headers = [
+        (key.lower().encode("utf-8"), value.encode("utf-8"))
+        for key, value in (headers or {}).items()
+    ]
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": method,
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode("utf-8"),
+            "query_string": query_string.encode("utf-8"),
+            "headers": encoded_headers,
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+        },
+        receive,
+    )
+
+
+def test_resolve_authenticated_user_id_prefers_configured_identity() -> None:
+    configured_user_id = uuid4()
+    request = _build_request(
+        method="GET",
+        path="/v0/threads",
+        headers={"x-alicebot-user-id": str(uuid4())},
+    )
+
+    resolved = main_module._resolve_authenticated_user_id(
+        Settings(app_env="test", auth_user_id=str(configured_user_id)),
+        request,
+    )
+
+    assert resolved == configured_user_id
+
+
+def test_resolve_authenticated_user_id_allows_dev_without_header() -> None:
+    request = _build_request(method="GET", path="/v0/threads")
+
+    resolved = main_module._resolve_authenticated_user_id(
+        Settings(app_env="test", auth_user_id=""),
+        request,
+    )
+
+    assert resolved is None
+
+
+def test_rewrite_user_id_query_param_rejects_mismatch() -> None:
+    request = _build_request(
+        method="GET",
+        path="/v0/threads",
+        query_string="user_id=00000000-0000-0000-0000-000000000002",
+    )
+
+    with pytest.raises(ValueError, match="query user_id does not match authenticated user"):
+        main_module._rewrite_user_id_query_param(
+            request,
+            uuid4(),
+        )
+
+
+def test_rewrite_user_id_json_body_injects_missing_user_id() -> None:
+    authenticated_user_id = uuid4()
+    thread_id = uuid4()
+    request = _build_request(
+        method="POST",
+        path="/v0/responses",
+        body=json.dumps({"thread_id": str(thread_id), "message": "hello"}).encode("utf-8"),
+        headers={"content-type": "application/json"},
+    )
+
+    rewritten_request = asyncio.run(
+        main_module._rewrite_user_id_json_body(request, authenticated_user_id)
+    )
+    rewritten_body = asyncio.run(rewritten_request.body())
+
+    assert json.loads(rewritten_body) == {
+        "thread_id": str(thread_id),
+        "message": "hello",
+        "user_id": str(authenticated_user_id),
+    }
+
+
+def test_rewrite_user_id_json_body_rejects_mismatch() -> None:
+    request = _build_request(
+        method="POST",
+        path="/v0/responses",
+        body=json.dumps(
+            {
+                "user_id": "00000000-0000-0000-0000-000000000001",
+                "thread_id": str(uuid4()),
+                "message": "hello",
+            }
+        ).encode("utf-8"),
+        headers={"content-type": "application/json"},
+    )
+
+    with pytest.raises(ValueError, match="request user_id does not match authenticated user"):
+        asyncio.run(main_module._rewrite_user_id_json_body(request, uuid4()))
 
 
 def test_compile_context_returns_trace_and_context_pack(monkeypatch) -> None:
@@ -1086,6 +1203,84 @@ def test_generate_assistant_response_returns_502_with_trace_when_model_invocatio
         "metadata": {
             "agent_profile_id": "assistant_default",
         },
+    }
+
+
+def test_generate_assistant_response_enforces_rate_limit(monkeypatch) -> None:
+    user_id = uuid4()
+    thread_id = uuid4()
+    settings = Settings(
+        app_env="test",
+        database_url="postgresql://app",
+        response_rate_limit_max_requests=1,
+        response_rate_limit_window_seconds=60,
+    )
+
+    @contextmanager
+    def fake_user_connection(_database_url: str, _current_user_id):
+        yield object()
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(
+        main_module.ContinuityStore,
+        "get_thread",
+        lambda _self, thread_id: {
+            "id": thread_id,
+            "user_id": user_id,
+            "title": "Thread",
+            "agent_profile_id": "assistant_default",
+            "created_at": datetime.now(),
+            "updated_at": datetime.now(),
+        },
+    )
+    monkeypatch.setattr(
+        main_module,
+        "generate_response",
+        lambda *_args, **_kwargs: {
+            "assistant": {
+                "event_id": "assistant-event-123",
+                "sequence_no": 5,
+                "text": "Hello back.",
+                "model_provider": "openai_responses",
+                "model": "gpt-5-mini",
+            },
+            "trace": {
+                "compile_trace_id": "compile-trace-123",
+                "compile_trace_event_count": 11,
+                "response_trace_id": "response-trace-123",
+                "response_trace_event_count": 2,
+            },
+        },
+    )
+    main_module.response_rate_limiter.reset()
+
+    first_response = main_module.generate_assistant_response(
+        main_module.GenerateResponseRequest(
+            user_id=user_id,
+            thread_id=thread_id,
+            message="Hello?",
+        )
+    )
+    second_response = main_module.generate_assistant_response(
+        main_module.GenerateResponseRequest(
+            user_id=user_id,
+            thread_id=thread_id,
+            message="Hello again?",
+        )
+    )
+    main_module.response_rate_limiter.reset()
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 429
+    retry_after = int(second_response.headers["Retry-After"])
+    assert 1 <= retry_after <= 60
+    assert json.loads(second_response.body) == {
+        "detail": {
+            "code": "response_rate_limit_exceeded",
+            "message": "response generation rate limit exceeded; max 1 requests per 60 seconds",
+            "retry_after_seconds": retry_after,
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- harden gmail/calendar file secret managers with private directory/file permissions and atomic writes
- add production configuration safeguards for auth user binding and response throttling values
- add server-side request auth binding and per-user response rate limit guard coverage
- update tests and runbook notes for the pentest hardening scope

## Verification
- ./.venv/bin/python -m pytest tests/unit/test_calendar_secret_manager.py tests/unit/test_config.py tests/unit/test_gmail_secret_manager.py tests/unit/test_main.py -q
  - PASS (70 passed)

Control Tower decision: MERGE_APPROVED (side sprint override).