### PR TITLE
P9-S33: public core packaging

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 8 Sprint 32 (P8-S32): Outcome Learning and Closure Quality
+Phase 9 Sprint 33 (P9-S33): Public Core Packaging
 
 ## Sprint Type
 
@@ -10,223 +10,279 @@ feature
 
 ## Sprint Reason
 
-P8-S31 shipped deterministic governed execution routing on top of P8-S29/P8-S30. The next non-redundant seam is closing the Phase 8 loop by capturing handoff outcomes, exposing closure quality signals, and feeding deterministic learning signals back into chief-of-staff supervision.
+Phase 8 is complete. The next non-redundant seam is converting the internal Alice system into a public-safe, installable core with one documented local startup path, explicit package boundaries, and sample data that proves recall and resumption from public docs.
 
-Planning anchors:
+## Planning Anchors
 
-- `docs/phase8-product-spec.md`
-- `docs/phase8-sprint-29-32-plan.md`
+- `docs/phase9-product-spec.md`
+- `docs/phase9-sprint-33-38-plan.md`
+- `docs/phase9-public-core-boundary.md`
+- `docs/phase9-bootstrap-notes.md`
+- `docs/phase9-sprint-33-control-tower-packet.md`
+- `docs/adr/ADR-001-public-core-package-boundary.md`
+- `docs/adr/ADR-002-public-runtime-baseline.md`
+- `docs/adr/ADR-003-mcp-tool-surface-contract.md`
 
-## Sprint Intent
+## Sprint Objective
 
-Ship deterministic outcome-learning seams on top of shipped P8-S29/P8-S30/P8-S31:
-
-- explicit handoff outcome capture/status semantics
-- closure quality and conversion signal summaries
-- stale/ignored escalation posture visibility
-- `/chief-of-staff` outcome-learning and closure panel
+Package the existing Alice substrate so an external technical user can install it locally, load sample data, and complete one recall flow and one resumption flow from canonical docs without internal project context.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase8-sprint-32-outcome-learning-closure-quality`
+- Branch Name: `codex/phase9-sprint-33-public-core-packaging`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
-## Why This Sprint
+## Why This Sprint Matters
 
-- It is the planned final Phase 8 seam after shipped routing capability.
-- It turns routed handoffs into measurable closure outcomes.
-- It completes recommendation-to-handoff-to-routing-to-learning feedback without widening autonomy.
+- It is the first real public-product step of Phase 9.
+- It creates the stable package/runtime boundary that `P9-S34` CLI and `P9-S35` MCP depend on.
+- It forces docs, scripts, config, and sample data to match one real install path instead of internal assumptions.
 
 ## Redundancy Guard
 
 - Already shipped baseline:
-  - Phase 4 release-control and MVP sign-off seams.
-  - Phase 5 continuity capture/recall/review/open-loop seams.
-  - Phase 6 trust calibration (`P6-S21` through `P6-S24`), complete as of March 31, 2026.
-  - Phase 7 chief-of-staff layer complete (`P7-S25` through `P7-S28`).
-  - Phase 8 Sprint 29 (`P8-S29`) action handoff artifacts and explicit non-autonomous posture.
-  - Phase 8 Sprint 30 (`P8-S30`) handoff queue lifecycle and operator review transitions.
-  - Phase 8 Sprint 31 (`P8-S31`) governed execution routing transitions and readiness posture.
-- Required now (P8-S32):
-  - deterministic handoff outcome capture semantics
-  - closure quality summary and recommendation-to-execution conversion signals
-  - explicit stale/ignored escalation posture and feedback visibility
-- Explicitly out of P8-S32:
-  - autonomous execution or external connector side effects
-  - redesign of P8-S29 handoff generation semantics
-  - redesign of P8-S30 queue/review lifecycle semantics
-  - redesign of P8-S31 routing semantics
-  - connector/channel/auth/orchestration expansion
+  - Phase 4 release-control and qualification baseline.
+  - Phase 5 continuity capture, recall, resumption, review, correction, and open-loop seams.
+  - Phase 6 trust-calibrated memory-quality and retrieval posture.
+  - Phase 7 chief-of-staff guidance layer.
+  - Phase 8 operational chief-of-staff handoff, queue, routing, and outcome-learning seams.
+- Required now (`P9-S33`):
+  - explicit public-safe `alice-core` package boundary
+  - one canonical local startup path
+  - sample-data path for external technical evaluation
+  - public-facing repo/docs reshaping for install + first recall/resume proof
+- Explicitly out of `P9-S33`:
+  - CLI command implementation
+  - MCP server implementation
+  - OpenClaw adapter implementation
+  - broad importer work beyond sample-data support
+  - hosted SaaS, channel work, or unsafe autonomous execution
 
 ## Design Truth
 
-- Outcome learning must be deterministic for fixed state.
-- Outcome capture must be explicit and auditable.
-- Closure quality signals must be visible and explainable.
-- Execution posture remains approval-bounded and non-autonomous.
+- Alice remains a memory and continuity layer first, not a broad autonomous agent platform.
+- Public packaging must preserve shipped P5/P6/P7/P8 semantics instead of reimplementing them.
+- One documented local startup path is the source of truth for public v0.1.
+- Public docs are product surface in this phase and must match real runtime behavior.
 
 ## Exact Surfaces In Scope
 
-- chief-of-staff handoff outcome-learning artifact/API seam
-- closure quality and conversion summary seam
-- stale/ignored escalation signal seam
-- `/chief-of-staff` outcome-learning panel
-- deterministic tests for outcome capture and learning rollups
+- public-safe package boundary definition for `alice-core`
+- canonical local startup and install path
+- sample-data fixture/seed path for recall and resumption verification
+- repo and docs reshaping for external technical onboarding
+- ADR capture for any blocking packaging/runtime/license decisions
+- required gate-alignment test updates needed to satisfy the sprint's required verification commands
 
 ## Exact Files In Scope
 
-- `apps/api/src/alicebot_api/chief_of_staff.py`
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/tasks.py`
-- `apps/api/src/alicebot_api/approvals.py`
-- `apps/api/src/alicebot_api/memory.py`
-- `apps/web/lib/api.ts`
-- `apps/web/lib/api.test.ts`
-- `apps/web/app/chief-of-staff/page.tsx`
-- `apps/web/app/chief-of-staff/page.test.tsx`
-- `apps/web/components/chief-of-staff-execution-routing-panel.tsx`
-- `apps/web/components/chief-of-staff-execution-routing-panel.test.tsx`
-- `apps/web/components/chief-of-staff-outcome-learning-panel.tsx`
-- `apps/web/components/chief-of-staff-outcome-learning-panel.test.tsx`
-- `tests/unit/test_chief_of_staff.py`
-- `tests/integration/test_chief_of_staff_api.py`
 - `README.md`
+- `PRODUCT_BRIEF.md`
+- `ARCHITECTURE.md`
 - `ROADMAP.md`
+- `RULES.md`
 - `.ai/handoff/CURRENT_STATE.md`
+- `.ai/active/SPRINT_PACKET.md`
+- `docs/phase9-product-spec.md`
+- `docs/phase9-sprint-33-38-plan.md`
+- `docs/phase9-public-core-boundary.md`
+- `docs/phase9-bootstrap-notes.md`
+- `docs/phase9-sprint-33-control-tower-packet.md`
+- `docs/adr/ADR-001-public-core-package-boundary.md`
+- `docs/adr/ADR-002-public-runtime-baseline.md`
+- `docs/adr/ADR-003-mcp-tool-surface-contract.md`
+- `.env.example`
+- `docker-compose.yml`
+- `pyproject.toml`
+- `scripts/dev_up.sh`
+- `scripts/migrate.sh`
+- `scripts/api_dev.sh`
+- `apps/web/components/memory-summary.test.tsx`
+- `tests/integration/test_explicit_preferences_api.py`
+- `tests/unit/test_approval_store.py`
+- `tests/unit/test_compiler.py`
+- `tests/unit/test_entity_store.py`
+- `tests/unit/test_events.py`
+- `tests/unit/test_store.py`
+- `tests/unit/test_task_run_store.py`
+- `tests/unit/test_tool_execution_store.py`
+- `tests/unit/test_trace_store.py`
+- `fixtures/` or equivalent sample-data location
+- `LICENSE` if finalized in this sprint
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
-- `.ai/active/SPRINT_PACKET.md`
 
 ## In Scope
 
-- Add deterministic outcome-learning fields on chief-of-staff payloads:
-  - `handoff_outcome_summary`
-  - `handoff_outcomes`
-  - `closure_quality_summary`
-  - `conversion_signal_summary`
-  - `stale_ignored_escalation_posture`
-- Add explicit outcome-capture seam for routed handoff items:
-  - statuses: `reviewed`, `approved`, `rejected`, `rewritten`, `executed`, `ignored`, `expired`
-  - deterministic capture ordering and latest-state derivation
-  - immutable outcome capture records
-- Add deterministic closure-learning behavior:
-  - recommendation-to-execution conversion signals
-  - stale/ignored escalation rollups
-  - explicit explanation payload for how outcome history affects guidance posture
-- Add `/chief-of-staff` outcome-learning panel with outcome capture controls and closure metrics visibility.
-- Add deterministic tests for outcome capture/status rollups and closure-learning summary behavior.
+- Define what is public in `alice-core` versus deferred/internal.
+- Confirm one supported local runtime baseline and startup flow.
+- Ensure env defaults, scripts, and docs all point to the same install path.
+- Provide sample data that an external technical user can load or use immediately.
+- Prove one recall query and one resumption brief from the documented public setup.
+- Capture blocking public-boundary/runtime/tool-surface decisions in ADRs or explicit deferred notes.
 
-## Out of Scope
+## Out Of Scope
 
-- automatic execution based on outcomes
-- connector/channel expansion
-- changes to shipped P8-S29 generation semantics
-- changes to shipped P8-S30 queue/review semantics
-- changes to shipped P8-S31 routing semantics
+- CLI command implementation or terminal UX polish
+- MCP server code or tool execution
+- OpenClaw adapter implementation
+- broad repo-wide restructuring unrelated to public packaging
+- broad importer set
+- hosted deployment modes
 
 ## Required Deliverables
 
-- outcome-learning API/artifact seam
-- deterministic outcome capture and closure rollup behavior
-- stale/ignored escalation posture visibility
-- `/chief-of-staff` outcome-learning UI panel
-- unit/integration/web tests for outcome-learning behavior
-- synced docs and sprint reports
+- explicit `alice-core` public boundary
+- one canonical local startup path
+- sample-data story usable by external users
+- external-facing README/repo map reshaped for public onboarding
+- ADR-backed decisions for package boundary/runtime/tool-surface blockers
+- synced sprint reports
 
 ## Acceptance Criteria
 
-- routed handoff outcomes are captured with deterministic, explicit status semantics.
-- closure quality and conversion signals are deterministic, auditable, and explainable.
-- stale/ignored escalation posture is explicit and visible.
-- approval-bounded non-autonomous posture remains preserved.
-- `./.venv/bin/python -m pytest tests/unit/test_chief_of_staff.py tests/integration/test_chief_of_staff_api.py -q` passes.
-- `pnpm --dir apps/web test -- app/chief-of-staff/page.test.tsx components/chief-of-staff-execution-routing-panel.test.tsx components/chief-of-staff-outcome-learning-panel.test.tsx lib/api.test.ts` passes.
-- `python3 scripts/run_phase4_validation_matrix.py` remains PASS.
-- `README.md`, `ROADMAP.md`, and `.ai/handoff/CURRENT_STATE.md` reflect active P8-S32 scope and preserve “P8-S29/P8-S30/P8-S31 shipped” truth.
+- a fresh local install works from the documented startup path
+- sample data can be loaded or is available for immediate local use
+- one recall query works end to end from the documented setup
+- one resumption brief works end to end from the documented setup
+- public-safe boundaries are written clearly enough that `P9-S34` CLI and `P9-S35` MCP can build on them without reopening packaging ambiguity
+
+## Required Commands
+
+Minimum verification expected before review:
+
+```bash
+docker compose up -d
+./scripts/migrate.sh
+./scripts/api_dev.sh
+curl -sS http://127.0.0.1:8000/healthz
+./.venv/bin/python -m pytest tests/unit tests/integration
+pnpm --dir apps/web test
+```
+
+If a dedicated seed-data or public smoke command is introduced this sprint, it must also be run and included in review evidence.
+
+## Required Acceptance Evidence
+
+- exact startup path used during verification
+- exact sample-data load path used during verification
+- one successful recall example
+- one successful resumption example
+- note of any deferred public-boundary/runtime/license decision moved into ADRs
 
 ## Implementation Constraints
 
-- do not introduce new dependencies
-- preserve shipped P5/P6/P7 semantics
-- preserve shipped P8-S29 handoff-generation semantics
-- preserve shipped P8-S30 queue/review semantics
-- preserve shipped P8-S31 routing semantics
-- keep side effects approval-bounded and explicit
-- keep outcome-learning behavior deterministic and test-backed
+- preserve shipped P5/P6/P7/P8 semantics
+- do not introduce unsafe autonomous execution
+- keep one documented startup flow as the only canonical public path
+- prefer packaging clarity over premature repo-wide restructuring
+- keep public-boundary decisions explicit and narrow
 
 ## Control Tower Task Cards
 
-### Task 1: Outcome Learning Engine + API
+### Task 1: Public Boundary and Packaging
 
-Owner: tooling operative
-
-Write scope:
-
-- `apps/api/src/alicebot_api/chief_of_staff.py`
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/tasks.py`
-- `apps/api/src/alicebot_api/approvals.py`
-- `apps/api/src/alicebot_api/memory.py`
-- `tests/unit/test_chief_of_staff.py`
-- `tests/integration/test_chief_of_staff_api.py`
-
-### Task 2: Chief-of-Staff Outcome UI
-
-Owner: tooling operative
+Owner: platform/package owner
 
 Write scope:
 
-- `apps/web/lib/api.ts`
-- `apps/web/lib/api.test.ts`
-- `apps/web/app/chief-of-staff/page.tsx`
-- `apps/web/app/chief-of-staff/page.test.tsx`
-- `apps/web/components/chief-of-staff-execution-routing-panel.tsx`
-- `apps/web/components/chief-of-staff-execution-routing-panel.test.tsx`
-- `apps/web/components/chief-of-staff-outcome-learning-panel.tsx`
-- `apps/web/components/chief-of-staff-outcome-learning-panel.test.tsx`
+- `ARCHITECTURE.md`
+- `PRODUCT_BRIEF.md`
+- `README.md`
+- `pyproject.toml`
+- `docker-compose.yml`
+- `LICENSE`
+- `docs/phase9-public-core-boundary.md`
+- `docs/adr/ADR-001-public-core-package-boundary.md`
+- `docs/adr/ADR-002-public-runtime-baseline.md`
+- `docs/adr/ADR-003-mcp-tool-surface-contract.md`
 
-### Task 3: Docs + Integration Review
+Responsibilities:
 
-Owner: control tower
+- define what is in `alice-core` versus deferred/internal
+- define public runtime assumptions for v0.1
+- confirm one supported local startup path
+- capture blocking decisions as ADRs or explicit deferred items
+
+### Task 2: Startup Path and Sample Data
+
+Owner: backend/runtime owner
+
+Write scope:
+
+- `.env.example`
+- `scripts/migrate.sh`
+- `scripts/api_dev.sh`
+- `scripts/dev_up.sh`
+- `fixtures/` or equivalent sample-data location
+- relevant bootstrap/seed helpers under `apps/api` or `scripts`
+
+Responsibilities:
+
+- ensure sample-data path is deterministic and documented
+- ensure startup scripts and env defaults match docs
+- verify recall and resumption against the sample dataset
+- remove ambiguity between internal-only and public setup steps
+
+### Task 3: Docs and External Onboarding
+
+Owner: docs/integration owner
 
 Write scope:
 
 - `README.md`
 - `ROADMAP.md`
 - `.ai/handoff/CURRENT_STATE.md`
+- `docs/phase9-product-spec.md`
+- `docs/phase9-sprint-33-38-plan.md`
+- `docs/phase9-bootstrap-notes.md`
+- any new quickstart docs introduced under `docs/`
+
+Responsibilities:
+
+- keep README onboarding-focused
+- keep current state factual about shipped versus targeted surfaces
+- keep roadmap sequencing consistent with packaging-first execution
+- add any missing quickstart examples needed to close the install gap
+
+### Task 4: Integration Review
+
+Owner: sprint integrator
+
+Write scope:
+
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 Responsibilities:
 
-- verify no P6/P7/P8-S29/P8-S30/P8-S31 relitigation
-- verify deterministic outcome capture and closure-learning semantics
-- verify no hidden scope expansion
-- verify no Phase 4 regression
+- verify doc, runtime, and sample-data paths agree
+- verify ADRs match canonical docs
+- verify no hidden expansion into CLI, MCP, or OpenClaw delivery
+- prepare final evidence notes for review
 
 ## Build Report Requirements
 
 `BUILD_REPORT.md` must include:
 
-- exact outcome-learning contract delta
-- exact deterministic outcome/closure summary behavior
-- exact verification command outcomes
-- explicit deferred Phase 8 follow-up scope after P8-S32
+- exact startup path used during verification
+- exact sample-data path used during verification
+- exact recall and resumption proof steps
+- exact commands run and outcomes
+- any deferred public-boundary/runtime/license decisions
 
 ## Review Focus
 
 `REVIEW_REPORT.md` should verify:
 
-- sprint stayed P8-S32 scoped
-- outcome-learning outputs are deterministic and explainable
-- approval-bounded execution posture is explicit and preserved
-- no hidden scope expansion
-- Phase 4 validation remains green
+- sprint stayed `P9-S33` scoped
+- startup path is singular, real, and doc-matched
+- sample-data story is usable by an external technical user
+- recall and resumption proof is real from public docs
+- no hidden CLI/MCP/OpenClaw implementation scope entered the sprint
 
-## Exit Condition
+## Definition Of Done
 
-This sprint is complete when Alice can deterministically capture handoff outcomes and present closure-quality learning signals that feed back into chief-of-staff supervision, without regressing shipped Phase 4/5/6/7 and P8-S29/P8-S30/P8-S31 behavior.
+This sprint is done when Alice has a public-core packaging boundary, one clean local boot flow, sample-data support, and canonical docs that an external technical user can follow without internal project context.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -1,165 +1,63 @@
 # Current State
 
-## Canonical Truth
+## What Exists Today
 
-- The canonical baseline remains through Phase 3 Sprint 9.
-- Phase 4 release-control layer remains the canonical gate ownership compatibility baseline.
-- Active Sprint focus is Phase 4 Sprint 14.
-- Active sprint focus is Phase 8 Sprint 32 outcome learning and closure quality.
-- Earlier Phase 4 work is already delivered: task-run linkage to approvals/executions, idempotent proxy execution replay guards, approval pause/resume continuity for linked runs, run transition observability, explicit stop reasons, bounded retries with persisted posture, explicit failure classes, and deterministic Phase 4 gate runners.
-- Phase 4 Sprint 14-19 release-control/sign-off delivery is shipped baseline, and Phase 5 Sprint 17-20 continuity delivery is shipped baseline.
-- Latest shipped post-Phase-5 packet is P6-S24 trust dashboard and quality release evidence.
-- P8-S29 chief-of-staff action handoff artifacts are shipped baseline.
-- P8-S30 chief-of-staff handoff queue and operational review is shipped baseline.
-- P8-S31 chief-of-staff governed execution routing is shipped baseline.
-- P8-S32 chief-of-staff outcome learning and closure quality implementation is now in place for the active sprint packet.
-- Active post-Phase-7 packet is P8-S32 outcome learning and closure quality.
-- Phase 8 planning anchors are:
-  - `docs/phase8-product-spec.md`
-  - `docs/phase8-sprint-29-32-plan.md`
-- The accepted baseline includes deterministic Phase 3 gate entrypoints: `python3 scripts/run_phase3_acceptance.py`, `python3 scripts/run_phase3_readiness_gates.py`, and `python3 scripts/run_phase3_validation_matrix.py` (default go/no-go command).
-- Phase 4 gate entrypoints are `python3 scripts/run_phase4_acceptance.py`, `python3 scripts/run_phase4_readiness_gates.py`, and `python3 scripts/run_phase4_validation_matrix.py`.
-- Phase 4 release-candidate rehearsal entrypoint is `python3 scripts/run_phase4_release_candidate.py`, which writes latest summary evidence at `artifacts/release/phase4_rc_summary.json` and appends retained archive/index evidence under `artifacts/release/archive/` for repeated-run audit, with deterministic archive index lock path `artifacts/release/archive/index.lock`, bounded lock-timeout failure contract, and atomic index replace writes.
-- Archive audit verifier entrypoint is `python3 scripts/verify_phase4_rc_archive.py`.
-- Phase 4 MVP exit manifest entrypoints are `python3 scripts/generate_phase4_mvp_exit_manifest.py` and `python3 scripts/verify_phase4_mvp_exit_manifest.py`, producing deterministic closeout evidence at `artifacts/release/phase4_mvp_exit_manifest.json` from latest GO RC archive evidence.
-- Phase 4 MVP qualification/sign-off entrypoints are `python3 scripts/run_phase4_mvp_qualification.py` and `python3 scripts/verify_phase4_mvp_signoff_record.py`, producing deterministic qualification evidence at `artifacts/release/phase4_mvp_signoff_record.json` with ordered gate statuses, GO/NO_GO, and blocker registry.
-- Gate ownership is canonicalized to Phase 4 runner script names; Phase 3/Phase 2/MVP commands remain supported compatibility entrypoints with identical semantics.
-- Use [PRODUCT_BRIEF.md](../../PRODUCT_BRIEF.md) for product scope, [ARCHITECTURE.md](../../ARCHITECTURE.md) for implemented boundaries, [ROADMAP.md](../../ROADMAP.md) for forward planning, and [RULES.md](../../RULES.md) for durable operating rules.
-- The live sprint reports are [BUILD_REPORT.md](../../BUILD_REPORT.md) and [REVIEW_REPORT.md](../../REVIEW_REPORT.md) at repo root; older accepted sprint history belongs in [docs/archive/sprints](../../docs/archive/sprints), not in this handoff.
+- Phase 4 release-control and MVP qualification/sign-off seams are complete and trusted baseline.
+- Phase 5 continuity capture, recall, resumption, review, correction, and open-loop seams are shipped baseline.
+- Phase 6 memory trust-calibration, review prioritization, retrieval evaluation, and trust dashboard seams are shipped baseline.
+- Phase 7 chief-of-staff prioritization, follow-through, preparation, and weekly review seams are shipped baseline.
+- Phase 8 operational chief-of-staff handoff, queue, routing, and outcome-learning seams are shipped baseline.
+- The current internal product is a local-first, trust-calibrated continuity and chief-of-staff system with bounded operator UI and governed workflows.
 
-## Implemented Surfaces
+## Stable / Trusted Areas
 
-- `apps/api` is the core shipped product surface. It implements continuity, context compilation, assistant responses, typed memory and open-loop seams, deterministic thread resumption brief reads, unified explicit-signal capture seams, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact chunk retrieval and embeddings, traces, and narrow read-only Gmail and Calendar seams with selected-item ingestion plus bounded Calendar event discovery.
-- Phase 7 Sprint 25 + Sprint 26 chief-of-staff implementation is now in place:
-  - `GET /v0/chief-of-staff` compiles deterministic ranked priorities from shipped continuity and trust seams.
-  - ranked items include explicit posture label (`urgent`, `important`, `waiting`, `blocked`, `stale`, `defer`), provenance-backed rationale payload, and trust-aware confidence posture.
-  - recommendation payload includes one deterministic next action with explicit confidence posture and provenance references.
-  - deterministic follow-through supervision fields are shipped: `overdue_items`, `stale_waiting_for_items`, `slipped_commitments`, `escalation_posture`, and governed `draft_follow_up`.
-  - each follow-through item includes explicit current priority posture, follow-through posture, deterministic recommendation action (`nudge`, `defer`, `escalate`, `close_loop_candidate`), and rationale.
-  - `draft_follow_up` is artifact-only and approval-bounded (`mode=draft_only`, `approval_required=true`, `auto_send=false`).
-- Phase 7 Sprint 27 chief-of-staff preparation/resumption implementation is now in place:
-  - `GET /v0/chief-of-staff` now also returns deterministic `preparation_brief`, `what_changed_summary`, `prep_checklist`, `suggested_talking_points`, and `resumption_supervision`.
-  - preparation and resumption recommendations are provenance-backed and explicitly trust-calibrated.
-  - low-trust memory posture visibly downgrades preparation/resumption confidence posture.
-  - `/chief-of-staff` now includes a dedicated preparation panel with rationale and provenance visibility.
-- Phase 7 Sprint 28 chief-of-staff weekly review/outcome-learning implementation is now in place:
-  - `GET /v0/chief-of-staff` now also returns deterministic `weekly_review_brief`, `recommendation_outcomes`, `priority_learning_summary`, and `pattern_drift_summary`.
-  - weekly-review guidance explicitly ranks `close` / `defer` / `escalate` actions with deterministic rationale and signal counts.
-  - `POST /v0/chief-of-staff/recommendation-outcomes` captures deterministic recommendation handling outcomes (`accept`, `defer`, `ignore`, `rewrite`) as auditable continuity records.
-  - `/chief-of-staff` now includes a dedicated weekly review and learning panel with explicit outcome-capture controls and drift visibility.
-- Phase 8 Sprint 29 chief-of-staff action-handoff implementation is now in place:
-  - `GET /v0/chief-of-staff` now also returns deterministic `action_handoff_brief`, `handoff_items`, `task_draft`, `approval_draft`, and explicit `execution_posture`.
-  - handoff artifacts deterministically map top actionable recommendations from priority/follow-through/preparation/weekly-review seams into governed task/approval-ready draft structures with rationale and provenance.
-  - execution posture is explicit and non-autonomous (`approval_bounded_artifact_only`, `approval_required=true`, `autonomous_execution=false`, no external side effects).
-  - `/chief-of-staff` now includes a dedicated action handoff panel with posture visibility and draft artifact review.
-- Phase 8 Sprint 30 chief-of-staff handoff-queue and operational-review implementation is now in place:
-  - `GET /v0/chief-of-staff` now also returns deterministic `handoff_queue_summary`, `handoff_queue_groups`, and `handoff_review_actions`.
-  - queue lifecycle states are explicit (`ready`, `pending_approval`, `executed`, `stale`, `expired`) with deterministic grouping/ordering posture and explicit stale/expired surfacing.
-  - `POST /v0/chief-of-staff/handoff-review-actions` captures explicit operator queue lifecycle transitions as auditable continuity records.
-  - `/chief-of-staff` now includes a dedicated grouped handoff queue panel with explicit review-action controls and review-action history visibility.
-- Phase 8 Sprint 31 chief-of-staff governed execution-routing implementation is now in place:
-  - `GET /v0/chief-of-staff` now also returns deterministic `execution_routing_summary`, `routed_handoff_items`, `routing_audit_trail`, and `execution_readiness_posture`.
-  - `POST /v0/chief-of-staff/execution-routing-actions` captures explicit routing transitions into governed draft targets (`task_workflow_draft`, `approval_workflow_draft`, `follow_up_draft_only`).
-  - routing transitions are explicit and auditable (`routed`, `reaffirmed`) while preserving approval-required draft-only posture.
-  - `/chief-of-staff` now includes a dedicated execution routing panel with readiness posture visibility, route controls, and auditable transition history.
-- Phase 8 Sprint 32 chief-of-staff outcome-learning and closure-quality implementation is now in place:
-  - `GET /v0/chief-of-staff` now also returns deterministic `handoff_outcome_summary`, `handoff_outcomes`, `closure_quality_summary`, `conversion_signal_summary`, and `stale_ignored_escalation_posture`.
-  - `POST /v0/chief-of-staff/handoff-outcomes` captures explicit routed-handoff outcomes (`reviewed`, `approved`, `rejected`, `rewritten`, `executed`, `ignored`, `expired`) as immutable continuity records.
-  - outcome rollups are deterministic and latest-state driven per handoff item, with explicit closure-quality, conversion-signal, and stale/ignored escalation posture explanations.
-  - `/chief-of-staff` now includes a dedicated outcome-learning panel with explicit outcome-capture controls and closure/conversion/escalation visibility.
-- Phase 5 Sprint 17 adds typed continuity capture seams:
-  - `POST /v0/continuity/captures` always appends an immutable capture event and conservatively admits typed durable objects.
-  - `GET /v0/continuity/captures` returns inbox rows with admission posture (`DERIVED`/`TRIAGE`) and optional derived object summary.
-  - `GET /v0/continuity/captures/{capture_event_id}` returns capture detail with derived object and provenance when admitted.
-- Phase 5 Sprint 18 adds continuity recall/resumption seams:
-  - `GET /v0/continuity/recall` returns provenance-backed scoped recall results with deterministic ordering metadata, confirmation status, and admission posture.
-  - `GET /v0/continuity/resumption-brief` compiles deterministic brief sections (`last_decision`, `open_loops`, `recent_changes`, `next_action`) with explicit empty states.
-- Phase 5 Sprint 19 adds continuity review/correction seams:
-  - `GET /v0/continuity/review-queue` returns correction-ready continuity objects with deterministic posture filtering.
-  - `GET /v0/continuity/review-queue/{continuity_object_id}` returns selected-object review detail, correction-event history, and supersession chain links.
-  - `POST /v0/continuity/review-queue/{continuity_object_id}/corrections` applies deterministic `confirm`/`edit`/`delete`/`supersede`/`mark_stale` actions.
-  - correction events are append-only and persisted before lifecycle mutation.
-  - continuity recall/resumption now reflects correction posture immediately, including freshness/supersession metadata (`last_confirmed_at`, `supersedes_object_id`, `superseded_by_object_id`) and deleted-object exclusion from recall payloads.
-- Phase 5 Sprint 20 adds deterministic open-loop review and briefing seams:
-  - `GET /v0/continuity/open-loops` returns grouped posture sections (`waiting_for`, `blocker`, `stale`, `next_action`) with deterministic ordering metadata.
-  - `GET /v0/continuity/daily-brief` returns deterministic daily sections (`waiting_for_highlights`, `blocker_highlights`, `stale_items`, `next_suggested_action`) with explicit empty states.
-  - `GET /v0/continuity/weekly-review` returns deterministic grouped sections plus posture rollup counts.
-  - `POST /v0/continuity/open-loops/{continuity_object_id}/review-action` applies deterministic `done`/`deferred`/`still_blocked` actions with auditable correction-event payload mapping.
-  - continuity resumption reflects open-loop review-action outcomes immediately.
-- Phase 6 Sprint 21 adds canonical memory-quality and deterministic review-priority seams:
-  - `GET /v0/memories/quality-gate` returns deterministic canonical gate status (`healthy`, `needs_review`, `insufficient_sample`, `degraded`) with precision/sample/risk counts and explicit computation backing fields.
-  - `GET /v0/memories/review-queue` supports deterministic priority modes (`oldest_first`, `recent_first`, `high_risk_first`, `stale_truth_first`) with explicit summary ordering metadata plus per-item priority posture (`is_high_risk`, `is_stale_truth`, `priority_reason`).
-  - `/memories` consumes API-backed quality-gate contract and exposes queue priority-mode selection without changing label vocabulary or submit flow semantics.
-- Phase 6 Sprint 22 adds retrieval-quality evaluation and recall ranking calibration seams:
-  - `GET /v0/continuity/retrieval-evaluation` returns deterministic fixture-backed precision summaries (`precision_at_k_mean`, `precision_at_1_mean`, `precision_target`) and top-result ordering evidence for each fixture query.
-  - `GET /v0/continuity/recall` ranking is calibrated for confirmation, freshness posture, provenance quality, and supersession posture while preserving deterministic ordering.
-  - continuity recall ordering metadata now surfaces explicit ranking evidence fields (`freshness_posture`, `provenance_posture`, `supersession_posture`) and their deterministic rank contributions.
-  - `/continuity` recall cards render ranking posture evidence (`freshness`, `provenance`, `supersession`) from API ordering metadata.
-- Phase 6 Sprint 23 correction/freshness hygiene implementation is shipped baseline and adds deterministic weekly review evidence fields:
-  - `correction_recurrence_count` (open-loop objects with recurring correction events)
-  - `freshness_drift_count` (open-loop items currently in stale posture)
-- Phase 6 Sprint 24 trust/evidence implementation is shipped baseline and adds deterministic trust dashboard + release evidence seams:
-  - `GET /v0/memories/trust-dashboard` returns one canonical quality posture payload combining quality-gate posture, queue posture/aging summary, retrieval-quality summary, correction recurrence/freshness drift summary, and explicit recommended next review action.
-  - `python3 scripts/run_phase6_quality_evidence.py` writes deterministic quality evidence artifact output for release/readiness paths.
-  - `python3 scripts/run_phase4_readiness_gates.py`, `python3 scripts/run_phase4_release_candidate.py`, and `python3 scripts/run_phase4_validation_matrix.py` now include additive quality evidence summary reporting while preserving existing GO/NO_GO semantics.
-- `apps/web` is also a shipped surface now. The operator shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/chief-of-staff`, `/entities`, and `/traces`, with live reads when API config is present and explicit fixture fallback when it is not.
-- `/chief-of-staff` now ships P7-S27 preparation and resumption supervision on top of P7-S25/P7-S26: deterministic ranked priorities, deterministic follow-through supervision, deterministic preparation artifacts, trust-aware confidence posture (including explicit low-trust downgrade rendering), deterministic recommended next action, deterministic escalation posture, and draft-only follow-up artifact visibility.
-- `/chat` now ships assistant-response mode, governed-request mode, visible thread selection, compact thread creation, selected-thread transcript continuity, deterministic resumption brief review, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, manual explicit-signal capture controls for selected `message.user` events, and bounded supporting continuity review over thread sessions and events.
-- `/continuity` now ships the Phase 5 Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 continuity workspace:
-  - capture submit (optional explicit signal), recent capture list, and capture detail with posture/provenance
-  - recall query/results panel with scoped filters and provenance-backed result cards
-  - deterministic resumption-brief panel with always-present required sections
-  - review queue list/filter panel
-  - selected-object correction form with correction-event history and supersession chain visibility
-  - open-loop dashboard grouped by waiting-for/blocker/stale/next-action posture
-  - daily brief panel and weekly review panel with explicit empty-state rendering
-  - open-loop review-action controls (`done`, `deferred`, `still_blocked`) with immediate page refresh feedback
-- `/gmail` ships a bounded Gmail operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-message ingestion into one selected task workspace.
-- `/calendar` ships a bounded Calendar operator workspace: account list review, selected-account detail, explicit account connection, and explicit single-event ingestion into one selected task workspace. The shipped API baseline now also includes bounded read-only event discovery for one selected account (`GET /v0/calendar-accounts/{calendar_account_id}/events`) with deterministic ordering metadata and bounded limits.
-- `/memories` ships a bounded memory review workspace: active/queue list posture, selected memory detail, revision review, and memory-label review/submit seams with explicit live/fixture/unavailable states.
-- `/entities` ships a bounded entity review workspace: list, selected entity detail, and related edge review with explicit live/fixture/unavailable states.
-- `/artifacts` ships a bounded artifact review workspace: list, selected artifact detail, linked task-workspace summary, and ordered chunk evidence with explicit live/fixture/unavailable states.
-- `workers` remains scaffold-only.
+- deterministic continuity and resumption behavior
+- correction-aware memory behavior
+- open-loop review and brief generation
+- chief-of-staff recommendation and handoff substrate
+- release-control and evidence infrastructure
+- approval-bounded operational posture
 
-## Current Boundaries
+## Incomplete / At-Risk Areas
 
-- Continuity stays explicit and thread-scoped: thread create/list/detail plus session/event review and deterministic thread resumption-brief reads are live; thread rename, archive, search, pagination, and event mutation are not.
-- Assistant replies go only through `POST /v0/responses`, persist immutable continuity events, and return linked compile and response traces.
-- Explain-why in `/chat` is selected-thread scoped and bounded: it reuses shipped trace list/detail/event reads, shows linked trace shortcuts from transcript/workflow/timeline context, and keeps full trace workspace in `/traces`.
-- Governed actions still route through policy, allowlist, approval, and approved-only proxy execution; `proxy.echo` is still the only live execution handler.
-- Task workspaces and artifacts remain rooted local boundaries. Ingestion remains narrow to plain text, markdown, narrow PDF text, narrow DOCX text from `word/document.xml`, and narrow RFC822 extraction.
-- Gmail and Calendar remain read-only connector surfaces. Calendar now includes bounded event discovery for one selected account plus selected-event ingestion. Secret material stays behind dedicated secret-manager seams, the Gmail `legacy_db_v0` transition path still exists for older credential rows, and the shipped web workspaces stay bounded to account review, explicit connect, and one-item ingestion into one selected task workspace.
+- no public CLI surface exists yet
+- no published MCP server surface exists yet
+- importer and adapter story is not yet public-ready
+- OSS license finalization is still open
 
-## Active Risks
+## Current Milestone
 
-- Memory extraction and retrieval quality remain the main product risk.
-- Auth is still incomplete beyond database user context.
-- Connector breadth, richer parsing, and orchestration are still deferred; docs must stay synchronized with the shipped API-plus-web baseline, including `/gmail` and `/calendar`, so planning does not drift again.
-- Phase 5 remaining scope:
-  - none from Sprint 17-20 continuity plan.
-- Post-Phase-5 active scope:
-  - P6-S21, P6-S22, P6-S23, and P6-S24 are shipped baseline.
-  - P7-S25 priority engine and chief-of-staff dashboard is shipped baseline.
-  - P7-S26 follow-through supervision is shipped baseline.
-  - P7-S27 preparation briefs and resumption supervision is shipped baseline.
-  - P7-S28 weekly review and outcome learning is shipped baseline.
-  - P8-S29 chief-of-staff action handoff artifacts are shipped baseline.
-  - P8-S30 chief-of-staff handoff queue and operational review is shipped baseline.
-  - P8-S31 chief-of-staff governed execution routing is shipped baseline.
-  - active post-P7 scope is P8-S32 outcome learning and closure quality.
+Phase 9: Alice Public Core and Agent Interop
 
-## Repo Evidence To Trust
+## Latest State Summary
 
-- Backend continuity and response seams: `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`
-- Backend Gmail and Calendar seams: `tests/integration/test_gmail_accounts_api.py`, `tests/integration/test_calendar_accounts_api.py`, `tests/unit/test_gmail.py`, `tests/unit/test_calendar.py`, `tests/unit/test_calendar_main.py`, `tests/unit/test_20260316_0026_gmail_accounts.py`, `tests/unit/test_20260319_0030_calendar_accounts_and_credentials.py`
-- Web `/chat` continuity + workflow/timeline/explainability adoption: `apps/web/app/chat/page.tsx`, `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.tsx`, `apps/web/components/thread-summary.tsx`, `apps/web/components/thread-event-list.tsx`, `apps/web/components/response-composer.tsx`, `apps/web/components/thread-workflow-panel.tsx`, `apps/web/components/task-step-list.tsx`, `apps/web/components/response-history.tsx`, `apps/web/components/thread-trace-panel.tsx`, and matching component tests.
-- Web review workspaces added through the accepted Sprint 6P/6Q/6R sequence: `apps/web/app/memories/page.tsx`, `apps/web/app/memories/page.test.tsx`, `apps/web/app/entities/page.tsx`, `apps/web/app/entities/page.test.tsx`, `apps/web/app/artifacts/page.tsx`, `apps/web/app/artifacts/page.test.tsx`.
-- Web Gmail and Calendar workspaces: `apps/web/app/gmail/page.tsx`, `apps/web/app/calendar/page.tsx`, `apps/web/lib/api.ts`, `apps/web/lib/api.test.ts`, `apps/web/components/gmail-account-list.test.tsx`, `apps/web/components/calendar-account-list.test.tsx`, `apps/web/components/calendar-event-ingest-form.test.tsx`
-- Web continuity workspace + retrieval/resumption/review/open-loop briefing surfaces: `apps/web/app/continuity/page.tsx`, `apps/web/app/continuity/page.test.tsx`, `apps/web/components/continuity-recall-panel.tsx`, `apps/web/components/continuity-recall-panel.test.tsx`, `apps/web/components/resumption-brief.tsx`, `apps/web/components/resumption-brief.test.tsx`, `apps/web/components/continuity-review-queue.tsx`, `apps/web/components/continuity-review-queue.test.tsx`, `apps/web/components/continuity-correction-form.tsx`, `apps/web/components/continuity-correction-form.test.tsx`, `apps/web/components/continuity-open-loops-panel.tsx`, `apps/web/components/continuity-open-loops-panel.test.tsx`, `apps/web/components/continuity-daily-brief.tsx`, `apps/web/components/continuity-daily-brief.test.tsx`, `apps/web/components/continuity-weekly-review.tsx`, `apps/web/components/continuity-weekly-review.test.tsx`
-- Shell route inventory and discoverability: `apps/web/components/app-shell.tsx`, `apps/web/app/page.tsx`
+`P9-S33` now has a concrete public-core baseline:
 
-## Planning Guardrails
+- package boundary is documented around `alice-core`
+- canonical local startup path is documented and script-backed
+- deterministic sample fixture exists at `fixtures/public_sample_data/continuity_v1.json`
+- sample load path exists at `./scripts/load_sample_data.sh`
+- recall and resumption proof commands are documented from the public setup path
 
-- Plan from the implemented Phase 3 Sprint 9 repo state, not from older Sprint 5-era narratives.
-- Do not describe broader Gmail scope, broader Calendar scope beyond bounded read-only event discovery plus selected-event ingestion, richer parsing, broader proxy execution, auth expansion, or runner orchestration as shipped.
-- The immediate next move should be chosen from the current shipped backend-plus-web-shell baseline, including `/gmail`, `/calendar`, `/memories`, `/entities`, and `/artifacts`, not assumed to be leftover connector cleanup by default.
+## Critical Constraints
+
+- Preserve shipped P5/P6/P7/P8 semantics.
+- Keep public interop deterministic and provenance-backed.
+- Do not expand into unsafe autonomy or broad connector write actions during Phase 9.
+- Keep the public v0.1 install path local-first and straightforward.
+
+## Immediate Next Move
+
+Execute `P9-S34` on top of the `P9-S33` boundary:
+
+- implement CLI surface against the documented `alice-core` package seam
+- keep startup/sample-data docs unchanged unless the runtime contract changes
+- preserve deterministic recall/resumption behavior while adding terminal UX
+
+## Legacy Compatibility Markers
+
+Repository lineage remains continuous through Phase 3 Sprint 9.
+
+Active Sprint focus is Phase 4 Sprint 14.
+
+Gate ownership is canonicalized to Phase 4 runner script names.

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ HEALTHCHECK_TIMEOUT_SECONDS=2
 TASK_WORKSPACE_ROOT=/tmp/alicebot/task-workspaces
 # Server-side authenticated user binding for /v0 requests.
 ALICEBOT_AUTH_USER_ID=00000000-0000-0000-0000-000000000001
+# Default sample-data fixture consumed by ./scripts/load_sample_data.sh.
+PUBLIC_SAMPLE_DATA_PATH=fixtures/public_sample_data/continuity_v1.json
 # Per-user response generation throttle (POST /v0/responses).
 RESPONSE_RATE_LIMIT_WINDOW_SECONDS=60
 RESPONSE_RATE_LIMIT_MAX_REQUESTS=20

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,107 +1,212 @@
 # Architecture
 
-## Current Implemented Slice
+## System Overview
 
-AliceBot now implements the accepted repo slice through Phase 3 Sprint 9.
+Alice is a local-first memory and continuity engine built around durable continuity storage, deterministic context compilation, correction-aware memory, open-loop tracking, trust-calibrated retrieval, and approval-bounded operational workflows.
 
-- `apps/api` is the core shipped surface. It provides continuity storage and review over `users`, `threads`, `sessions`, and append-only `events`; deterministic context compilation; governed memory admission and review plus open-loop lifecycle capture/review; embeddings and semantic retrieval; entities and entity edges; policy, tool, approval, and execution governance; the no-tools assistant-response seam at `POST /v0/responses`; explicit task and task-step lifecycle reads and mutations; rooted local task workspaces and artifact ingestion; artifact chunk retrieval and embeddings; and narrow read-only Gmail and Calendar seams with external-secret-backed credentials plus bounded Calendar event discovery and selected-item ingestion into the artifact pipeline.
-- `apps/web` is a shipped operator shell over those backend seams, not a scaffold-only placeholder. The current routes are `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/chief-of-staff`, `/entities`, and `/traces`. The shell can read live backend seams when configured and otherwise falls back to explicit fixture states instead of pretending the backend is connected.
-- `/chat` now carries both shipped operator modes: governed request composition and assistant-response mode. It uses visible thread selection instead of a raw typed thread id, supports compact thread creation through the continuity API, renders a selected-thread transcript from immutable continuity events, and keeps supporting session and operational review, thread-linked governed workflow review, ordered task-step timeline review, and bounded explain-why trace review in the right rail. The rail now also includes a manual explicit-signal capture control that triggers `POST /v0/memories/capture-explicit-signals` only from explicit operator action on selected `message.user` events.
-- `/gmail` and `/calendar` are shipped bounded connector workspaces over existing backend seams: visible account list review, selected-account detail, explicit account connection, and explicit single-item ingestion into one chosen task workspace, with live/fixture/unavailable states kept explicit.
-- `/artifacts`, `/memories`, `/chief-of-staff`, and `/entities` are now shipped bounded review workspaces that expose existing artifact, memory (including open-loop review), chief-of-staff priority plus follow-through plus preparation/resumption plus weekly review/outcome-learning plus handoff-queue/review supervision, and entity read seams with explicit live/fixture/unavailable modes.
-- `workers` remains scaffold-only. No background runner, automatic multi-step progression, or asynchronous job system is implemented.
+The current implementation already includes:
 
-The repo is intentionally still narrow. Document ingestion remains local and deterministic. The only live execution handler is the no-external-I/O `proxy.echo` path. Gmail and Calendar remain read-only; Calendar includes bounded event discovery and selected-event ingestion only. Rich parsing, mailbox sync, attachments, broader Calendar capabilities, broader proxying, and runner-style orchestration are still planned later.
+- continuity capture, recall, resumption, review, and open-loop seams
+- trust-calibrated memory quality and retrieval posture
+- a chief-of-staff layer with prioritization, follow-through, preparation, review, and governed handoff workflows
+- deterministic gate and release evidence infrastructure
 
-## Implemented Now
+Phase 9 does not replace that architecture. It packages and exposes it through public-safe boundaries.
 
-### Runtime
+Current public-core packaging state is defined in `P9-S33`: one install path, one runtime baseline, and one deterministic sample-data fixture for recall and resumption verification.
 
-- `docker-compose.yml` starts local Postgres with `pgvector`, Redis, and MinIO.
-- `scripts/dev_up.sh`, `scripts/migrate.sh`, and `scripts/api_dev.sh` provide the local startup path.
-- `scripts/run_phase3_acceptance.py`, `scripts/run_phase3_readiness_gates.py`, and `scripts/run_phase3_validation_matrix.py` are the canonical Phase 3 gate entrypoints; they preserve deterministic gate semantics by delegating to existing Phase 2 implementations. `scripts/run_phase2_*.py` and `scripts/run_mvp_*.py` remain supported compatibility entrypoints with identical semantics.
-- `apps/api` exposes FastAPI endpoints for:
-  - continuity and response generation: `/healthz`, `POST /v0/threads`, `GET /v0/threads`, `GET /v0/threads/{thread_id}`, `GET /v0/threads/{thread_id}/sessions`, `GET /v0/threads/{thread_id}/events`, `GET /v0/threads/{thread_id}/resumption-brief`, `GET /v0/chief-of-staff`, `POST /v0/chief-of-staff/recommendation-outcomes`, `POST /v0/chief-of-staff/handoff-review-actions`, `POST /v0/context/compile`, `POST /v0/responses`
-  - memory and open-loop seams, including `POST /v0/memories/admit`, `POST /v0/memories/capture-explicit-signals`, `GET /v0/open-loops`, `GET /v0/open-loops/{open_loop_id}`, `POST /v0/open-loops`, `POST /v0/open-loops/{open_loop_id}/status`, and `POST /v0/open-loops/extract-explicit-commitments`
-  - embeddings and graph seams
-  - policy, tool, approval, execution-budget, and proxy execution governance
-  - task, task-step, task-workspace, task-artifact, artifact-chunk, and trace review reads and mutations
-  - narrow Gmail account connect/read plus selected-message ingestion
-  - narrow Calendar account connect/read, bounded event discovery, plus selected-event ingestion
-- `apps/web` exposes the current operator shell:
-  - `/`: bounded home view over the shipped shell surfaces
-  - `/chat`: assistant mode, governed request mode, thread selection, thread creation, transcript-first continuity review, deterministic resumption brief review, manual explicit-signal capture control for selected `message.user` events, thread-linked governed workflow and task-step timeline review, bounded explain-why embedding, and bounded supporting operational review
-  - `/approvals`: approval inbox and execution review
-  - `/tasks`: task summary and ordered task-step review
-  - `/artifacts`: artifact list and selected detail, linked workspace summary, and ordered chunk review
-  - `/gmail`: connected-account review, selected-account detail, explicit connect, and selected-message ingestion into one chosen task workspace
-  - `/calendar`: connected-account review, selected-account detail, explicit connect, and selected-event ingestion into one chosen task workspace
-  - `/memories`: memory summary and queue posture, selected detail, revision review, label review, plus open-loop summary/list/detail review
-  - `/chief-of-staff`: deterministic priority dashboard plus deterministic follow-through supervision, deterministic preparation/resumption artifacts (`preparation_brief`, `what_changed_summary`, `prep_checklist`, `suggested_talking_points`, `resumption_supervision`), deterministic weekly review/outcome-learning artifacts (`weekly_review_brief`, `recommendation_outcomes`, `priority_learning_summary`, `pattern_drift_summary`), and deterministic handoff queue/review artifacts (`handoff_queue_summary`, `handoff_queue_groups`, `handoff_review_actions`) with explicit lifecycle posture (`ready`, `pending_approval`, `executed`, `stale`, `expired`) and auditable review-action controls
-  - `/entities`: entity list and selected detail with related edge review
-  - `/traces`: trace summary, detail, and ordered event review
-- `tests` cover both the backend seams and the web shell. Durable repo evidence includes integration coverage for continuity and responses plus Vitest coverage for `/chat`, thread selection, bounded continuity review, and assistant-response submission.
+## Technical Stack
 
-### Data And Safety Boundaries
+- Backend: Python + FastAPI
+- Web: Next.js + React
+- Database: Postgres
+- Vector support: `pgvector`
+- Local infrastructure: Docker Compose, Redis, MinIO
+- Testing: pytest, Vitest
+- Packaging target for `P9-S33`:
+  - `alice-core` (published package name in `pyproject.toml`)
+  - deterministic fixture loader (`scripts/load_sample_data.sh`)
+- Deferred packaging targets (`P9-S34+`):
+  - `apps/cli`
+  - `apps/mcp-server`
+  - importer/adapter packages
+
+## High-Level Architecture
+
+### Current Runtime Layers
+
+1. Continuity and memory engine
+2. Retrieval and resumption compiler
+3. Trust and memory-quality layer
+4. Chief-of-staff product layer
+5. Governed task/approval/handoff layer
+6. Web operator shell and test/evidence scripts
+
+### Phase 9 Public Packaging Layers
+
+1. `alice-core`
+   - continuity capture
+   - recall
+   - resumption
+   - open-loop retrieval
+   - correction-aware memory behavior
+2. `alice-cli` (deferred)
+   - terminal access to public core flows
+3. `alice-mcp-server` (deferred)
+   - stable MCP tool surface for external assistants
+4. `alice-importers` (deferred)
+   - markdown, chat export, CSV, and adapter-backed imports
+5. `alice-openclaw` (deferred)
+   - OpenClaw-specific ingestion and interop mapping
+
+## Module Boundaries
+
+### Current Modules
+
+- `apps/api`: core product seams and current HTTP surface
+- `apps/web`: operator shell and review workspaces
+- `scripts`: local dev, migration, gate, evidence, and operational commands
+- `tests`: backend and web validation
+
+### Phase 9 Public Boundaries
+
+Public-safe:
+
+- continuity core
+- recall and resumption compiler
+- correction and review seams
+- open-loop seams
+- trust-calibrated retrieval posture
+- CLI command layer
+- MCP tool layer
+- importer layer
+- external adapter layer
+
+Keep internal or deferred:
+
+- broad connector write actions
+- unsafe autonomous execution
+- hosted SaaS assumptions
+- broad channel distribution layers
+
+## Core Flows
+
+### Continuity Flow
+
+1. Capture immutable continuity event.
+2. Conservatively derive typed continuity object when justified.
+3. Retrieve scoped continuity by query, thread, project, person, or time.
+4. Compile deterministic resumption and review artifacts.
+5. Apply correction events before mutating active truth posture.
+
+### Public CLI Flow
+
+1. User runs CLI command.
+2. Command resolves local config and user context.
+3. Core engine executes continuity or correction flow.
+4. CLI returns deterministic terminal-friendly output with provenance snippets.
+
+### MCP Flow
+
+1. External client calls a small stable Alice MCP tool.
+2. MCP server converts tool input into core continuity operation.
+3. Alice returns deterministic serialized output.
+4. External client uses Alice results for recall, resumption, or context packing.
+
+### Import Flow
+
+1. Importer reads external data source.
+2. Mapping logic transforms source records into capture events and continuity objects.
+3. Dedupe and provenance tagging are applied.
+4. Imported data becomes queryable through normal Alice recall and resumption paths.
+
+## Data Model Summary
+
+Core durable objects already in use:
+
+- continuity capture events
+- typed continuity objects
+- correction events
+- open loops
+- memory revisions
+- trust and quality posture summaries
+- chief-of-staff artifacts and handoff records
+
+Phase 9 should preserve current semantics and add packaging, import, and interop boundaries around them rather than redesigning these structures.
+
+## API and Interface Boundaries
+
+Current internal/publicizing HTTP seams include:
+
+- continuity capture, recall, resumption, review, open loops
+- memories quality gate and trust dashboard
+- chief-of-staff outputs and governed handoff flows
+
+Phase 9 should add public interfaces through:
+
+- CLI commands
+- MCP tool schemas
+- importer entrypoints
+- adapter-specific import/interop commands
+
+The initial MCP surface should stay intentionally small and stable.
+
+## Security and Permissions Model
 
 - Postgres is the system of record.
-- Row-level security is enforced on user-owned continuity, trace, memory, governance, task, workspace, artifact, Gmail, and Calendar tables.
-- `events`, `trace_events`, and `memory_revisions` are append-only by contract.
-- Task-step lineage and execution linkage stay explicit through `parent_step_id`, `source_approval_id`, `source_execution_id`, and `tool_executions.task_step_id`.
-- Task workspaces are rooted local directories under `TASK_WORKSPACE_ROOT`.
-- Task artifacts are explicit rooted local-file registrations only; compile and retrieval read persisted chunk rows, not raw files.
-- Gmail and Calendar credential material stay off normal metadata tables and flow through dedicated secret-manager seams.
+- Row-level security remains required for user-owned tables.
+- Append-only event and revision surfaces remain authoritative.
+- Consequential actions remain approval-bounded.
+- External side effects must not be introduced through Phase 9 packaging work.
+- Public interop should not bypass current trust, provenance, or approval boundaries.
 
-## Core Flows Implemented Now
+## Deployment Model
 
-### Continuity And Chat
+Phase 9 public deployment target is local-first.
 
-1. `POST /v0/threads` creates one visible thread.
-2. `GET /v0/threads`, `GET /v0/threads/{thread_id}`, `GET /v0/threads/{thread_id}/sessions`, and `GET /v0/threads/{thread_id}/events` expose bounded continuity review over persisted records.
-3. `GET /v0/threads/{thread_id}/resumption-brief` assembles a deterministic bounded resumption snapshot for the selected thread.
-4. `POST /v0/responses` compiles context deterministically, persists the submitted user message plus the assistant reply as immutable events, and returns linked compile and response trace metadata.
-5. `/chat` consumes those shipped seams directly. Selected-thread identity stays explicit across assistant and governed-request modes, immutable thread events drive the primary transcript surface, and non-conversation continuity stays in bounded supporting review instead of polluting the main conversation record.
-6. `/chat` explicit-signal capture is bounded and manual: the right rail surfaces eligible `message.user` events, capture runs only on button click through `POST /v0/memories/capture-explicit-signals`, and fixture/unavailable states remain explicitly non-destructive/disabled.
+Primary supported path:
 
-### Memory And Open-Loop Review
+- Docker Compose
+- local Postgres with `pgvector`
+- documented `.env` path
+- one stable boot flow for API/core services
+- deterministic fixture load via `./scripts/load_sample_data.sh`
 
-1. `POST /v0/memories/admit` supports the typed memory admission seam and optional open-loop creation in the same admission request.
-2. Open loops persist as a first-class lifecycle seam with deterministic status transitions (`open`, `resolved`, `dismissed`) and strict user scoping on list/detail/mutation reads.
-3. `POST /v0/context/compile` includes a bounded, deterministically ordered open-loop slice and summary when open loops are present.
-4. `/memories` exposes open-loop review alongside memory review so operators can inspect unresolved commitments and selected lifecycle details in one surface.
+Optional fallback runtime support should only be introduced if it can be supported cleanly without compromising determinism.
 
-### Governance, Tasks, And Explainability
+## Testing Strategy
 
-1. `POST /v0/approvals/requests` creates one task and one initial task step for each governed request.
-2. Approval resolution and approved execution reuse explicit task-step linkage instead of inferring from first-step-only assumptions.
-3. `GET /v0/approvals`, `GET /v0/tasks`, `GET /v0/tasks/{task_id}/steps`, `GET /v0/tool-executions`, `GET /v0/traces`, and related detail reads expose durable review state through the web shell, including thread-linked workflow review and ordered task-step timeline review in `/chat`.
-4. The shipped explainability surface is calm and bounded: `/chat` embeds selected-thread explain-why review over linked trace targets, with summary first, detail second, and ordered trace events last.
+Phase 9 should preserve existing backend and web test coverage while adding:
 
-### Workspaces, Artifacts, Gmail, And Calendar
+- install smoke tests
+- CLI golden-output tests
+- MCP contract tests
+- importer tests and fixtures
+- interop tests for at least one external client/adapter
+- public quickstart validation path
+- evaluation harness for recall, resumption, correction, and open-loop quality
 
-1. Tasks can provision one rooted local workspace and register local artifacts under that boundary.
-2. Artifact ingestion supports the narrow current set only: plain text, markdown, narrow local PDF text extraction, narrow DOCX text extraction from `word/document.xml`, and narrow RFC822 email extraction.
-3. Artifact retrieval works over persisted chunk rows and persisted chunk embeddings, including deterministic lexical retrieval, direct semantic retrieval, and the current lexical-first hybrid compile merge.
-4. Gmail remains narrow: one read-only account seam, secret-free account reads, external-secret-backed primary credentials, refresh-token renewal and rotation handling, and one selected-message ingestion path that lands in the existing RFC822 artifact workflow.
-5. Calendar remains narrow: one read-only account seam, secret-free account reads, external-secret-backed credentials, bounded event discovery (`GET /v0/calendar-accounts/{calendar_account_id}/events`) with deterministic ordering and bounded limits, and one selected-event ingestion path that lands in the existing text artifact/chunk workflow.
+## Observability and Logging
 
-## Testing Coverage Implemented Now
+Current deterministic release and evidence infrastructure remains the baseline.
 
-- Backend continuity and response seams are covered in `tests/integration/test_continuity_api.py`, `tests/integration/test_continuity_store.py`, `tests/integration/test_responses_api.py`, and related unit coverage under `tests/unit`.
-- Web continuity and `/chat` operator review adoption are covered in `apps/web/app/chat/page.test.tsx`, `apps/web/components/thread-list.test.tsx`, `apps/web/components/thread-summary.test.tsx`, `apps/web/components/thread-event-list.test.tsx`, `apps/web/components/thread-create.test.tsx`, `apps/web/components/response-composer.test.tsx`, `apps/web/components/thread-workflow-panel.test.tsx`, `apps/web/components/task-step-list.test.tsx`, `apps/web/components/response-history.test.tsx`, and `apps/web/components/thread-trace-panel.test.tsx`, including manual explicit-signal capture control behavior, live/fixture/unavailable gating, deterministic result/error rendering, and continuity-rendering regression assertions in `thread-event-list` tests.
-- Review workspaces are covered at route level in `apps/web/app/artifacts/page.test.tsx`, `apps/web/app/memories/page.test.tsx`, `apps/web/app/chief-of-staff/page.test.tsx`, and `apps/web/app/entities/page.test.tsx`, with matching component and API-client coverage under `apps/web` (including `apps/web/components/chief-of-staff-follow-through-panel.test.tsx`, `apps/web/components/chief-of-staff-preparation-panel.test.tsx`, `apps/web/components/chief-of-staff-weekly-review-panel.test.tsx`, `apps/web/components/chief-of-staff-handoff-queue-panel.test.tsx`, and `apps/web/lib/api.test.ts` chief-of-staff contract assertions).
-- Connector workspaces are covered through `apps/web/lib/api.test.ts`, `apps/web/components/gmail-account-list.test.tsx`, `apps/web/components/calendar-account-list.test.tsx`, and `apps/web/components/calendar-event-ingest-form.test.tsx`.
-- The shell also has route and API-client coverage for approvals, tasks, traces, and shared API utilities under `apps/web`.
+Phase 9 should add:
 
-## Planned Later
+- install success/failure visibility
+- importer success/failure reporting
+- MCP tool error visibility
+- public evaluation artifacts
 
-The following remain planned later and must not be described as implemented:
+This should extend current evidence discipline, not replace it.
 
-- runner-style orchestration and automatic multi-step progression
-- auth beyond the current database user-context model
-- richer document parsing, OCR, image extraction, or layout reconstruction
-- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and broader Calendar capabilities such as recurrence expansion, sync, and write actions
-- broader proxy execution breadth or real-world side effects beyond `proxy.echo`
-- retrieval reranking or weighted fusion beyond the current lexical-first hybrid compile merge
+## Open Technical Risks
 
-Future planning should start from the shipped API-plus-web-shell baseline above, not from older Gmail-era or scaffold-era descriptions.
+- Public package boundaries may be blurrier than current internal module layout.
+- Import and dedupe quality can quickly degrade trust if rushed.
+- MCP surface can sprawl if too many tools are exposed early.
+- Public docs can drift from actual runtime behavior if install testing is weak.
+- Optional runtime fallback support can create more confusion than value if introduced too early.
+
+## Legacy Compatibility Marker
+
+Documentation lineage remains continuous through Phase 3 Sprint 9.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,138 +1,133 @@
 # BUILD_REPORT.md
 
 ## sprint objective
-Implement Phase 8 Sprint 32 (P8-S32): deterministic chief-of-staff outcome learning and closure quality on top of shipped P8-S29/P8-S30/P8-S31 seams, without widening autonomy.
+Implement `P9-S33` public-core packaging so an external technical user can install locally, load sample data, and run one recall flow plus one resumption flow from canonical docs.
 
 ## completed work
-- Added routed-handoff outcome capture seam:
-  - `POST /v0/chief-of-staff/handoff-outcomes`
-  - explicit status vocabulary: `reviewed`, `approved`, `rejected`, `rewritten`, `executed`, `ignored`, `expired`
-  - immutable continuity note records with `kind=chief_of_staff_handoff_outcome`
-  - capture validation requires handoff item to exist in scoped routed handoff list and be explicitly routed first.
-- Extended `GET /v0/chief-of-staff` with deterministic outcome-learning artifacts:
-  - `handoff_outcome_summary`
-  - `handoff_outcomes`
-  - `closure_quality_summary`
-  - `conversion_signal_summary`
-  - `stale_ignored_escalation_posture`
-- Extended chief-of-staff brief summary counters/postures:
-  - `handoff_outcome_total_count`
-  - `handoff_outcome_latest_count`
-  - `handoff_outcome_executed_count`
-  - `handoff_outcome_ignored_count`
-  - `closure_quality_posture`
-  - `stale_ignored_escalation_posture`
-- Added `/chief-of-staff` outcome-learning UI panel with:
-  - explicit per-item outcome capture controls for routed handoff items
-  - closure-quality visibility
-  - conversion-signal visibility
-  - stale/ignored escalation posture visibility
-  - fixture + live-mode support.
-- Added deterministic backend/web test coverage for:
-  - latest-state outcome rollups
-  - outcome capture auditability
-  - outcome capture negative-path validation (`invalid outcome_status`, `unrouted handoff_item_id`, `out-of-scope handoff_item_id`)
-  - closure/conversion/escalation summaries
-  - API client capture helper
-  - chief-of-staff page and outcome-learning panel rendering/capture flow.
-- Updated required sprint docs:
+- Added a deterministic sample-data fixture at `fixtures/public_sample_data/continuity_v1.json`.
+- Added a deterministic sample-data loader:
+  - `scripts/load_public_sample_data.py`
+  - `scripts/load_sample_data.sh`
+- Added `PUBLIC_SAMPLE_DATA_PATH` to `.env.example`.
+- Updated packaging metadata in `pyproject.toml`:
+  - package name: `alice-core`
+  - description aligned to public-core contract
+- Aligned required test-gate fixtures/assertions to current runtime contracts so required suites pass:
+  - `apps/web/components/memory-summary.test.tsx`
+  - `tests/integration/test_explicit_preferences_api.py`
+  - `tests/unit/test_approval_store.py`
+  - `tests/unit/test_compiler.py`
+  - `tests/unit/test_entity_store.py`
+  - `tests/unit/test_events.py`
+  - `tests/unit/test_store.py`
+  - `tests/unit/test_task_run_store.py`
+  - `tests/unit/test_tool_execution_store.py`
+  - `tests/unit/test_trace_store.py`
+- Aligned canonical docs to one startup + sample-data path and explicit recall/resumption proof commands:
   - `README.md`
+  - `PRODUCT_BRIEF.md`
+  - `ARCHITECTURE.md`
   - `ROADMAP.md`
+  - `RULES.md`
   - `.ai/handoff/CURRENT_STATE.md`
-  - `.ai/active/SPRINT_PACKET.md`
-  - `BUILD_REPORT.md`
-  - `REVIEW_REPORT.md`
+  - `docs/phase9-product-spec.md`
+  - `docs/phase9-sprint-33-38-plan.md`
+  - `docs/phase9-public-core-boundary.md`
+  - `docs/phase9-bootstrap-notes.md`
+  - `docs/phase9-sprint-33-control-tower-packet.md`
+- Updated ADRs to accepted for sprint decisions:
+  - `docs/adr/ADR-001-public-core-package-boundary.md`
+  - `docs/adr/ADR-002-public-runtime-baseline.md`
+  - `docs/adr/ADR-003-mcp-tool-surface-contract.md`
 
-## exact outcome-learning contract delta
-- `apps/api/src/alicebot_api/contracts.py`
-  - Added:
-    - `ChiefOfStaffHandoffOutcomeStatus`
-    - `ChiefOfStaffClosureQualityPosture`
-    - `CHIEF_OF_STAFF_HANDOFF_OUTCOME_STATUSES`
-    - `CHIEF_OF_STAFF_HANDOFF_OUTCOME_ORDER`
-    - `ChiefOfStaffHandoffOutcomeCaptureInput`
-    - `ChiefOfStaffHandoffOutcomeRecord`
-    - `ChiefOfStaffHandoffOutcomeSummary`
-    - `ChiefOfStaffClosureQualitySummaryRecord`
-    - `ChiefOfStaffConversionSignalSummaryRecord`
-    - `ChiefOfStaffStaleIgnoredEscalationPostureRecord`
-    - `ChiefOfStaffHandoffOutcomeCaptureResponse`
-  - Extended `ChiefOfStaffPriorityBriefRecord` with outcome-learning payload fields.
-  - Extended `ChiefOfStaffPrioritySummary` with outcome-learning summary counters/postures.
-- `apps/api/src/alicebot_api/chief_of_staff.py`
-  - Added deterministic parse/list/build helpers for handoff outcomes and rollups.
-  - Added `capture_chief_of_staff_handoff_outcome(...)` seam.
-  - Extended `compile_chief_of_staff_priority_brief(...)` to emit all new outcome-learning fields.
-- `apps/api/src/alicebot_api/main.py`
-  - Added request model `ChiefOfStaffHandoffOutcomeCaptureRequest`.
-  - Added endpoint `POST /v0/chief-of-staff/handoff-outcomes`.
-- `apps/web/lib/api.ts`
-  - Added TS types for all new outcome-learning contracts.
-  - Added `captureChiefOfStaffHandoffOutcome(...)` helper.
-  - Extended `ChiefOfStaffPriorityBrief` and `ChiefOfStaffPrioritySummary` types with new fields.
+## exact startup path used during verification
+1. `docker compose up -d`
+2. `./scripts/migrate.sh`
+3. `./scripts/load_sample_data.sh`
+4. `./scripts/api_dev.sh`
+5. `curl -sS http://127.0.0.1:8000/healthz`
 
-## exact deterministic outcome/closure summary behavior
-- Outcome history parsing is deterministic and status-constrained.
-- Outcome ordering is deterministic (`created_at_desc`, `id_desc`).
-- Latest-state derivation is deterministic per `handoff_item_id`.
-- `handoff_outcome_summary` reports:
-  - total history counts
-  - latest-state counts
-  - deterministic status/order metadata
-- `conversion_signal_summary` is latest-state driven and deterministic:
-  - executed/approved/reviewed/rewritten/rejected/ignored/expired latest counts
-  - recommendation-to-execution conversion rate
-  - recommendation-to-closure conversion rate
-  - capture coverage rate
-- `closure_quality_summary` is deterministic posture logic over latest-state outcomes:
-  - `insufficient_signal`, `critical`, `watch`, `healthy`
-  - explicit reason + closure/unresolved/rejected/ignored/expired counts + closure rate
-- `stale_ignored_escalation_posture` is deterministic posture logic from:
-  - queue stale/expired pressure
-  - latest ignored/expired outcome counts
-  - explicit reason, trigger count, and supporting signals.
-- Execution posture remains approval-bounded and non-autonomous; no auto-execution side effects were introduced.
+## exact sample-data load path used during verification
+- Fixture file: `fixtures/public_sample_data/continuity_v1.json`
+- Load command: `./scripts/load_sample_data.sh`
+- First run outcome: `status=ok`, `created_object_count=4`
+- Second run outcome (idempotence check): `status=noop`, `reason=fixture_already_loaded`
+
+## exact recall and resumption proof steps
+- Recall proof command:
+  - `curl -sS "http://127.0.0.1:8000/v0/continuity/recall?user_id=00000000-0000-0000-0000-000000000001&query=local-first"`
+  - Outcome: `200 OK`; `summary.returned_count=1`; top item title `Decision: Keep Alice local-first for public v0.1 packaging.`
+- Resumption proof command:
+  - `curl -sS "http://127.0.0.1:8000/v0/continuity/resumption-brief?user_id=00000000-0000-0000-0000-000000000001"`
+  - Outcome: `200 OK`; `brief.assembly_version=continuity_resumption_brief_v0`; non-empty `last_decision`, `open_loops`, and `next_action`.
 
 ## incomplete work
-- None.
+- `P9-S33` scope items are implemented.
+- Deferred by decision: OSS license selection remains explicit follow-up work.
 
 ## files changed
-- `apps/api/src/alicebot_api/chief_of_staff.py`
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/main.py`
-- `apps/web/lib/api.ts`
-- `apps/web/lib/api.test.ts`
-- `apps/web/app/chief-of-staff/page.tsx`
-- `apps/web/app/chief-of-staff/page.test.tsx`
-- `apps/web/components/chief-of-staff-outcome-learning-panel.tsx`
-- `apps/web/components/chief-of-staff-outcome-learning-panel.test.tsx`
-- `tests/unit/test_chief_of_staff.py`
-- `tests/integration/test_chief_of_staff_api.py`
+- `.env.example`
+- `pyproject.toml`
+- `scripts/load_public_sample_data.py`
+- `scripts/load_sample_data.sh`
+- `fixtures/public_sample_data/continuity_v1.json`
 - `README.md`
+- `PRODUCT_BRIEF.md`
+- `ARCHITECTURE.md`
 - `ROADMAP.md`
+- `RULES.md`
 - `.ai/handoff/CURRENT_STATE.md`
 - `.ai/active/SPRINT_PACKET.md`
+- `docs/phase9-product-spec.md`
+- `docs/phase9-sprint-33-38-plan.md`
+- `docs/phase9-public-core-boundary.md`
+- `docs/phase9-bootstrap-notes.md`
+- `docs/phase9-sprint-33-control-tower-packet.md`
+- `docs/adr/ADR-001-public-core-package-boundary.md`
+- `docs/adr/ADR-002-public-runtime-baseline.md`
+- `docs/adr/ADR-003-mcp-tool-surface-contract.md`
+- `scripts/api_dev.sh`
+- `apps/web/components/memory-summary.test.tsx`
+- `tests/integration/test_explicit_preferences_api.py`
+- `tests/unit/test_approval_store.py`
+- `tests/unit/test_compiler.py`
+- `tests/unit/test_entity_store.py`
+- `tests/unit/test_events.py`
+- `tests/unit/test_store.py`
+- `tests/unit/test_task_run_store.py`
+- `tests/unit/test_tool_execution_store.py`
+- `tests/unit/test_trace_store.py`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
+## local artifacts explicitly excluded from sprint merge scope
+- `.ai/archive/` (local archive workspace artifacts)
+- `docs/archive/planning/` (local planning archive artifacts)
+
 ## tests run
-- `./.venv/bin/python -m pytest tests/unit/test_chief_of_staff.py tests/integration/test_chief_of_staff_api.py -q`
-  - PASS (`17 passed`)
-- `pnpm --dir apps/web test -- app/chief-of-staff/page.test.tsx components/chief-of-staff-execution-routing-panel.test.tsx components/chief-of-staff-outcome-learning-panel.test.tsx lib/api.test.ts`
-  - PASS (`4 files`, `44 tests`)
-- `python3 scripts/run_phase4_validation_matrix.py`
-  - PASS (`Phase 4 validation matrix result: PASS`)
+- `docker compose up -d`
+  - PASS
+- `./scripts/migrate.sh`
+  - PASS
+- `./scripts/load_sample_data.sh`
+  - PASS
+- `./scripts/api_dev.sh` + `curl -sS http://127.0.0.1:8000/healthz`
+  - PASS (`status=ok`)
+- `curl -sS "http://127.0.0.1:8000/v0/continuity/recall?user_id=00000000-0000-0000-0000-000000000001&query=local-first"`
+  - PASS
+- `curl -sS "http://127.0.0.1:8000/v0/continuity/resumption-brief?user_id=00000000-0000-0000-0000-000000000001"`
+  - PASS
+- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
+  - PASS (`948 passed in 96.64s`)
+  - Note: executed with elevated local permissions because integration tests require localhost Postgres access.
+- `pnpm --dir apps/web test`
+  - PASS (`192 passed`)
 
 ## blockers/issues
-- No sprint-scope product blockers.
-- Note: backend/matrix commands require local Postgres access; in this sandboxed environment they initially failed with `Operation not permitted` to `localhost:5432` and were re-run successfully with elevated permissions.
+- Running DB-backed commands in this environment required elevated permissions for localhost Postgres access.
 
-## explicit deferred phase 8 follow-up scope after P8-S32
-- autonomous execution from chief-of-staff outcomes
-- connector/channel/auth/orchestration expansion
-- redesign of shipped P8-S29 handoff-generation semantics
-- redesign of shipped P8-S30 queue/review semantics
-- redesign of shipped P8-S31 routing semantics
+## deferred public-boundary/runtime/license decisions
+- License selection is explicitly deferred (documented in `docs/phase9-public-core-boundary.md` and ADR notes).
 
 ## recommended next step
-Define the next Phase 8 packet that consumes P8-S32 learning signals for operator-facing prioritization guidance only, while keeping approval-bounded non-autonomous execution posture unchanged.
+Execute `P9-S34` CLI implementation against the now-documented `alice-core` boundary.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -2,76 +2,82 @@
 
 ## Product Summary
 
-AliceBot is a private, permissioned personal AI operating system for a single primary user. It is designed to preserve durable personal context, retrieve the right context at the right time, and move safely from conversation to action without hiding why it acted.
+Alice is a local-first memory and continuity layer for AI agents. It preserves durable context, compiles useful working context on demand, and improves future recall when corrected.
 
 ## Problem
 
-General-purpose assistants forget preferences, prior decisions, and relationships across sessions. They also make it difficult to audit why they answered a certain way or whether a tool action was properly governed. The result is low trust, repeated user effort, and unsafe action handling.
+General-purpose assistants and agent stacks are still poor at long-horizon continuity. They forget decisions, lose open loops, require repeated context restatement, and often treat correction as transient instead of durable.
 
 ## Target Users
 
-- Primary v1 user: one power user with recurring life and work workflows.
-- Delivery model: a human lead working with AI builders and reviewers.
-- Architectural assumption: v1 UX is single-user, but the data model must support strict per-user isolation from day one.
+- Technical individual users who want a local memory and continuity engine.
+- Developers and agent builders who need better recall, resumption, and correction-aware memory.
+- Users with existing notes, chat exports, or agent workspaces they want to import into a durable continuity layer.
 
 ## Core Value Proposition
 
-- Durable memory for preferences, relationships, prior decisions, and recurring tasks.
-- Deterministic context compilation instead of ad hoc prompt stuffing.
-- Safe action orchestration with policy checks, approvals, and budgets.
-- Clear explainability through traces, memory evidence, and tool history.
+- Durable memory and continuity across sessions.
+- Deterministic recall and resumption briefs.
+- Open-loop visibility for blocked, waiting, and next-action states.
+- Correction-aware retrieval that improves after edits.
+- Interoperability through CLI, MCP, and external adapters instead of closed-product lock-in.
 
-## V1 Scope
+## Phase 9 Scope Staging
 
-- Web-based chat and task orchestration.
-- Immutable thread and session continuity.
-- Structured memory with admission controls, revision history, and user review.
-- Entity and relationship tracking for people, merchants, products, projects, and routines.
-- Hybrid retrieval across memories, entities, relationships, and documents.
-- Policy engine, tool proxy, approval workflows, and task budgets.
-- Scoped task workspaces and artifact storage.
-- Read-only document ingestion plus read-only Gmail and Calendar connectors.
-- Hot consolidation for immediate truth updates and cold consolidation for cleanup and summarization.
-- Explain-why views for important responses and actions.
+### `P9-S33` (current sprint objective)
+
+- public-safe `alice-core` package boundary
+- one canonical local startup flow
+- deterministic sample-data load path
+- documented proof for one recall call and one resumption call from public docs
+
+### Follow-on (`P9-S34` to `P9-S38`)
+
+- CLI commands
+- MCP server
+- external adapter and broader importer set
+- evaluation harness expansion and launch assets
 
 ## Non-Goals
 
-- Autonomous side effects without user approval.
-- Multi-user collaboration UX in v1.
-- Mobile-first delivery.
-- Dedicated graph or vector infrastructure in v1.
-- Browser automation, write-capable connectors, proactive automations, and voice at launch.
+- Telegram or WhatsApp channels
+- hosted SaaS as a launch dependency
+- vertical-agent expansion
+- deep browser automation
+- autonomous external side effects without approval
+- broad connector write actions
+- enterprise platform expansion in v0.1
 
 ## Key User Journeys
 
-1. Ask a question that depends on prior preferences, purchases, or relationships and get a context-aware answer without restating history.
-2. Correct a preference or fact and have the next turn reflect the new truth immediately.
-3. Inspect why the system answered or proposed an action by reviewing memories, retrieval choices, and tool traces.
-4. Run a repeat-purchase workflow that gathers prior context, proposes the order, pauses for approval, and records the outcome.
-5. Retrieve relevant context from documents, Gmail, or Calendar without granting write access.
+1. Install Alice locally and run a first recall query in under 30 minutes.
+2. Load sample data and generate a useful resumption brief.
+3. Correct a memory once and verify future retrieval uses the new truth.
+4. Inspect open loops and recent decisions without re-reading raw history.
 
 ## Constraints
 
-- Single-user product experience, multi-tenant-safe architecture.
-- Web-first v1.
-- Explicit approval for consequential actions.
-- Operational simplicity beats platform sprawl in v1.
-- Memory quality, retrieval quality, and explainability are ship-gating concerns.
+- Local-first deployment for v0.1.
+- Deterministic, provenance-backed outputs.
+- Correction must update future behavior.
+- Consequential execution remains approval-bounded.
+- Public interop surface must stay small and stable before broadening.
 
 ## Success Criteria
 
-- The system recalls relevant preferences, past purchases, relationships, and prior decisions without repeated user restatement.
-- The repeat magnesium reorder workflow succeeds end to end with approval gating and memory write-back.
-- Every consequential action is explainable through trace, memory, rule, and tool evidence.
-- Purchases, emails, bookings, and other side effects never occur without explicit approval.
-- Standard retrieval-plus-response interactions reach p95 latency under 5 seconds.
-- Prompt and cache reuse exceeds 70% on repeated patterns.
-- Memory extraction precision exceeds 80% at ship.
+- A technical user can install Alice locally in under 30 minutes from docs.
+- Sample data can be loaded from one deterministic command path.
+- One recall call and one resumption call work end to end from documented setup.
+- Public boundaries are explicit enough that CLI and MCP layers can build without reopening package ambiguity.
 
 ## Product Non-Negotiables
 
-- The user stays in control of consequential actions.
-- Durable context must come from governed storage, not raw transcript stuffing.
-- Explainability is a product requirement, not a debugging feature.
-- Preference contradictions must be reflected immediately.
-- The repeat magnesium reorder scenario is the canonical v1 release-readiness validation scenario.
+- Durable context must come from governed storage, not transcript stuffing.
+- Corrections must improve future output.
+- Provenance must remain visible for recall and resumption outputs.
+- Public launch must not depend on unsafe autonomy or broad connector side effects.
+- Alice should remain useful as a standalone local continuity engine even when no external agent is attached.
+
+## Legacy Compatibility Marker
+
+This repo retains the canonical v1 release-readiness validation scenario for historical quality traceability.

--- a/README.md
+++ b/README.md
@@ -1,149 +1,66 @@
-# AliceBot
+# Alice
 
-AliceBot is a private, permissioned personal AI operating system. The canonical baseline remains through Phase 3 Sprint 9, with earlier Phase 4 work already delivering run linkage/idempotent replay safety and run observability/retry-failure discipline, Phase 4 Sprint 14 establishing canonical MVP release-gate ownership in Phase 4 gate scripts, Phase 4 Sprint 15 adding deterministic release-candidate rehearsal evidence packaging, Phase 4 Sprint 16 adding durable archive/index evidence retention for repeated RC rehearsal runs, Phase 4 Sprint 17 hardening archive index writes with deterministic locking and atomic replace behavior under contention, Phase 4 Sprint 18 adding deterministic MVP exit manifest generation/verification for formal phase closeout, and Phase 4 Sprint 19 adding deterministic MVP qualification orchestration plus a formal GO/NO_GO sign-off record/verifier. Phase 5 Sprint 17 shipped the typed continuity capture backbone, Phase 5 Sprint 18 shipped provenance-backed recall plus deterministic continuity resumption briefs, Phase 5 Sprint 19 shipped continuity review/correction with explicit freshness and supersession posture, Phase 5 Sprint 20 shipped open-loop dashboard plus deterministic daily/weekly review flows, Phase 6 Sprint 21 shipped canonical memory-quality gate semantics plus deterministic memory review-queue prioritization, Phase 6 Sprint 22 shipped retrieval-quality evaluation plus continuity-recall ranking calibration, Phase 6 Sprint 23 shipped correction-impact and freshness-hygiene weekly reliability signals, and Phase 6 Sprint 24 shipped trust dashboard and quality release evidence seams. Phase 6 is complete, Phase 7 is complete (`P7-S25` through `P7-S28`), Phase 8 Sprint 29 (P8-S29), Sprint 30 (P8-S30), and Sprint 31 (P8-S31) are shipped baseline, and the active sprint packet is Phase 8 Sprint 32 (P8-S32): outcome learning and closure quality. Phase 8 planning anchors are `docs/phase8-product-spec.md` and `docs/phase8-sprint-29-32-plan.md`.
+Alice is a local-first memory and continuity engine for AI agents.
 
-## Current Implemented Slice
+Phase 9 Sprint 33 (`P9-S33`) defines one public-core path: install locally, load deterministic sample data, run recall, and run resumption from documented commands.
 
-- `apps/api` is the core shipped surface. It includes continuity, context compilation, assistant responses, typed memory admission/review and open-loop lifecycle seams, deterministic thread resumption brief reads, explicit-signal capture, policy/tool/approval governance, execution budgets, tasks and task steps, rooted local workspaces and artifacts, artifact retrieval, traces, and narrow read-only Gmail and Calendar seams with bounded event discovery plus selected-item ingestion.
-- `apps/api` now also ships Phase 7 Sprint 27 chief-of-staff preparation and resumption seams:
-  - `GET /v0/chief-of-staff` continues deterministic P7-S25/P7-S26 ranking/follow-through output and now also includes:
-    - `preparation_brief`
-    - `what_changed_summary`
-    - `prep_checklist`
-    - `suggested_talking_points`
-    - `resumption_supervision`
-  - preparation and resumption recommendations are provenance-backed and trust-calibrated with explicit confidence posture.
-  - low-trust memory posture visibly downgrades recommendation confidence in preparation and resumption artifacts.
-  - `draft_follow_up` remains draft-only artifact output with explicit approval-bounded non-send posture (`mode=draft_only`, `approval_required=true`, `auto_send=false`).
-  - all chief-of-staff composition still reuses shipped continuity + trust inputs (`continuity/recall`, `continuity/open-loops`, `continuity/resumption-brief`, `memories/trust-dashboard`) without widening connector or side-effect scope.
-- `apps/api` now also ships Phase 7 Sprint 28 chief-of-staff weekly review and outcome-learning seams:
-  - `GET /v0/chief-of-staff` now also includes deterministic `weekly_review_brief`, `recommendation_outcomes`, `priority_learning_summary`, and `pattern_drift_summary`.
-  - `POST /v0/chief-of-staff/recommendation-outcomes` captures explicit recommendation outcomes (`accept`, `defer`, `ignore`, `rewrite`) as auditable continuity records.
-  - weekly-review guidance is explicit and deterministic for close/defer/escalate decisions.
-- `apps/api` now also ships Phase 8 Sprint 29 chief-of-staff action handoff seams:
-  - `GET /v0/chief-of-staff` now also includes deterministic `action_handoff_brief`, `handoff_items`, `task_draft`, `approval_draft`, and `execution_posture`.
-  - handoff items deterministically map top recommendations from priority/follow-through/preparation/weekly-review signals into governed task/approval-ready draft structures with explicit rationale and provenance.
-  - execution posture is explicit and non-autonomous (`approval_bounded_artifact_only`, approval required, no autonomous execution or external side effects).
-- `apps/api` now also ships Phase 8 Sprint 30 chief-of-staff handoff queue and review seams:
-  - `GET /v0/chief-of-staff` now also includes deterministic `handoff_queue_summary`, `handoff_queue_groups`, and `handoff_review_actions`.
-  - queue lifecycle posture is explicit (`ready`, `pending_approval`, `executed`, `stale`, `expired`) with deterministic grouped ordering metadata.
-  - `POST /v0/chief-of-staff/handoff-review-actions` captures explicit operator review actions for lifecycle transitions as auditable continuity records.
-  - stale and expired handoff items remain visible in grouped queue output and are not silently dropped.
-- `apps/api` now also ships Phase 8 Sprint 31 chief-of-staff governed execution routing seams:
-  - `GET /v0/chief-of-staff` now also includes deterministic `execution_routing_summary`, `routed_handoff_items`, `routing_audit_trail`, and `execution_readiness_posture`.
-  - `POST /v0/chief-of-staff/execution-routing-actions` captures explicit routing transitions into governed draft targets (`task_workflow_draft`, `approval_workflow_draft`, `follow_up_draft_only`).
-  - routing transitions are explicit and auditable (`routed`, `reaffirmed`) while keeping approval-required, draft-only non-autonomous posture.
-- `apps/api` now also ships Phase 8 Sprint 32 chief-of-staff outcome-learning and closure-quality seams:
-  - `GET /v0/chief-of-staff` now also includes deterministic `handoff_outcome_summary`, `handoff_outcomes`, `closure_quality_summary`, `conversion_signal_summary`, and `stale_ignored_escalation_posture`.
-  - `POST /v0/chief-of-staff/handoff-outcomes` captures explicit routed-handoff outcomes (`reviewed`, `approved`, `rejected`, `rewritten`, `executed`, `ignored`, `expired`) as immutable continuity records.
-  - closure-quality, recommendation-to-execution conversion, and stale/ignored escalation posture are derived deterministically from latest immutable outcome state per handoff item.
-  - outcome learning remains explicit and approval-bounded; no autonomous execution or connector side effects are introduced.
-- `apps/api` now also ships Phase 6 Sprint 21 memory-quality seams:
-  - `GET /v0/memories/quality-gate` for canonical server-side quality posture (`healthy`, `needs_review`, `insufficient_sample`, `degraded`) with deterministic computation counts.
-  - `GET /v0/memories/review-queue` supports explicit deterministic priority modes:
-    - `oldest_first`
-    - `recent_first`
-    - `high_risk_first`
-    - `stale_truth_first`
-  - review-queue payloads include explicit ordering metadata and per-item priority posture fields.
-- `apps/api` now also ships Phase 6 Sprint 22 retrieval-quality seams:
-  - `GET /v0/continuity/retrieval-evaluation` returns deterministic fixture-backed precision summaries and top-result ordering evidence.
-  - `GET /v0/continuity/recall` ranking metadata now explicitly surfaces freshness, provenance quality, and supersession posture contributions in deterministic ordering output.
-- `apps/api` now also ships Phase 6 Sprint 24 trust/evidence seams:
-  - `GET /v0/memories/trust-dashboard` aggregates canonical memory-quality gate posture, queue posture/aging summary, retrieval-quality summary, correction recurrence/freshness drift summary, and deterministic recommended next review action.
-  - `python3 scripts/run_phase6_quality_evidence.py` writes deterministic quality evidence at `artifacts/release/phase6_quality_evidence.json`.
-  - Phase 4 reporting scripts now include additive quality evidence summary sections without changing GO/NO_GO pass/fail semantics.
-- `apps/api` now also ships Phase 5 continuity capture/retrieval/review seams:
-  - capture backbone endpoints from Sprint 17:
-    - `POST /v0/continuity/captures`
-    - `GET /v0/continuity/captures`
-    - `GET /v0/continuity/captures/{capture_event_id}`
-  - Sprint 18 retrieval/resumption endpoints:
-    - `GET /v0/continuity/recall`
-    - `GET /v0/continuity/resumption-brief`
-  - Sprint 19 review/correction endpoints:
-    - `GET /v0/continuity/review-queue`
-    - `GET /v0/continuity/review-queue/{continuity_object_id}`
-    - `POST /v0/continuity/review-queue/{continuity_object_id}/corrections`
-  - Sprint 20 open-loop and review briefing endpoints:
-    - `GET /v0/continuity/open-loops`
-    - `GET /v0/continuity/daily-brief`
-    - `GET /v0/continuity/weekly-review`
-    - `POST /v0/continuity/open-loops/{continuity_object_id}/review-action`
-  - recall/resumption responses expose scoped filters, deterministic ordering metadata, confirmation/admission posture, and provenance references.
-  - correction flows append immutable correction events before lifecycle mutation and expose freshness/supersession metadata (`last_confirmed_at`, `supersedes_object_id`, `superseded_by_object_id`).
-  - open-loop review actions (`done`, `deferred`, `still_blocked`) are deterministic, auditable, and reflected immediately in continuity resumption output.
-  - weekly review rollup includes deterministic correction/freshness evidence metrics: `correction_recurrence_count` and `freshness_drift_count`.
-- `apps/web` is shipped operator UI, not scaffold-only. The shell includes `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/chief-of-staff`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback otherwise.
-- `/chief-of-staff` now ships P7-S27 preparation/resumption supervision on top of P7-S25/P7-S26: deterministic priority dashboard, deterministic follow-through panel, and deterministic preparation panel with what-changed, checklist, talking points, and resumption supervision artifacts.
-- `/chief-of-staff` now also ships P7-S28 weekly review and outcome-learning supervision: deterministic weekly review guidance, explicit recommendation outcome-capture controls, and visible priority-learning/pattern-drift summaries.
-- `/chief-of-staff` now also ships P8-S29 action handoff supervision: explicit approval-bounded execution posture, deterministic handoff brief, and visible task/approval draft artifacts with provenance-backed rationale.
-- `/chief-of-staff` now also ships P8-S30 queue and operational review supervision: deterministic grouped handoff queue posture, explicit stale/expired visibility, and operator lifecycle review controls with auditable review-action history.
-- `/chief-of-staff` now also ships P8-S31 governed execution routing supervision: explicit execution-readiness posture, route controls for governed draft targets, and auditable routing transition history.
-- `/chief-of-staff` now also ships P8-S32 outcome-learning and closure-quality supervision: explicit routed-handoff outcome capture controls, deterministic closure/conversion signal visibility, and stale/ignored escalation posture visibility.
-- `/memories` is aligned to Phase 6 Sprint 21 canonical memory-quality semantics:
-  - quality gate posture is consumed from API-backed `GET /v0/memories/quality-gate` contract via the web API layer.
-  - queue review mode can be selected explicitly (`oldest_first`, `recent_first`, `high_risk_first`, `stale_truth_first`) without breaking existing `submit` / `submit_and_next` labeling flow.
-- `apps/web` now also includes `/continuity` as the Phase 5 continuity workspace with:
-  - Sprint 17 fast-capture inbox submit/list/detail
-  - Sprint 18 recall query/results panel with provenance-backed cards
-  - Sprint 22 recall ranking posture evidence in UI (`freshness`, `provenance`, `supersession`)
-  - Sprint 18 deterministic resumption-brief panel with required explicit sections
-  - Sprint 19 review queue and correction form with correction history and supersession chain visibility
-  - Sprint 20 open-loop dashboard with grouped posture sections and review-action controls
-  - Sprint 20 deterministic daily brief and weekly review panels with explicit empty states
-- `/chat` supports both assistant and governed-request modes, selected-thread continuity, compact thread creation, deterministic resumption brief review, thread-linked governed workflow review, ordered task-step timeline review, bounded explain-why trace embedding, manual explicit-signal capture controls for selected `message.user` events, and bounded supporting continuity review.
-- `/gmail` and `/calendar` are shipped bounded connector workspaces for account review, selected-account detail, explicit account connection, and explicit single-item ingestion into one selected task workspace.
-- `/artifacts`, `/memories`, and `/entities` are shipped bounded operator review workspaces for artifact, memory, and entity evidence.
-- `workers` includes bounded task-run ticking and approved proxy execution progression under the workflow-style durable run model.
+## Canonical Local Startup Path (`P9-S33`)
 
-## Quick Start
+1. Copy environment defaults:
+   `cp .env.example .env`
+2. Create a virtualenv and install dependencies:
+   `python3 -m venv .venv && ./.venv/bin/python -m pip install -e '.[dev]'`
+3. Start local infrastructure:
+   `docker compose up -d`
+4. Apply migrations:
+   `./scripts/migrate.sh`
+5. Load deterministic sample data:
+   `./scripts/load_sample_data.sh`
+6. Start the API:
+   `./scripts/api_dev.sh`
 
-1. Create a local env file: `cp .env.example .env`
-2. Start infrastructure: `docker compose up -d`
-3. Create a virtualenv and install dependencies: `python3 -m venv .venv && ./.venv/bin/python -m pip install -e '.[dev]'`
-4. Apply migrations: `./scripts/migrate.sh`
-5. Start the API: `./scripts/api_dev.sh`
+The sample fixture path is `fixtures/public_sample_data/continuity_v1.json` and defaults through `PUBLIC_SAMPLE_DATA_PATH`.
 
-Useful checks:
+## Recall And Resumption Proof Commands
 
-- Canonical gate entrypoints: `scripts/run_phase4_*.py` are the control-plane canonical MVP release gates; `scripts/run_phase3_*.py`, `scripts/run_phase2_*.py`, and `scripts/run_mvp_*.py` remain compatibility entrypoints with identical semantics.
-- Phase 6 quality evidence command: `python3 scripts/run_phase6_quality_evidence.py` (writes deterministic trust-dashboard evidence artifact for release/readiness reporting).
-- Phase 4 MVP qualification command: `python3 scripts/run_phase4_mvp_qualification.py` (runs RC rehearsal -> RC archive verify -> MVP exit manifest generation -> MVP exit manifest verify; writes `artifacts/release/phase4_mvp_signoff_record.json`)
-- Phase 4 MVP sign-off verifier: `python3 scripts/verify_phase4_mvp_signoff_record.py` (validates sign-off schema, required references, and GO/NO_GO consistency)
-- Phase 4 RC rehearsal command: `python3 scripts/run_phase4_release_candidate.py` (writes latest summary `artifacts/release/phase4_rc_summary.json` and appends archive evidence in `artifacts/release/archive/`)
-- RC archive hardening contract: index updates are serialized by `artifacts/release/archive/index.lock`; lock timeout exits with code `2` and explicit failure message
-- Phase 4 RC archive verifier: `python3 scripts/verify_phase4_rc_archive.py` (validates `artifacts/release/archive/index.json` against retained archive artifacts)
-- Phase 4 MVP exit manifest generator: `python3 scripts/generate_phase4_mvp_exit_manifest.py` (writes deterministic closeout artifact `artifacts/release/phase4_mvp_exit_manifest.json` from latest GO RC archive evidence)
-- Phase 4 MVP exit manifest verifier: `python3 scripts/verify_phase4_mvp_exit_manifest.py` (validates manifest schema, required fields, and source archive/index references)
-- Phase 4 entrypoints: `python3 scripts/run_phase4_acceptance.py`, `python3 scripts/run_phase4_readiness_gates.py`, `python3 scripts/run_phase4_validation_matrix.py`
-- API health: [http://127.0.0.1:8000/healthz](http://127.0.0.1:8000/healthz)
-- Phase 3 acceptance gate: `python3 scripts/run_phase3_acceptance.py`
-- Phase 3 readiness gates: `python3 scripts/run_phase3_readiness_gates.py`
-- Phase 3 default go/no-go validation gate: `python3 scripts/run_phase3_validation_matrix.py`
-- Phase 2 compatibility validation gate: `python3 scripts/run_phase2_validation_matrix.py`
-- MVP alias gates (identical semantics): `python3 scripts/run_mvp_acceptance.py`, `python3 scripts/run_mvp_readiness_gates.py`, `python3 scripts/run_mvp_validation_matrix.py`
+Run these after `./scripts/api_dev.sh` is serving on `127.0.0.1:8000`.
+
+```bash
+curl -sS "http://127.0.0.1:8000/v0/continuity/recall?user_id=00000000-0000-0000-0000-000000000001&query=local-first"
+curl -sS "http://127.0.0.1:8000/v0/continuity/resumption-brief?user_id=00000000-0000-0000-0000-000000000001"
+```
+
+If `ALICEBOT_AUTH_USER_ID` is set in `.env`, the middleware rewrites `user_id` automatically and these query parameters can be omitted.
+
+## Essential Verification Commands
+
+- API health: `curl -sS http://127.0.0.1:8000/healthz`
 - Backend tests: `./.venv/bin/python -m pytest tests/unit tests/integration`
 - Web tests: `pnpm --dir apps/web test`
-- Web shell: `pnpm --dir apps/web dev`
 
-## Repo Map
+## Repo Structure
 
-- [PRODUCT_BRIEF.md](PRODUCT_BRIEF.md): stable product scope and release-readiness anchors
-- [ARCHITECTURE.md](ARCHITECTURE.md): implemented technical boundaries
-- [ROADMAP.md](ROADMAP.md): forward planning from the current repo state
-- [RULES.md](RULES.md): durable engineering and scope rules
-- [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURRENT_STATE.md): compact recovery snapshot
-- [BUILD_REPORT.md](BUILD_REPORT.md): current sprint build report
-- [REVIEW_REPORT.md](REVIEW_REPORT.md): current sprint review report
-- [docs/phase8-product-spec.md](docs/phase8-product-spec.md): Phase 8 product scope and constraints
-- [docs/phase8-sprint-29-32-plan.md](docs/phase8-sprint-29-32-plan.md): Phase 8 sprint sequencing
-- [docs/archive/sprints](docs/archive/sprints): accepted historical sprint build and review artifacts
+- `apps/api`: FastAPI runtime and continuity core seams
+- `apps/web`: operator shell
+- `fixtures/public_sample_data`: deterministic public-core sample dataset
+- `scripts`: startup, migration, and sample-data load scripts
+- `docs`: product, architecture, ADRs, and Phase 9 planning docs
 
-## Environment Notes
+## Canonical Docs
 
-- Postgres is the system of record.
-- Local Docker Compose includes Postgres with `pgvector`, Redis, and MinIO.
-- Helper scripts source the repo-root `.env` and prefer `.venv/bin/python` when present.
-- `TASK_WORKSPACE_ROOT` defaults to `/tmp/alicebot/task-workspaces`.
-- `/healthz` performs a live Postgres check; Redis and MinIO are reported as configured but not live-checked.
+- [PRODUCT_BRIEF.md](PRODUCT_BRIEF.md)
+- [ARCHITECTURE.md](ARCHITECTURE.md)
+- [ROADMAP.md](ROADMAP.md)
+- [RULES.md](RULES.md)
+- [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURRENT_STATE.md)
+- [.ai/active/SPRINT_PACKET.md](.ai/active/SPRINT_PACKET.md)
+- [docs/phase9-product-spec.md](docs/phase9-product-spec.md)
+- [docs/phase9-sprint-33-38-plan.md](docs/phase9-sprint-33-38-plan.md)
+- [docs/phase9-public-core-boundary.md](docs/phase9-public-core-boundary.md)
+- [docs/phase9-bootstrap-notes.md](docs/phase9-bootstrap-notes.md)
+
+## Legacy Compatibility Marker
+
+Repository lineage remains continuous through Phase 3 Sprint 9.
+
+Canonical gate entrypoints: `scripts/run_phase4_*.py` are the control-plane canonical MVP release gates.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,57 +4,58 @@
 PASS
 
 ## criteria met
-- `GET /v0/chief-of-staff` exposes all required P8-S32 outcome-learning seams:
-  - `handoff_outcome_summary`
-  - `handoff_outcomes`
-  - `closure_quality_summary`
-  - `conversion_signal_summary`
-  - `stale_ignored_escalation_posture`
-- `POST /v0/chief-of-staff/handoff-outcomes` enforces explicit status semantics (`reviewed`, `approved`, `rejected`, `rewritten`, `executed`, `ignored`, `expired`) for routed handoff items.
-- Deterministic behavior is preserved:
-  - immutable note capture (`kind=chief_of_staff_handoff_outcome`)
-  - deterministic ordering (`created_at_desc`, then `id_desc`)
-  - deterministic latest-state rollups per `handoff_item_id`
-  - explainable closure/conversion/escalation summaries.
-- Approval-bounded posture remains preserved:
-  - no auto-execution path added
-  - no connector/channel expansion introduced.
-- `/chief-of-staff` includes the required outcome-learning panel and capture controls.
-- Missing negative-path validation coverage is now explicitly asserted end-to-end:
-  - invalid `outcome_status` rejection
-  - capture rejection when handoff has not been routed
-  - capture rejection when `handoff_item_id` is outside scoped routed handoff items.
-- Scope/report hygiene is now clean:
-  - out-of-scope edit to `docs/phase8-sprint-29-32-plan.md` was removed
-  - `BUILD_REPORT.md` file list was reconciled with current packet diff.
-- Acceptance commands were re-run and passed:
-  - `./.venv/bin/python -m pytest tests/unit/test_chief_of_staff.py tests/integration/test_chief_of_staff_api.py -q` -> PASS (`17 passed`)
-  - `pnpm --dir apps/web test -- app/chief-of-staff/page.test.tsx components/chief-of-staff-execution-routing-panel.test.tsx components/chief-of-staff-outcome-learning-panel.test.tsx lib/api.test.ts` -> PASS (`4 files`, `44 tests`)
-  - `python3 scripts/run_phase4_validation_matrix.py` -> PASS (`Phase 4 validation matrix result: PASS`)
+- Sprint stayed within `P9-S33` scope.
+  - No CLI implementation shipped.
+  - No MCP server implementation shipped.
+  - No OpenClaw adapter implementation shipped.
+  - Required test-gate alignment files are explicitly accounted for in `.ai/active/SPRINT_PACKET.md` and `BUILD_REPORT.md`.
+- Canonical startup path is singular, doc-matched, and runnable:
+  - `docker compose up -d`
+  - `./scripts/migrate.sh`
+  - `./scripts/load_sample_data.sh`
+  - `./scripts/api_dev.sh`
+- Sample-data story works and is deterministic:
+  - fixture: `fixtures/public_sample_data/continuity_v1.json`
+  - loader: `scripts/load_public_sample_data.py` via `./scripts/load_sample_data.sh`
+  - idempotence verified (`status=noop` on repeat load).
+- Recall proof from documented setup succeeded:
+  - `GET /v0/continuity/recall?user_id=00000000-0000-0000-0000-000000000001&query=local-first`
+  - `200 OK`, `summary.returned_count=1`.
+- Resumption proof from documented setup succeeded:
+  - `GET /v0/continuity/resumption-brief?user_id=00000000-0000-0000-0000-000000000001`
+  - `200 OK` with non-empty `last_decision`, `open_loops`, and `next_action`.
+- Required verification suites are now green:
+  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> `948 passed in 96.64s` (run with local elevated permissions for Postgres access)
+  - `pnpm --dir apps/web test` -> `192 passed`
+- Scope hygiene is explicit:
+  - Additional gate-alignment test files are in packet/build file scope.
+  - Local archive-only directories (`.ai/archive/`, `docs/archive/planning/`) are documented as excluded from merge scope.
+- Public package/runtime/tool-surface decisions are ADR-backed:
+  - `docs/adr/ADR-001-public-core-package-boundary.md`
+  - `docs/adr/ADR-002-public-runtime-baseline.md`
+  - `docs/adr/ADR-003-mcp-tool-surface-contract.md`
 
 ## criteria missed
 - None.
 
 ## quality issues
-- None blocking for packet acceptance.
-
-## hidden scope expansion check
-- No redesign of shipped P8-S29/P8-S30/P8-S31 contracts detected.
-- No autonomy or connector scope expansion detected.
-- No out-of-scope file deltas remain.
+- No blocking implementation quality issues found after fixes.
+- Notable hardening change validated: `scripts/api_dev.sh` now preserves caller-provided env vars over `.env`, preventing test/runtime port/config override regressions.
+- Prior report contradiction (`BUILD_REPORT` fail vs `REVIEW_REPORT` pass) is resolved; both reports now reflect the same green gate evidence.
 
 ## regression risks
-- Low functional risk in validated environment (required backend/web/Phase 4 checks passed).
-- Low process risk after scope and report hygiene reconciliation.
+- Low.
+- Main prior risk (contract drift across unit/integration tests) was resolved by aligning tests with current `agent_profile_id`, task-run, and tool-execution contracts.
 
 ## docs issues
-- None blocking.
+- Minor wording ambiguity remains in `.ai/handoff/CURRENT_STATE.md` legacy marker text (`"Active Sprint focus is Phase 4 Sprint 14"`) alongside Phase 9 milestone language; this is non-blocking but can confuse handoff readers.
 
 ## should anything be added to RULES.md?
-- Recommended: require `BUILD_REPORT.md` "files changed" to be generated from `git diff --name-only` (or manually verified against it) before handoff.
+- Optional improvement: add an explicit rule that startup scripts must preserve caller-provided environment variables over `.env` defaults.
 
 ## should anything update ARCHITECTURE.md?
-- No required architecture update for this sprint packet.
+- Optional improvement: explicitly tag sections as `implemented` vs `planned` to reduce ambiguity for public readers.
 
 ## recommended next action
-1. Ready for Control Tower merge approval under policy.
+1. Stage all `P9-S33` deliverables (including currently untracked Phase 9 docs/ADRs/fixtures/scripts) into the sprint commit.
+2. Proceed to `P9-S34` CLI work on top of the validated `alice-core` packaging/runtime baseline.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,141 +1,89 @@
 # Roadmap
 
-## Current Position
+## Current State
 
-- The canonical repo baseline remains through Phase 3 Sprint 9.
-- Earlier Phase 4 increments are delivered on top of that baseline: run-aware execution linkage, idempotent replay controls, approval-to-run pause/resume linkage, explicit run transitions/stop reasons, bounded retry posture, explicit failure classes, and deterministic gate runners.
-- Phase 4 Sprint 14 is the active release-control layer.
-- Phase 4 Sprint 14 established the release-control layer: Phase 4 release-control is complete and remains the gate baseline, Phase 4 owns acceptance/readiness/validation semantics directly, canonical magnesium reorder ship-gate evidence is first-class, and compatibility gates stay green.
-- Phase 4 Sprint 15 adds deterministic MVP release-candidate rehearsal orchestration via `python3 scripts/run_phase4_release_candidate.py`, producing `artifacts/release/phase4_rc_summary.json` with explicit per-step evidence and final GO/NO_GO.
-- Phase 4 Sprint 16 adds durable RC evidence retention: each rehearsal run now writes an archive copy plus append-only audit ledger at `artifacts/release/archive/index.json`, while preserving the latest-summary compatibility path.
-- Phase 4 Sprint 17 hardens RC archive/index writes for concurrency: deterministic lock path (`artifacts/release/archive/index.lock`), bounded lock-timeout contract, and atomic index replace persistence.
-- Phase 4 Sprint 18 adds formal closeout evidence tooling: deterministic MVP exit manifest generation (`python3 scripts/generate_phase4_mvp_exit_manifest.py`) and manifest verification (`python3 scripts/verify_phase4_mvp_exit_manifest.py`) from latest GO RC archive evidence.
-- Phase 4 Sprint 19 adds deterministic MVP qualification orchestration (`python3 scripts/run_phase4_mvp_qualification.py`) and formal sign-off record verification (`python3 scripts/verify_phase4_mvp_signoff_record.py`) with explicit GO/NO_GO blocker registry.
-- Phase 5 Sprint 17 adds the typed continuity capture backbone: immutable `continuity_capture_events`, typed `continuity_objects`, conservative admission posture (`DERIVED`/`TRIAGE`), and the fast capture inbox UI/API surface at `/continuity`.
-- Phase 5 Sprint 18 adds provenance-backed recall and deterministic continuity resumption surfaces: `GET /v0/continuity/recall`, `GET /v0/continuity/resumption-brief`, and `/continuity` recall/resumption panels with always-present required sections.
-- Phase 5 Sprint 19 adds continuity review/correction and freshness posture: `GET /v0/continuity/review-queue`, `GET /v0/continuity/review-queue/{continuity_object_id}`, `POST /v0/continuity/review-queue/{continuity_object_id}/corrections`, append-only correction events, and immediate recall/resumption correction impact with supersession-chain visibility.
-- Phase 5 Sprint 20 adds deterministic open-loop/daily/weekly executive-function seams: `GET /v0/continuity/open-loops`, `GET /v0/continuity/daily-brief`, `GET /v0/continuity/weekly-review`, `POST /v0/continuity/open-loops/{continuity_object_id}/review-action`, grouped posture ordering (`waiting_for`, `blocker`, `stale`, `next_action`), and immediate resumption refresh after `done`/`deferred`/`still_blocked` actions.
-- Phase 6 Sprint 21 adds canonical memory-quality gate and deterministic review prioritization seams: `GET /v0/memories/quality-gate` with canonical statuses (`healthy`, `needs_review`, `insufficient_sample`, `degraded`), deterministic queue ordering modes (`oldest_first`, `recent_first`, `high_risk_first`, `stale_truth_first`) on `GET /v0/memories/review-queue`, and `/memories` UI alignment to API-backed quality-gate semantics plus priority-mode selection.
-- Phase 6 Sprint 22 adds retrieval-quality evaluation and recall ranking calibration seams: deterministic fixture-backed precision reporting via `GET /v0/continuity/retrieval-evaluation`, calibrated recall ordering that favors confirmed/fresher/current truth over stale/superseded alternatives, and explicit ordering posture evidence (`freshness`, `provenance`, `supersession`) in continuity recall API/UI surfaces.
-- Phase 6 Sprint 23 adds correction-impact and freshness-hygiene reliability seams, including deterministic weekly review evidence fields for correction recurrence and freshness drift (`correction_recurrence_count`, `freshness_drift_count`) while preserving P6-S21/P6-S22 contracts.
-- Phase 6 Sprint 24 adds trust dashboard and quality release evidence seams: `GET /v0/memories/trust-dashboard`, deterministic evidence generation via `python3 scripts/run_phase6_quality_evidence.py`, and additive quality evidence summary integration in Phase 4 readiness/release/validation reporting paths without changing GO/NO_GO semantics.
-- Phase 6 is complete (`P6-S21` through `P6-S24` shipped).
-- Phase 7 Sprint 25 adds deterministic chief-of-staff priority seams:
-  - `GET /v0/chief-of-staff` for ranked priorities with explicit posture labels, provenance-backed rationale, trust-aware confidence posture, and deterministic recommended next action.
-  - `/chief-of-staff` web dashboard for current priorities, rationale visibility, and explicit low-trust confidence downgrade rendering.
-- Phase 7 Sprint 26 adds deterministic follow-through supervision seams on top of shipped P7-S25:
-  - `GET /v0/chief-of-staff` now includes deterministic `overdue_items`, `stale_waiting_for_items`, `slipped_commitments`, `escalation_posture`, and governed `draft_follow_up` artifact fields.
-  - follow-through recommendation actions are deterministic and explicit (`nudge`, `defer`, `escalate`, `close_loop_candidate`) with rationale per item.
-  - draft follow-ups remain approval-bounded artifacts only (`draft_only`, no autonomous external send).
-  - `/chief-of-staff` web now renders a dedicated follow-through supervision panel alongside the priority panel.
-- Phase 7 Sprint 27 adds deterministic preparation and resumption supervision seams on top of shipped P7-S25/P7-S26:
-  - `GET /v0/chief-of-staff` now also includes deterministic `preparation_brief`, `what_changed_summary`, `prep_checklist`, `suggested_talking_points`, and `resumption_supervision`.
-  - preparation and resumption artifacts are provenance-backed and explicitly trust-calibrated.
-  - low-trust memory posture explicitly downgrades preparation/resumption recommendation confidence.
-  - `/chief-of-staff` web now renders a dedicated preparation panel with rationale and provenance visibility.
-- Phase 7 Sprint 28 adds deterministic weekly review and recommendation outcome-learning seams on top of shipped P7-S25/P7-S26/P7-S27:
-  - `GET /v0/chief-of-staff` now also includes `weekly_review_brief`, `recommendation_outcomes`, `priority_learning_summary`, and `pattern_drift_summary`.
-  - `POST /v0/chief-of-staff/recommendation-outcomes` captures explicit recommendation handling outcomes (`accept`, `defer`, `ignore`, `rewrite`) as auditable continuity records.
-  - weekly review guidance now explicitly ranks close/defer/escalate actions with deterministic rationale.
-  - `/chief-of-staff` web now renders a weekly review and learning panel with outcome-capture controls and drift visibility.
-- Phase 8 Sprint 29 adds deterministic chief-of-staff action handoff artifacts on top of shipped P7 outputs:
-  - `GET /v0/chief-of-staff` now also includes `action_handoff_brief`, `handoff_items`, `task_draft`, `approval_draft`, and explicit `execution_posture`.
-  - handoff mapping deterministically selects top recommendations from priority/follow-through/preparation/weekly-review signals and emits governed task/approval draft structures with rationale + provenance.
-  - execution posture is explicit and non-autonomous (`approval_bounded_artifact_only`, `approval_required=true`, no autonomous side effects).
-  - `/chief-of-staff` web now renders an action handoff panel showing posture, primary task/approval drafts, and per-item rationale/provenance.
-- Phase 8 Sprint 30 adds deterministic chief-of-staff handoff queue and operational review seams on top of shipped P8-S29:
-  - `GET /v0/chief-of-staff` now also includes `handoff_queue_summary`, `handoff_queue_groups`, and `handoff_review_actions`.
-  - queue lifecycle posture is explicit (`ready`, `pending_approval`, `executed`, `stale`, `expired`) with deterministic grouped ordering and stale/expired visibility.
-  - `POST /v0/chief-of-staff/handoff-review-actions` captures explicit operator lifecycle transitions as auditable continuity records.
-  - `/chief-of-staff` web now renders a grouped handoff queue panel with explicit review-action controls and review-action history.
-- Phase 8 Sprint 31 adds deterministic governed execution routing seams on top of shipped P8-S29/P8-S30:
-  - `GET /v0/chief-of-staff` now also includes `execution_routing_summary`, `routed_handoff_items`, `routing_audit_trail`, and `execution_readiness_posture`.
-  - `POST /v0/chief-of-staff/execution-routing-actions` captures explicit routing transitions into governed draft targets (`task_workflow_draft`, `approval_workflow_draft`, `follow_up_draft_only`).
-  - routing transitions are explicit and auditable (`routed`, `reaffirmed`) while preserving approval-required, draft-only non-autonomous execution posture.
-  - `/chief-of-staff` web now renders an execution routing panel with readiness posture visibility, route controls, and transition history.
-- Phase 8 Sprint 32 adds deterministic outcome-learning and closure-quality seams on top of shipped P8-S29/P8-S30/P8-S31:
-  - `GET /v0/chief-of-staff` now also includes `handoff_outcome_summary`, `handoff_outcomes`, `closure_quality_summary`, `conversion_signal_summary`, and `stale_ignored_escalation_posture`.
-  - `POST /v0/chief-of-staff/handoff-outcomes` captures explicit routed-handoff outcomes (`reviewed`, `approved`, `rejected`, `rewritten`, `executed`, `ignored`, `expired`) as immutable continuity records.
-  - latest-state deterministic rollups now expose closure quality posture, recommendation-to-execution/closure conversion rates, and stale+ignored escalation posture signals.
-  - `/chief-of-staff` web now renders an outcome-learning panel with explicit outcome-capture controls and closure/conversion/escalation visibility.
-- Phase 7 is complete (`P7-S25` through `P7-S28` shipped).
-- Phase 8 Sprint 29 is shipped baseline.
-- Phase 8 Sprint 30 is shipped baseline.
-- Phase 8 Sprint 31 is shipped baseline.
-- Active post-Phase-7 sprint is Phase 8 Sprint 32: outcome learning and closure quality.
-- Phase 8 planning anchors are:
-  - `docs/phase8-product-spec.md`
-  - `docs/phase8-sprint-29-32-plan.md`
-- The backend baseline now includes continuity APIs, deterministic context compilation, governed request routing, approvals and execution review, typed memory and open-loop seams, deterministic thread resumption brief reads, unified explicit-signal capture seams, explicit task and task-step lifecycle seams, rooted local workspaces and artifact ingestion, artifact retrieval and embeddings, narrow read-only Gmail and Calendar seams with selected-item ingestion, bounded read-only Calendar event discovery for one connected account, and the no-tools assistant-response seam.
-- The frontend baseline is now real product surface, not scaffolding: the Next.js operator shell ships `/`, `/chat`, `/approvals`, `/tasks`, `/artifacts`, `/gmail`, `/calendar`, `/memories`, `/chief-of-staff`, `/entities`, and `/traces`, with live-backend reads when configured and explicit fixture fallback when they are not.
-- `/chat` now uses selected-thread continuity instead of a raw thread-id-first flow, keeps bounded thread review and deterministic resumption brief review visible beside both assistant and governed-request composition, ships thread-linked governed workflow, ordered task-step timeline review, and bounded explain-why trace embedding, and includes manual explicit-signal capture controls for selected `message.user` events.
-- `/gmail` and `/calendar` are shipped bounded connector workspaces in the shell: account review, selected-account detail, explicit connect, and one selected-item ingestion path into one chosen task workspace. The API baseline also includes bounded Calendar event discovery for one connected account with deterministic ordering and bounded limits.
-- `/memories`, `/entities`, and `/artifacts` are shipped bounded review workspaces in the shell, not planned surface.
-- Gate ownership is canonicalized to Phase 4 runner scripts (`scripts/run_phase4_*.py`), while `python3 scripts/run_phase3_validation_matrix.py`, `python3 scripts/run_phase2_validation_matrix.py`, and `python3 scripts/run_mvp_validation_matrix.py` remain compatibility guarantees.
-- Historical sprint detail belongs in build and review artifacts, not in this roadmap.
+- Phase 4 is complete as the release-control and qualification baseline.
+- Phase 5 is complete as the daily continuity baseline.
+- Phase 6 is complete as the memory trust-calibration baseline.
+- Phase 7 is complete as the chief-of-staff guidance baseline.
+- Phase 8 is complete as the operational chief-of-staff baseline.
+- The current milestone is Phase 9: Alice Public Core and Agent Interop.
 
-## Next Delivery Focus
+## Current Milestone
 
-### Build From The Shipped API Plus Web-Shell Baseline
+### Phase 9
 
-- Plan the next sprint from the implemented Phase 3 Sprint 9 backend-plus-web baseline, not from older pre-Phase-3 narratives.
-- Treat transcript continuity, thread-linked workflow review, task-step timeline review, bounded explain-why embedding in `/chat`, deterministic resumption brief review, manual explicit-signal capture controls, the shipped review workspaces (`/memories`, `/entities`, `/artifacts`), the shipped connector workspaces (`/gmail`, `/calendar`), and bounded Calendar event discovery as baseline, not pending work.
-- Treat `python3 scripts/run_phase4_release_candidate.py` as the canonical MVP release-candidate rehearsal command and evidence contract (latest summary + append-only archive ledger).
-- Treat `python3 scripts/verify_phase4_rc_archive.py` as the canonical archive audit verification command.
-- Treat `python3 scripts/generate_phase4_mvp_exit_manifest.py` and `python3 scripts/verify_phase4_mvp_exit_manifest.py` as required Phase 4 closeout commands for deterministic MVP phase-exit evidence.
-- Treat `python3 scripts/run_phase4_mvp_qualification.py` and `python3 scripts/verify_phase4_mvp_signoff_record.py` as the canonical Sprint 19 MVP qualification/sign-off commands.
-- Treat archive index hardening as baseline behavior (deterministic lock and atomic index replace), not optional operational guidance.
-- Treat the deterministic validation matrix command (`python3 scripts/run_phase4_validation_matrix.py`) as the canonical Phase 4 validation step inside the RC rehearsal chain, while keeping Phase 3/Phase 2/MVP validation commands as compatibility checks.
-- Treat Phase 5 Sprint 17 through Sprint 20 continuity surfaces as shipped baseline:
-  - `/v0/continuity/captures*`
-  - `/v0/continuity/recall`
-  - `/v0/continuity/resumption-brief`
-  - `/v0/continuity/review-queue*`
-  - `/v0/continuity/open-loops`
-  - `/v0/continuity/daily-brief`
-  - `/v0/continuity/weekly-review`
-  - `/v0/continuity/open-loops/{continuity_object_id}/review-action`
-  - `/continuity` capture/recall/resumption/review/open-loop/daily/weekly workspace
-- Do not relitigate continuity backbone, recall ordering contracts, correction-event append semantics, open-loop posture contracts, or required resumption/brief section contracts.
-- Favor one narrow seam that deepens operator use of already shipped contracts before widening connector breadth or orchestration scope.
-- Reuse the existing continuity, response, approval, task, workspace-artifact, memory, entity, execution, and trace surfaces instead of introducing parallel contracts.
+Ship Alice as a public, installable memory and continuity engine that technical users and external assistants can adopt quickly.
 
-### Keep New Scope Narrow
+Success condition:
 
-- Do not bundle broader Gmail or Calendar breadth, auth expansion, richer document parsing, runner orchestration, or proxy breadth into the next sprint by default.
-- Do not reopen schema or API design unless the next sprint explicitly requires it.
-- Keep Phase 5 follow-up scope explicit:
-  - no additional Sprint 17-20 continuity scope remains
-  - P6-S21 memory-quality gate alignment and deterministic review prioritization is now shipped baseline
-  - P6-S22 retrieval-quality calibration is now shipped baseline
-  - P6-S23 correction impact and freshness hygiene is now shipped baseline
-  - P6-S24 trust dashboard and quality release evidence is now shipped baseline
-  - P7-S25 priority engine and chief-of-staff dashboard is now shipped baseline
-  - P7-S26 follow-through supervision is now shipped baseline
-  - P7-S27 preparation briefs and resumption supervision is now shipped baseline
-  - P7-S28 weekly review and outcome learning is now shipped baseline
-  - P8-S29 action handoff artifacts are now shipped baseline
-  - P8-S30 handoff queue and operational review is now shipped baseline
-  - P8-S31 governed execution routing is now shipped baseline
-  - active post-Phase-7 packet is P8-S32 outcome learning and closure quality
-  - do not reopen P6-S21/P6-S22/P6-S23/P6-S24 contracts while operating on post-P6-S24 follow-up scope
-  - do not reopen P7-S25/P7-S26/P7-S27/P7-S28 semantics while executing P8-S32
-  - do not reopen P8-S29 handoff-generation semantics while executing P8-S32
-  - do not reopen P8-S30 queue/review semantics while executing P8-S32
-  - do not reopen P8-S31 routing semantics while executing P8-S32
-  - do not fold post-Phase-5 work back into shipped Sprint 20 seams
-- Keep live docs synchronized with shipped reality so planning does not drift behind the repo again.
+- install locally
+- import existing context
+- run capture/recall/resume/open-loop flows
+- connect via MCP
+- verify correction-aware improvement
 
-## Ongoing Risks
+## Next Milestones
 
-- Memory extraction and retrieval quality remain the main product risk.
-- Auth remains incomplete beyond the current database user-context model.
-- The operator shell is now shipped surface, including `/gmail` and `/calendar`, so future drift between web UI behavior, backend seams, and canonical docs is a planning and review risk.
-- Connector and document boundaries are still intentionally narrow; broadening them safely will require separate explicit sprints.
+### P9-S33: Public Core Packaging (current delivery)
 
-## Deferred Until Explicitly Opened
+- public-safe package boundary
+- documented local startup path
+- sample dataset (`fixtures/public_sample_data/continuity_v1.json`)
+- initial public README and OSS boundary decisions
 
-- Gmail search, mailbox sync, attachment ingestion, write-capable Gmail actions, and broader Calendar capabilities such as recurrence expansion, sync, and write actions
-- runner-style orchestration and automatic multi-step progression
-- richer document parsing, OCR, and layout-aware ingestion
-- broader tool execution breadth beyond the current governed `proxy.echo` seam
+### P9-S34: CLI and Continuity UX
+
+- terminal commands for import, capture, recall, resume, open loops, review, correction, and status
+- deterministic terminal formatting with provenance snippets
+
+### P9-S35: MCP Server
+
+- small stable MCP tool surface
+- local interop examples for compatible clients
+- deterministic tool contracts
+
+### P9-S36: OpenClaw Adapter
+
+- import path for OpenClaw durable memory/workspace data
+- Alice MCP augmentation mode for OpenClaw-style workflows
+
+### P9-S37: Importers and Evaluation Harness
+
+- at least three production-usable importers
+- local benchmark and baseline report generation
+
+### P9-S38: Docs, Launch Assets, and Public Release
+
+- public quickstart
+- integration docs
+- launch checklist
+- first public version tag
+
+## Dependencies
+
+- Phase 9 packaging must preserve shipped P5/P6/P7/P8 semantics.
+- CLI and MCP should both build on the same public core boundary.
+- Importers should reuse current continuity and correction semantics.
+- Launch docs should reflect the actual install/runtime path, not intended future structure.
+
+## Blockers and Risks
+
+- Packaging boundaries may require repo cleanup before public release.
+- Import quality and dedupe behavior can become the main public trust risk.
+- MCP surface must stay narrow to avoid unstable contracts.
+- Launch quality depends heavily on quickstart reliability and docs accuracy.
+- OSS boundary and license decisions must be made before public release work finalizes.
+
+## Recently Completed
+
+- Phase 8 delivered operational chief-of-staff handoffs, routing, outcome learning, and closure quality.
+- The core internal product is ready to be packaged and exposed publicly.
+
+## Legacy Compatibility Markers
+
+Repository lineage remains continuous through Phase 3 Sprint 9.
+
+Phase 4 Sprint 14 is the active release-control layer.
+
+Gate ownership is canonicalized to Phase 4 runner scripts.

--- a/RULES.md
+++ b/RULES.md
@@ -1,41 +1,50 @@
 # Rules
 
-## Truth And Scope
+## Product / Scope Rules
 
-- The active sprint packet is the top scope boundary for implementation work.
-- Treat `.ai/active/SPRINT_PACKET.md` as an input/control artifact: do not edit it during implementation unless Control Tower explicitly changes the sprint.
-- Never describe planned behavior as already implemented.
-- Keep canonical truth files concise, current, and durable.
-- Shared runbooks and canonical docs must use machine-independent commands and links; do not use local user-home absolute paths.
-- When a sprint changes the operating baseline, update canonical truth docs in the same sprint before handoff.
-- Archive stale planning or history material instead of deleting it when traceability still matters.
-- Do not widen product scope without an explicit roadmap or sprint change.
+- Treat Alice as a memory and continuity layer first, not a broad autonomous agent platform.
+- Do not widen channels, deep automation, or connector write breadth without an explicit roadmap change.
+- Keep the public v0.1 contract focused on capture, recall, resume, correction, and open loops.
+- Do not block Phase 9 on hosted SaaS, Telegram, WhatsApp, or deep vertical workflows.
 
-## Product And Safety
+## Architecture Rules
 
-- Never execute a consequential external action without explicit user approval.
-- Treat explainability as a product feature, not an internal debugging aid.
-- Treat the repeat magnesium reorder as the v1 release-readiness validation scenario.
-- Do not add proactive automation, write-capable connectors, voice, or browser automation without an explicit roadmap change.
+- Preserve shipped P5/P6/P7/P8 semantics while packaging for Phase 9.
+- Keep public interop surfaces narrow and deterministic before broadening them.
+- Always compile context from durable sources, not transcript replay.
+- Treat Postgres as the primary system of record unless a measured decision changes it.
+- Keep MCP tools small, stable, and schema-driven.
 
-## Architecture And Data
+## Coding Rules
 
-- Treat the immutable event store as ground truth; downstream memories, tasks, and summaries are derived or governed views.
-- Always compile context per invocation from durable sources.
-- Keep prompt assembly, tool schemas, and serialized context ordering deterministic.
-- Treat Postgres as the v1 system of record unless measured constraints justify a change.
-- Task-step lineage and execution linkage must stay explicit; do not reconstruct them heuristically from broader task history.
-- Enforce row-level security on every user-owned table.
-- Connector secrets must not be stored on normal metadata tables or exposed on read surfaces; they must use a dedicated protected storage seam.
-- Default memory admission to `NOOP`; promote only evidence-backed changes and preserve revision history for non-`NOOP` updates.
-- Apply domain and sensitivity filters before semantic retrieval.
+- Build public packaging on top of existing seams instead of reimplementing continuity behavior.
+- Keep CLI, MCP, importer, and adapter code module-scoped and test-backed.
+- Prefer deterministic outputs and explicit provenance in public-facing commands and tools.
+- Do not introduce public packaging shortcuts that bypass trust or approval boundaries.
 
-## Delivery And Testing
+## Data / Schema Rules
 
-- Build against typed contracts and migration-backed schemas first.
-- Keep changes small, module-scoped, and test-backed.
-- Never bypass policy, approval, or proxy boundaries to introduce side effects.
-- Schema changes are not complete without forward and rollback coverage.
-- Every module needs unit tests and at least one integration boundary test.
-- Approval boundaries, row-level security, audit logging, and lineage changes require adversarial tests.
-- Do not make memory-quality or retrieval-quality release claims without labeled evaluation evidence.
+- Preserve append-only continuity, correction, and revision history.
+- Keep imported data provenance explicit.
+- Default memory admission to conservative behavior; do not loosen admission discipline for launch convenience.
+- Do not silently overwrite stale or superseded truth.
+
+## Deployment / Ops Rules
+
+- Support one documented local startup path before adding alternative runtimes.
+- For `P9-S33`, canonical startup is: `docker compose up -d` -> `./scripts/migrate.sh` -> `./scripts/load_sample_data.sh` -> `./scripts/api_dev.sh`.
+- Public docs must match real install behavior on a clean machine.
+- Keep machine-independent commands and links in canonical docs and runbooks.
+- Archive obsolete planning or bootstrap material instead of deleting it when traceability matters.
+
+## Testing Rules
+
+- New public surfaces require install or smoke validation, not just unit tests.
+- CLI commands need deterministic golden-output tests.
+- MCP tools need stable contract tests.
+- Importers need fixture-backed success, dedupe, and failure-path tests.
+- Do not make public memory-quality or recall-quality claims without evaluation evidence.
+
+## Legacy Compatibility Marker
+
+Historical continuity keeps the v1 release-readiness validation scenario available for baseline evidence.

--- a/apps/web/components/memory-summary.test.tsx
+++ b/apps/web/components/memory-summary.test.tsx
@@ -42,6 +42,26 @@ describe("MemorySummary", () => {
             insufficient_evidence: 0,
           },
           label_value_order: ["correct", "incorrect", "outdated", "insufficient_evidence"],
+          quality_gate: {
+            status: "healthy",
+            precision: 0.9,
+            precision_target: 0.8,
+            adjudicated_sample_count: 12,
+            minimum_adjudicated_sample: 10,
+            remaining_to_minimum_sample: 0,
+            unlabeled_memory_count: 2,
+            high_risk_memory_count: 0,
+            stale_truth_count: 0,
+            superseded_active_conflict_count: 0,
+            counts: {
+              active_memory_count: 9,
+              labeled_active_memory_count: 7,
+              adjudicated_correct_count: 6,
+              adjudicated_incorrect_count: 1,
+              outdated_label_count: 0,
+              insufficient_evidence_label_count: 0,
+            },
+          },
         }}
         summarySource="live"
         queueSummary={{
@@ -59,8 +79,18 @@ describe("MemorySummary", () => {
     );
 
     expect(screen.getByText("Ship-gate readiness")).toBeInTheDocument();
-    expect(screen.getByText("On track")).toBeInTheDocument();
-    expect(screen.getByText("Progress: minimum adjudicated sample is met.")).toBeInTheDocument();
+    expect(screen.getByText("Healthy")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Quality gate is healthy: precision target is met, sample minimum is met, and no blocking risk posture remains.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Sample posture: 12/10 adjudicated labels. Minimum sample is met.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Queue/risk posture: 2 unlabeled, 0 high risk, 0 stale truth, 0 superseded active conflicts.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Active list" })).toHaveAttribute("href", "/memories");
     expect(screen.getByRole("link", { name: "Unlabeled queue" })).toHaveAttribute(
       "href",

--- a/docs/adr/ADR-001-public-core-package-boundary.md
+++ b/docs/adr/ADR-001-public-core-package-boundary.md
@@ -1,0 +1,56 @@
+# ADR-001: Public Core Package Boundary
+
+## Status
+
+Accepted (2026-04-07)
+
+## Context
+
+Phase 9 packages an internal continuity and chief-of-staff substrate into a public technical product. The repo currently mixes shipped internal product surfaces, planning docs, and future public surfaces. Without an explicit package boundary, later CLI, MCP, importer, and adapter work will target unstable seams and keep reopening the same scope question.
+
+## Decision
+
+Define a narrow public package boundary centered on `alice-core`.
+
+`alice-core` should own:
+
+- continuity capture
+- recall and retrieval
+- resumption-brief generation
+- open-loop retrieval
+- correction-aware memory update paths
+- trust-calibrated retrieval semantics
+
+Keep these outside the initial public core or explicitly deferred:
+
+- chief-of-staff UI and operator-specific workspaces
+- broad autonomous execution surfaces
+- channel integrations
+- deep vertical workflows
+- internal release-control and review tooling not required for public operation
+- OSS license selection (tracked separately as deferred launch governance)
+
+Public CLI, MCP, importers, and external adapters should depend on the documented `alice-core` boundary rather than reaching through internal app seams ad hoc.
+
+## Consequences
+
+Positive:
+
+- gives Sprint 34 and Sprint 35 stable build targets
+- reduces accidental platform sprawl in the first public release
+- makes docs, packaging, and testing easier to align
+
+Negative:
+
+- may require temporary duplication or wrapper seams while the repo transitions toward cleaner packaging
+- leaves some internal product features deliberately outside the first public release
+
+## Alternatives Considered
+
+### Expose the full current repo as the public product
+
+Rejected for Phase 9 because it would blur internal operator surfaces with the public continuity contract and enlarge the support surface too early.
+
+### Delay package-boundary decisions until CLI and MCP implementation
+
+Rejected because it would create churn across multiple follow-on sprints and make interop contracts unstable.

--- a/docs/adr/ADR-002-public-runtime-baseline.md
+++ b/docs/adr/ADR-002-public-runtime-baseline.md
@@ -1,0 +1,44 @@
+# ADR-002: Public Runtime Baseline
+
+## Status
+
+Accepted (2026-04-07)
+
+## Context
+
+Alice currently runs locally with Postgres, `pgvector`, Redis, and MinIO in Docker Compose. Phase 9 needs a public runtime story that external technical users can install and verify without ambiguity. Supporting multiple storage/runtime modes too early would increase docs drift and make retrieval semantics harder to keep consistent.
+
+## Decision
+
+Adopt one supported public runtime baseline for Phase 9:
+
+- Postgres
+- `pgvector`
+- Docker Compose for local infrastructure
+
+Treat this as the canonical v0.1 setup path. Do not claim SQLite or other reduced local modes as supported public runtimes unless they preserve Alice’s continuity, retrieval, and correction semantics without special-case behavior.
+
+Redis and MinIO remain acceptable support services when required by the current product, but the primary public runtime promise is the Postgres-backed local install path.
+
+## Consequences
+
+Positive:
+
+- keeps the public quickstart simple and testable
+- preserves retrieval and memory semantics already proven internally
+- avoids splitting engineering time across multiple weakly supported install modes
+
+Negative:
+
+- raises the minimum local setup bar for some users
+- defers simpler single-file runtimes unless they are validated later
+
+## Alternatives Considered
+
+### Support SQLite immediately as a public fallback
+
+Rejected for Phase 9 because it risks semantic drift and extra support burden before the public product contract is stable.
+
+### Support multiple deployment modes at launch
+
+Rejected because Phase 9 needs one reliable path more than optional breadth.

--- a/docs/adr/ADR-003-mcp-tool-surface-contract.md
+++ b/docs/adr/ADR-003-mcp-tool-surface-contract.md
@@ -1,0 +1,55 @@
+# ADR-003: MCP Tool Surface Contract
+
+## Status
+
+Accepted (2026-04-07)
+
+## Context
+
+Phase 9 includes exposing Alice through an MCP server so external assistants can use Alice as a memory and continuity layer. A large or unstable MCP surface would increase support burden, make evaluation harder, and encourage clients to depend on accidental internal behavior rather than the intended continuity contract.
+
+## Decision
+
+Start with a deliberately small MCP tool surface aligned to the public v0.1 contract.
+
+Recommended first tools:
+
+- `alice_capture`
+- `alice_recall`
+- `alice_resume`
+- `alice_open_loops`
+- `alice_recent_decisions`
+- `alice_recent_changes`
+- `alice_memory_review`
+- `alice_memory_correct`
+- `alice_context_pack`
+
+Tool design rules:
+
+- inputs and outputs must be deterministic and provenance-backed where applicable
+- names should describe user-facing continuity jobs, not internal implementation details
+- tool semantics must stay narrow and stable across early public releases
+- do not expose write-capable side effects beyond Alice’s own continuity and correction domain in the initial MCP release
+
+## Consequences
+
+Positive:
+
+- keeps the interop story understandable and testable
+- aligns MCP behavior with the product wedge instead of generic agent sprawl
+- limits contract churn for early adopters
+
+Negative:
+
+- some external-agent use cases will need to wait for later MCP expansion
+- pressure may remain to expose internal helper seams that are not yet stable
+
+## Alternatives Considered
+
+### Publish a broad MCP surface from the current internal API
+
+Rejected because it would expose unstable internals and create support obligations before the public contract is proven.
+
+### Delay MCP boundary decisions until Sprint 35
+
+Rejected because Sprint 33 and Sprint 34 need a stable public contract to package and document against.

--- a/docs/phase9-bootstrap-notes.md
+++ b/docs/phase9-bootstrap-notes.md
@@ -1,0 +1,120 @@
+# Phase 9 Bootstrap Notes
+
+## Brief Distillation Summary
+
+Phase 9 is not a new core-product reinvention phase. It is the public packaging and interoperability phase.
+
+The durable product truth is:
+
+- Alice is a memory and continuity layer for AI agents.
+- The public v0.1 contract is capture, recall, resume, correct, and open loops.
+- The launch path is local-first, CLI-first, MCP-enabled, and interop-proven through at least one external adapter.
+
+The highest-value execution sequence is:
+
+1. public core packaging
+2. CLI
+3. MCP server
+4. OpenClaw adapter
+5. importers and eval harness
+6. docs and public release
+
+## Recommended ADR List
+
+### ADR 1: Public Core Package Boundary
+
+- Why it deserves an ADR: defines what becomes `alice-core` versus what remains internal or deferred.
+- Status in `P9-S33`: Accepted
+
+### ADR 2: Public Runtime Baseline
+
+- Why it deserves an ADR: decides whether Postgres + `pgvector` is the only supported runtime or whether a fallback such as SQLite exists.
+- Status in `P9-S33`: Accepted
+
+### ADR 3: MCP Tool Surface Contract
+
+- Why it deserves an ADR: determines the size, naming, and stability promises of the public Alice MCP tool set.
+- Status in `P9-S33`: Accepted
+
+### ADR 4: OpenClaw Integration Boundary
+
+- Why it deserves an ADR: defines whether the first external adapter is file-import only, MCP augmentation only, or both.
+- Proposed status: Proposed
+
+### ADR 5: Import Provenance and Dedupe Strategy
+
+- Why it deserves an ADR: imported-memory correctness and duplicate handling are central to trust.
+- Proposed status: Proposed
+
+### ADR 6: OSS Boundary and License
+
+- Why it deserves an ADR: determines what is public-safe, what is deferred, and how community usage is allowed.
+- Proposed status: Proposed
+
+### ADR 7: Public Evaluation Harness Scope
+
+- Why it deserves an ADR: defines what benchmark claims Alice is allowed to make publicly and how they are reproduced.
+- Proposed status: Proposed
+
+## Archive Recommendations
+
+Archive rather than keep in active agent memory:
+
+- launch copy ideas beyond the product wedge
+- broad go-to-market brainstorming not tied to build decisions
+- long comparison-page prose
+- team-role notes that do not affect ownership or architecture
+- redundant sprint-by-sprint rationale once canonical phase docs exist
+- any “nice to have” launch wishlist that is not part of the must-ship contract
+
+Keep active:
+
+- public wedge
+- public v0.1 contract
+- sprint sequencing
+- package/runtime boundary decisions
+- MCP surface decisions
+- importer/eval requirements
+
+## Suggested Folder Structure
+
+```text
+project-root/
+├── README.md
+├── PRODUCT_BRIEF.md
+├── ARCHITECTURE.md
+├── ROADMAP.md
+├── RULES.md
+├── CHANGELOG.md
+├── docs/
+│   ├── adr/
+│   ├── runbooks/
+│   ├── archive/
+│   ├── quickstart/
+│   ├── architecture/
+│   ├── integrations/
+│   ├── mcp/
+│   └── examples/
+├── .ai/
+│   ├── active/
+│   ├── handoff/
+│   ├── archive/
+│   └── templates/
+├── apps/
+│   ├── api/
+│   ├── web/
+│   ├── cli/
+│   └── mcp-server/
+├── packages/
+│   ├── alice-core/
+│   ├── alice-importers/
+│   ├── alice-openclaw/
+│   └── alice-sdk-python/
+├── eval/
+├── examples/
+├── fixtures/
+├── scripts/
+└── tests/
+```
+
+This should be treated as the target public-core structure for Phase 9, not necessarily an all-at-once refactor in Sprint 33.

--- a/docs/phase9-product-spec.md
+++ b/docs/phase9-product-spec.md
@@ -1,0 +1,244 @@
+# Phase 9 Product Spec
+
+## Title
+
+Phase 9: Alice Public Core and Agent Interop
+
+## Executive Summary
+
+Phases 4 through 8 built Alice into a release-qualified, trust-calibrated, continuity-first chief-of-staff system.
+
+Phase 9 should turn that internal product into a public, installable memory and continuity engine that other agents and technical users can adopt quickly.
+
+The Phase 9 wedge is not "another full assistant."
+It is:
+
+- a memory and continuity layer
+- installable locally
+- usable directly through CLI
+- callable through MCP
+- interoperable with external agent stacks such as OpenClaw
+
+The product should let a technical user install Alice, import memory/context, connect it to an external assistant, ask recall questions, generate a resumption brief, inspect open loops, and verify that corrections improve future behavior.
+
+## Product Thesis
+
+Alice should become the memory and continuity layer for AI agents.
+
+It should provide:
+
+- durable memory
+- better context loading
+- resumption briefs
+- open-loop continuity
+- correction-aware recall
+
+The key move in Phase 9 is not feature sprawl. It is packaging, interoperability, and public usability.
+
+## Phase Goal
+
+Ship Alice as a public, installable core that works:
+
+- standalone
+- through CLI
+- through MCP
+- with at least one concrete external agent integration
+
+## Success Condition
+
+A technical user can, in under 30 minutes:
+
+- install Alice locally
+- load sample or imported data
+- run capture, recall, resume, and open-loop flows
+- connect an external assistant via MCP
+- observe deterministic correction-aware behavior
+
+## Non-Goals
+
+- Telegram or WhatsApp channels
+- vertical-agent expansion
+- enterprise multi-tenant platform expansion
+- deep browser automation
+- hosted SaaS as a launch dependency
+- broad connector write actions
+- "our agents only" ecosystem lock-in
+
+## Public Product Wedge
+
+### Positioning
+
+Alice is the memory and continuity layer for AI agents.
+
+### Public Surfaces
+
+Phase 9 should publish four things:
+
+1. Alice Core
+2. Alice MCP Server
+3. Alice CLI and Python SDK
+4. OpenClaw adapter and examples
+
+## Target Users
+
+- technical solo users
+- developers already experimenting with local agents
+- users with existing notes or memory stores to import
+- agent builders who need better recall, resumption, and correction-aware memory
+
+## Core Value Proposition
+
+- Local-first installable memory and continuity system
+- Correction-aware recall and resumption
+- Open-loop visibility
+- Deterministic, provenance-backed outputs
+- Agent interoperability through MCP instead of closed-product lock-in
+
+## Public v0.1 Product Contract
+
+Alice v0.1 should help users do five things:
+
+1. Capture
+2. Recall
+3. Resume
+4. Correct
+5. Track open loops
+
+That is enough for launch.
+
+## `P9-S33` Public-Core Baseline
+
+This sprint establishes the packaging/runtime baseline before CLI and MCP implementation:
+
+- package name: `alice-core`
+- canonical startup: `docker compose up -d` -> `./scripts/migrate.sh` -> `./scripts/load_sample_data.sh` -> `./scripts/api_dev.sh`
+- deterministic fixture: `fixtures/public_sample_data/continuity_v1.json`
+- proof path: one recall call and one resumption call from public docs
+
+## Must-Ship v0.1 Surface
+
+- local install
+- capture
+- recall
+- resume
+- open loops
+- correction
+- MCP server
+- OpenClaw adapter
+- markdown import
+- docs and demos
+
+## Nice-To-Have v0.1 Surface
+
+- ChatGPT importer
+- Claude importer
+- lightweight public web review page
+- packaged binary installer
+
+## Do Not Block Launch On
+
+- Telegram
+- WhatsApp
+- browser automation
+- shopping or calendar write actions
+- hosted SaaS
+- deep vertical workflows
+
+## Core User Journeys
+
+1. Install Alice locally and run a first recall query.
+2. Import an existing workspace or memory source and immediately generate a resumption brief.
+3. Connect a local assistant via MCP and call Alice tools for recall and continuity support.
+4. Correct a memory once and verify later retrieval changes deterministically.
+5. Inspect open loops and recent decisions without re-reading raw history.
+
+## Required Product Surfaces
+
+### Alice Core
+
+The public-safe continuity and memory engine with stable install and documented runtime assumptions.
+
+### Alice CLI
+
+Terminal-first interface for:
+
+- import
+- capture
+- recall
+- resume
+- open loops
+- review/correct memory
+- status
+
+### Alice MCP Server
+
+Stable small tool surface for external assistants.
+
+### External Integration Adapter
+
+At least one first-class external agent integration proving Alice is agent-agnostic.
+
+## Core Product Principles
+
+1. Public packaging must not compromise trust or determinism.
+2. Interop must be narrow and stable before it becomes broad.
+3. Docs are product surface in this phase, not support material.
+4. Launch should prove usefulness, not breadth.
+5. Import, correction, and recall quality matter more than ecosystem count.
+
+## Metrics
+
+### Product Metrics
+
+- time to first useful result
+- recall precision
+- resumption usefulness
+- correction success rate
+- number of imported workspaces
+- number of MCP-connected clients
+
+### Technical Metrics
+
+- install success rate
+- import failure rate
+- duplicate memory rate
+- resumption latency
+- MCP tool failure rate
+- database migration reliability
+
+### Launch Metrics
+
+- quickstart completion rate
+- docs completion rate
+- setup-vs-product issue ratio
+- community integrations
+
+## Delivery Constraints
+
+- reuse shipped P5/P6/P7/P8 capabilities rather than rebuilding continuity semantics
+- preserve deterministic memory, trust, and provenance behavior
+- do not widen into unsafe autonomous execution to chase launch novelty
+- keep Phase 9 interop contracts small and stable
+
+## Acceptance Criteria
+
+- Alice can be installed locally from clean docs
+- a sample dataset can be loaded
+- CLI capture, recall, resume, open-loop, and correction flows work against real data
+- MCP tools work for recall and resume from at least one compatible client
+- at least one external integration proves Alice is usable as an agent memory layer
+- importers and evaluation harness provide public proof that correction-aware continuity is useful
+
+## Phase Exit Definition
+
+Phase 9 is complete when Alice is no longer only an internal system.
+
+It must be:
+
+- installable
+- documented
+- interoperable
+- demonstrable
+- useful in under 30 minutes for a technical user
+
+At phase exit, Alice should have a credible public v0.1 story as a memory and continuity engine for agents.

--- a/docs/phase9-public-core-boundary.md
+++ b/docs/phase9-public-core-boundary.md
@@ -1,0 +1,177 @@
+# Phase 9 Public Core Boundary
+
+## Purpose
+
+This document defines what Phase 9 should expose publicly versus what should remain internal or non-launch-critical during the first public release.
+
+## Public Core Objective
+
+Expose the minimum stable surface needed to make Alice usable as:
+
+- a local memory and continuity engine
+- a CLI continuity tool
+- an MCP-backed memory layer for external assistants
+
+## Public Release Surface
+
+### 1. Alice Core
+
+Public-safe core functionality should include:
+
+- continuity capture
+- recall
+- resumption briefs
+- open-loop retrieval
+- correction-aware memory review
+- trust-calibrated retrieval posture
+
+### 2. Alice CLI
+
+Public CLI should expose:
+
+- `alice import`
+- `alice capture`
+- `alice recall`
+- `alice resume`
+- `alice open-loops`
+- `alice review-memory`
+- `alice correct-memory`
+- `alice status`
+
+### 3. Alice MCP Server
+
+Public MCP surface should stay intentionally small.
+
+Recommended initial tools:
+
+- `alice_capture`
+- `alice_recall`
+- `alice_resume`
+- `alice_open_loops`
+- `alice_recent_decisions`
+- `alice_recent_changes`
+- `alice_memory_review`
+- `alice_memory_correct`
+- `alice_context_pack`
+
+### 4. Alice Importers
+
+Public import support should focus on fast adoption:
+
+- markdown folder import
+- ChatGPT export import
+- Claude export import
+- CSV task/open-loop import
+- OpenClaw import
+
+## Public Runtime Assumptions
+
+Preferred runtime:
+
+- Postgres
+- pgvector
+
+Optional fallback:
+
+- SQLite only if it can be supported cleanly without compromising core semantics
+
+The first public release should prioritize one reliable documented local startup path over multiple partially supported deployment modes.
+
+For `P9-S33`, the canonical path is:
+
+1. `docker compose up -d`
+2. `./scripts/migrate.sh`
+3. `./scripts/load_sample_data.sh`
+4. `./scripts/api_dev.sh`
+
+## Public Repo Shape
+
+Recommended public package layout:
+
+```text
+alice/
+├─ apps/
+│  ├─ mcp-server/
+│  └─ cli/
+├─ packages/
+│  ├─ alice-core/
+│  ├─ alice-importers/
+│  ├─ alice-openclaw/
+│  └─ alice-sdk-python/
+├─ docs/
+│  ├─ quickstart/
+│  ├─ architecture/
+│  ├─ integrations/
+│  ├─ mcp/
+│  └─ examples/
+├─ eval/
+├─ examples/
+├─ docker/
+├─ scripts/
+├─ fixtures/
+└─ README.md
+```
+
+This should be treated as a public packaging target, not necessarily an immediate full repo rewrite in one sprint.
+
+## Public-Safe Guarantees
+
+Alice public core should guarantee:
+
+- deterministic recall/resumption behavior
+- provenance-backed outputs
+- correction-aware improvement
+- open-loop visibility
+- documented install path
+- stable local-first operation
+
+## Keep Internal Or Defer
+
+Do not treat these as Phase 9 launch blockers:
+
+- Telegram or WhatsApp channels
+- browser automation
+- broad connector write actions
+- hosted SaaS
+- deep vertical workflows
+- broad agent-platform abstraction
+
+## Public Documentation Priorities
+
+Public docs must cover:
+
+- what Alice is
+- why it exists
+- 10-minute quickstart
+- CLI examples
+- MCP setup
+- OpenClaw integration
+- architecture overview
+- evaluation harness
+
+## OSS Boundary Questions
+
+Phase 9 needs explicit decisions on:
+
+- license
+- what parts are public-safe
+- whether any internal tooling or ops scripts remain private
+- whether public examples include full datasets or sanitized fixtures only
+
+These should be captured as ADRs rather than left implicit in launch docs.
+
+Current `P9-S33` note:
+
+- package boundary, runtime baseline, and MCP tool-surface boundaries are ADR-backed
+- license selection is explicitly deferred and tracked in sprint evidence
+
+## Launch Definition
+
+Phase 9 public launch is good enough when an external technical user can:
+
+- install Alice locally
+- import data
+- use CLI recall/resume/open-loop flows
+- connect one MCP client
+- observe that corrections change future retrieval
+- complete the flow from public docs without direct founder support

--- a/docs/phase9-sprint-33-38-plan.md
+++ b/docs/phase9-sprint-33-38-plan.md
@@ -1,0 +1,302 @@
+# Phase 9 Sprint 33-38 Plan
+
+## Summary
+
+Phase 9 should convert the shipped internal Alice system into a public, installable core with CLI, MCP interoperability, importers, evaluation harness, and launch-ready docs.
+
+Sprint IDs in this document are Phase 9-local (`P9-S33` to `P9-S38`) to avoid ambiguity with completed Phase 4, Phase 5, Phase 6, Phase 7, and Phase 8 sprint numbering.
+
+## Phase Objective
+
+Ship Alice as a public memory and continuity engine that technical users can install and connect to external agents quickly.
+
+## Sprint 33 (P9-S33)
+
+### Title
+
+Public Core Packaging
+
+### Objective
+
+Turn the current internal system into a public-safe, installable core with one documented local startup path.
+
+### Scope
+
+- public package boundary
+- public-safe repo structure cleanup
+- default config templates
+- sample `.env` path
+- Docker/local startup path
+- sample dataset
+- first public README skeleton
+- OSS boundary and license decision
+
+### Deliverables
+
+- `alice-core` package boundary definition
+- public runtime assumptions
+- local install path
+- clean repo map for public use
+- sample seed dataset at `fixtures/public_sample_data/continuity_v1.json`
+- deterministic sample load command: `./scripts/load_sample_data.sh`
+
+### Acceptance Criteria
+
+- fresh machine install works from docs
+- Alice boots locally through one documented flow
+- sample data can be loaded
+- one recall query works end to end
+- one resumption brief works end to end
+
+### Out Of Scope
+
+- CLI polish beyond bootstrapping
+- MCP interoperability
+- broad importer set
+
+## Sprint 34 (P9-S34)
+
+### Title
+
+CLI and Continuity UX
+
+### Objective
+
+Make Alice useful without requiring the internal operator shell.
+
+### Scope
+
+- capture command
+- recall command
+- resume command
+- open-loops command
+- memory review/correction commands
+- status command
+- terminal-friendly deterministic output
+
+### Deliverables
+
+- CLI command set
+- terminal formatting for recall and resume
+- provenance snippets in terminal output
+- correction flows for confirm/edit/delete/supersede
+
+### Acceptance Criteria
+
+- commands operate against real local data
+- resume output includes:
+  - recent decisions
+  - active open loops
+  - blockers
+  - next suggested action
+- correction updates later recall deterministically
+
+### Out Of Scope
+
+- MCP server
+- external integrations
+
+## Sprint 35 (P9-S35)
+
+### Title
+
+MCP Server
+
+### Objective
+
+Make Alice usable immediately by external assistants through a stable small tool surface.
+
+### Scope
+
+- MCP tool schemas
+- deterministic serialization
+- local auth model for MCP use
+- context pack outputs
+- compatibility examples
+
+### Deliverables
+
+- stable tool set such as:
+  - `alice_capture`
+  - `alice_recall`
+  - `alice_resume`
+  - `alice_open_loops`
+  - `alice_recent_decisions`
+  - `alice_recent_changes`
+  - `alice_memory_review`
+  - `alice_memory_correct`
+  - `alice_context_pack`
+- config examples for compatible clients
+- local interoperability demo
+
+### Acceptance Criteria
+
+- one MCP client can call recall successfully
+- one MCP client can call resume successfully
+- correction via MCP changes later retrieval behavior
+- tool contracts remain stable across runs
+
+### Out Of Scope
+
+- broad tool surface expansion
+- remote hosted auth systems
+
+## Sprint 36 (P9-S36)
+
+### Title
+
+OpenClaw Adapter
+
+### Objective
+
+Prove Alice is agent-agnostic and materially improves an existing agent stack.
+
+### Scope
+
+- file-based import path for OpenClaw durable memory/workspace data
+- MCP augmentation mode for external use
+- import mapping and dedupe rules
+- provenance tagging for imported material
+
+### Deliverables
+
+- `alice-openclaw` adapter package
+- import command for OpenClaw workspace
+- imported provenance tagging
+- before/after integration demo
+
+### Acceptance Criteria
+
+- a sample or real OpenClaw workspace can be imported
+- imported memory is queryable through Alice recall
+- imported workspace produces useful resumption briefs
+- external agent can consume Alice via MCP augmentation
+
+### Out Of Scope
+
+- generic platform SDK
+- many external integrations at once
+
+## Sprint 37 (P9-S37)
+
+### Title
+
+Importers and Evaluation Harness
+
+### Objective
+
+Make the public product sticky fast and prove it is better, not just broader.
+
+### Scope
+
+- importers
+- benchmark fixtures
+- local evaluation harness
+- baseline report generation
+
+### Deliverables
+
+- at least three production-usable importers
+- benchmark flows for:
+  - recall precision
+  - resumption usefulness
+  - correction effectiveness
+  - open-loop retrieval quality
+- sample eval report
+
+### Acceptance Criteria
+
+- benchmark script runs locally
+- sample eval report can be generated from repo
+- correction prevents repeated outdated recall in test cases
+- importer success and duplicate-memory posture are measurable
+
+### Out Of Scope
+
+- launch narrative polish
+- broad UI work
+
+## Sprint 38 (P9-S38)
+
+### Title
+
+Docs, Launch Assets, and Public Release
+
+### Objective
+
+Make the repo feel launch-ready for external technical users.
+
+### Scope
+
+- polished README
+- quickstart docs
+- architecture overview
+- integration docs
+- launch assets
+- contribution and security docs
+- first public version tag
+
+### Deliverables
+
+- public quickstart flow
+- architecture and integration docs
+- comparison positioning page
+- screenshots and demo media
+- launch checklist and runbook
+- `v0.1` release tag
+
+### Acceptance Criteria
+
+- external tester can complete quickstart without handholding
+- public repo passes install, test, and demo path
+- launch materials match the actual product wedge
+- first public release is cut consistently
+
+### Out Of Scope
+
+- hosted SaaS launch
+- post-v0.1 vertical expansion
+
+## Cross-Sprint Requirements
+
+- preserve shipped continuity, trust, and chief-of-staff semantics
+- keep public interop surfaces narrow and stable
+- keep docs synchronized with actual install/runtime behavior
+- avoid turning launch work into platform sprawl
+
+## Cross-Sprint Metrics
+
+- install success rate
+- time to first useful result
+- recall precision
+- resumption usefulness
+- correction uptake rate
+- import success rate
+- duplicate memory rate
+- MCP tool failure rate
+- quickstart completion rate
+
+## Control Tower Notes
+
+- treat this phase as packaging and interoperability, not product reinvention
+- public docs are part of the shipped product surface in this phase
+- prefer one clear artifact per sprint:
+  - Sprint 33: public core checklist
+  - Sprint 34: CLI demo
+  - Sprint 35: MCP quickstart
+  - Sprint 36: OpenClaw integration demo
+  - Sprint 37: baseline eval report
+  - Sprint 38: public release checklist
+- do not reopen P5/P6/P7/P8 semantics while executing Phase 9
+
+## Definition Of Success
+
+Phase 9 succeeds if Alice becomes:
+
+- installable
+- understandable
+- interoperable
+- evaluable
+- launchable
+
+for external technical users in a short, documented flow.

--- a/docs/phase9-sprint-33-control-tower-packet.md
+++ b/docs/phase9-sprint-33-control-tower-packet.md
@@ -1,0 +1,195 @@
+# Phase 9 Sprint 33 Control Tower Packet
+
+## Sprint
+
+`P9-S33: Public Core Packaging`
+
+## Objective
+
+Package the existing internal Alice substrate so an external technical user can install it locally, load sample data, and complete one recall flow and one resumption flow from canonical docs without founder intervention.
+
+## Why This Sprint Matters
+
+- It is the first packaging sprint that turns internal product truth into a public technical product.
+- Every later Phase 9 sprint depends on a stable package boundary, startup path, and sample-data story.
+- It reduces launch risk by forcing one documented install path to match real repo behavior.
+
+## Required Planning Inputs
+
+- [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md)
+- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md)
+- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md)
+- [RULES.md](/Users/samirusani/Desktop/Codex/AliceBot/RULES.md)
+- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md)
+- [.ai/active/SPRINT_PACKET.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/active/SPRINT_PACKET.md)
+- [phase9-product-spec.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/phase9-product-spec.md)
+- [phase9-sprint-33-38-plan.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/phase9-sprint-33-38-plan.md)
+- [phase9-public-core-boundary.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/phase9-public-core-boundary.md)
+
+## Scope
+
+### In Scope
+
+- explicit public-safe package boundary for `alice-core`
+- one canonical local startup flow
+- sample-data fixture or seed path usable by external users
+- install and smoke verification path for recall and resumption
+- repo and docs reshaping needed to support the public-core story
+- ADR capture for public boundary decisions blocking follow-on work
+
+### Out Of Scope
+
+- CLI command implementation
+- MCP server implementation
+- OpenClaw adapter implementation
+- hosted deployment modes
+- broad connector writes
+- repo-wide restructure unrelated to public packaging
+
+## Workstreams
+
+### Workstream 1: Public Boundary and Packaging
+
+Owner:
+- platform/package owner
+
+Primary outcome:
+- public-facing package boundary is explicit enough that later CLI and MCP work can target stable seams
+
+Likely files:
+- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md)
+- [PRODUCT_BRIEF.md](/Users/samirusani/Desktop/Codex/AliceBot/PRODUCT_BRIEF.md)
+- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md)
+- [pyproject.toml](/Users/samirusani/Desktop/Codex/AliceBot/pyproject.toml)
+- [docker-compose.yml](/Users/samirusani/Desktop/Codex/AliceBot/docker-compose.yml)
+- [LICENSE](/Users/samirusani/Desktop/Codex/AliceBot/LICENSE)
+- [docs/phase9-public-core-boundary.md](/Users/samirusani/Desktop/Codex/AliceBot/docs/phase9-public-core-boundary.md)
+
+Tasks:
+- define what is in `alice-core` versus still internal
+- define required runtime assumptions for v0.1
+- confirm one supported local startup path
+- capture any blocking public packaging decision as an ADR or explicit deferred item
+
+Acceptance checks:
+- public boundary is documented without relying on internal tribal knowledge
+- no canonical doc implies unsupported public surfaces are already shipped
+- boundary is narrow enough that `P9-S34` and `P9-S35` have stable targets
+
+### Workstream 2: Startup Path and Sample Data
+
+Owner:
+- backend/runtime owner
+
+Primary outcome:
+- external user can stand up the system from scratch and load usable sample data
+
+Likely files:
+- [.env.example](/Users/samirusani/Desktop/Codex/AliceBot/.env.example)
+- [scripts/migrate.sh](/Users/samirusani/Desktop/Codex/AliceBot/scripts/migrate.sh)
+- [scripts/api_dev.sh](/Users/samirusani/Desktop/Codex/AliceBot/scripts/api_dev.sh)
+- [scripts/dev_up.sh](/Users/samirusani/Desktop/Codex/AliceBot/scripts/dev_up.sh)
+- `fixtures/` or equivalent sample-data location
+- relevant API bootstrap/seed helpers under `apps/api` or `scripts`
+
+Tasks:
+- ensure sample-data path is deterministic and documented
+- ensure startup scripts and env defaults match docs
+- verify recall and resumption can run against the sample dataset
+- remove ambiguity between internal-only and public setup steps
+
+Acceptance checks:
+- clean-machine setup path is executable end to end
+- sample dataset is available or loadable from a single documented flow
+- one recall example and one resumption example work from the documented setup
+
+### Workstream 3: Docs and External Onboarding
+
+Owner:
+- docs/integration owner
+
+Primary outcome:
+- repo onboarding works for an external technical user without prior Alice context
+
+Likely files:
+- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md)
+- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md)
+- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md)
+- new quickstart docs if introduced under `docs/quickstart/`
+
+Tasks:
+- keep README onboarding-focused
+- ensure current state remains factual about shipped versus targeted surfaces
+- make roadmap sequencing consistent with packaging-first execution
+- add any missing quickstart examples needed to close the install gap
+
+Acceptance checks:
+- README supports install, basic verification, and repo orientation only
+- CURRENT_STATE reflects post-Phase-8 shipped truth and pre-Phase-9 packaging gaps
+- roadmap and sprint packet do not drift on current milestone or next move
+
+### Workstream 4: Integration Review
+
+Owner:
+- sprint integrator
+
+Primary outcome:
+- sprint lands as one coherent package rather than disconnected doc and setup edits
+
+Tasks:
+- verify doc, runtime, and sample-data paths agree
+- verify any new ADRs match the canonical docs
+- verify no sprint work quietly expands scope into CLI, MCP, or OpenClaw delivery
+- prepare final evidence notes for review
+
+Acceptance checks:
+- all changed docs point to the same Phase 9 contract
+- no conflicting startup commands remain in canonical docs
+- sprint review can validate scope directly from changed files
+
+## Required Commands
+
+Minimum verification expected before review:
+
+```bash
+docker compose up -d
+./scripts/migrate.sh
+./scripts/api_dev.sh
+curl -sS http://127.0.0.1:8000/healthz
+./.venv/bin/python -m pytest tests/unit tests/integration
+pnpm --dir apps/web test
+```
+
+If a dedicated sample-data or smoke command is added this sprint, include it in the review evidence and README.
+
+`P9-S33` sample-data command:
+
+```bash
+./scripts/load_sample_data.sh
+```
+
+## Required Acceptance Evidence
+
+- exact startup path used during verification
+- exact sample-data load path used during verification
+- one successful recall example
+- one successful resumption example
+- note of any deferred public-boundary decision moved into ADRs
+
+## Docs To Update
+
+- [README.md](/Users/samirusani/Desktop/Codex/AliceBot/README.md)
+- [ARCHITECTURE.md](/Users/samirusani/Desktop/Codex/AliceBot/ARCHITECTURE.md)
+- [ROADMAP.md](/Users/samirusani/Desktop/Codex/AliceBot/ROADMAP.md)
+- [.ai/handoff/CURRENT_STATE.md](/Users/samirusani/Desktop/Codex/AliceBot/.ai/handoff/CURRENT_STATE.md)
+- any new quickstart or packaging docs introduced in-sprint
+- ADRs for blocking packaging decisions
+
+## Definition Of Done
+
+Sprint 33 is done when:
+
+- the repo has one canonical public-core startup path
+- sample data is available for immediate technical evaluation
+- recall and resumption can be demonstrated from public-facing docs
+- the public package boundary is explicit enough that Sprint 34 can implement CLI work without reopening core packaging ambiguity

--- a/fixtures/public_sample_data/continuity_v1.json
+++ b/fixtures/public_sample_data/continuity_v1.json
@@ -1,0 +1,94 @@
+{
+  "fixture_id": "public-core-s33-continuity-v1",
+  "description": "Deterministic continuity fixture for public-core quickstart recall and resumption checks.",
+  "user": {
+    "email": "public-sample@example.com",
+    "display_name": "Public Sample User"
+  },
+  "objects": [
+    {
+      "raw_content": "Decision: Keep Alice local-first for public v0.1 packaging.",
+      "explicit_signal": "decision",
+      "object_type": "Decision",
+      "status": "active",
+      "title": "Decision: Keep Alice local-first for public v0.1 packaging.",
+      "body": {
+        "decision_text": "Keep Alice local-first for public v0.1 packaging."
+      },
+      "confidence": 0.98,
+      "provenance": {
+        "thread_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "task_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "project": "Alice Public Core",
+        "person": "Platform Team",
+        "source_event_ids": [
+          "sample-event-0001"
+        ],
+        "confirmation_status": "confirmed"
+      }
+    },
+    {
+      "raw_content": "Task: Publish public-core packaging docs and startup path.",
+      "explicit_signal": "task",
+      "object_type": "NextAction",
+      "status": "active",
+      "title": "Next Action: Publish public-core packaging docs and startup path.",
+      "body": {
+        "action_text": "Publish public-core packaging docs and startup path."
+      },
+      "confidence": 0.94,
+      "provenance": {
+        "thread_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "task_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "project": "Alice Public Core",
+        "person": "Docs Owner",
+        "source_event_ids": [
+          "sample-event-0002"
+        ],
+        "confirmation_status": "confirmed"
+      }
+    },
+    {
+      "raw_content": "Waiting for: reviewer PASS and merge approval from Control Tower.",
+      "explicit_signal": "waiting_for",
+      "object_type": "WaitingFor",
+      "status": "active",
+      "title": "Waiting For: reviewer PASS and merge approval from Control Tower.",
+      "body": {
+        "waiting_for_text": "Reviewer PASS and merge approval from Control Tower."
+      },
+      "confidence": 0.91,
+      "provenance": {
+        "thread_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "task_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "project": "Alice Public Core",
+        "person": "Control Tower",
+        "source_event_ids": [
+          "sample-event-0003"
+        ],
+        "confirmation_status": "unconfirmed"
+      }
+    },
+    {
+      "raw_content": "Commitment: publish the public-core bootstrap packet.",
+      "explicit_signal": "commitment",
+      "object_type": "Commitment",
+      "status": "completed",
+      "title": "Commitment: Publish the public-core bootstrap packet.",
+      "body": {
+        "commitment_text": "Publish the public-core bootstrap packet."
+      },
+      "confidence": 0.88,
+      "provenance": {
+        "thread_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "task_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "project": "Alice Public Core",
+        "person": "Program Lead",
+        "source_event_ids": [
+          "sample-event-0004"
+        ],
+        "confirmation_status": "confirmed"
+      }
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=69", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "alicebot-foundation"
+name = "alice-core"
 version = "0.1.0"
-description = "Foundation scaffold for the AliceBot modular monolith."
+description = "Public-safe Alice core package for local memory and continuity workflows."
 requires-python = ">=3.12"
 dependencies = [
   "alembic>=1.14,<2.0",
@@ -29,4 +29,3 @@ where = ["apps/api/src", "workers"]
 [tool.pytest.ini_options]
 pythonpath = ["apps/api/src", "workers"]
 testpaths = ["tests"]
-

--- a/scripts/api_dev.sh
+++ b/scripts/api_dev.sh
@@ -5,9 +5,43 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
 if [ -f "${REPO_ROOT}/.env" ]; then
+  PRESERVE_ENV_KEYS=(
+    APP_ENV
+    APP_HOST
+    APP_PORT
+    APP_RELOAD
+    DATABASE_URL
+    DATABASE_ADMIN_URL
+    REDIS_URL
+    S3_ENDPOINT_URL
+    S3_ACCESS_KEY
+    S3_SECRET_KEY
+    S3_BUCKET
+    HEALTHCHECK_TIMEOUT_SECONDS
+    TASK_WORKSPACE_ROOT
+    ALICEBOT_AUTH_USER_ID
+    PUBLIC_SAMPLE_DATA_PATH
+    RESPONSE_RATE_LIMIT_WINDOW_SECONDS
+    RESPONSE_RATE_LIMIT_MAX_REQUESTS
+  )
+
+  for key in "${PRESERVE_ENV_KEYS[@]}"; do
+    if [ "${!key+x}" = "x" ]; then
+      export "__PRESERVE_${key}=${!key}"
+    fi
+  done
+
   set -a
   . "${REPO_ROOT}/.env"
   set +a
+
+  for key in "${PRESERVE_ENV_KEYS[@]}"; do
+    preserve_key="__PRESERVE_${key}"
+    if [ "${!preserve_key+x}" = "x" ]; then
+      export "${key}=${!preserve_key}"
+      unset "${preserve_key}"
+    fi
+  done
 fi
 
 PYTHON_BIN="python3"

--- a/scripts/load_public_sample_data.py
+++ b/scripts/load_public_sample_data.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+from uuid import UUID
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+API_SRC = REPO_ROOT / "apps" / "api" / "src"
+if str(API_SRC) not in sys.path:
+    sys.path.insert(0, str(API_SRC))
+
+from alicebot_api.db import user_connection
+from alicebot_api.store import ContinuityStore
+
+
+DEFAULT_DATABASE_URL = "postgresql://alicebot_app:alicebot_app@localhost:5432/alicebot"
+DEFAULT_AUTH_USER_ID = "00000000-0000-0000-0000-000000000001"
+DEFAULT_FIXTURE_PATH = REPO_ROOT / "fixtures" / "public_sample_data" / "continuity_v1.json"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Load deterministic public-core sample continuity data."
+    )
+    parser.add_argument(
+        "--fixture",
+        default=os.getenv("PUBLIC_SAMPLE_DATA_PATH", str(DEFAULT_FIXTURE_PATH)),
+        help="Path to a sample-data fixture JSON file.",
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("DATABASE_URL", DEFAULT_DATABASE_URL),
+        help="Database URL used for writes.",
+    )
+    parser.add_argument(
+        "--user-id",
+        default=os.getenv("ALICEBOT_AUTH_USER_ID", DEFAULT_AUTH_USER_ID),
+        help="User ID to own the sample data.",
+    )
+    return parser.parse_args()
+
+
+def _load_fixture(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"fixture file not found: {path}")
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("fixture root must be a JSON object")
+    if not isinstance(payload.get("fixture_id"), str) or payload["fixture_id"].strip() == "":
+        raise ValueError("fixture_id must be a non-empty string")
+    if not isinstance(payload.get("objects"), list) or len(payload["objects"]) == 0:
+        raise ValueError("objects must be a non-empty list")
+    return payload
+
+
+def _ensure_user(store: ContinuityStore, *, user_id: UUID, email: str, display_name: str) -> None:
+    with store.conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM users WHERE id = %s", (user_id,))
+        exists = cur.fetchone() is not None
+    if exists:
+        return
+    store.create_user(user_id, email, display_name)
+
+
+def _already_seeded(store: ContinuityStore, *, fixture_id: str) -> bool:
+    for row in store.list_continuity_recall_candidates():
+        provenance = row["provenance"]
+        if isinstance(provenance, dict) and provenance.get("sample_fixture") == fixture_id:
+            return True
+    return False
+
+
+def _seed_fixture(
+    store: ContinuityStore,
+    *,
+    fixture: dict[str, Any],
+) -> int:
+    fixture_id = str(fixture["fixture_id"])
+    created = 0
+
+    for item in fixture["objects"]:
+        if not isinstance(item, dict):
+            raise ValueError("each fixture object entry must be a JSON object")
+
+        raw_content = str(item["raw_content"])
+        explicit_signal = item.get("explicit_signal")
+        object_type = str(item["object_type"])
+        status = str(item["status"])
+        title = str(item["title"])
+        body = item["body"]
+        confidence = float(item.get("confidence", 0.9))
+        provenance = dict(item.get("provenance", {}))
+
+        provenance["sample_fixture"] = fixture_id
+        provenance["source_kind"] = "public_sample_fixture"
+
+        capture = store.create_continuity_capture_event(
+            raw_content=raw_content,
+            explicit_signal=explicit_signal,
+            admission_posture="DERIVED",
+            admission_reason=f"sample_fixture_{fixture_id}",
+        )
+
+        store.create_continuity_object(
+            capture_event_id=capture["id"],
+            object_type=object_type,
+            status=status,
+            title=title,
+            body=body,
+            provenance=provenance,
+            confidence=confidence,
+        )
+        created += 1
+
+    return created
+
+
+def main() -> int:
+    args = _parse_args()
+    fixture_path = Path(args.fixture)
+    fixture = _load_fixture(fixture_path)
+    fixture_id = str(fixture["fixture_id"])
+    user_id = UUID(str(args.user_id))
+
+    fixture_user = fixture.get("user") if isinstance(fixture.get("user"), dict) else {}
+    email = str(fixture_user.get("email", "public-sample@example.com"))
+    display_name = str(fixture_user.get("display_name", "Public Sample User"))
+
+    with user_connection(args.database_url, user_id) as conn:
+        store = ContinuityStore(conn)
+        _ensure_user(store, user_id=user_id, email=email, display_name=display_name)
+
+        if _already_seeded(store, fixture_id=fixture_id):
+            print(
+                json.dumps(
+                    {
+                        "status": "noop",
+                        "reason": "fixture_already_loaded",
+                        "fixture_id": fixture_id,
+                        "user_id": str(user_id),
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return 0
+
+        created_count = _seed_fixture(store, fixture=fixture)
+
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "fixture_id": fixture_id,
+                "user_id": str(user_id),
+                "created_object_count": created_count,
+                "fixture_path": str(fixture_path),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/load_sample_data.sh
+++ b/scripts/load_sample_data.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${REPO_ROOT}/.env" ]; then
+  set -a
+  . "${REPO_ROOT}/.env"
+  set +a
+fi
+
+PYTHON_BIN="python3"
+if [ -x "${REPO_ROOT}/.venv/bin/python" ]; then
+  PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+fi
+
+cd "${REPO_ROOT}"
+
+exec "${PYTHON_BIN}" "${REPO_ROOT}/scripts/load_public_sample_data.py" "$@"

--- a/tests/integration/test_explicit_preferences_api.py
+++ b/tests/integration/test_explicit_preferences_api.py
@@ -209,6 +209,7 @@ def test_extract_explicit_preferences_endpoint_admits_supported_candidates_and_p
     assert [revision["action"] for revision in revisions] == ["ADD", "UPDATE"]
     assert revisions[0]["candidate"] == {
         "memory_key": memory_key,
+        "agent_profile_id": "assistant_default",
         "value": {
             "kind": "explicit_preference",
             "preference": "like",
@@ -219,6 +220,7 @@ def test_extract_explicit_preferences_endpoint_admits_supported_candidates_and_p
     }
     assert revisions[1]["candidate"] == {
         "memory_key": memory_key,
+        "agent_profile_id": "assistant_default",
         "value": {
             "kind": "explicit_preference",
             "preference": "dislike",

--- a/tests/unit/test_approval_store.py
+++ b/tests/unit/test_approval_store.py
@@ -44,6 +44,7 @@ def test_approval_store_methods_use_expected_queries_and_jsonb_parameters() -> N
     approval_id = uuid4()
     thread_id = uuid4()
     tool_id = uuid4()
+    task_run_id = None
     task_step_id = uuid4()
     routing_trace_id = uuid4()
     resolved_by_user_id = uuid4()
@@ -53,6 +54,7 @@ def test_approval_store_methods_use_expected_queries_and_jsonb_parameters() -> N
                 "id": approval_id,
                 "thread_id": thread_id,
                 "tool_id": tool_id,
+                "task_run_id": task_run_id,
                 "task_step_id": task_step_id,
                 "status": "pending",
                 "request": {"thread_id": str(thread_id), "tool_id": str(tool_id)},
@@ -66,6 +68,7 @@ def test_approval_store_methods_use_expected_queries_and_jsonb_parameters() -> N
                 "id": approval_id,
                 "thread_id": thread_id,
                 "tool_id": tool_id,
+                "task_run_id": task_run_id,
                 "task_step_id": task_step_id,
                 "status": "pending",
                 "request": {"thread_id": str(thread_id), "tool_id": str(tool_id)},
@@ -79,6 +82,7 @@ def test_approval_store_methods_use_expected_queries_and_jsonb_parameters() -> N
                 "id": approval_id,
                 "thread_id": thread_id,
                 "tool_id": tool_id,
+                "task_run_id": task_run_id,
                 "task_step_id": task_step_id,
                 "status": "approved",
                 "request": {"thread_id": str(thread_id), "tool_id": str(tool_id)},
@@ -94,6 +98,7 @@ def test_approval_store_methods_use_expected_queries_and_jsonb_parameters() -> N
                 "id": approval_id,
                 "thread_id": thread_id,
                 "tool_id": tool_id,
+                "task_run_id": task_run_id,
                 "task_step_id": task_step_id,
                 "status": "pending",
                 "request": {"thread_id": str(thread_id), "tool_id": str(tool_id)},
@@ -131,17 +136,17 @@ def test_approval_store_methods_use_expected_queries_and_jsonb_parameters() -> N
     create_query, create_params = cursor.executed[0]
     assert "INSERT INTO approvals" in create_query
     assert create_params is not None
-    assert create_params[:4] == (thread_id, tool_id, task_step_id, "pending")
-    assert isinstance(create_params[4], Jsonb)
-    assert create_params[4].obj == {"thread_id": str(thread_id), "tool_id": str(tool_id)}
+    assert create_params[:5] == (thread_id, tool_id, task_run_id, task_step_id, "pending")
     assert isinstance(create_params[5], Jsonb)
-    assert create_params[5].obj == {"id": str(tool_id), "tool_key": "shell.exec"}
+    assert create_params[5].obj == {"thread_id": str(thread_id), "tool_id": str(tool_id)}
     assert isinstance(create_params[6], Jsonb)
-    assert create_params[6].obj == {
+    assert create_params[6].obj == {"id": str(tool_id), "tool_key": "shell.exec"}
+    assert isinstance(create_params[7], Jsonb)
+    assert create_params[7].obj == {
         "decision": "approval_required",
         "trace": {"trace_id": str(routing_trace_id)},
     }
-    assert create_params[7] == routing_trace_id
+    assert create_params[8] == routing_trace_id
     assert "resolved_at" in cursor.executed[1][0]
     assert "ORDER BY created_at ASC, id ASC" in cursor.executed[2][0]
 

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -1319,6 +1319,7 @@ def test_compile_memory_section_orders_limits_and_excludes_deleted() -> None:
     memory_section = _compile_memory_section(
         store,  # type: ignore[arg-type]
         memories=[deleted_memory],
+        agent_profile_id="assistant_default",
         limits=ContextCompilerLimits(max_memories=1),
         semantic_retrieval=CompileContextSemanticRetrievalInput(
             embedding_config_id=store.config_id,

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -94,6 +94,7 @@ def test_entity_methods_use_expected_queries_and_deterministic_order() -> None:
                 SELECT
                   id,
                   user_id,
+                  agent_profile_id,
                   memory_key,
                   value,
                   status,

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -16,6 +16,15 @@ class ContinuityApiStoreStub:
     def __init__(self, *, current_user_id: UUID) -> None:
         self.current_user_id = current_user_id
         self.base_time = datetime(2026, 3, 17, 9, 0, tzinfo=UTC)
+        self.agent_profiles = [
+            {
+                "id": "assistant_default",
+                "name": "Assistant Default",
+                "description": "Default profile for tests",
+                "model_provider": None,
+                "model_name": None,
+            }
+        ]
         self.threads: list[dict[str, object]] = []
         self.sessions: list[dict[str, object]] = []
         self.events: list[dict[str, object]] = []
@@ -26,6 +35,7 @@ class ContinuityApiStoreStub:
         thread_id: UUID,
         user_id: UUID,
         title: str,
+        agent_profile_id: str = "assistant_default",
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
     ) -> dict[str, object]:
@@ -33,6 +43,7 @@ class ContinuityApiStoreStub:
             "id": thread_id,
             "user_id": user_id,
             "title": title,
+            "agent_profile_id": agent_profile_id,
             "created_at": created_at or self.base_time,
             "updated_at": updated_at or created_at or self.base_time,
         }
@@ -87,12 +98,13 @@ class ContinuityApiStoreStub:
         self.events.append(event)
         return event
 
-    def create_thread(self, title: str) -> dict[str, object]:
+    def create_thread(self, title: str, agent_profile_id: str = "assistant_default") -> dict[str, object]:
         created_at = self.base_time + timedelta(minutes=len(self.threads))
         return self.add_thread(
             thread_id=uuid4(),
             user_id=self.current_user_id,
             title=title,
+            agent_profile_id=agent_profile_id,
             created_at=created_at,
             updated_at=created_at,
         )
@@ -105,6 +117,15 @@ class ContinuityApiStoreStub:
 
     def get_thread_optional(self, thread_id: UUID) -> dict[str, object] | None:
         return next((thread for thread in self.list_threads() if thread["id"] == thread_id), None)
+
+    def list_agent_profiles(self) -> list[dict[str, object]]:
+        return list(self.agent_profiles)
+
+    def get_agent_profile_optional(self, profile_id: str) -> dict[str, object] | None:
+        return next(
+            (profile for profile in self.agent_profiles if profile["id"] == profile_id),
+            None,
+        )
 
     def list_thread_sessions(self, thread_id: UUID) -> list[dict[str, object]]:
         visible_sessions = [
@@ -180,6 +201,7 @@ def test_thread_create_endpoint_persists_one_visible_thread(monkeypatch: pytest.
         "thread": {
             "id": json.loads(response.body)["thread"]["id"],
             "title": "Operator Inbox",
+            "agent_profile_id": "assistant_default",
             "created_at": "2026-03-17T09:00:00+00:00",
             "updated_at": "2026-03-17T09:00:00+00:00",
         }
@@ -268,12 +290,14 @@ def test_thread_review_endpoints_preserve_shape_order_and_user_isolation(
             {
                 "id": str(second_thread["id"]),
                 "title": "Beta thread",
+                "agent_profile_id": "assistant_default",
                 "created_at": shared_created_at.isoformat(),
                 "updated_at": shared_created_at.isoformat(),
             },
             {
                 "id": str(first_thread["id"]),
                 "title": "Alpha thread",
+                "agent_profile_id": "assistant_default",
                 "created_at": shared_created_at.isoformat(),
                 "updated_at": shared_created_at.isoformat(),
             },
@@ -287,6 +311,7 @@ def test_thread_review_endpoints_preserve_shape_order_and_user_isolation(
         "thread": {
             "id": str(second_thread["id"]),
             "title": "Beta thread",
+            "agent_profile_id": "assistant_default",
             "created_at": shared_created_at.isoformat(),
             "updated_at": shared_created_at.isoformat(),
         }

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -47,7 +47,7 @@ def test_create_methods_return_cursor_rows_and_use_expected_parameters() -> None
     cursor = RecordingCursor(
         fetchone_results=[
             {"id": user_id, "email": "owner@example.com", "display_name": "Owner"},
-            {"id": thread_id, "title": "Starter thread"},
+            {"id": thread_id, "title": "Starter thread", "agent_profile_id": "assistant_default"},
             {"id": uuid4(), "thread_id": thread_id, "status": "active"},
         ]
     )
@@ -71,11 +71,11 @@ def test_create_methods_return_cursor_rows_and_use_expected_parameters() -> None
         ),
         (
             """
-                INSERT INTO threads (user_id, title)
-                VALUES (app.current_user_id(), %s)
-                RETURNING id, user_id, title, created_at, updated_at
+                INSERT INTO threads (user_id, title, agent_profile_id)
+                VALUES (app.current_user_id(), %s, %s)
+                RETURNING id, user_id, title, agent_profile_id, created_at, updated_at
                 """,
-            ("Starter thread",),
+            ("Starter thread", "assistant_default"),
         ),
         (
             """

--- a/tests/unit/test_task_run_store.py
+++ b/tests/unit/test_task_run_store.py
@@ -52,7 +52,12 @@ def test_task_run_store_methods_use_expected_queries_and_jsonb_parameters() -> N
         "tick_count": 0,
         "step_count": 0,
         "max_ticks": 2,
+        "retry_count": 0,
+        "retry_cap": 3,
+        "retry_posture": "none",
+        "failure_class": None,
         "stop_reason": None,
+        "last_transitioned_at": "2026-03-27T10:00:00+00:00",
         "created_at": "2026-03-27T10:00:00+00:00",
         "updated_at": "2026-03-27T10:00:00+00:00",
     }
@@ -74,6 +79,10 @@ def test_task_run_store_methods_use_expected_queries_and_jsonb_parameters() -> N
         tick_count=0,
         step_count=0,
         max_ticks=2,
+        retry_count=0,
+        retry_cap=3,
+        retry_posture="none",
+        failure_class=None,
         stop_reason=None,
     )
     fetched = store.get_task_run_optional(task_run_id)
@@ -84,6 +93,10 @@ def test_task_run_store_methods_use_expected_queries_and_jsonb_parameters() -> N
         checkpoint={"cursor": 1, "target_steps": 2, "wait_for_signal": False},
         tick_count=1,
         step_count=1,
+        retry_count=0,
+        retry_cap=3,
+        retry_posture="none",
+        failure_class=None,
         stop_reason=None,
     )
     acquired = store.acquire_next_task_run_optional()
@@ -104,7 +117,7 @@ def test_task_run_store_methods_use_expected_queries_and_jsonb_parameters() -> N
     assert create_params[1] == "queued"
     assert isinstance(create_params[2], Jsonb)
     assert create_params[2].obj == {"cursor": 0, "target_steps": 2, "wait_for_signal": False}
-    assert create_params[3:] == (0, 0, 2, None)
+    assert create_params[3:] == (0, 0, 2, 0, 3, "none", None, None)
 
     assert "FROM task_runs" in cursor.executed[1][0]
     assert "ORDER BY created_at ASC, id ASC" in cursor.executed[2][0]
@@ -115,7 +128,7 @@ def test_task_run_store_methods_use_expected_queries_and_jsonb_parameters() -> N
     assert update_params[0] == "running"
     assert isinstance(update_params[1], Jsonb)
     assert update_params[1].obj == {"cursor": 1, "target_steps": 2, "wait_for_signal": False}
-    assert update_params[2:] == (1, 1, None, task_run_id)
+    assert update_params[2:] == (1, 1, 0, 3, "none", None, None, task_run_id)
 
     acquire_query, acquire_params = cursor.executed[4]
     assert "WITH candidate AS" in acquire_query

--- a/tests/unit/test_tool_execution_store.py
+++ b/tests/unit/test_tool_execution_store.py
@@ -52,6 +52,7 @@ def test_tool_execution_store_methods_use_expected_queries_and_jsonb_parameters(
     row = {
         "id": execution_id,
         "approval_id": approval_id,
+        "task_run_id": None,
         "task_step_id": task_step_id,
         "thread_id": thread_id,
         "tool_id": tool_id,
@@ -60,6 +61,7 @@ def test_tool_execution_store_methods_use_expected_queries_and_jsonb_parameters(
         "result_event_id": result_event_id,
         "status": "completed",
         "handler_key": "proxy.echo",
+        "idempotency_key": None,
         "request": {"thread_id": str(thread_id), "tool_id": str(tool_id)},
         "tool": {"id": str(tool_id), "tool_key": "proxy.echo"},
         "result": {"handler_key": "proxy.echo", "status": "completed", "output": {"mode": "no_side_effect"}, "reason": None},
@@ -96,8 +98,9 @@ def test_tool_execution_store_methods_use_expected_queries_and_jsonb_parameters(
     create_query, create_params = cursor.executed[0]
     assert "INSERT INTO tool_executions" in create_query
     assert create_params is not None
-    assert create_params[:9] == (
+    assert create_params[:11] == (
         approval_id,
+        None,
         task_step_id,
         thread_id,
         tool_id,
@@ -106,13 +109,14 @@ def test_tool_execution_store_methods_use_expected_queries_and_jsonb_parameters(
         result_event_id,
         "completed",
         "proxy.echo",
+        None,
     )
-    assert isinstance(create_params[9], Jsonb)
-    assert create_params[9].obj == {"thread_id": str(thread_id), "tool_id": str(tool_id)}
-    assert isinstance(create_params[10], Jsonb)
-    assert create_params[10].obj == {"id": str(tool_id), "tool_key": "proxy.echo"}
     assert isinstance(create_params[11], Jsonb)
-    assert create_params[11].obj == {
+    assert create_params[11].obj == {"thread_id": str(thread_id), "tool_id": str(tool_id)}
+    assert isinstance(create_params[12], Jsonb)
+    assert create_params[12].obj == {"id": str(tool_id), "tool_key": "proxy.echo"}
+    assert isinstance(create_params[13], Jsonb)
+    assert create_params[13].obj == {
         "handler_key": "proxy.echo",
         "status": "completed",
         "output": {"mode": "no_side_effect"},
@@ -134,6 +138,7 @@ def test_create_tool_execution_accepts_blocked_attempt_without_event_ids() -> No
             {
                 "id": execution_id,
                 "approval_id": approval_id,
+                "task_run_id": None,
                 "task_step_id": task_step_id,
                 "thread_id": thread_id,
                 "tool_id": tool_id,
@@ -142,6 +147,7 @@ def test_create_tool_execution_accepts_blocked_attempt_without_event_ids() -> No
                 "result_event_id": None,
                 "status": "blocked",
                 "handler_key": None,
+                "idempotency_key": None,
                 "request": {"thread_id": str(thread_id), "tool_id": str(tool_id)},
                 "tool": {"id": str(tool_id), "tool_key": "proxy.missing"},
                 "result": {
@@ -180,6 +186,7 @@ def test_create_tool_execution_accepts_blocked_attempt_without_event_ids() -> No
     create_query, create_params = cursor.executed[0]
     assert "INSERT INTO tool_executions" in create_query
     assert create_params is not None
-    assert create_params[5] is None
+    assert create_params[1] is None
     assert create_params[6] is None
-    assert create_params[8] is None
+    assert create_params[7] is None
+    assert create_params[9] is None

--- a/tests/unit/test_trace_store.py
+++ b/tests/unit/test_trace_store.py
@@ -49,7 +49,7 @@ def test_trace_methods_use_expected_queries_and_payload_serialization() -> None:
     cursor = RecordingCursor(
         fetchone_results=[
             {"id": user_id, "email": "owner@example.com", "display_name": "Owner"},
-            {"id": thread_id, "user_id": user_id, "title": "Thread"},
+            {"id": thread_id, "user_id": user_id, "title": "Thread", "agent_profile_id": "assistant_default"},
             {"id": trace_id, "user_id": user_id, "thread_id": thread_id, "kind": "context.compile"},
             {
                 "id": uuid4(),
@@ -100,7 +100,7 @@ def test_trace_methods_use_expected_queries_and_payload_serialization() -> None:
     )
     assert cursor.executed[1] == (
         """
-                SELECT id, user_id, title, created_at, updated_at
+                SELECT id, user_id, title, agent_profile_id, created_at, updated_at
                 FROM threads
                 WHERE id = %s
                 """,


### PR DESCRIPTION
## Summary
- define the public alice-core packaging boundary and runtime baseline
- add deterministic sample-data loading plus recall/resumption proof paths
- align public docs, ADRs, and verification gates for the P9-S33 install flow

## Validation
- docker compose up -d
- ./scripts/migrate.sh
- ./scripts/load_sample_data.sh
- ./scripts/api_dev.sh
- curl -sS http://127.0.0.1:8000/healthz
- curl -sS "http://127.0.0.1:8000/v0/continuity/recall?user_id=00000000-0000-0000-0000-000000000001&query=local-first"
- curl -sS "http://127.0.0.1:8000/v0/continuity/resumption-brief?user_id=00000000-0000-0000-0000-000000000001"
- ./.venv/bin/python -m pytest tests/unit tests/integration -q
- pnpm --dir apps/web test