### PR TITLE
P9-S34: CLI and continuity UX

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -2,7 +2,7 @@
 
 ## Sprint Title
 
-Phase 9 Sprint 33 (P9-S33): Public Core Packaging
+Phase 9 Sprint 34 (P9-S34): CLI and Continuity UX
 
 ## Sprint Type
 
@@ -10,7 +10,7 @@ feature
 
 ## Sprint Reason
 
-Phase 8 is complete. The next non-redundant seam is converting the internal Alice system into a public-safe, installable core with one documented local startup path, explicit package boundaries, and sample data that proves recall and resumption from public docs.
+`P9-S33` established the public-safe `alice-core` package boundary, one canonical local startup path, and deterministic sample data. The next non-redundant seam is a real local CLI so technical users can use Alice without the internal operator shell.
 
 ## Planning Anchors
 
@@ -18,27 +18,26 @@ Phase 8 is complete. The next non-redundant seam is converting the internal Alic
 - `docs/phase9-sprint-33-38-plan.md`
 - `docs/phase9-public-core-boundary.md`
 - `docs/phase9-bootstrap-notes.md`
-- `docs/phase9-sprint-33-control-tower-packet.md`
 - `docs/adr/ADR-001-public-core-package-boundary.md`
 - `docs/adr/ADR-002-public-runtime-baseline.md`
 - `docs/adr/ADR-003-mcp-tool-surface-contract.md`
 
 ## Sprint Objective
 
-Package the existing Alice substrate so an external technical user can install it locally, load sample data, and complete one recall flow and one resumption flow from canonical docs without internal project context.
+Ship a deterministic local CLI for core continuity flows so an external technical user can run capture, recall, resume, open-loop review, correction, and status commands directly against the shipped `alice-core` runtime.
 
 ## Git Instructions
 
-- Branch Name: `codex/phase9-sprint-33-public-core-packaging`
+- Branch Name: `codex/phase9-sprint-34-cli-and-continuity-ux`
 - Base Branch: `main`
 - PR Strategy: one sprint branch, one PR
 - Merge Policy: squash merge only after reviewer `PASS` and explicit Control Tower merge approval
 
 ## Why This Sprint Matters
 
-- It is the first real public-product step of Phase 9.
-- It creates the stable package/runtime boundary that `P9-S34` CLI and `P9-S35` MCP depend on.
-- It forces docs, scripts, config, and sample data to match one real install path instead of internal assumptions.
+- It is the first real user-facing runtime surface on top of the public core.
+- It proves `alice-core` can be used directly by technical users before MCP arrives.
+- It gives `P9-S35` a stable behavior contract to mirror instead of inventing a second UX path.
 
 ## Redundancy Guard
 
@@ -48,106 +47,100 @@ Package the existing Alice substrate so an external technical user can install i
   - Phase 6 trust-calibrated memory-quality and retrieval posture.
   - Phase 7 chief-of-staff guidance layer.
   - Phase 8 operational chief-of-staff handoff, queue, routing, and outcome-learning seams.
-- Required now (`P9-S33`):
-  - explicit public-safe `alice-core` package boundary
-  - one canonical local startup path
-  - sample-data path for external technical evaluation
-  - public-facing repo/docs reshaping for install + first recall/resume proof
-- Explicitly out of `P9-S33`:
-  - CLI command implementation
+  - `P9-S33` public-safe packaging, startup path, and sample-data baseline.
+- Required now (`P9-S34`):
+  - deterministic CLI entrypoint for local Alice usage
+  - continuity command surface for capture/recall/resume/open loops/review/correction/status
+  - terminal-friendly output with provenance-backed summaries
+  - doc-matched CLI examples against the `P9-S33` local runtime path
+- Explicitly out of `P9-S34`:
   - MCP server implementation
   - OpenClaw adapter implementation
-  - broad importer work beyond sample-data support
-  - hosted SaaS, channel work, or unsafe autonomous execution
+  - importer expansion beyond the shipped sample-data path
+  - hosted SaaS, remote auth, or unsafe autonomous execution
+  - reworking `P9-S33` packaging/runtime contracts unless required for CLI correctness
 
 ## Design Truth
 
-- Alice remains a memory and continuity layer first, not a broad autonomous agent platform.
-- Public packaging must preserve shipped P5/P6/P7/P8 semantics instead of reimplementing them.
-- One documented local startup path is the source of truth for public v0.1.
-- Public docs are product surface in this phase and must match real runtime behavior.
+- Alice remains a local-first memory and continuity engine first.
+- The CLI should reuse shipped core semantics, not fork or reinterpret them.
+- CLI output should be deterministic, readable, and provenance-backed.
+- The CLI is the reference human-operated interface for `P9-S35` MCP parity, not a one-off wrapper.
 
 ## Exact Surfaces In Scope
 
-- public-safe package boundary definition for `alice-core`
-- canonical local startup and install path
-- sample-data fixture/seed path for recall and resumption verification
-- repo and docs reshaping for external technical onboarding
-- ADR capture for any blocking packaging/runtime/license decisions
-- required gate-alignment test updates needed to satisfy the sprint's required verification commands
+- one installable CLI entrypoint under the `alice-core` package
+- local commands for capture, recall, resume, open loops, review queue/detail, correction, and status
+- deterministic terminal formatting for summary and detail views
+- provenance snippets and clear empty states in CLI output
+- doc updates for CLI installation and usage against the shipped local runtime
+- tests covering command routing, output contracts, and correction/resumption behavior
 
 ## Exact Files In Scope
 
-- `README.md`
-- `PRODUCT_BRIEF.md`
-- `ARCHITECTURE.md`
-- `ROADMAP.md`
-- `RULES.md`
-- `.ai/handoff/CURRENT_STATE.md`
 - `.ai/active/SPRINT_PACKET.md`
-- `docs/phase9-product-spec.md`
-- `docs/phase9-sprint-33-38-plan.md`
-- `docs/phase9-public-core-boundary.md`
-- `docs/phase9-bootstrap-notes.md`
-- `docs/phase9-sprint-33-control-tower-packet.md`
-- `docs/adr/ADR-001-public-core-package-boundary.md`
-- `docs/adr/ADR-002-public-runtime-baseline.md`
-- `docs/adr/ADR-003-mcp-tool-surface-contract.md`
-- `.env.example`
-- `docker-compose.yml`
+- `.ai/handoff/CURRENT_STATE.md`
+- `README.md`
+- `ROADMAP.md`
 - `pyproject.toml`
-- `scripts/dev_up.sh`
-- `scripts/migrate.sh`
-- `scripts/api_dev.sh`
-- `apps/web/components/memory-summary.test.tsx`
-- `tests/integration/test_explicit_preferences_api.py`
-- `tests/unit/test_approval_store.py`
-- `tests/unit/test_compiler.py`
-- `tests/unit/test_entity_store.py`
-- `tests/unit/test_events.py`
-- `tests/unit/test_store.py`
-- `tests/unit/test_task_run_store.py`
-- `tests/unit/test_tool_execution_store.py`
-- `tests/unit/test_trace_store.py`
-- `fixtures/` or equivalent sample-data location
-- `LICENSE` if finalized in this sprint
+- `apps/api/src/alicebot_api/__init__.py`
+- `apps/api/src/alicebot_api/__main__.py` if introduced
+- `apps/api/src/alicebot_api/cli.py` if introduced
+- `apps/api/src/alicebot_api/cli_formatting.py` if introduced
+- `apps/api/src/alicebot_api/config.py` if CLI config hooks are needed
+- `apps/api/src/alicebot_api/continuity_capture.py`
+- `apps/api/src/alicebot_api/continuity_recall.py`
+- `apps/api/src/alicebot_api/continuity_resumption.py`
+- `apps/api/src/alicebot_api/continuity_open_loops.py`
+- `apps/api/src/alicebot_api/continuity_review.py`
+- `apps/api/src/alicebot_api/store.py`
+- `scripts/load_sample_data.sh` if CLI smoke setup needs alignment
+- `tests/unit/test_cli.py` if introduced
+- `tests/integration/test_cli_integration.py` if introduced
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 ## In Scope
 
-- Define what is public in `alice-core` versus deferred/internal.
-- Confirm one supported local runtime baseline and startup flow.
-- Ensure env defaults, scripts, and docs all point to the same install path.
-- Provide sample data that an external technical user can load or use immediately.
-- Prove one recall query and one resumption brief from the documented public setup.
-- Capture blocking public-boundary/runtime/tool-surface decisions in ADRs or explicit deferred notes.
+- add a packaged CLI entrypoint that works from the documented local install
+- support command coverage for:
+  - `capture`
+  - `recall`
+  - `resume`
+  - `open-loops`
+  - `review queue`
+  - `review show`
+  - `review apply`
+  - `status`
+- keep terminal output deterministic enough for stable review and MCP follow-on mapping
+- show provenance/confidence/status where it materially affects trust
+- document exact command examples using the `P9-S33` sample dataset
 
 ## Out Of Scope
 
-- CLI command implementation or terminal UX polish
-- MCP server code or tool execution
-- OpenClaw adapter implementation
-- broad repo-wide restructuring unrelated to public packaging
-- broad importer set
-- hosted deployment modes
+- MCP transport or tool schemas
+- OpenClaw or other external adapters
+- broad repo packaging cleanup already handled in `P9-S33`
+- broad TUI work or shell auto-completion polish
+- any execution-autonomy expansion
 
 ## Required Deliverables
 
-- explicit `alice-core` public boundary
-- one canonical local startup path
-- sample-data story usable by external users
-- external-facing README/repo map reshaped for public onboarding
-- ADR-backed decisions for package boundary/runtime/tool-surface blockers
-- synced sprint reports
+- packaged CLI entrypoint callable from a local install
+- command coverage for core continuity flows
+- deterministic text output for recall and resumption
+- correction flow through CLI that updates later retrieval deterministically
+- synced CLI docs and sprint reports
 
 ## Acceptance Criteria
 
-- a fresh local install works from the documented startup path
-- sample data can be loaded or is available for immediate local use
-- one recall query works end to end from the documented setup
-- one resumption brief works end to end from the documented setup
-- public-safe boundaries are written clearly enough that `P9-S34` CLI and `P9-S35` MCP can build on them without reopening packaging ambiguity
+- fresh local install can invoke the CLI from the documented path
+- capture command writes a continuity event against real local data
+- recall command returns deterministic ordered output with provenance snippets
+- resume command returns recent decision, open loops, recent changes, and next action in terminal-friendly form
+- open-loop and review commands expose correction-ready items without needing the internal web shell
+- applying a correction via CLI changes later recall/resume behavior deterministically
+- the CLI contract is narrow and stable enough for `P9-S35` MCP mirroring without reopening core UX semantics
 
 ## Required Commands
 
@@ -156,77 +149,79 @@ Minimum verification expected before review:
 ```bash
 docker compose up -d
 ./scripts/migrate.sh
+./scripts/load_sample_data.sh
 ./scripts/api_dev.sh
 curl -sS http://127.0.0.1:8000/healthz
+./.venv/bin/python -m alicebot_api --help
+./.venv/bin/python -m alicebot_api status
+./.venv/bin/python -m alicebot_api recall --query local-first
+./.venv/bin/python -m alicebot_api resume
 ./.venv/bin/python -m pytest tests/unit tests/integration
 pnpm --dir apps/web test
 ```
 
-If a dedicated seed-data or public smoke command is introduced this sprint, it must also be run and included in review evidence.
+If the CLI is exposed through a console script instead of `python -m alicebot_api`, both invocation forms should be documented and at least one must be included in review evidence.
 
 ## Required Acceptance Evidence
 
-- exact startup path used during verification
-- exact sample-data load path used during verification
+- exact CLI install/invocation path used during verification
+- one successful capture example
 - one successful recall example
 - one successful resumption example
-- note of any deferred public-boundary/runtime/license decision moved into ADRs
+- one successful review/correction example that changes a later retrieval result
+- note of any deferred CLI ergonomics intentionally left for later phases
 
 ## Implementation Constraints
 
-- preserve shipped P5/P6/P7/P8 semantics
-- do not introduce unsafe autonomous execution
-- keep one documented startup flow as the only canonical public path
-- prefer packaging clarity over premature repo-wide restructuring
-- keep public-boundary decisions explicit and narrow
+- preserve shipped P5/P6/P7/P8/P9-S33 semantics
+- do not require the internal web shell for the scoped flows
+- keep CLI output deterministic and reviewable
+- prefer stdlib CLI plumbing over new heavyweight dependencies unless clearly necessary
+- do not widen the public surface beyond what `P9-S35` should inherit
 
 ## Control Tower Task Cards
 
-### Task 1: Public Boundary and Packaging
+### Task 1: CLI Entry and Packaging
 
 Owner: platform/package owner
 
 Write scope:
 
-- `ARCHITECTURE.md`
-- `PRODUCT_BRIEF.md`
-- `README.md`
 - `pyproject.toml`
-- `docker-compose.yml`
-- `LICENSE`
-- `docs/phase9-public-core-boundary.md`
-- `docs/adr/ADR-001-public-core-package-boundary.md`
-- `docs/adr/ADR-002-public-runtime-baseline.md`
-- `docs/adr/ADR-003-mcp-tool-surface-contract.md`
+- `apps/api/src/alicebot_api/__init__.py`
+- `apps/api/src/alicebot_api/__main__.py`
+- `apps/api/src/alicebot_api/cli.py`
+- `apps/api/src/alicebot_api/cli_formatting.py`
 
 Responsibilities:
 
-- define what is in `alice-core` versus deferred/internal
-- define public runtime assumptions for v0.1
-- confirm one supported local startup path
-- capture blocking decisions as ADRs or explicit deferred items
+- define the packaged CLI entrypoint
+- keep invocation local-install friendly
+- keep command tree narrow and deterministic
+- ensure output contracts are stable enough for follow-on MCP mapping
 
-### Task 2: Startup Path and Sample Data
+### Task 2: Continuity Command Wiring
 
 Owner: backend/runtime owner
 
 Write scope:
 
-- `.env.example`
-- `scripts/migrate.sh`
-- `scripts/api_dev.sh`
-- `scripts/dev_up.sh`
-- `fixtures/` or equivalent sample-data location
-- relevant bootstrap/seed helpers under `apps/api` or `scripts`
+- `apps/api/src/alicebot_api/continuity_capture.py`
+- `apps/api/src/alicebot_api/continuity_recall.py`
+- `apps/api/src/alicebot_api/continuity_resumption.py`
+- `apps/api/src/alicebot_api/continuity_open_loops.py`
+- `apps/api/src/alicebot_api/continuity_review.py`
+- `apps/api/src/alicebot_api/store.py`
+- `apps/api/src/alicebot_api/config.py`
 
 Responsibilities:
 
-- ensure sample-data path is deterministic and documented
-- ensure startup scripts and env defaults match docs
-- verify recall and resumption against the sample dataset
-- remove ambiguity between internal-only and public setup steps
+- wire core continuity functions into CLI-safe calls
+- preserve deterministic ordering and validation behavior
+- expose provenance/trust signals where needed
+- ensure correction flows update later recall and resumption behavior
 
-### Task 3: Docs and External Onboarding
+### Task 3: Docs and Examples
 
 Owner: docs/integration owner
 
@@ -235,54 +230,36 @@ Write scope:
 - `README.md`
 - `ROADMAP.md`
 - `.ai/handoff/CURRENT_STATE.md`
-- `docs/phase9-product-spec.md`
-- `docs/phase9-sprint-33-38-plan.md`
-- `docs/phase9-bootstrap-notes.md`
-- any new quickstart docs introduced under `docs/`
 
 Responsibilities:
 
-- keep README onboarding-focused
-- keep current state factual about shipped versus targeted surfaces
-- keep roadmap sequencing consistent with packaging-first execution
-- add any missing quickstart examples needed to close the install gap
+- document exact CLI invocation path
+- add example commands against the shipped sample data
+- keep docs aligned with the `P9-S33` startup path instead of reopening packaging guidance
+- make the next seam toward MCP explicit
 
-### Task 4: Integration Review
+### Task 4: Verification and Reports
 
 Owner: sprint integrator
 
 Write scope:
 
+- `tests/unit/test_cli.py`
+- `tests/integration/test_cli_integration.py`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 Responsibilities:
 
-- verify doc, runtime, and sample-data paths agree
-- verify ADRs match canonical docs
-- verify no hidden expansion into CLI, MCP, or OpenClaw delivery
-- prepare final evidence notes for review
-
-## Build Report Requirements
-
-`BUILD_REPORT.md` must include:
-
-- exact startup path used during verification
-- exact sample-data path used during verification
-- exact recall and resumption proof steps
-- exact commands run and outcomes
-- any deferred public-boundary/runtime/license decisions
-
-## Review Focus
-
-`REVIEW_REPORT.md` should verify:
-
-- sprint stayed `P9-S33` scoped
-- startup path is singular, real, and doc-matched
-- sample-data story is usable by an external technical user
-- recall and resumption proof is real from public docs
-- no hidden CLI/MCP/OpenClaw implementation scope entered the sprint
+- prove command coverage against the shipped local runtime
+- keep CLI output assertions stable and narrow
+- document exact acceptance evidence and any deferred ergonomics
+- keep scope hygiene explicit if any supporting files are touched
 
 ## Definition Of Done
 
-This sprint is done when Alice has a public-core packaging boundary, one clean local boot flow, sample-data support, and canonical docs that an external technical user can follow without internal project context.
+- `P9-S34` CLI entrypoint exists and is callable from a documented local install
+- core continuity flows are usable from the terminal without the internal shell
+- command output is deterministic enough for review and future MCP parity
+- docs, tests, build report, and review report are aligned
+- no `P9-S35` MCP work or `P9-S36` adapter work leaks into the sprint

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -7,7 +7,7 @@
 - Phase 6 memory trust-calibration, review prioritization, retrieval evaluation, and trust dashboard seams are shipped baseline.
 - Phase 7 chief-of-staff prioritization, follow-through, preparation, and weekly review seams are shipped baseline.
 - Phase 8 operational chief-of-staff handoff, queue, routing, and outcome-learning seams are shipped baseline.
-- The current internal product is a local-first, trust-calibrated continuity and chief-of-staff system with bounded operator UI and governed workflows.
+- The current product surface is a local-first, trust-calibrated continuity and chief-of-staff system with bounded operator UI, governed workflows, and a shipped local continuity CLI.
 
 ## Stable / Trusted Areas
 
@@ -20,7 +20,6 @@
 
 ## Incomplete / At-Risk Areas
 
-- no public CLI surface exists yet
 - no published MCP server surface exists yet
 - importer and adapter story is not yet public-ready
 - OSS license finalization is still open
@@ -31,13 +30,21 @@ Phase 9: Alice Public Core and Agent Interop
 
 ## Latest State Summary
 
-`P9-S33` now has a concrete public-core baseline:
+`P9-S33` and `P9-S34` are now shipped baselines:
 
 - package boundary is documented around `alice-core`
 - canonical local startup path is documented and script-backed
 - deterministic sample fixture exists at `fixtures/public_sample_data/continuity_v1.json`
 - sample load path exists at `./scripts/load_sample_data.sh`
-- recall and resumption proof commands are documented from the public setup path
+- packaged CLI entrypoint exists at `python -m alicebot_api` (optional console script `alicebot`)
+- continuity command coverage exists for capture, recall, resume, open-loops, review queue/show/apply, and status
+- correction flow through CLI now deterministically changes later recall/resume outputs
+
+The next active seam is `P9-S35`:
+
+- mirror the shipped CLI continuity contract via MCP tool transport
+- keep parity strict with existing deterministic CLI semantics
+- avoid reopening continuity behavior in transport work
 
 ## Critical Constraints
 
@@ -48,11 +55,11 @@ Phase 9: Alice Public Core and Agent Interop
 
 ## Immediate Next Move
 
-Execute `P9-S34` on top of the `P9-S33` boundary:
+Execute `P9-S35` on top of the `P9-S33`/`P9-S34` boundary:
 
-- implement CLI surface against the documented `alice-core` package seam
-- keep startup/sample-data docs unchanged unless the runtime contract changes
-- preserve deterministic recall/resumption behavior while adding terminal UX
+- map MCP tools directly to the shipped CLI behavior contract
+- preserve deterministic output semantics for parity tests
+- keep startup/sample-data path unchanged while MCP is introduced
 
 ## Legacy Compatibility Markers
 

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,102 +1,51 @@
 # BUILD_REPORT.md
 
 ## sprint objective
-Implement `P9-S33` public-core packaging so an external technical user can install locally, load sample data, and run one recall flow plus one resumption flow from canonical docs.
+Ship `P9-S34` by adding a deterministic local CLI for core continuity flows (`capture`, `recall`, `resume`, `open-loops`, `review queue/show/apply`, `status`) on top of the shipped `alice-core` runtime.
 
 ## completed work
-- Added a deterministic sample-data fixture at `fixtures/public_sample_data/continuity_v1.json`.
-- Added a deterministic sample-data loader:
-  - `scripts/load_public_sample_data.py`
-  - `scripts/load_sample_data.sh`
-- Added `PUBLIC_SAMPLE_DATA_PATH` to `.env.example`.
-- Updated packaging metadata in `pyproject.toml`:
-  - package name: `alice-core`
-  - description aligned to public-core contract
-- Aligned required test-gate fixtures/assertions to current runtime contracts so required suites pass:
-  - `apps/web/components/memory-summary.test.tsx`
-  - `tests/integration/test_explicit_preferences_api.py`
-  - `tests/unit/test_approval_store.py`
-  - `tests/unit/test_compiler.py`
-  - `tests/unit/test_entity_store.py`
-  - `tests/unit/test_events.py`
-  - `tests/unit/test_store.py`
-  - `tests/unit/test_task_run_store.py`
-  - `tests/unit/test_tool_execution_store.py`
-  - `tests/unit/test_trace_store.py`
-- Aligned canonical docs to one startup + sample-data path and explicit recall/resumption proof commands:
-  - `README.md`
-  - `PRODUCT_BRIEF.md`
-  - `ARCHITECTURE.md`
-  - `ROADMAP.md`
-  - `RULES.md`
-  - `.ai/handoff/CURRENT_STATE.md`
-  - `docs/phase9-product-spec.md`
-  - `docs/phase9-sprint-33-38-plan.md`
-  - `docs/phase9-public-core-boundary.md`
-  - `docs/phase9-bootstrap-notes.md`
-  - `docs/phase9-sprint-33-control-tower-packet.md`
-- Updated ADRs to accepted for sprint decisions:
-  - `docs/adr/ADR-001-public-core-package-boundary.md`
-  - `docs/adr/ADR-002-public-runtime-baseline.md`
-  - `docs/adr/ADR-003-mcp-tool-surface-contract.md`
-
-## exact startup path used during verification
-1. `docker compose up -d`
-2. `./scripts/migrate.sh`
-3. `./scripts/load_sample_data.sh`
-4. `./scripts/api_dev.sh`
-5. `curl -sS http://127.0.0.1:8000/healthz`
-
-## exact sample-data load path used during verification
-- Fixture file: `fixtures/public_sample_data/continuity_v1.json`
-- Load command: `./scripts/load_sample_data.sh`
-- First run outcome: `status=ok`, `created_object_count=4`
-- Second run outcome (idempotence check): `status=noop`, `reason=fixture_already_loaded`
-
-## exact recall and resumption proof steps
-- Recall proof command:
-  - `curl -sS "http://127.0.0.1:8000/v0/continuity/recall?user_id=00000000-0000-0000-0000-000000000001&query=local-first"`
-  - Outcome: `200 OK`; `summary.returned_count=1`; top item title `Decision: Keep Alice local-first for public v0.1 packaging.`
-- Resumption proof command:
-  - `curl -sS "http://127.0.0.1:8000/v0/continuity/resumption-brief?user_id=00000000-0000-0000-0000-000000000001"`
-  - Outcome: `200 OK`; `brief.assembly_version=continuity_resumption_brief_v0`; non-empty `last_decision`, `open_loops`, and `next_action`.
+- Added packaged CLI entrypoint and module entry support:
+  - `apps/api/src/alicebot_api/cli.py`
+  - `apps/api/src/alicebot_api/cli_formatting.py`
+  - `apps/api/src/alicebot_api/__main__.py`
+  - `pyproject.toml` (`[project.scripts] alicebot = "alicebot_api.cli:main"`)
+- Kept CLI behavior on existing continuity seams (no core semantic fork):
+  - capture: `capture_continuity_input`
+  - recall: `query_continuity_recall`
+  - resume: `compile_continuity_resumption_brief`
+  - open-loops: `compile_continuity_open_loop_dashboard`
+  - review queue/show/apply: `list_continuity_review_queue`, `get_continuity_review_detail`, `apply_continuity_correction`
+  - status: runtime health + continuity/review/open-loop/retrieval summary
+- Added deterministic terminal formatting with provenance/trust signals:
+  - stable section order
+  - stable scope rendering
+  - stable list rendering and confidence/posture fields
+  - explicit empty states
+- Added CLI-focused tests:
+  - `tests/unit/test_cli.py`
+  - `tests/integration/test_cli_integration.py`
+- Updated sprint-scoped docs:
+  - `README.md` (CLI invocation and examples)
+  - `ROADMAP.md` (`P9-S34` shipped baseline, `P9-S35` next seam)
+  - `.ai/handoff/CURRENT_STATE.md` (CLI shipped summary and next seam)
+- Preserved control-doc truth marker compatibility in `.ai/handoff/CURRENT_STATE.md` (`Active Sprint focus is Phase 4 Sprint 14`) to keep baseline gate checks green.
 
 ## incomplete work
-- `P9-S33` scope items are implemented.
-- Deferred by decision: OSS license selection remains explicit follow-up work.
+- None inside `P9-S34` scope.
+- Intentionally deferred (out of scope): MCP transport/tool schemas (`P9-S35`), adapters/importer expansion, CLI ergonomics polish (autocomplete/TUI enhancements).
 
 ## files changed
-- `.env.example`
-- `pyproject.toml`
-- `scripts/load_public_sample_data.py`
-- `scripts/load_sample_data.sh`
-- `fixtures/public_sample_data/continuity_v1.json`
-- `README.md`
-- `PRODUCT_BRIEF.md`
-- `ARCHITECTURE.md`
-- `ROADMAP.md`
-- `RULES.md`
-- `.ai/handoff/CURRENT_STATE.md`
 - `.ai/active/SPRINT_PACKET.md`
-- `docs/phase9-product-spec.md`
-- `docs/phase9-sprint-33-38-plan.md`
-- `docs/phase9-public-core-boundary.md`
-- `docs/phase9-bootstrap-notes.md`
-- `docs/phase9-sprint-33-control-tower-packet.md`
-- `docs/adr/ADR-001-public-core-package-boundary.md`
-- `docs/adr/ADR-002-public-runtime-baseline.md`
-- `docs/adr/ADR-003-mcp-tool-surface-contract.md`
-- `scripts/api_dev.sh`
-- `apps/web/components/memory-summary.test.tsx`
-- `tests/integration/test_explicit_preferences_api.py`
-- `tests/unit/test_approval_store.py`
-- `tests/unit/test_compiler.py`
-- `tests/unit/test_entity_store.py`
-- `tests/unit/test_events.py`
-- `tests/unit/test_store.py`
-- `tests/unit/test_task_run_store.py`
-- `tests/unit/test_tool_execution_store.py`
-- `tests/unit/test_trace_store.py`
+- `apps/api/src/alicebot_api/cli.py`
+- `apps/api/src/alicebot_api/cli_formatting.py`
+- `apps/api/src/alicebot_api/__main__.py`
+- `apps/api/src/alicebot_api/__init__.py`
+- `pyproject.toml`
+- `tests/unit/test_cli.py`
+- `tests/integration/test_cli_integration.py`
+- `README.md`
+- `ROADMAP.md`
+- `.ai/handoff/CURRENT_STATE.md`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
@@ -108,26 +57,45 @@ Implement `P9-S33` public-core packaging so an external technical user can insta
 - `docker compose up -d`
   - PASS
 - `./scripts/migrate.sh`
-  - PASS
+  - PASS (required elevated local DB access)
 - `./scripts/load_sample_data.sh`
-  - PASS
-- `./scripts/api_dev.sh` + `curl -sS http://127.0.0.1:8000/healthz`
+  - PASS (`status=noop`, fixture already present)
+- `APP_RELOAD=false ./scripts/api_dev.sh` + `curl -sS http://127.0.0.1:8000/healthz`
   - PASS (`status=ok`)
-- `curl -sS "http://127.0.0.1:8000/v0/continuity/recall?user_id=00000000-0000-0000-0000-000000000001&query=local-first"`
+- `./.venv/bin/python -m alicebot_api --help`
   - PASS
-- `curl -sS "http://127.0.0.1:8000/v0/continuity/resumption-brief?user_id=00000000-0000-0000-0000-000000000001"`
+- `./.venv/bin/python -m alicebot_api status`
+  - PASS (database reachable, continuity metrics rendered)
+- `./.venv/bin/python -m alicebot_api recall --query local-first`
+  - PASS (deterministic ordered output with provenance snippets)
+- `./.venv/bin/python -m alicebot_api resume`
+  - PASS (last decision/open loops/recent changes/next action sections)
+- `./.venv/bin/python -m alicebot_api open-loops --limit 20`
   - PASS
-- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-  - PASS (`948 passed in 96.64s`)
-  - Note: executed with elevated local permissions because integration tests require localhost Postgres access.
+- `./.venv/bin/python -m alicebot_api capture "Decision: CLI verification keeps deterministic continuity output." --explicit-signal decision`
+  - PASS
+- `./.venv/bin/python -m alicebot_api review queue --status correction_ready --limit 20`
+  - PASS
+- `./.venv/bin/python -m alicebot_api review show b5bfdbcc-cbb2-440f-9e4e-7ebabdb41f3f`
+  - PASS
+- `./.venv/bin/python -m alicebot_api review apply b5bfdbcc-cbb2-440f-9e4e-7ebabdb41f3f --action supersede ...`
+  - PASS
+- `./.venv/bin/python -m alicebot_api recall --query local-first --limit 20` (post-correction)
+  - PASS (updated active decision ranked ahead of superseded prior decision)
+- `./.venv/bin/python -m alicebot_api resume --max-recent-changes 5 --max-open-loops 5` (post-correction)
+  - PASS (last decision updated deterministically after correction)
+- `./.venv/bin/python -m pytest tests/unit/test_cli.py -q`
+  - PASS (`5 passed`)
+- `./.venv/bin/python -m pytest tests/integration/test_cli_integration.py -q`
+  - PASS (`1 passed`)
+- `./.venv/bin/python -m pytest tests/unit tests/integration`
+  - PASS (`954 passed in 85.02s`) (required elevated local DB access)
 - `pnpm --dir apps/web test`
   - PASS (`192 passed`)
 
 ## blockers/issues
-- Running DB-backed commands in this environment required elevated permissions for localhost Postgres access.
-
-## deferred public-boundary/runtime/license decisions
-- License selection is explicitly deferred (documented in `docs/phase9-public-core-boundary.md` and ADR notes).
+- Sandbox-restricted localhost Postgres access required elevated execution for DB-backed commands/tests.
+- Initial backend full-suite run failed at collection due duplicate test-module basename (`test_cli.py` in both unit and integration); resolved by renaming integration test file to `tests/integration/test_cli_integration.py`.
 
 ## recommended next step
-Execute `P9-S34` CLI implementation against the now-documented `alice-core` boundary.
+Start `P9-S35` by mirroring the shipped CLI continuity contract via a narrow MCP tool surface, with parity tests that compare MCP outputs to current CLI deterministic output for the same dataset/scope.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Alice is a local-first memory and continuity engine for AI agents.
 
-Phase 9 Sprint 33 (`P9-S33`) defines one public-core path: install locally, load deterministic sample data, run recall, and run resumption from documented commands.
+`P9-S33` shipped the public-core baseline. `P9-S34` ships a deterministic local CLI for continuity flows on top of that baseline.
 
 ## Canonical Local Startup Path (`P9-S33`)
 
@@ -21,16 +21,38 @@ Phase 9 Sprint 33 (`P9-S33`) defines one public-core path: install locally, load
 
 The sample fixture path is `fixtures/public_sample_data/continuity_v1.json` and defaults through `PUBLIC_SAMPLE_DATA_PATH`.
 
-## Recall And Resumption Proof Commands
+## CLI Invocation Path (`P9-S34`)
 
-Run these after `./scripts/api_dev.sh` is serving on `127.0.0.1:8000`.
+CLI works from the local editable install:
 
 ```bash
-curl -sS "http://127.0.0.1:8000/v0/continuity/recall?user_id=00000000-0000-0000-0000-000000000001&query=local-first"
-curl -sS "http://127.0.0.1:8000/v0/continuity/resumption-brief?user_id=00000000-0000-0000-0000-000000000001"
+./.venv/bin/python -m alicebot_api --help
 ```
 
-If `ALICEBOT_AUTH_USER_ID` is set in `.env`, the middleware rewrites `user_id` automatically and these query parameters can be omitted.
+Optional console-script entrypoint (after editable install):
+
+```bash
+alicebot --help
+```
+
+If `ALICEBOT_AUTH_USER_ID` is set (default in `.env.example`), CLI commands run in that user scope. Otherwise CLI defaults to `00000000-0000-0000-0000-000000000001`.
+
+## CLI Continuity Commands
+
+Run these against the `P9-S33` sample dataset after startup:
+
+```bash
+./.venv/bin/python -m alicebot_api status
+./.venv/bin/python -m alicebot_api capture "Decision: Keep Alice local-first for CLI verification." --explicit-signal decision
+./.venv/bin/python -m alicebot_api recall --query local-first
+./.venv/bin/python -m alicebot_api resume
+./.venv/bin/python -m alicebot_api open-loops
+./.venv/bin/python -m alicebot_api review queue --status correction_ready --limit 20
+./.venv/bin/python -m alicebot_api review show <continuity_object_id>
+./.venv/bin/python -m alicebot_api review apply <continuity_object_id> --action supersede --replacement-title "Decision: Updated title" --replacement-body-json '{"decision_text":"Updated title"}' --replacement-provenance-json '{"thread_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}' --replacement-confidence 0.97
+```
+
+The CLI output is deterministic text (stable section order and provenance snippets) to support `P9-S35` MCP parity.
 
 ## Essential Verification Commands
 

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,58 +4,35 @@
 PASS
 
 ## criteria met
-- Sprint stayed within `P9-S33` scope.
-  - No CLI implementation shipped.
-  - No MCP server implementation shipped.
-  - No OpenClaw adapter implementation shipped.
-  - Required test-gate alignment files are explicitly accounted for in `.ai/active/SPRINT_PACKET.md` and `BUILD_REPORT.md`.
-- Canonical startup path is singular, doc-matched, and runnable:
-  - `docker compose up -d`
-  - `./scripts/migrate.sh`
-  - `./scripts/load_sample_data.sh`
-  - `./scripts/api_dev.sh`
-- Sample-data story works and is deterministic:
-  - fixture: `fixtures/public_sample_data/continuity_v1.json`
-  - loader: `scripts/load_public_sample_data.py` via `./scripts/load_sample_data.sh`
-  - idempotence verified (`status=noop` on repeat load).
-- Recall proof from documented setup succeeded:
-  - `GET /v0/continuity/recall?user_id=00000000-0000-0000-0000-000000000001&query=local-first`
-  - `200 OK`, `summary.returned_count=1`.
-- Resumption proof from documented setup succeeded:
-  - `GET /v0/continuity/resumption-brief?user_id=00000000-0000-0000-0000-000000000001`
-  - `200 OK` with non-empty `last_decision`, `open_loops`, and `next_action`.
-- Required verification suites are now green:
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> `948 passed in 96.64s` (run with local elevated permissions for Postgres access)
-  - `pnpm --dir apps/web test` -> `192 passed`
-- Scope hygiene is explicit:
-  - Additional gate-alignment test files are in packet/build file scope.
-  - Local archive-only directories (`.ai/archive/`, `docs/archive/planning/`) are documented as excluded from merge scope.
-- Public package/runtime/tool-surface decisions are ADR-backed:
-  - `docs/adr/ADR-001-public-core-package-boundary.md`
-  - `docs/adr/ADR-002-public-runtime-baseline.md`
-  - `docs/adr/ADR-003-mcp-tool-surface-contract.md`
+- `P9-S34` packaged CLI entrypoint is implemented and callable from documented local install path (`python -m alicebot_api`).
+- Required command coverage is present: `capture`, `recall`, `resume`, `open-loops`, `review queue`, `review show`, `review apply`, `status`.
+- CLI output is deterministic and terminal-friendly, with stable section ordering, explicit empty states, and provenance/trust fields where relevant.
+- Correction flow is wired end-to-end and deterministically updates later recall/resume outcomes.
+- Sprint docs are aligned with delivered CLI surface (`README.md`, `ROADMAP.md`, `.ai/handoff/CURRENT_STATE.md`, reports).
+- Merge-readiness gap is resolved: required new CLI/test files are now added to git (no longer untracked).
+- The only remaining non-sprint worktree paths are local archive directories explicitly excluded from merge scope (`.ai/archive/`, `docs/archive/planning/`).
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking implementation quality issues found after fixes.
-- Notable hardening change validated: `scripts/api_dev.sh` now preserves caller-provided env vars over `.env`, preventing test/runtime port/config override regressions.
-- Prior report contradiction (`BUILD_REPORT` fail vs `REVIEW_REPORT` pass) is resolved; both reports now reflect the same green gate evidence.
+- No blocking quality issues identified for `P9-S34` scope.
+- Existing out-of-scope tracked churn previously noted in planning docs has been removed from the tracked diff.
 
 ## regression risks
-- Low.
-- Main prior risk (contract drift across unit/integration tests) was resolved by aligning tests with current `agent_profile_id`, task-run, and tool-execution contracts.
+- Low. Relevant CLI unit/integration tests and full backend/web suites pass in this environment.
+- Residual risk is standard future contract drift risk if downstream (`P9-S35`) parity tests are not kept strict against CLI behavior.
 
 ## docs issues
-- Minor wording ambiguity remains in `.ai/handoff/CURRENT_STATE.md` legacy marker text (`"Active Sprint focus is Phase 4 Sprint 14"`) alongside Phase 9 milestone language; this is non-blocking but can confuse handoff readers.
+- No blocking docs issues in sprint scope.
+- CLI invocation and command examples are present and consistent with shipped runtime behavior.
 
 ## should anything be added to RULES.md?
-- Optional improvement: add an explicit rule that startup scripts must preserve caller-provided environment variables over `.env` defaults.
+- Optional hardening: add a rule to avoid duplicate pytest module basenames across different test directories to prevent collection/import collisions.
 
 ## should anything update ARCHITECTURE.md?
-- Optional improvement: explicitly tag sections as `implemented` vs `planned` to reduce ambiguity for public readers.
+- No required update. Implementation aligns with existing Phase 9 public-layer architecture and does not alter core semantics.
 
 ## recommended next action
-1. Stage all `P9-S33` deliverables (including currently untracked Phase 9 docs/ADRs/fixtures/scripts) into the sprint commit.
-2. Proceed to `P9-S34` CLI work on top of the validated `alice-core` packaging/runtime baseline.
+1. Finalize PR with current scoped changes and verification evidence.
+2. Begin `P9-S35` by mirroring this CLI contract in MCP with explicit parity tests.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,19 +25,20 @@ Success condition:
 
 ## Next Milestones
 
-### P9-S33: Public Core Packaging (current delivery)
+### P9-S33: Public Core Packaging (shipped baseline)
 
 - public-safe package boundary
 - documented local startup path
 - sample dataset (`fixtures/public_sample_data/continuity_v1.json`)
 - initial public README and OSS boundary decisions
 
-### P9-S34: CLI and Continuity UX
+### P9-S34: CLI and Continuity UX (shipped baseline)
 
-- terminal commands for import, capture, recall, resume, open loops, review, correction, and status
+- packaged local CLI entrypoint (`python -m alicebot_api`, optional `alicebot`)
+- terminal commands for capture, recall, resume, open loops, review, correction, and status
 - deterministic terminal formatting with provenance snippets
 
-### P9-S35: MCP Server
+### P9-S35: MCP Server (next active seam)
 
 - small stable MCP tool surface
 - local interop examples for compatible clients
@@ -78,7 +79,7 @@ Success condition:
 ## Recently Completed
 
 - Phase 8 delivered operational chief-of-staff handoffs, routing, outcome learning, and closure quality.
-- The core internal product is ready to be packaged and exposed publicly.
+- `P9-S33` delivered the public-safe `alice-core` boundary, canonical local startup path, and deterministic sample-data proof.
 
 ## Legacy Compatibility Markers
 

--- a/apps/api/src/alicebot_api/__init__.py
+++ b/apps/api/src/alicebot_api/__init__.py
@@ -1,2 +1,5 @@
 """AliceBot foundation API package."""
 
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/apps/api/src/alicebot_api/__main__.py
+++ b/apps/api/src/alicebot_api/__main__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from alicebot_api.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -1,0 +1,580 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import os
+import sys
+from uuid import UUID
+
+import psycopg
+
+from alicebot_api.cli_formatting import (
+    format_capture_output,
+    format_open_loops_output,
+    format_recall_output,
+    format_resume_output,
+    format_review_apply_output,
+    format_review_detail_output,
+    format_review_queue_output,
+    format_status_output,
+)
+from alicebot_api.config import Settings, get_settings
+from alicebot_api.continuity_capture import (
+    ContinuityCaptureValidationError,
+    capture_continuity_input,
+)
+from alicebot_api.continuity_open_loops import (
+    ContinuityOpenLoopValidationError,
+    compile_continuity_open_loop_dashboard,
+)
+from alicebot_api.continuity_recall import (
+    ContinuityRecallValidationError,
+    query_continuity_recall,
+)
+from alicebot_api.continuity_resumption import (
+    ContinuityResumptionValidationError,
+    compile_continuity_resumption_brief,
+)
+from alicebot_api.continuity_review import (
+    ContinuityReviewNotFoundError,
+    ContinuityReviewValidationError,
+    apply_continuity_correction,
+    get_continuity_review_detail,
+    list_continuity_review_queue,
+)
+from alicebot_api.contracts import (
+    CONTINUITY_CAPTURE_EXPLICIT_SIGNALS,
+    CONTINUITY_CORRECTION_ACTIONS,
+    DEFAULT_CONTINUITY_OPEN_LOOP_LIMIT,
+    DEFAULT_CONTINUITY_RECALL_LIMIT,
+    DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    DEFAULT_CONTINUITY_REVIEW_LIMIT,
+    MAX_CONTINUITY_OPEN_LOOP_LIMIT,
+    MAX_CONTINUITY_RECALL_LIMIT,
+    MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    MAX_CONTINUITY_REVIEW_LIMIT,
+    ContinuityCaptureCreateInput,
+    ContinuityCorrectionInput,
+    ContinuityOpenLoopDashboardQueryInput,
+    ContinuityRecallQueryInput,
+    ContinuityResumptionBriefRequestInput,
+    ContinuityReviewQueueQueryInput,
+)
+from alicebot_api.db import ping_database, user_connection
+from alicebot_api.retrieval_evaluation import get_retrieval_evaluation_summary
+from alicebot_api.store import ContinuityStore, JsonObject
+
+DEFAULT_CLI_USER_ID = "00000000-0000-0000-0000-000000000001"
+REVIEW_STATUS_CHOICES = ("correction_ready", "active", "stale", "superseded", "deleted", "all")
+
+
+@dataclass(frozen=True, slots=True)
+class CLIContext:
+    settings: Settings
+    database_url: str
+    user_id: UUID
+
+
+def _parse_uuid(value: str) -> UUID:
+    try:
+        return UUID(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid UUID value: {value}") from exc
+
+
+def _parse_datetime(value: str) -> datetime:
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"invalid datetime value '{value}'. Use ISO-8601 format."
+        ) from exc
+
+
+def _parse_optional_json_object(raw_value: str | None, *, option_name: str) -> JsonObject | None:
+    if raw_value is None:
+        return None
+    try:
+        payload = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{option_name} must be valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{option_name} must be a JSON object")
+    return payload
+
+
+def _add_scope_filter_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--query", default=None, help="Optional query text.")
+    parser.add_argument("--thread-id", type=_parse_uuid, default=None, help="Optional thread UUID scope.")
+    parser.add_argument("--task-id", type=_parse_uuid, default=None, help="Optional task UUID scope.")
+    parser.add_argument("--project", default=None, help="Optional project scope.")
+    parser.add_argument("--person", default=None, help="Optional person scope.")
+    parser.add_argument("--since", type=_parse_datetime, default=None, help="Optional start time (ISO-8601).")
+    parser.add_argument("--until", type=_parse_datetime, default=None, help="Optional end time (ISO-8601).")
+
+
+def _resolve_user_id(settings: Settings, user_id_flag: str | None) -> UUID:
+    if user_id_flag is not None:
+        return _parse_uuid(user_id_flag)
+    if settings.auth_user_id != "":
+        return UUID(settings.auth_user_id)
+    return UUID(os.getenv("ALICEBOT_AUTH_USER_ID", DEFAULT_CLI_USER_ID))
+
+
+def _build_context(args: argparse.Namespace) -> CLIContext:
+    settings = get_settings()
+    database_url = args.database_url if args.database_url is not None else settings.database_url
+    user_id = _resolve_user_id(settings, args.user_id)
+    return CLIContext(settings=settings, database_url=database_url, user_id=user_id)
+
+
+@contextmanager
+def _store_context(ctx: CLIContext) -> Iterator[ContinuityStore]:
+    with user_connection(ctx.database_url, ctx.user_id) as conn:
+        yield ContinuityStore(conn)
+
+
+def _run_capture(ctx: CLIContext, args: argparse.Namespace) -> str:
+    raw_content = " ".join(args.raw_content).strip()
+    with _store_context(ctx) as store:
+        payload = capture_continuity_input(
+            store,
+            user_id=ctx.user_id,
+            request=ContinuityCaptureCreateInput(
+                raw_content=raw_content,
+                explicit_signal=args.explicit_signal,
+            ),
+        )
+    return format_capture_output(payload)
+
+
+def _run_recall(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = query_continuity_recall(
+            store,
+            user_id=ctx.user_id,
+            request=ContinuityRecallQueryInput(
+                query=args.query,
+                thread_id=args.thread_id,
+                task_id=args.task_id,
+                project=args.project,
+                person=args.person,
+                since=args.since,
+                until=args.until,
+                limit=args.limit,
+            ),
+        )
+    return format_recall_output(payload)
+
+
+def _run_resume(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = compile_continuity_resumption_brief(
+            store,
+            user_id=ctx.user_id,
+            request=ContinuityResumptionBriefRequestInput(
+                query=args.query,
+                thread_id=args.thread_id,
+                task_id=args.task_id,
+                project=args.project,
+                person=args.person,
+                since=args.since,
+                until=args.until,
+                max_recent_changes=args.max_recent_changes,
+                max_open_loops=args.max_open_loops,
+            ),
+        )
+    return format_resume_output(payload)
+
+
+def _run_open_loops(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = compile_continuity_open_loop_dashboard(
+            store,
+            user_id=ctx.user_id,
+            request=ContinuityOpenLoopDashboardQueryInput(
+                query=args.query,
+                thread_id=args.thread_id,
+                task_id=args.task_id,
+                project=args.project,
+                person=args.person,
+                since=args.since,
+                until=args.until,
+                limit=args.limit,
+            ),
+        )
+    return format_open_loops_output(payload)
+
+
+def _run_review_queue(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = list_continuity_review_queue(
+            store,
+            user_id=ctx.user_id,
+            request=ContinuityReviewQueueQueryInput(
+                status=args.status,
+                limit=args.limit,
+            ),
+        )
+    return format_review_queue_output(payload)
+
+
+def _run_review_show(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = get_continuity_review_detail(
+            store,
+            user_id=ctx.user_id,
+            continuity_object_id=args.continuity_object_id,
+        )
+    return format_review_detail_output(payload)
+
+
+def _run_review_apply(ctx: CLIContext, args: argparse.Namespace) -> str:
+    body = _parse_optional_json_object(args.body_json, option_name="--body-json")
+    provenance = _parse_optional_json_object(args.provenance_json, option_name="--provenance-json")
+    replacement_body = _parse_optional_json_object(
+        args.replacement_body_json,
+        option_name="--replacement-body-json",
+    )
+    replacement_provenance = _parse_optional_json_object(
+        args.replacement_provenance_json,
+        option_name="--replacement-provenance-json",
+    )
+
+    with _store_context(ctx) as store:
+        payload = apply_continuity_correction(
+            store,
+            user_id=ctx.user_id,
+            continuity_object_id=args.continuity_object_id,
+            request=ContinuityCorrectionInput(
+                action=args.action,
+                reason=args.reason,
+                title=args.title,
+                body=body,
+                provenance=provenance,
+                confidence=args.confidence,
+                replacement_title=args.replacement_title,
+                replacement_body=replacement_body,
+                replacement_provenance=replacement_provenance,
+                replacement_confidence=args.replacement_confidence,
+            ),
+        )
+    return format_review_apply_output(payload)
+
+
+def _run_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
+    database_reachable = ping_database(
+        ctx.database_url,
+        timeout_seconds=ctx.settings.healthcheck_timeout_seconds,
+    )
+
+    status_payload: dict[str, object] = {
+        "user_id": str(ctx.user_id),
+        "database_status": "reachable" if database_reachable else "unreachable",
+        "continuity_capture_events": 0,
+        "continuity_objects_total": 0,
+        "continuity_objects_active": 0,
+        "continuity_objects_stale": 0,
+        "continuity_objects_superseded": 0,
+        "continuity_objects_deleted": 0,
+        "review_correction_ready": 0,
+        "review_active": 0,
+        "review_stale": 0,
+        "review_superseded": 0,
+        "review_deleted": 0,
+        "open_loops_total": 0,
+        "open_loops_waiting_for": 0,
+        "open_loops_blocker": 0,
+        "open_loops_stale": 0,
+        "open_loops_next_action": 0,
+        "retrieval_eval_status": "unknown",
+        "retrieval_precision_at_k_mean": "0.000",
+        "retrieval_precision_at_1_mean": "0.000",
+    }
+    if not database_reachable:
+        return format_status_output(status_payload)
+
+    with _store_context(ctx) as store:
+        review_counts = {
+            "active": store.count_continuity_review_queue(statuses=["active"]),
+            "stale": store.count_continuity_review_queue(statuses=["stale"]),
+            "superseded": store.count_continuity_review_queue(statuses=["superseded"]),
+            "deleted": store.count_continuity_review_queue(statuses=["deleted"]),
+        }
+
+        recall_candidates = store.list_continuity_recall_candidates()
+        object_status_counts = {
+            "active": 0,
+            "stale": 0,
+            "superseded": 0,
+            "deleted": 0,
+        }
+        for candidate in recall_candidates:
+            status = str(candidate["status"])
+            if status in object_status_counts:
+                object_status_counts[status] += 1
+
+        open_loops = compile_continuity_open_loop_dashboard(
+            store,
+            user_id=ctx.user_id,
+            request=ContinuityOpenLoopDashboardQueryInput(limit=0),
+        )
+        open_loop_dashboard = open_loops["dashboard"]
+
+        retrieval_summary = get_retrieval_evaluation_summary(
+            store,
+            user_id=ctx.user_id,
+        )["summary"]
+
+        status_payload.update(
+            {
+                "continuity_capture_events": store.count_continuity_capture_events(),
+                "continuity_objects_total": len(recall_candidates),
+                "continuity_objects_active": object_status_counts["active"],
+                "continuity_objects_stale": object_status_counts["stale"],
+                "continuity_objects_superseded": object_status_counts["superseded"],
+                "continuity_objects_deleted": object_status_counts["deleted"],
+                "review_correction_ready": review_counts["active"] + review_counts["stale"],
+                "review_active": review_counts["active"],
+                "review_stale": review_counts["stale"],
+                "review_superseded": review_counts["superseded"],
+                "review_deleted": review_counts["deleted"],
+                "open_loops_total": open_loop_dashboard["summary"]["total_count"],
+                "open_loops_waiting_for": open_loop_dashboard["waiting_for"]["summary"]["total_count"],
+                "open_loops_blocker": open_loop_dashboard["blocker"]["summary"]["total_count"],
+                "open_loops_stale": open_loop_dashboard["stale"]["summary"]["total_count"],
+                "open_loops_next_action": open_loop_dashboard["next_action"]["summary"]["total_count"],
+                "retrieval_eval_status": retrieval_summary["status"],
+                "retrieval_precision_at_k_mean": f"{retrieval_summary['precision_at_k_mean']:.3f}",
+                "retrieval_precision_at_1_mean": f"{retrieval_summary['precision_at_1_mean']:.3f}",
+            }
+        )
+
+    return format_status_output(status_payload)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="alicebot",
+        description="Deterministic local CLI for Alice continuity workflows.",
+    )
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help="Override database URL. Defaults to settings/env DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--user-id",
+        default=None,
+        help=(
+            "Override acting user UUID. Defaults to ALICEBOT_AUTH_USER_ID when set, "
+            f"otherwise {DEFAULT_CLI_USER_ID}."
+        ),
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    capture_parser = subparsers.add_parser("capture", help="Capture continuity input.")
+    capture_parser.add_argument("raw_content", nargs="+", help="Raw continuity text to capture.")
+    capture_parser.add_argument(
+        "--explicit-signal",
+        choices=CONTINUITY_CAPTURE_EXPLICIT_SIGNALS,
+        default=None,
+        help="Optional explicit signal for deterministic derivation.",
+    )
+    capture_parser.set_defaults(handler=_run_capture)
+
+    recall_parser = subparsers.add_parser("recall", help="Recall continuity objects.")
+    _add_scope_filter_arguments(recall_parser)
+    recall_parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_CONTINUITY_RECALL_LIMIT,
+        help=f"Max results (1-{MAX_CONTINUITY_RECALL_LIMIT}).",
+    )
+    recall_parser.set_defaults(handler=_run_recall)
+
+    resume_parser = subparsers.add_parser("resume", help="Compile continuity resumption brief.")
+    _add_scope_filter_arguments(resume_parser)
+    resume_parser.add_argument(
+        "--max-recent-changes",
+        type=int,
+        default=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        help=f"Recent change limit (0-{MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT}).",
+    )
+    resume_parser.add_argument(
+        "--max-open-loops",
+        type=int,
+        default=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+        help=f"Open loop limit (0-{MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT}).",
+    )
+    resume_parser.set_defaults(handler=_run_resume)
+
+    open_loops_parser = subparsers.add_parser(
+        "open-loops",
+        help="List open-loop dashboard grouped by posture.",
+    )
+    _add_scope_filter_arguments(open_loops_parser)
+    open_loops_parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_CONTINUITY_OPEN_LOOP_LIMIT,
+        help=f"Per-posture item limit (0-{MAX_CONTINUITY_OPEN_LOOP_LIMIT}).",
+    )
+    open_loops_parser.set_defaults(handler=_run_open_loops)
+
+    review_parser = subparsers.add_parser("review", help="Review queue and correction commands.")
+    review_subparsers = review_parser.add_subparsers(dest="review_command", required=True)
+
+    review_queue_parser = review_subparsers.add_parser("queue", help="List review queue.")
+    review_queue_parser.add_argument(
+        "--status",
+        choices=REVIEW_STATUS_CHOICES,
+        default="correction_ready",
+        help="Queue status filter.",
+    )
+    review_queue_parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_CONTINUITY_REVIEW_LIMIT,
+        help=f"Max queue results (1-{MAX_CONTINUITY_REVIEW_LIMIT}).",
+    )
+    review_queue_parser.set_defaults(handler=_run_review_queue)
+
+    review_show_parser = review_subparsers.add_parser("show", help="Show detail for one review object.")
+    review_show_parser.add_argument("continuity_object_id", type=_parse_uuid, help="Continuity object UUID.")
+    review_show_parser.set_defaults(handler=_run_review_show)
+
+    review_apply_parser = review_subparsers.add_parser("apply", help="Apply a continuity correction.")
+    review_apply_parser.add_argument("continuity_object_id", type=_parse_uuid, help="Continuity object UUID.")
+    review_apply_parser.add_argument(
+        "--action",
+        required=True,
+        choices=CONTINUITY_CORRECTION_ACTIONS,
+        help="Correction action.",
+    )
+    review_apply_parser.add_argument("--reason", default=None, help="Optional correction reason.")
+    review_apply_parser.add_argument("--title", default=None, help="Replacement title for edit.")
+    review_apply_parser.add_argument(
+        "--body-json",
+        default=None,
+        help="JSON object payload for body replacement on edit.",
+    )
+    review_apply_parser.add_argument(
+        "--provenance-json",
+        default=None,
+        help="JSON object payload for provenance replacement on edit.",
+    )
+    review_apply_parser.add_argument(
+        "--confidence",
+        type=float,
+        default=None,
+        help="Updated confidence for edit/supersede.",
+    )
+    review_apply_parser.add_argument(
+        "--replacement-title",
+        default=None,
+        help="Replacement title for supersede.",
+    )
+    review_apply_parser.add_argument(
+        "--replacement-body-json",
+        default=None,
+        help="JSON object payload for supersede replacement body.",
+    )
+    review_apply_parser.add_argument(
+        "--replacement-provenance-json",
+        default=None,
+        help="JSON object payload for supersede replacement provenance.",
+    )
+    review_apply_parser.add_argument(
+        "--replacement-confidence",
+        type=float,
+        default=None,
+        help="Replacement confidence for supersede.",
+    )
+    review_apply_parser.set_defaults(handler=_run_review_apply)
+
+    status_parser = subparsers.add_parser("status", help="Show local continuity runtime status.")
+    status_parser.set_defaults(handler=_run_status)
+
+    return parser
+
+
+def _validate_limit(value: int, *, option_name: str, minimum: int, maximum: int) -> None:
+    if value < minimum or value > maximum:
+        raise ValueError(f"{option_name} must be between {minimum} and {maximum}")
+
+
+def _validate_arguments(args: argparse.Namespace) -> None:
+    if args.command == "recall":
+        _validate_limit(
+            args.limit,
+            option_name="--limit",
+            minimum=1,
+            maximum=MAX_CONTINUITY_RECALL_LIMIT,
+        )
+    elif args.command == "resume":
+        _validate_limit(
+            args.max_recent_changes,
+            option_name="--max-recent-changes",
+            minimum=0,
+            maximum=MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        )
+        _validate_limit(
+            args.max_open_loops,
+            option_name="--max-open-loops",
+            minimum=0,
+            maximum=MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+        )
+    elif args.command == "open-loops":
+        _validate_limit(
+            args.limit,
+            option_name="--limit",
+            minimum=0,
+            maximum=MAX_CONTINUITY_OPEN_LOOP_LIMIT,
+        )
+    elif args.command == "review" and args.review_command == "queue":
+        _validate_limit(
+            args.limit,
+            option_name="--limit",
+            minimum=1,
+            maximum=MAX_CONTINUITY_REVIEW_LIMIT,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        _validate_arguments(args)
+        ctx = _build_context(args)
+        handler = args.handler
+        output = handler(ctx, args)
+    except (
+        ValueError,
+        psycopg.Error,
+        ContinuityCaptureValidationError,
+        ContinuityRecallValidationError,
+        ContinuityResumptionValidationError,
+        ContinuityOpenLoopValidationError,
+        ContinuityReviewValidationError,
+        ContinuityReviewNotFoundError,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(output)
+    return 0
+
+
+__all__ = ["build_parser", "main"]

--- a/apps/api/src/alicebot_api/cli_formatting.py
+++ b/apps/api/src/alicebot_api/cli_formatting.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import json
+from typing import Mapping, Sequence
+
+from alicebot_api.contracts import (
+    ContinuityCaptureCreateResponse,
+    ContinuityCorrectionApplyResponse,
+    ContinuityOpenLoopDashboardResponse,
+    ContinuityRecallResultRecord,
+    ContinuityRecallResponse,
+    ContinuityResumptionBriefResponse,
+    ContinuityReviewDetailResponse,
+    ContinuityReviewQueueResponse,
+)
+
+
+_SCOPE_KEY_ORDER = ("thread_id", "task_id", "project", "person", "since", "until")
+_RECALL_ITEM_PREFIX = "  "
+
+
+def _format_float(value: float) -> str:
+    return f"{value:.3f}"
+
+
+def _format_scope(scope: Mapping[str, object]) -> str:
+    rendered: list[str] = []
+    for key in _SCOPE_KEY_ORDER:
+        if key not in scope:
+            continue
+        value = scope[key]
+        if value is None:
+            continue
+        rendered.append(f"{key}={value}")
+    if not rendered:
+        return "(none)"
+    return ", ".join(rendered)
+
+
+def _format_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _format_provenance_refs(item: ContinuityRecallResultRecord) -> str:
+    refs = item["provenance_references"]
+    if len(refs) == 0:
+        return "(none)"
+    return "; ".join(f"{ref['source_kind']}:{ref['source_id']}" for ref in refs)
+
+
+def _render_recall_item(
+    item: ContinuityRecallResultRecord,
+    *,
+    index: int | None = None,
+    prefix: str = _RECALL_ITEM_PREFIX,
+) -> list[str]:
+    marker = "-" if index is None else f"{index}."
+    lines = [
+        f"{prefix}{marker} [{item['object_type']}|{item['status']}] {item['title']}",
+        f"{prefix}  id={item['id']} capture_event_id={item['capture_event_id']}",
+        (
+            f"{prefix}  confidence={_format_float(item['confidence'])} "
+            f"relevance={_format_float(item['relevance'])} "
+            f"confirmation={item['confirmation_status']}"
+        ),
+        (
+            f"{prefix}  freshness={item['ordering']['freshness_posture']} "
+            f"provenance={item['ordering']['provenance_posture']} "
+            f"supersession={item['ordering']['supersession_posture']}"
+        ),
+        f"{prefix}  provenance_refs={_format_provenance_refs(item)}",
+    ]
+    return lines
+
+
+def _render_recall_list_section(
+    *,
+    title: str,
+    items: Sequence[ContinuityRecallResultRecord],
+    limit: int,
+    total_count: int,
+    order: Sequence[str],
+    empty_message: str,
+) -> list[str]:
+    lines = [
+        f"{title} (returned={len(items)} total={total_count} limit={limit})",
+        f"order: {', '.join(order)}",
+    ]
+    if len(items) == 0:
+        lines.append(f"empty: {empty_message}")
+        return lines
+
+    for index, item in enumerate(items, start=1):
+        lines.extend(_render_recall_item(item, index=index))
+    return lines
+
+
+def format_capture_output(payload: ContinuityCaptureCreateResponse) -> str:
+    capture = payload["capture"]["capture_event"]
+    derived = payload["capture"]["derived_object"]
+
+    lines = [
+        "capture result",
+        f"capture_event_id: {capture['id']}",
+        f"created_at: {capture['created_at']}",
+        f"admission_posture: {capture['admission_posture']}",
+        f"admission_reason: {capture['admission_reason']}",
+        f"explicit_signal: {capture['explicit_signal']}",
+    ]
+
+    if derived is None:
+        lines.append("derived_object: none")
+    else:
+        lines.extend(
+            [
+                f"derived_object_id: {derived['id']}",
+                f"derived_object_type: {derived['object_type']}",
+                f"derived_object_status: {derived['status']}",
+                f"derived_confidence: {_format_float(derived['confidence'])}",
+                f"derived_title: {derived['title']}",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def format_recall_output(payload: ContinuityRecallResponse) -> str:
+    summary = payload["summary"]
+    lines = [
+        "recall summary",
+        f"query: {summary['query']}",
+        f"filters: {_format_scope(summary['filters'])}",
+        (
+            f"returned: {summary['returned_count']}/{summary['total_count']} "
+            f"(limit={summary['limit']})"
+        ),
+        f"order: {', '.join(summary['order'])}",
+    ]
+
+    items = payload["items"]
+    if len(items) == 0:
+        lines.append("empty: no continuity results in requested scope.")
+        return "\n".join(lines)
+
+    lines.append("items:")
+    for index, item in enumerate(items, start=1):
+        lines.extend(_render_recall_item(item, index=index))
+    return "\n".join(lines)
+
+
+def format_resume_output(payload: ContinuityResumptionBriefResponse) -> str:
+    brief = payload["brief"]
+    lines = [
+        "resumption brief",
+        f"assembly_version: {brief['assembly_version']}",
+        f"scope: {_format_scope(brief['scope'])}",
+        f"sources: {', '.join(brief['sources'])}",
+    ]
+
+    lines.append("last_decision:")
+    last_decision = brief["last_decision"]
+    if last_decision["item"] is None:
+        lines.append(f"  empty: {last_decision['empty_state']['message']}")
+    else:
+        lines.extend(_render_recall_item(last_decision["item"]))
+
+    lines.extend(
+        _render_recall_list_section(
+            title="open_loops",
+            items=brief["open_loops"]["items"],
+            limit=brief["open_loops"]["summary"]["limit"],
+            total_count=brief["open_loops"]["summary"]["total_count"],
+            order=brief["open_loops"]["summary"]["order"],
+            empty_message=brief["open_loops"]["empty_state"]["message"],
+        )
+    )
+    lines.extend(
+        _render_recall_list_section(
+            title="recent_changes",
+            items=brief["recent_changes"]["items"],
+            limit=brief["recent_changes"]["summary"]["limit"],
+            total_count=brief["recent_changes"]["summary"]["total_count"],
+            order=brief["recent_changes"]["summary"]["order"],
+            empty_message=brief["recent_changes"]["empty_state"]["message"],
+        )
+    )
+
+    lines.append("next_action:")
+    next_action = brief["next_action"]
+    if next_action["item"] is None:
+        lines.append(f"  empty: {next_action['empty_state']['message']}")
+    else:
+        lines.extend(_render_recall_item(next_action["item"]))
+
+    return "\n".join(lines)
+
+
+def format_open_loops_output(payload: ContinuityOpenLoopDashboardResponse) -> str:
+    dashboard = payload["dashboard"]
+    summary = dashboard["summary"]
+    lines = [
+        "open loops dashboard",
+        f"scope: {_format_scope(dashboard['scope'])}",
+        f"sources: {', '.join(dashboard['sources'])}",
+        (
+            f"summary: total={summary['total_count']} "
+            f"limit={summary['limit']} "
+            f"posture_order={','.join(summary['posture_order'])}"
+        ),
+    ]
+
+    for posture in ("waiting_for", "blocker", "stale", "next_action"):
+        section = dashboard[posture]
+        lines.extend(
+            _render_recall_list_section(
+                title=posture,
+                items=section["items"],
+                limit=section["summary"]["limit"],
+                total_count=section["summary"]["total_count"],
+                order=section["summary"]["order"],
+                empty_message=section["empty_state"]["message"],
+            )
+        )
+
+    return "\n".join(lines)
+
+
+def format_review_queue_output(payload: ContinuityReviewQueueResponse) -> str:
+    summary = payload["summary"]
+    lines = [
+        "review queue",
+        (
+            f"status={summary['status']} "
+            f"returned={summary['returned_count']}/{summary['total_count']} "
+            f"limit={summary['limit']}"
+        ),
+        f"order: {', '.join(summary['order'])}",
+    ]
+
+    items = payload["items"]
+    if len(items) == 0:
+        lines.append("empty: no review items in requested status.")
+        return "\n".join(lines)
+
+    for index, item in enumerate(items, start=1):
+        lines.extend(
+            [
+                f"{index}. [{item['object_type']}|{item['status']}] {item['title']}",
+                f"   id={item['id']} capture_event_id={item['capture_event_id']}",
+                f"   confidence={_format_float(item['confidence'])} last_confirmed_at={item['last_confirmed_at']}",
+                f"   provenance={_format_json(item['provenance'])}",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def format_review_detail_output(payload: ContinuityReviewDetailResponse) -> str:
+    review = payload["review"]
+    continuity_object = review["continuity_object"]
+    supersession = review["supersession_chain"]
+
+    lines = [
+        "review detail",
+        f"continuity_object_id: {continuity_object['id']}",
+        f"type: {continuity_object['object_type']}",
+        f"status: {continuity_object['status']}",
+        f"title: {continuity_object['title']}",
+        f"confidence: {_format_float(continuity_object['confidence'])}",
+        f"last_confirmed_at: {continuity_object['last_confirmed_at']}",
+        f"body: {_format_json(continuity_object['body'])}",
+        f"provenance: {_format_json(continuity_object['provenance'])}",
+        (
+            "supersession_chain: "
+            f"supersedes={None if supersession['supersedes'] is None else supersession['supersedes']['id']} "
+            f"superseded_by={None if supersession['superseded_by'] is None else supersession['superseded_by']['id']}"
+        ),
+        f"correction_event_count: {len(review['correction_events'])}",
+    ]
+
+    for index, event in enumerate(review["correction_events"], start=1):
+        lines.append(
+            f"event {index}: id={event['id']} action={event['action']} "
+            f"reason={event['reason']} created_at={event['created_at']}"
+        )
+
+    return "\n".join(lines)
+
+
+def format_review_apply_output(payload: ContinuityCorrectionApplyResponse) -> str:
+    continuity_object = payload["continuity_object"]
+    correction_event = payload["correction_event"]
+    replacement_object = payload["replacement_object"]
+
+    lines = [
+        "review apply result",
+        f"continuity_object_id: {continuity_object['id']}",
+        f"continuity_object_status: {continuity_object['status']}",
+        f"continuity_object_title: {continuity_object['title']}",
+        f"correction_event_id: {correction_event['id']}",
+        f"correction_action: {correction_event['action']}",
+        f"correction_reason: {correction_event['reason']}",
+        f"correction_created_at: {correction_event['created_at']}",
+    ]
+
+    if replacement_object is None:
+        lines.append("replacement_object_id: none")
+    else:
+        lines.extend(
+            [
+                f"replacement_object_id: {replacement_object['id']}",
+                f"replacement_status: {replacement_object['status']}",
+                f"replacement_title: {replacement_object['title']}",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def format_status_output(status: Mapping[str, object]) -> str:
+    lines = [
+        "alice-core status",
+        f"user_id: {status['user_id']}",
+        f"database: {status['database_status']}",
+        f"continuity_capture_events: {status['continuity_capture_events']}",
+        f"continuity_objects_total: {status['continuity_objects_total']}",
+        (
+            "continuity_object_statuses: "
+            f"active={status['continuity_objects_active']} "
+            f"stale={status['continuity_objects_stale']} "
+            f"superseded={status['continuity_objects_superseded']} "
+            f"deleted={status['continuity_objects_deleted']}"
+        ),
+        (
+            "review_queue: "
+            f"correction_ready={status['review_correction_ready']} "
+            f"active={status['review_active']} "
+            f"stale={status['review_stale']} "
+            f"superseded={status['review_superseded']} "
+            f"deleted={status['review_deleted']}"
+        ),
+        (
+            "open_loops: "
+            f"total={status['open_loops_total']} "
+            f"waiting_for={status['open_loops_waiting_for']} "
+            f"blocker={status['open_loops_blocker']} "
+            f"stale={status['open_loops_stale']} "
+            f"next_action={status['open_loops_next_action']}"
+        ),
+        (
+            "retrieval_eval: "
+            f"status={status['retrieval_eval_status']} "
+            f"precision_at_k_mean={status['retrieval_precision_at_k_mean']} "
+            f"precision_at_1_mean={status['retrieval_precision_at_1_mean']}"
+        ),
+    ]
+    return "\n".join(lines)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dev = [
   "pytest>=8.3,<9.0",
 ]
 
+[project.scripts]
+alicebot = "alicebot_api.cli:main"
+
 [tool.setuptools.package-dir]
 "" = "."
 

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from uuid import UUID, uuid4
+
+from alicebot_api.db import user_connection
+from alicebot_api.store import ContinuityStore
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def seed_user(database_url: str, *, email: str) -> UUID:
+    user_id = uuid4()
+    with user_connection(database_url, user_id) as conn:
+        ContinuityStore(conn).create_user(user_id, email, email.split("@", 1)[0].title())
+    return user_id
+
+
+def build_cli_env(*, database_url: str, user_id: UUID) -> dict[str, str]:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    env["ALICEBOT_AUTH_USER_ID"] = str(user_id)
+
+    pythonpath_entries = [str(REPO_ROOT / "apps" / "api" / "src"), str(REPO_ROOT / "workers")]
+    existing_pythonpath = env.get("PYTHONPATH")
+    if existing_pythonpath:
+        pythonpath_entries.append(existing_pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    return env
+
+
+def run_cli(args: list[str], *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "alicebot_api", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_command_surface_and_correction_flow(migrated_database_urls) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="cli-user@example.com")
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+
+        legacy_capture = store.create_continuity_capture_event(
+            raw_content="Decision: Legacy rollout plan",
+            explicit_signal="decision",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_decision",
+        )
+        legacy_decision = store.create_continuity_object(
+            capture_event_id=legacy_capture["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: Legacy rollout plan",
+            body={"decision_text": "Legacy rollout plan"},
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["cli-seed-1"]},
+            confidence=0.91,
+            last_confirmed_at=datetime(2026, 3, 30, 9, 0, tzinfo=UTC),
+        )
+
+        waiting_capture = store.create_continuity_capture_event(
+            raw_content="Waiting For: Reviewer PASS",
+            explicit_signal="waiting_for",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_waiting_for",
+        )
+        waiting_for = store.create_continuity_object(
+            capture_event_id=waiting_capture["id"],
+            object_type="WaitingFor",
+            status="active",
+            title="Waiting For: Reviewer PASS",
+            body={"waiting_for_text": "Reviewer PASS"},
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["cli-seed-2"]},
+            confidence=0.9,
+        )
+
+    env = build_cli_env(database_url=migrated_database_urls["app"], user_id=user_id)
+
+    help_result = run_cli(["--help"], env=env)
+    assert help_result.returncode == 0
+    assert "capture" in help_result.stdout
+    assert "review" in help_result.stdout
+    assert "status" in help_result.stdout
+
+    status_result = run_cli(["status"], env=env)
+    assert status_result.returncode == 0
+    assert "database: reachable" in status_result.stdout
+    assert "continuity_capture_events: 2" in status_result.stdout
+
+    capture_result = run_cli(
+        [
+            "capture",
+            "Task: Publish CLI usage docs",
+            "--explicit-signal",
+            "task",
+        ],
+        env=env,
+    )
+    assert capture_result.returncode == 0
+    assert "capture_event_id:" in capture_result.stdout
+    assert "derived_object_type: NextAction" in capture_result.stdout
+
+    recall_before = run_cli(
+        [
+            "recall",
+            "--query",
+            "rollout",
+            "--thread-id",
+            str(thread_id),
+            "--limit",
+            "20",
+        ],
+        env=env,
+    )
+    assert recall_before.returncode == 0
+    assert "Decision: Legacy rollout plan" in recall_before.stdout
+
+    resume_before = run_cli(
+        [
+            "resume",
+            "--thread-id",
+            str(thread_id),
+            "--max-recent-changes",
+            "5",
+            "--max-open-loops",
+            "5",
+        ],
+        env=env,
+    )
+    assert resume_before.returncode == 0
+    assert "last_decision:" in resume_before.stdout
+    assert "Decision: Legacy rollout plan" in resume_before.stdout
+
+    open_loops_result = run_cli(
+        ["open-loops", "--thread-id", str(thread_id), "--limit", "20"],
+        env=env,
+    )
+    assert open_loops_result.returncode == 0
+    assert "waiting_for (returned=1 total=1 limit=20)" in open_loops_result.stdout
+    assert waiting_for["title"] in open_loops_result.stdout
+
+    review_queue_result = run_cli(
+        ["review", "queue", "--status", "correction_ready", "--limit", "20"],
+        env=env,
+    )
+    assert review_queue_result.returncode == 0
+    assert str(legacy_decision["id"]) in review_queue_result.stdout
+
+    review_show_result = run_cli(
+        ["review", "show", str(legacy_decision["id"])],
+        env=env,
+    )
+    assert review_show_result.returncode == 0
+    assert f"continuity_object_id: {legacy_decision['id']}" in review_show_result.stdout
+
+    replacement_provenance = json.dumps({"thread_id": str(thread_id), "source_event_ids": ["cli-correction-1"]})
+    review_apply_result = run_cli(
+        [
+            "review",
+            "apply",
+            str(legacy_decision["id"]),
+            "--action",
+            "supersede",
+            "--reason",
+            "Latest decision supersedes legacy plan",
+            "--replacement-title",
+            "Decision: Updated rollout plan",
+            "--replacement-body-json",
+            '{"decision_text":"Updated rollout plan"}',
+            "--replacement-provenance-json",
+            replacement_provenance,
+            "--replacement-confidence",
+            "0.97",
+        ],
+        env=env,
+    )
+    assert review_apply_result.returncode == 0
+    assert "replacement_object_id: " in review_apply_result.stdout
+    assert "replacement_object_id: none" not in review_apply_result.stdout
+
+    recall_after = run_cli(
+        [
+            "recall",
+            "--thread-id",
+            str(thread_id),
+            "--query",
+            "rollout",
+            "--limit",
+            "20",
+        ],
+        env=env,
+    )
+    assert recall_after.returncode == 0
+    assert "Decision: Updated rollout plan" in recall_after.stdout
+
+    resume_after = run_cli(
+        [
+            "resume",
+            "--thread-id",
+            str(thread_id),
+            "--max-recent-changes",
+            "5",
+            "--max-open-loops",
+            "5",
+        ],
+        env=env,
+    )
+    assert resume_after.returncode == 0
+    assert "Decision: Updated rollout plan" in resume_after.stdout
+

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import alicebot_api.cli as cli_module
+from alicebot_api.config import Settings
+from alicebot_api.contracts import ContinuityRecallResponse
+
+
+def test_parser_routes_required_commands() -> None:
+    parser = cli_module.build_parser()
+    continuity_object_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+    cases = [
+        (["capture", "Decision: Keep rollout phased"], "_run_capture"),
+        (["recall"], "_run_recall"),
+        (["resume"], "_run_resume"),
+        (["open-loops"], "_run_open_loops"),
+        (["review", "queue"], "_run_review_queue"),
+        (["review", "show", continuity_object_id], "_run_review_show"),
+        (["review", "apply", continuity_object_id, "--action", "confirm"], "_run_review_apply"),
+        (["status"], "_run_status"),
+    ]
+
+    for argv, expected_handler_name in cases:
+        parsed = parser.parse_args(argv)
+        assert parsed.handler.__name__ == expected_handler_name
+
+
+def test_resolve_user_id_prefers_flag_then_settings_then_env_then_default(monkeypatch) -> None:
+    flag_user_id = UUID("11111111-1111-4111-8111-111111111111")
+    configured_user_id = UUID("22222222-2222-4222-8222-222222222222")
+    env_user_id = UUID("33333333-3333-4333-8333-333333333333")
+
+    settings_without_auth = Settings(auth_user_id="")
+    settings_with_auth = Settings(auth_user_id=str(configured_user_id))
+
+    monkeypatch.setenv("ALICEBOT_AUTH_USER_ID", str(env_user_id))
+    assert cli_module._resolve_user_id(settings_without_auth, str(flag_user_id)) == flag_user_id
+    assert cli_module._resolve_user_id(settings_with_auth, None) == configured_user_id
+    assert cli_module._resolve_user_id(settings_without_auth, None) == env_user_id
+
+    monkeypatch.delenv("ALICEBOT_AUTH_USER_ID")
+    assert cli_module._resolve_user_id(settings_without_auth, None) == UUID(cli_module.DEFAULT_CLI_USER_ID)
+
+
+def test_main_returns_error_for_non_object_json_on_review_apply(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        cli_module,
+        "get_settings",
+        lambda: Settings(database_url="postgresql://db", auth_user_id=str(uuid4())),
+    )
+
+    exit_code = cli_module.main(
+        [
+            "review",
+            "apply",
+            "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "--action",
+            "edit",
+            "--body-json",
+            "[]",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "error: --body-json must be a JSON object" in captured.err
+
+
+def test_recall_formatting_is_deterministic() -> None:
+    payload: ContinuityRecallResponse = {
+        "items": [
+            {
+                "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                "capture_event_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                "object_type": "Decision",
+                "status": "active",
+                "title": "Decision: Keep rollout phased",
+                "body": {"decision_text": "Keep rollout phased"},
+                "provenance": {"thread_id": "thread-1"},
+                "confirmation_status": "confirmed",
+                "admission_posture": "DERIVED",
+                "confidence": 0.95,
+                "relevance": 1.0,
+                "last_confirmed_at": "2026-03-30T10:00:00+00:00",
+                "supersedes_object_id": None,
+                "superseded_by_object_id": None,
+                "scope_matches": [{"kind": "thread", "value": "thread-1"}],
+                "provenance_references": [
+                    {"source_kind": "continuity_capture_event", "source_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"},
+                    {"source_kind": "thread", "source_id": "thread-1"},
+                ],
+                "ordering": {
+                    "scope_match_count": 1,
+                    "query_term_match_count": 2,
+                    "confirmation_rank": 3,
+                    "freshness_posture": "fresh",
+                    "freshness_rank": 4,
+                    "provenance_posture": "strong",
+                    "provenance_rank": 3,
+                    "supersession_posture": "current",
+                    "supersession_rank": 3,
+                    "posture_rank": 2,
+                    "lifecycle_rank": 4,
+                    "confidence": 0.95,
+                },
+                "created_at": "2026-03-30T09:59:00+00:00",
+                "updated_at": "2026-03-30T10:00:00+00:00",
+            }
+        ],
+        "summary": {
+            "query": "rollout",
+            "filters": {"thread_id": "thread-1", "since": None, "until": None},
+            "limit": 20,
+            "returned_count": 1,
+            "total_count": 1,
+            "order": ["relevance_desc", "created_at_desc", "id_desc"],
+        },
+    }
+
+    rendered = cli_module.format_recall_output(payload)
+
+    assert rendered == (
+        "recall summary\n"
+        "query: rollout\n"
+        "filters: thread_id=thread-1\n"
+        "returned: 1/1 (limit=20)\n"
+        "order: relevance_desc, created_at_desc, id_desc\n"
+        "items:\n"
+        "  1. [Decision|active] Decision: Keep rollout phased\n"
+        "    id=aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa capture_event_id=bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb\n"
+        "    confidence=0.950 relevance=1.000 confirmation=confirmed\n"
+        "    freshness=fresh provenance=strong supersession=current\n"
+        "    provenance_refs=continuity_capture_event:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb; thread:thread-1"
+    )
+
+
+def test_status_command_returns_unreachable_without_db_connection(monkeypatch, capsys) -> None:
+    user_id = UUID("44444444-4444-4444-8444-444444444444")
+    monkeypatch.setattr(
+        cli_module,
+        "get_settings",
+        lambda: Settings(
+            database_url="postgresql://db",
+            healthcheck_timeout_seconds=2,
+            auth_user_id=str(user_id),
+        ),
+    )
+    monkeypatch.setattr(cli_module, "ping_database", lambda *_args, **_kwargs: False)
+
+    exit_code = cli_module.main(["status"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "database: unreachable" in captured.out
+    assert f"user_id: {user_id}" in captured.out
+


### PR DESCRIPTION
## Summary
- add a packaged local CLI entrypoint for continuity flows
- provide deterministic terminal formatting for recall, resume, review, and status output
- align sprint docs and verification evidence with the shipped CLI contract

## Validation
- docker compose up -d
- ./scripts/migrate.sh
- ./scripts/load_sample_data.sh
- APP_RELOAD=false ./scripts/api_dev.sh
- curl -sS http://127.0.0.1:8000/healthz
- ./.venv/bin/python -m alicebot_api --help
- ./.venv/bin/python -m alicebot_api status
- ./.venv/bin/python -m alicebot_api recall --query local-first
- ./.venv/bin/python -m alicebot_api resume
- ./.venv/bin/python -m alicebot_api open-loops --limit 20
- ./.venv/bin/python -m alicebot_api capture "Decision: CLI verification keeps deterministic continuity output." --explicit-signal decision
- ./.venv/bin/python -m alicebot_api review queue --status correction_ready --limit 20
- ./.venv/bin/python -m alicebot_api review show b5bfdbcc-cbb2-440f-9e4e-7ebabdb41f3f
- ./.venv/bin/python -m alicebot_api review apply b5bfdbcc-cbb2-440f-9e4e-7ebabdb41f3f --action supersede ...
- ./.venv/bin/python -m pytest tests/unit/test_cli.py -q
- ./.venv/bin/python -m pytest tests/integration/test_cli_integration.py -q
- ./.venv/bin/python -m pytest tests/unit tests/integration
- pnpm --dir apps/web test