### PR TITLE
Build archive-first evidence pipeline

### DIFF
--- a/apps/api/alembic/versions/20260410_0050_archive_first_evidence_pipeline.py
+++ b/apps/api/alembic/versions/20260410_0050_archive_first_evidence_pipeline.py
@@ -1,0 +1,208 @@
+"""Add archive-first continuity evidence tables for imported artifacts."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260410_0050"
+down_revision = "20260410_0049"
+branch_labels = None
+depends_on = None
+
+_RLS_TABLES = (
+    "continuity_artifacts",
+    "continuity_artifact_copies",
+    "continuity_artifact_segments",
+    "continuity_object_evidence_links",
+)
+
+_UPGRADE_STATEMENTS = (
+    """
+        CREATE TABLE continuity_artifacts (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          source_kind text NOT NULL,
+          import_source_path text NOT NULL,
+          relative_path text NOT NULL,
+          display_name text NOT NULL,
+          media_type text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (id, user_id),
+          UNIQUE (user_id, source_kind, import_source_path, relative_path),
+          CONSTRAINT continuity_artifacts_source_kind_length_check
+            CHECK (char_length(source_kind) >= 1 AND char_length(source_kind) <= 100),
+          CONSTRAINT continuity_artifacts_import_source_path_length_check
+            CHECK (char_length(import_source_path) >= 1 AND char_length(import_source_path) <= 2000),
+          CONSTRAINT continuity_artifacts_relative_path_length_check
+            CHECK (char_length(relative_path) >= 1 AND char_length(relative_path) <= 1000),
+          CONSTRAINT continuity_artifacts_display_name_length_check
+            CHECK (char_length(display_name) >= 1 AND char_length(display_name) <= 280),
+          CONSTRAINT continuity_artifacts_media_type_length_check
+            CHECK (char_length(media_type) >= 1 AND char_length(media_type) <= 120)
+        );
+        """,
+    """
+        CREATE TABLE continuity_artifact_copies (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          artifact_id uuid NOT NULL,
+          checksum_sha256 text NOT NULL,
+          content_text text NOT NULL,
+          content_length_bytes integer NOT NULL,
+          content_encoding text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (id, user_id),
+          UNIQUE (user_id, artifact_id, checksum_sha256),
+          CONSTRAINT continuity_artifact_copies_artifact_fkey
+            FOREIGN KEY (artifact_id, user_id)
+            REFERENCES continuity_artifacts(id, user_id)
+            ON DELETE CASCADE,
+          CONSTRAINT continuity_artifact_copies_checksum_sha256_length_check
+            CHECK (char_length(checksum_sha256) = 64),
+          CONSTRAINT continuity_artifact_copies_content_length_bytes_check
+            CHECK (content_length_bytes >= 0),
+          CONSTRAINT continuity_artifact_copies_content_encoding_length_check
+            CHECK (char_length(content_encoding) >= 1 AND char_length(content_encoding) <= 40)
+        );
+        """,
+    """
+        CREATE TABLE continuity_artifact_segments (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          artifact_id uuid NOT NULL,
+          artifact_copy_id uuid NOT NULL,
+          source_item_id text NOT NULL,
+          sequence_no integer NOT NULL,
+          segment_kind text NOT NULL,
+          locator jsonb NOT NULL,
+          raw_content text NOT NULL,
+          checksum_sha256 text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (id, user_id),
+          UNIQUE (user_id, artifact_copy_id, source_item_id),
+          CONSTRAINT continuity_artifact_segments_artifact_fkey
+            FOREIGN KEY (artifact_id, user_id)
+            REFERENCES continuity_artifacts(id, user_id)
+            ON DELETE CASCADE,
+          CONSTRAINT continuity_artifact_segments_artifact_copy_fkey
+            FOREIGN KEY (artifact_copy_id, user_id)
+            REFERENCES continuity_artifact_copies(id, user_id)
+            ON DELETE CASCADE,
+          CONSTRAINT continuity_artifact_segments_source_item_id_length_check
+            CHECK (char_length(source_item_id) >= 1 AND char_length(source_item_id) <= 500),
+          CONSTRAINT continuity_artifact_segments_sequence_no_check
+            CHECK (sequence_no >= 1),
+          CONSTRAINT continuity_artifact_segments_segment_kind_length_check
+            CHECK (char_length(segment_kind) >= 1 AND char_length(segment_kind) <= 80),
+          CONSTRAINT continuity_artifact_segments_checksum_sha256_length_check
+            CHECK (char_length(checksum_sha256) = 64)
+        );
+        """,
+    """
+        CREATE TABLE continuity_object_evidence_links (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          continuity_object_id uuid NOT NULL,
+          artifact_id uuid NOT NULL,
+          artifact_copy_id uuid NOT NULL,
+          artifact_segment_id uuid NULL,
+          relationship text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (id, user_id),
+          CONSTRAINT continuity_object_evidence_links_object_fkey
+            FOREIGN KEY (continuity_object_id, user_id)
+            REFERENCES continuity_objects(id, user_id)
+            ON DELETE CASCADE,
+          CONSTRAINT continuity_object_evidence_links_artifact_fkey
+            FOREIGN KEY (artifact_id, user_id)
+            REFERENCES continuity_artifacts(id, user_id)
+            ON DELETE CASCADE,
+          CONSTRAINT continuity_object_evidence_links_artifact_copy_fkey
+            FOREIGN KEY (artifact_copy_id, user_id)
+            REFERENCES continuity_artifact_copies(id, user_id)
+            ON DELETE CASCADE,
+          CONSTRAINT continuity_object_evidence_links_artifact_segment_fkey
+            FOREIGN KEY (artifact_segment_id, user_id)
+            REFERENCES continuity_artifact_segments(id, user_id)
+            ON DELETE CASCADE,
+          CONSTRAINT continuity_object_evidence_links_relationship_length_check
+            CHECK (char_length(relationship) >= 1 AND char_length(relationship) <= 80)
+        );
+        """,
+    """
+        CREATE INDEX continuity_artifacts_user_kind_created_idx
+          ON continuity_artifacts (user_id, source_kind, created_at DESC, id DESC);
+        CREATE INDEX continuity_artifact_copies_artifact_created_idx
+          ON continuity_artifact_copies (artifact_id, created_at ASC, id ASC);
+        CREATE INDEX continuity_artifact_segments_artifact_sequence_idx
+          ON continuity_artifact_segments (artifact_id, sequence_no ASC, id ASC);
+        CREATE INDEX continuity_object_evidence_links_object_created_idx
+          ON continuity_object_evidence_links (continuity_object_id, created_at ASC, id ASC);
+        """,
+    "GRANT SELECT, INSERT ON continuity_artifacts TO alicebot_app",
+    "GRANT SELECT, INSERT ON continuity_artifact_copies TO alicebot_app",
+    "GRANT SELECT, INSERT ON continuity_artifact_segments TO alicebot_app",
+    "GRANT SELECT, INSERT ON continuity_object_evidence_links TO alicebot_app",
+    "ALTER TABLE continuity_artifacts ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE continuity_artifacts FORCE ROW LEVEL SECURITY",
+    "ALTER TABLE continuity_artifact_copies ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE continuity_artifact_copies FORCE ROW LEVEL SECURITY",
+    "ALTER TABLE continuity_artifact_segments ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE continuity_artifact_segments FORCE ROW LEVEL SECURITY",
+    "ALTER TABLE continuity_object_evidence_links ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE continuity_object_evidence_links FORCE ROW LEVEL SECURITY",
+    """
+        CREATE POLICY continuity_artifacts_read_own ON continuity_artifacts
+          FOR SELECT
+          USING (user_id = app.current_user_id());
+
+        CREATE POLICY continuity_artifacts_insert_own ON continuity_artifacts
+          FOR INSERT
+          WITH CHECK (user_id = app.current_user_id());
+
+        CREATE POLICY continuity_artifact_copies_read_own ON continuity_artifact_copies
+          FOR SELECT
+          USING (user_id = app.current_user_id());
+
+        CREATE POLICY continuity_artifact_copies_insert_own ON continuity_artifact_copies
+          FOR INSERT
+          WITH CHECK (user_id = app.current_user_id());
+
+        CREATE POLICY continuity_artifact_segments_read_own ON continuity_artifact_segments
+          FOR SELECT
+          USING (user_id = app.current_user_id());
+
+        CREATE POLICY continuity_artifact_segments_insert_own ON continuity_artifact_segments
+          FOR INSERT
+          WITH CHECK (user_id = app.current_user_id());
+
+        CREATE POLICY continuity_object_evidence_links_read_own ON continuity_object_evidence_links
+          FOR SELECT
+          USING (user_id = app.current_user_id());
+
+        CREATE POLICY continuity_object_evidence_links_insert_own ON continuity_object_evidence_links
+          FOR INSERT
+          WITH CHECK (user_id = app.current_user_id());
+        """,
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP TABLE IF EXISTS continuity_object_evidence_links",
+    "DROP TABLE IF EXISTS continuity_artifact_segments",
+    "DROP TABLE IF EXISTS continuity_artifact_copies",
+    "DROP TABLE IF EXISTS continuity_artifacts",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/chatgpt_import.py
+++ b/apps/api/src/alicebot_api/chatgpt_import.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from uuid import UUID
 
+from alicebot_api.continuity_evidence import SourceArtifactArchiveInput, archive_import_source_files
 from alicebot_api.importer_models import (
     ImporterNormalizedBatch,
     ImporterNormalizedItem,
@@ -68,6 +69,23 @@ def _read_json(path: Path) -> object:
         raise ChatGPTImportValidationError(
             f"invalid JSON at {path}: {exc.msg}"
         ) from exc
+
+
+def _read_chatgpt_source_files(source: str | Path) -> tuple[Path, list[Path]]:
+    source_path = Path(source).expanduser().resolve()
+    if not source_path.exists():
+        raise ChatGPTImportValidationError(f"ChatGPT source path does not exist: {source_path}")
+
+    source_files = [source_path] if source_path.is_file() else sorted(source_path.rglob("*.json"))
+    if not source_files:
+        raise ChatGPTImportValidationError("no ChatGPT JSON files were found at the source path")
+    return source_path, source_files
+
+
+def _relative_source_file(source_root: Path, file_path: Path) -> str:
+    if source_root.is_dir():
+        return str(file_path.relative_to(source_root))
+    return file_path.name
 
 
 def _normalize_message_text(value: object) -> str | None:
@@ -242,13 +260,7 @@ def _message_text(message: JsonObject) -> str | None:
 
 
 def load_chatgpt_payload(source: str | Path) -> ImporterNormalizedBatch:
-    source_path = Path(source).expanduser().resolve()
-    if not source_path.exists():
-        raise ChatGPTImportValidationError(f"ChatGPT source path does not exist: {source_path}")
-
-    source_files = [source_path] if source_path.is_file() else sorted(source_path.rglob("*.json"))
-    if not source_files:
-        raise ChatGPTImportValidationError("no ChatGPT JSON files were found at the source path")
+    source_path, source_files = _read_chatgpt_source_files(source)
 
     fixture_id: str | None = None
     workspace_id: str | None = None
@@ -350,7 +362,14 @@ def load_chatgpt_payload(source: str | Path) -> ImporterNormalizedBatch:
                 items.append(
                     ImporterNormalizedItem(
                         source_item_id=source_item_id,
-                        source_file=source_file.name,
+                        source_file=_relative_source_file(source_path, source_file),
+                        source_locator={
+                            "conversation_id": conversation_id,
+                            "message_id": message_id,
+                            "role": role,
+                        },
+                        source_segment_text=text,
+                        source_segment_kind="chatgpt_message",
                         object_type=object_type,
                         status=status,
                         raw_content=_build_raw_content(object_type=object_type, text=object_text),
@@ -383,7 +402,23 @@ def import_chatgpt_source(
     user_id: UUID,
     source: str | Path,
 ) -> JsonObject:
-    batch = load_chatgpt_payload(source)
+    source_path, source_files = _read_chatgpt_source_files(source)
+    archived_artifacts = archive_import_source_files(
+        store,
+        user_id=user_id,
+        source_kind="chatgpt_import",
+        import_source_path=str(source_path),
+        files=[
+            SourceArtifactArchiveInput(
+                relative_path=_relative_source_file(source_path, file_path),
+                display_name=file_path.name,
+                media_type="application/json",
+                content_text=file_path.read_text(encoding="utf-8"),
+            )
+            for file_path in source_files
+        ],
+    )
+    batch = load_chatgpt_payload(source_path)
     return import_normalized_batch(
         store,
         user_id=user_id,
@@ -395,6 +430,7 @@ def import_chatgpt_source(
             dedupe_key_field="chatgpt_dedupe_key",
             dedupe_posture=_DEFAULT_DEDUPE_POSTURE,
         ),
+        archived_artifacts=archived_artifacts,
     )
 
 

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -13,7 +13,9 @@ from uuid import UUID
 import psycopg
 
 from alicebot_api.cli_formatting import (
+    format_artifact_detail_output,
     format_capture_output,
+    format_explain_output,
     format_lifecycle_detail_output,
     format_lifecycle_list_output,
     format_open_loops_output,
@@ -28,6 +30,11 @@ from alicebot_api.config import Settings, get_settings
 from alicebot_api.continuity_capture import (
     ContinuityCaptureValidationError,
     capture_continuity_input,
+)
+from alicebot_api.continuity_evidence import (
+    ContinuityEvidenceNotFoundError,
+    build_continuity_explain,
+    get_continuity_artifact_detail,
 )
 from alicebot_api.continuity_objects import (
     default_continuity_promotable,
@@ -305,6 +312,26 @@ def _run_review_apply(ctx: CLIContext, args: argparse.Namespace) -> str:
             ),
         )
     return format_review_apply_output(payload)
+
+
+def _run_explain(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = build_continuity_explain(
+            store,
+            user_id=ctx.user_id,
+            continuity_object_id=args.continuity_object_id,
+        )
+    return format_explain_output(payload)
+
+
+def _run_evidence_artifact(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = get_continuity_artifact_detail(
+            store,
+            user_id=ctx.user_id,
+            artifact_id=args.artifact_id,
+        )
+    return format_artifact_detail_output(payload)
 
 
 def _run_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
@@ -608,6 +635,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     review_apply_parser.set_defaults(handler=_run_review_apply)
 
+    explain_parser = subparsers.add_parser("explain", help="Show raw evidence chain for one continuity object.")
+    explain_parser.add_argument("continuity_object_id", type=_parse_uuid, help="Continuity object UUID.")
+    explain_parser.set_defaults(handler=_run_explain)
+
+    evidence_parser = subparsers.add_parser("evidence", help="Inspect archived continuity artifacts.")
+    evidence_subparsers = evidence_parser.add_subparsers(dest="evidence_command", required=True)
+    evidence_artifact_parser = evidence_subparsers.add_parser("artifact", help="Show one archived artifact.")
+    evidence_artifact_parser.add_argument("artifact_id", type=_parse_uuid, help="Continuity artifact UUID.")
+    evidence_artifact_parser.set_defaults(handler=_run_evidence_artifact)
+
     status_parser = subparsers.add_parser("status", help="Show local continuity runtime status.")
     status_parser.set_defaults(handler=_run_status)
 
@@ -683,6 +720,7 @@ def main(argv: list[str] | None = None) -> int:
         ContinuityOpenLoopValidationError,
         ContinuityReviewValidationError,
         ContinuityReviewNotFoundError,
+        ContinuityEvidenceNotFoundError,
     ) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/apps/api/src/alicebot_api/cli_formatting.py
+++ b/apps/api/src/alicebot_api/cli_formatting.py
@@ -4,8 +4,10 @@ import json
 from typing import Mapping, Sequence
 
 from alicebot_api.contracts import (
+    ContinuityArtifactDetailResponse,
     ContinuityCaptureCreateResponse,
     ContinuityCorrectionApplyResponse,
+    ContinuityExplainResponse,
     ContinuityLifecycleDetailResponse,
     ContinuityLifecycleListResponse,
     ContinuityOpenLoopDashboardResponse,
@@ -330,6 +332,87 @@ def format_review_detail_output(payload: ContinuityReviewDetailResponse) -> str:
             f"reason={event['reason']} created_at={event['created_at']}"
         )
 
+    return "\n".join(lines)
+
+
+def format_explain_output(payload: ContinuityExplainResponse) -> str:
+    explain = payload["explain"]
+    continuity_object = explain["continuity_object"]
+    lines = [
+        "explain",
+        f"continuity_object_id: {continuity_object['id']}",
+        f"title: {continuity_object['title']}",
+        f"type: {continuity_object['object_type']}",
+        f"status: {continuity_object['status']}",
+        f"evidence_links: {len(explain['evidence_chain'])}",
+    ]
+    if len(explain["evidence_chain"]) == 0:
+        lines.append("evidence: none")
+        return "\n".join(lines)
+
+    for index, link in enumerate(explain["evidence_chain"], start=1):
+        lines.extend(
+            [
+                f"{index}. relationship={link['relationship']}",
+                (
+                    "   artifact="
+                    f"{link['artifact']['display_name']} "
+                    f"({link['artifact']['relative_path']}, {link['artifact']['source_kind']})"
+                ),
+                f"   artifact_copy_checksum={link['artifact_copy']['checksum_sha256']}",
+            ]
+        )
+        segment = link["artifact_segment"]
+        if segment is not None:
+            lines.extend(
+                [
+                    (
+                        "   segment="
+                        f"{segment['segment_kind']} "
+                        f"source_item_id={segment['source_item_id']} "
+                        f"locator={_format_json(segment['locator'])}"
+                    ),
+                    f"   raw_evidence={segment['raw_content']}",
+                ]
+            )
+    return "\n".join(lines)
+
+
+def format_artifact_detail_output(payload: ContinuityArtifactDetailResponse) -> str:
+    detail = payload["artifact_detail"]
+    artifact = detail["artifact"]
+    lines = [
+        "artifact detail",
+        f"artifact_id: {artifact['id']}",
+        f"source_kind: {artifact['source_kind']}",
+        f"import_source_path: {artifact['import_source_path']}",
+        f"relative_path: {artifact['relative_path']}",
+        f"media_type: {artifact['media_type']}",
+        f"copies: {len(detail['copies'])}",
+        f"segments: {len(detail['segments'])}",
+    ]
+    for index, artifact_copy in enumerate(detail["copies"], start=1):
+        lines.extend(
+            [
+                f"copy {index}: checksum={artifact_copy['checksum_sha256']}",
+                (
+                    "  content="
+                    f"{artifact_copy['content_encoding']} "
+                    f"bytes={artifact_copy['content_length_bytes']}"
+                ),
+            ]
+        )
+    for index, segment in enumerate(detail["segments"], start=1):
+        lines.extend(
+            [
+                (
+                    f"segment {index}: {segment['segment_kind']} "
+                    f"source_item_id={segment['source_item_id']}"
+                ),
+                f"  locator={_format_json(segment['locator'])}",
+                f"  raw={segment['raw_content']}",
+            ]
+        )
     return "\n".join(lines)
 
 

--- a/apps/api/src/alicebot_api/continuity_evidence.py
+++ b/apps/api/src/alicebot_api/continuity_evidence.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from uuid import UUID
+
+from psycopg.conninfo import make_conninfo
+
+from alicebot_api.continuity_objects import serialize_continuity_lifecycle_state_from_record
+from alicebot_api.contracts import (
+    ContinuityArtifactDetailRecord,
+    ContinuityArtifactDetailResponse,
+    ContinuityEvidenceArtifactCopyRecord,
+    ContinuityEvidenceArtifactRecord,
+    ContinuityEvidenceArtifactSegmentRecord,
+    ContinuityEvidenceLinkRecord,
+    ContinuityExplainRecord,
+    ContinuityExplainResponse,
+    ContinuityReviewObjectRecord,
+    isoformat_or_none,
+)
+from alicebot_api.db import user_connection
+from alicebot_api.store import (
+    ContinuityArtifactCopyRow,
+    ContinuityArtifactRow,
+    ContinuityArtifactSegmentRow,
+    ContinuityObjectEvidenceRow,
+    ContinuityObjectRow,
+    ContinuityStore,
+    JsonObject,
+)
+
+
+class ContinuityEvidenceNotFoundError(LookupError):
+    """Raised when a continuity evidence resource is not visible in scope."""
+
+
+@dataclass(frozen=True, slots=True)
+class SourceArtifactArchiveInput:
+    relative_path: str
+    display_name: str
+    media_type: str
+    content_text: str
+
+
+@dataclass(frozen=True, slots=True)
+class ArchivedArtifactRef:
+    artifact_id: UUID
+    artifact_copy_id: UUID
+    relative_path: str
+    checksum_sha256: str
+
+
+def _checksum_sha256(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def archive_import_source_files(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    source_kind: str,
+    import_source_path: str,
+    files: list[SourceArtifactArchiveInput],
+) -> dict[str, ArchivedArtifactRef]:
+    if not files:
+        return {}
+
+    archived: dict[str, ArchivedArtifactRef] = {}
+    info = store.conn.info
+    archive_database_url = make_conninfo(
+        "",
+        dbname=info.dbname,
+        user=info.user,
+        password=info.password,
+        host=info.host,
+        port=str(info.port),
+    )
+
+    with user_connection(archive_database_url, user_id) as archive_conn:
+        archive_store = ContinuityStore(archive_conn)
+        for file in files:
+            artifact = archive_store.upsert_continuity_artifact(
+                source_kind=source_kind,
+                import_source_path=import_source_path,
+                relative_path=file.relative_path,
+                display_name=file.display_name,
+                media_type=file.media_type,
+            )
+            checksum = _checksum_sha256(file.content_text)
+            artifact_copy = archive_store.upsert_continuity_artifact_copy(
+                artifact_id=artifact["id"],
+                checksum_sha256=checksum,
+                content_text=file.content_text,
+                content_length_bytes=len(file.content_text.encode("utf-8")),
+                content_encoding="utf-8",
+            )
+            archived[file.relative_path] = ArchivedArtifactRef(
+                artifact_id=artifact["id"],
+                artifact_copy_id=artifact_copy["id"],
+                relative_path=file.relative_path,
+                checksum_sha256=checksum,
+            )
+    return archived
+
+
+def checksum_sha256_for_text(value: str) -> str:
+    return _checksum_sha256(value)
+
+
+def _serialize_review_object(record: ContinuityObjectRow) -> ContinuityReviewObjectRecord:
+    return {
+        "id": str(record["id"]),
+        "capture_event_id": str(record["capture_event_id"]),
+        "object_type": record["object_type"],
+        "status": record["status"],
+        "lifecycle": serialize_continuity_lifecycle_state_from_record(record),
+        "title": record["title"],
+        "body": record["body"],
+        "provenance": record["provenance"],
+        "confidence": float(record["confidence"]),
+        "last_confirmed_at": isoformat_or_none(record["last_confirmed_at"]),
+        "supersedes_object_id": (
+            None if record["supersedes_object_id"] is None else str(record["supersedes_object_id"])
+        ),
+        "superseded_by_object_id": (
+            None if record["superseded_by_object_id"] is None else str(record["superseded_by_object_id"])
+        ),
+        "created_at": record["created_at"].isoformat(),
+        "updated_at": record["updated_at"].isoformat(),
+    }
+
+
+def _serialize_artifact(record: ContinuityArtifactRow) -> ContinuityEvidenceArtifactRecord:
+    return {
+        "id": str(record["id"]),
+        "source_kind": record["source_kind"],
+        "import_source_path": record["import_source_path"],
+        "relative_path": record["relative_path"],
+        "display_name": record["display_name"],
+        "media_type": record["media_type"],
+        "created_at": record["created_at"].isoformat(),
+    }
+
+
+def _serialize_artifact_copy(record: ContinuityArtifactCopyRow) -> ContinuityEvidenceArtifactCopyRecord:
+    return {
+        "id": str(record["id"]),
+        "checksum_sha256": record["checksum_sha256"],
+        "content_length_bytes": record["content_length_bytes"],
+        "content_encoding": record["content_encoding"],
+        "content_text": record["content_text"],
+        "created_at": record["created_at"].isoformat(),
+    }
+
+
+def _serialize_artifact_segment(
+    record: ContinuityArtifactSegmentRow,
+) -> ContinuityEvidenceArtifactSegmentRecord:
+    return {
+        "id": str(record["id"]),
+        "source_item_id": record["source_item_id"],
+        "sequence_no": record["sequence_no"],
+        "segment_kind": record["segment_kind"],
+        "locator": record["locator"],
+        "raw_content": record["raw_content"],
+        "checksum_sha256": record["checksum_sha256"],
+        "created_at": record["created_at"].isoformat(),
+    }
+
+
+def serialize_continuity_evidence_rows(
+    rows: list[ContinuityObjectEvidenceRow],
+) -> list[ContinuityEvidenceLinkRecord]:
+    serialized: list[ContinuityEvidenceLinkRecord] = []
+    for row in rows:
+        artifact: ContinuityEvidenceArtifactRecord = {
+            "id": str(row["artifact_id"]),
+            "source_kind": row["source_kind"],
+            "import_source_path": row["import_source_path"],
+            "relative_path": row["relative_path"],
+            "display_name": row["display_name"],
+            "media_type": row["media_type"],
+            "created_at": row["artifact_created_at"].isoformat(),
+        }
+        artifact_copy: ContinuityEvidenceArtifactCopyRecord = {
+            "id": str(row["artifact_copy_id"]),
+            "checksum_sha256": row["artifact_copy_checksum_sha256"],
+            "content_length_bytes": row["artifact_copy_content_length_bytes"],
+            "content_encoding": row["artifact_copy_content_encoding"],
+            "content_text": row["artifact_copy_content_text"],
+            "created_at": row["artifact_copy_created_at"].isoformat(),
+        }
+        artifact_segment = None
+        if row["artifact_segment_id"] is not None:
+            artifact_segment = {
+                "id": str(row["artifact_segment_id"]),
+                "source_item_id": row["segment_source_item_id"] or "",
+                "sequence_no": row["segment_sequence_no"] or 0,
+                "segment_kind": row["segment_kind"] or "unknown",
+                "locator": row["segment_locator"] or {},
+                "raw_content": row["segment_raw_content"] or "",
+                "checksum_sha256": row["segment_checksum_sha256"] or "",
+                "created_at": (
+                    row["segment_created_at"].isoformat()
+                    if row["segment_created_at"] is not None
+                    else ""
+                ),
+            }
+        serialized.append(
+            {
+                "id": str(row["id"]),
+                "relationship": row["relationship"],
+                "created_at": row["created_at"].isoformat(),
+                "artifact": artifact,
+                "artifact_copy": artifact_copy,
+                "artifact_segment": artifact_segment,
+            }
+        )
+    return serialized
+
+
+def build_continuity_explain(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    continuity_object_id: UUID,
+) -> ContinuityExplainResponse:
+    del user_id
+
+    continuity_object = store.get_continuity_object_optional(continuity_object_id)
+    if continuity_object is None:
+        raise ContinuityEvidenceNotFoundError(
+            f"continuity object {continuity_object_id} was not found"
+        )
+
+    explain: ContinuityExplainRecord = {
+        "continuity_object": _serialize_review_object(continuity_object),
+        "evidence_chain": serialize_continuity_evidence_rows(
+            store.list_continuity_object_evidence(continuity_object_id)
+        ),
+    }
+    return {"explain": explain}
+
+
+def get_continuity_artifact_detail(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    artifact_id: UUID,
+) -> ContinuityArtifactDetailResponse:
+    del user_id
+
+    artifact = store.get_continuity_artifact_optional(artifact_id)
+    if artifact is None:
+        raise ContinuityEvidenceNotFoundError(f"continuity artifact {artifact_id} was not found")
+
+    detail: ContinuityArtifactDetailRecord = {
+        "artifact": _serialize_artifact(artifact),
+        "copies": [
+            _serialize_artifact_copy(copy)
+            for copy in store.list_continuity_artifact_copies(artifact_id)
+        ],
+        "segments": [
+            _serialize_artifact_segment(segment)
+            for segment in store.list_continuity_artifact_segments(artifact_id)
+        ],
+    }
+    return {"artifact_detail": detail}
+
+
+__all__ = [
+    "ArchivedArtifactRef",
+    "ContinuityEvidenceNotFoundError",
+    "SourceArtifactArchiveInput",
+    "archive_import_source_files",
+    "build_continuity_explain",
+    "checksum_sha256_for_text",
+    "get_continuity_artifact_detail",
+    "serialize_continuity_evidence_rows",
+]

--- a/apps/api/src/alicebot_api/continuity_review.py
+++ b/apps/api/src/alicebot_api/continuity_review.py
@@ -387,6 +387,14 @@ def apply_continuity_correction(
             supersedes_object_id=current["id"],
             superseded_by_object_id=None,
         )
+        for evidence_link in store.list_continuity_object_evidence(current["id"]):
+            store.create_continuity_object_evidence_link(
+                continuity_object_id=replacement_object["id"],
+                artifact_id=evidence_link["artifact_id"],
+                artifact_copy_id=evidence_link["artifact_copy_id"],
+                artifact_segment_id=evidence_link["artifact_segment_id"],
+                relationship=evidence_link["relationship"],
+            )
 
         updated = store.update_continuity_object_optional(
             continuity_object_id=continuity_object_id,

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -2563,6 +2563,64 @@ class ContinuityReviewDetailResponse(TypedDict):
     review: ContinuityReviewDetail
 
 
+class ContinuityEvidenceArtifactRecord(TypedDict):
+    id: str
+    source_kind: str
+    import_source_path: str
+    relative_path: str
+    display_name: str
+    media_type: str
+    created_at: str
+
+
+class ContinuityEvidenceArtifactCopyRecord(TypedDict):
+    id: str
+    checksum_sha256: str
+    content_length_bytes: int
+    content_encoding: str
+    content_text: str
+    created_at: str
+
+
+class ContinuityEvidenceArtifactSegmentRecord(TypedDict):
+    id: str
+    source_item_id: str
+    sequence_no: int
+    segment_kind: str
+    locator: JsonObject
+    raw_content: str
+    checksum_sha256: str
+    created_at: str
+
+
+class ContinuityEvidenceLinkRecord(TypedDict):
+    id: str
+    relationship: str
+    created_at: str
+    artifact: ContinuityEvidenceArtifactRecord
+    artifact_copy: ContinuityEvidenceArtifactCopyRecord
+    artifact_segment: ContinuityEvidenceArtifactSegmentRecord | None
+
+
+class ContinuityExplainRecord(TypedDict):
+    continuity_object: ContinuityReviewObjectRecord
+    evidence_chain: list[ContinuityEvidenceLinkRecord]
+
+
+class ContinuityExplainResponse(TypedDict):
+    explain: ContinuityExplainRecord
+
+
+class ContinuityArtifactDetailRecord(TypedDict):
+    artifact: ContinuityEvidenceArtifactRecord
+    copies: list[ContinuityEvidenceArtifactCopyRecord]
+    segments: list[ContinuityEvidenceArtifactSegmentRecord]
+
+
+class ContinuityArtifactDetailResponse(TypedDict):
+    artifact_detail: ContinuityArtifactDetailRecord
+
+
 class ContinuityRecallScopeFilters(TypedDict):
     thread_id: NotRequired[str]
     task_id: NotRequired[str]

--- a/apps/api/src/alicebot_api/importer_models.py
+++ b/apps/api/src/alicebot_api/importer_models.py
@@ -91,6 +91,9 @@ class ImporterWorkspaceContext:
 class ImporterNormalizedItem:
     source_item_id: str
     source_file: str
+    source_locator: JsonObject
+    source_segment_text: str
+    source_segment_kind: str
     object_type: str
     status: str
     raw_content: str

--- a/apps/api/src/alicebot_api/importers/common.py
+++ b/apps/api/src/alicebot_api/importers/common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from uuid import UUID
 
+from alicebot_api.continuity_evidence import ArchivedArtifactRef, checksum_sha256_for_text
 from alicebot_api.importer_models import (
     ImporterNormalizedBatch,
     OBJECT_TYPE_TO_EXPLICIT_SIGNAL,
@@ -79,6 +80,7 @@ def import_normalized_batch(
     user_id: UUID,
     batch: ImporterNormalizedBatch,
     config: ImportPersistenceConfig,
+    archived_artifacts: dict[str, ArchivedArtifactRef],
 ) -> JsonObject:
     del user_id
 
@@ -93,12 +95,27 @@ def import_normalized_batch(
     imported_capture_ids: list[str] = []
     skipped_duplicates = 0
 
-    for item in batch.items:
+    for sequence_no, item in enumerate(batch.items, start=1):
         if item.dedupe_key in existing_dedupe_keys or item.dedupe_key in run_dedupe_keys:
             skipped_duplicates += 1
             continue
 
         run_dedupe_keys.add(item.dedupe_key)
+
+        archived_artifact = archived_artifacts.get(item.source_file)
+        if archived_artifact is None:
+            raise ValueError(f"missing archived artifact for source file '{item.source_file}'")
+
+        segment = store.upsert_continuity_artifact_segment(
+            artifact_id=archived_artifact.artifact_id,
+            artifact_copy_id=archived_artifact.artifact_copy_id,
+            source_item_id=item.source_item_id,
+            sequence_no=sequence_no,
+            segment_kind=item.source_segment_kind,
+            locator=item.source_locator,
+            raw_content=item.source_segment_text,
+            checksum_sha256=checksum_sha256_for_text(item.source_segment_text),
+        )
 
         capture = store.create_continuity_capture_event(
             raw_content=item.raw_content,
@@ -126,6 +143,11 @@ def import_normalized_batch(
             source_event_ids=source_event_ids,
             config=config,
         )
+        provenance["artifact_id"] = str(archived_artifact.artifact_id)
+        provenance["artifact_copy_id"] = str(archived_artifact.artifact_copy_id)
+        provenance["artifact_copy_checksum_sha256"] = archived_artifact.checksum_sha256
+        provenance["artifact_segment_id"] = str(segment["id"])
+        provenance["artifact_segment_source_item_id"] = item.source_item_id
 
         continuity_object = store.create_continuity_object(
             capture_event_id=capture["id"],
@@ -135,6 +157,13 @@ def import_normalized_batch(
             body=item.body,
             provenance=provenance,
             confidence=item.confidence,
+        )
+        store.create_continuity_object_evidence_link(
+            continuity_object_id=continuity_object["id"],
+            artifact_id=archived_artifact.artifact_id,
+            artifact_copy_id=archived_artifact.artifact_copy_id,
+            artifact_segment_id=segment["id"],
+            relationship="primary_source_segment",
         )
 
         imported_capture_ids.append(str(capture["id"]))

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -87,7 +87,9 @@ from alicebot_api.contracts import (
     MAX_CHIEF_OF_STAFF_PRIORITY_LIMIT,
     MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
     ContextCompilerLimits,
+    ContinuityArtifactDetailResponse,
     ContinuityCaptureCreateInput,
+    ContinuityExplainResponse,
     ContinuityLifecycleDetailResponse,
     ContinuityLifecycleListResponse,
     ContinuityLifecycleQueryInput,
@@ -352,6 +354,11 @@ from alicebot_api.continuity_capture import (
     capture_continuity_input,
     get_continuity_capture_detail,
     list_continuity_capture_inbox,
+)
+from alicebot_api.continuity_evidence import (
+    ContinuityEvidenceNotFoundError,
+    build_continuity_explain,
+    get_continuity_artifact_detail,
 )
 from alicebot_api.continuity_lifecycle import (
     ContinuityLifecycleNotFoundError,
@@ -4202,6 +4209,52 @@ def get_continuity_review_detail_endpoint(
                 continuity_object_id=continuity_object_id,
             )
     except ContinuityReviewNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/continuity/explain/{continuity_object_id}")
+def get_continuity_explain_endpoint(
+    continuity_object_id: UUID,
+    user_id: UUID,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: ContinuityExplainResponse = build_continuity_explain(
+                ContinuityStore(conn),
+                user_id=user_id,
+                continuity_object_id=continuity_object_id,
+            )
+    except ContinuityEvidenceNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/admin/debug/continuity/artifacts/{artifact_id}")
+def get_continuity_artifact_detail_endpoint(
+    artifact_id: UUID,
+    user_id: UUID,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: ContinuityArtifactDetailResponse = get_continuity_artifact_detail(
+                ContinuityStore(conn),
+                user_id=user_id,
+                artifact_id=artifact_id,
+            )
+    except ContinuityEvidenceNotFoundError as exc:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
 
     return JSONResponse(

--- a/apps/api/src/alicebot_api/markdown_import.py
+++ b/apps/api/src/alicebot_api/markdown_import.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 from uuid import UUID
 
+from alicebot_api.continuity_evidence import SourceArtifactArchiveInput, archive_import_source_files
 from alicebot_api.importer_models import (
     ImporterNormalizedBatch,
     ImporterNormalizedItem,
@@ -133,6 +134,12 @@ def _resolve_object_type_and_text(*, text: str, type_hint: str | None) -> tuple[
         return object_type, stripped
 
     return "Note", text
+
+
+def _relative_source_file(source_root: Path, file_path: Path) -> str:
+    if source_root.is_dir():
+        return str(file_path.relative_to(source_root))
+    return file_path.name
 
 
 def _parse_line_tags(line: str) -> tuple[str, dict[str, str]]:
@@ -284,7 +291,10 @@ def load_markdown_payload(source: str | Path) -> ImporterNormalizedBatch:
             items.append(
                 ImporterNormalizedItem(
                     source_item_id=source_item_id,
-                    source_file=file_path.name,
+                    source_file=_relative_source_file(source_path, file_path),
+                    source_locator={"line_number": line_number, "source_item_id": source_item_id},
+                    source_segment_text=raw_line,
+                    source_segment_kind="markdown_line",
                     object_type=object_type,
                     status=status,
                     raw_content=_build_raw_content(object_type=object_type, text=object_text),
@@ -317,7 +327,23 @@ def import_markdown_source(
     user_id: UUID,
     source: str | Path,
 ) -> JsonObject:
-    batch = load_markdown_payload(source)
+    source_path, markdown_files = _read_markdown_source(source)
+    archived_artifacts = archive_import_source_files(
+        store,
+        user_id=user_id,
+        source_kind="markdown_import",
+        import_source_path=str(source_path),
+        files=[
+            SourceArtifactArchiveInput(
+                relative_path=_relative_source_file(source_path, file_path),
+                display_name=file_path.name,
+                media_type="text/markdown",
+                content_text=file_path.read_text(encoding="utf-8"),
+            )
+            for file_path in markdown_files
+        ],
+    )
+    batch = load_markdown_payload(source_path)
     return import_normalized_batch(
         store,
         user_id=user_id,
@@ -329,6 +355,7 @@ def import_markdown_source(
             dedupe_key_field="markdown_dedupe_key",
             dedupe_posture=_DEFAULT_DEDUPE_POSTURE,
         ),
+        archived_artifacts=archived_artifacts,
     )
 
 

--- a/apps/api/src/alicebot_api/mcp_tools.py
+++ b/apps/api/src/alicebot_api/mcp_tools.py
@@ -10,6 +10,11 @@ from alicebot_api.continuity_capture import (
     ContinuityCaptureValidationError,
     capture_continuity_input,
 )
+from alicebot_api.continuity_evidence import (
+    ContinuityEvidenceNotFoundError,
+    build_continuity_explain,
+    get_continuity_artifact_detail,
+)
 from alicebot_api.continuity_open_loops import (
     ContinuityOpenLoopValidationError,
     compile_continuity_open_loop_dashboard,
@@ -486,6 +491,27 @@ def _handle_alice_memory_correct(context: MCPRuntimeContext, arguments: Mapping[
         )
 
 
+def _handle_alice_explain(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    with _store_context(context) as store:
+        return build_continuity_explain(
+            store,
+            user_id=context.user_id,
+            continuity_object_id=_parse_required_uuid(arguments, "continuity_object_id"),
+        )
+
+
+def _handle_alice_artifact_inspect(
+    context: MCPRuntimeContext,
+    arguments: Mapping[str, object],
+) -> JsonObject:
+    with _store_context(context) as store:
+        return get_continuity_artifact_detail(
+            store,
+            user_id=context.user_id,
+            artifact_id=_parse_required_uuid(arguments, "artifact_id"),
+        )
+
+
 def _handle_alice_context_pack(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
     open_loops_limit = _parse_int(
         arguments,
@@ -704,6 +730,30 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
         },
     },
     {
+        "name": "alice_explain",
+        "description": "Show the raw evidence chain backing one continuity object.",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["continuity_object_id"],
+            "properties": {
+                "continuity_object_id": {"type": "string", "format": "uuid"},
+            },
+        },
+    },
+    {
+        "name": "alice_artifact_inspect",
+        "description": "Inspect one archived artifact with copies and extracted segments.",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["artifact_id"],
+            "properties": {
+                "artifact_id": {"type": "string", "format": "uuid"},
+            },
+        },
+    },
+    {
         "name": "alice_context_pack",
         "description": "Assemble a deterministic continuity context pack for scoped external-agent use.",
         "inputSchema": {
@@ -746,6 +796,8 @@ _TOOL_HANDLERS = {
     "alice_recent_changes": _handle_alice_recent_changes,
     "alice_memory_review": _handle_alice_memory_review,
     "alice_memory_correct": _handle_alice_memory_correct,
+    "alice_explain": _handle_alice_explain,
+    "alice_artifact_inspect": _handle_alice_artifact_inspect,
     "alice_context_pack": _handle_alice_context_pack,
 }
 
@@ -774,6 +826,7 @@ def call_mcp_tool(
         ContinuityOpenLoopValidationError,
         ContinuityReviewValidationError,
         ContinuityReviewNotFoundError,
+        ContinuityEvidenceNotFoundError,
     ) as exc:
         raise MCPToolError(str(exc)) from exc
     except (TypeError, ValueError) as exc:

--- a/apps/api/src/alicebot_api/openclaw_adapter.py
+++ b/apps/api/src/alicebot_api/openclaw_adapter.py
@@ -300,6 +300,12 @@ def _normalize_entry(
     return OpenClawNormalizedItem(
         source_item_id=source_item_id,
         source_file=source_file,
+        source_locator={
+            "source_identifier": source_identifier,
+            "entry_index": entry_index + 1,
+        },
+        source_segment_text=canonical_json_string(raw_entry),
+        source_segment_kind="openclaw_entry",
         object_type=object_type,
         status=status,
         raw_content=_build_raw_content(object_type=object_type, text=text),
@@ -333,6 +339,29 @@ def _extract_context(
         workspace_name=pick_first_text(payload.get("name"), payload.get("title")),
         source_path=str(source_path),
     )
+
+
+def list_openclaw_source_files(source: str | Path) -> tuple[Path, list[Path]]:
+    source_path = Path(source).expanduser().resolve()
+    if not source_path.exists():
+        raise OpenClawAdapterValidationError(f"OpenClaw source path does not exist: {source_path}")
+
+    if source_path.is_file():
+        return source_path, [source_path]
+
+    files: list[Path] = []
+    for filename in (*_SUPPORTED_WORKSPACE_FILENAMES, *_SUPPORTED_MEMORY_FILENAMES):
+        candidate = source_path / filename
+        if candidate.exists():
+            files.append(candidate)
+
+    if files:
+        return source_path, files
+
+    json_files = sorted(path for path in source_path.iterdir() if path.suffix == ".json")
+    if not json_files:
+        raise OpenClawAdapterValidationError("no OpenClaw memory entries were found at the source path")
+    return source_path, json_files
 
 
 def load_openclaw_payload(source: str | Path) -> OpenClawNormalizedBatch:
@@ -419,5 +448,6 @@ def load_openclaw_payload(source: str | Path) -> OpenClawNormalizedBatch:
 
 __all__ = [
     "OpenClawAdapterValidationError",
+    "list_openclaw_source_files",
     "load_openclaw_payload",
 ]

--- a/apps/api/src/alicebot_api/openclaw_import.py
+++ b/apps/api/src/alicebot_api/openclaw_import.py
@@ -3,17 +3,24 @@ from __future__ import annotations
 from pathlib import Path
 from uuid import UUID
 
+from alicebot_api.continuity_evidence import SourceArtifactArchiveInput, archive_import_source_files
 from alicebot_api.importer_models import (
     ImporterNormalizedBatch,
     ImporterNormalizedItem,
     ImporterWorkspaceContext,
 )
 from alicebot_api.importers.common import ImportPersistenceConfig, import_normalized_batch
-from alicebot_api.openclaw_adapter import load_openclaw_payload
+from alicebot_api.openclaw_adapter import list_openclaw_source_files, load_openclaw_payload
 from alicebot_api.store import ContinuityStore, JsonObject
 
 
 _OPENCLAW_DEDUPE_POSTURE = "workspace_and_payload_fingerprint"
+
+
+def _relative_source_file(source_root: Path, file_path: Path) -> str:
+    if source_root.is_dir():
+        return str(file_path.relative_to(source_root))
+    return file_path.name
 
 
 def _to_generic_batch(source: str | Path) -> ImporterNormalizedBatch:
@@ -29,6 +36,9 @@ def _to_generic_batch(source: str | Path) -> ImporterNormalizedBatch:
             ImporterNormalizedItem(
                 source_item_id=item.source_item_id,
                 source_file=item.source_file,
+                source_locator=item.source_locator,
+                source_segment_text=item.source_segment_text,
+                source_segment_kind=item.source_segment_kind,
                 object_type=item.object_type,
                 status=item.status,
                 raw_content=item.raw_content,
@@ -49,6 +59,22 @@ def import_openclaw_source(
     user_id: UUID,
     source: str | Path,
 ) -> JsonObject:
+    source_path, source_files = list_openclaw_source_files(source)
+    archived_artifacts = archive_import_source_files(
+        store,
+        user_id=user_id,
+        source_kind="openclaw_import",
+        import_source_path=str(source_path),
+        files=[
+            SourceArtifactArchiveInput(
+                relative_path=_relative_source_file(source_path, file_path),
+                display_name=file_path.name,
+                media_type="application/json",
+                content_text=file_path.read_text(encoding="utf-8"),
+            )
+            for file_path in source_files
+        ],
+    )
     generic_batch = _to_generic_batch(source)
     return import_normalized_batch(
         store,
@@ -62,6 +88,7 @@ def import_openclaw_source(
             dedupe_posture=_OPENCLAW_DEDUPE_POSTURE,
             source_label="OpenClaw",
         ),
+        archived_artifacts=archived_artifacts,
     )
 
 

--- a/apps/api/src/alicebot_api/openclaw_models.py
+++ b/apps/api/src/alicebot_api/openclaw_models.py
@@ -31,6 +31,9 @@ class OpenClawWorkspaceContext:
 class OpenClawNormalizedItem:
     source_item_id: str
     source_file: str
+    source_locator: JsonObject
+    source_segment_text: str
+    source_segment_kind: str
     object_type: str
     status: str
     raw_content: str

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -220,6 +220,82 @@ class ContinuityRecallCandidateRow(TypedDict):
     capture_created_at: datetime
 
 
+class ContinuityArtifactRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    source_kind: str
+    import_source_path: str
+    relative_path: str
+    display_name: str
+    media_type: str
+    created_at: datetime
+
+
+class ContinuityArtifactCopyRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    artifact_id: UUID
+    checksum_sha256: str
+    content_text: str
+    content_length_bytes: int
+    content_encoding: str
+    created_at: datetime
+
+
+class ContinuityArtifactSegmentRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    artifact_id: UUID
+    artifact_copy_id: UUID
+    source_item_id: str
+    sequence_no: int
+    segment_kind: str
+    locator: JsonObject
+    raw_content: str
+    checksum_sha256: str
+    created_at: datetime
+
+
+class ContinuityObjectEvidenceLinkRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    continuity_object_id: UUID
+    artifact_id: UUID
+    artifact_copy_id: UUID
+    artifact_segment_id: UUID | None
+    relationship: str
+    created_at: datetime
+
+
+class ContinuityObjectEvidenceRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    continuity_object_id: UUID
+    artifact_id: UUID
+    artifact_copy_id: UUID
+    artifact_segment_id: UUID | None
+    relationship: str
+    created_at: datetime
+    source_kind: str
+    import_source_path: str
+    relative_path: str
+    display_name: str
+    media_type: str
+    artifact_created_at: datetime
+    artifact_copy_checksum_sha256: str
+    artifact_copy_content_text: str
+    artifact_copy_content_length_bytes: int
+    artifact_copy_content_encoding: str
+    artifact_copy_created_at: datetime
+    segment_source_item_id: str | None
+    segment_sequence_no: int | None
+    segment_kind: str | None
+    segment_locator: JsonObject | None
+    segment_raw_content: str | None
+    segment_checksum_sha256: str | None
+    segment_created_at: datetime | None
+
+
 class EmbeddingConfigRow(TypedDict):
     id: UUID
     user_id: UUID
@@ -4110,6 +4186,302 @@ LIST_CONTINUITY_RECALL_CANDIDATES_SQL = """
                 ORDER BY continuity_objects.created_at DESC, continuity_objects.id DESC
                 """
 
+UPSERT_CONTINUITY_ARTIFACT_SQL = """
+                INSERT INTO continuity_artifacts (
+                  user_id,
+                  source_kind,
+                  import_source_path,
+                  relative_path,
+                  display_name,
+                  media_type
+                )
+                VALUES (
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s
+                )
+                ON CONFLICT (user_id, source_kind, import_source_path, relative_path)
+                DO NOTHING
+                RETURNING
+                  id,
+                  user_id,
+                  source_kind,
+                  import_source_path,
+                  relative_path,
+                  display_name,
+                  media_type,
+                  created_at
+                """
+
+GET_CONTINUITY_ARTIFACT_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  source_kind,
+                  import_source_path,
+                  relative_path,
+                  display_name,
+                  media_type,
+                  created_at
+                FROM continuity_artifacts
+                WHERE id = %s
+                """
+
+GET_CONTINUITY_ARTIFACT_BY_SOURCE_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  source_kind,
+                  import_source_path,
+                  relative_path,
+                  display_name,
+                  media_type,
+                  created_at
+                FROM continuity_artifacts
+                WHERE source_kind = %s
+                  AND import_source_path = %s
+                  AND relative_path = %s
+                """
+
+UPSERT_CONTINUITY_ARTIFACT_COPY_SQL = """
+                INSERT INTO continuity_artifact_copies (
+                  user_id,
+                  artifact_id,
+                  checksum_sha256,
+                  content_text,
+                  content_length_bytes,
+                  content_encoding
+                )
+                VALUES (
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s
+                )
+                ON CONFLICT (user_id, artifact_id, checksum_sha256)
+                DO NOTHING
+                RETURNING
+                  id,
+                  user_id,
+                  artifact_id,
+                  checksum_sha256,
+                  content_text,
+                  content_length_bytes,
+                  content_encoding,
+                  created_at
+                """
+
+GET_CONTINUITY_ARTIFACT_COPY_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  artifact_id,
+                  checksum_sha256,
+                  content_text,
+                  content_length_bytes,
+                  content_encoding,
+                  created_at
+                FROM continuity_artifact_copies
+                WHERE id = %s
+                """
+
+GET_CONTINUITY_ARTIFACT_COPY_BY_CHECKSUM_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  artifact_id,
+                  checksum_sha256,
+                  content_text,
+                  content_length_bytes,
+                  content_encoding,
+                  created_at
+                FROM continuity_artifact_copies
+                WHERE artifact_id = %s
+                  AND checksum_sha256 = %s
+                """
+
+LIST_CONTINUITY_ARTIFACT_COPIES_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  artifact_id,
+                  checksum_sha256,
+                  content_text,
+                  content_length_bytes,
+                  content_encoding,
+                  created_at
+                FROM continuity_artifact_copies
+                WHERE artifact_id = %s
+                ORDER BY created_at ASC, id ASC
+                """
+
+UPSERT_CONTINUITY_ARTIFACT_SEGMENT_SQL = """
+                INSERT INTO continuity_artifact_segments (
+                  user_id,
+                  artifact_id,
+                  artifact_copy_id,
+                  source_item_id,
+                  sequence_no,
+                  segment_kind,
+                  locator,
+                  raw_content,
+                  checksum_sha256
+                )
+                VALUES (
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s
+                )
+                ON CONFLICT (user_id, artifact_copy_id, source_item_id)
+                DO NOTHING
+                RETURNING
+                  id,
+                  user_id,
+                  artifact_id,
+                  artifact_copy_id,
+                  source_item_id,
+                  sequence_no,
+                  segment_kind,
+                  locator,
+                  raw_content,
+                  checksum_sha256,
+                  created_at
+                """
+
+GET_CONTINUITY_ARTIFACT_SEGMENT_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  artifact_id,
+                  artifact_copy_id,
+                  source_item_id,
+                  sequence_no,
+                  segment_kind,
+                  locator,
+                  raw_content,
+                  checksum_sha256,
+                  created_at
+                FROM continuity_artifact_segments
+                WHERE id = %s
+                """
+
+GET_CONTINUITY_ARTIFACT_SEGMENT_BY_SOURCE_ITEM_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  artifact_id,
+                  artifact_copy_id,
+                  source_item_id,
+                  sequence_no,
+                  segment_kind,
+                  locator,
+                  raw_content,
+                  checksum_sha256,
+                  created_at
+                FROM continuity_artifact_segments
+                WHERE artifact_copy_id = %s
+                  AND source_item_id = %s
+                """
+
+LIST_CONTINUITY_ARTIFACT_SEGMENTS_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  artifact_id,
+                  artifact_copy_id,
+                  source_item_id,
+                  sequence_no,
+                  segment_kind,
+                  locator,
+                  raw_content,
+                  checksum_sha256,
+                  created_at
+                FROM continuity_artifact_segments
+                WHERE artifact_id = %s
+                ORDER BY sequence_no ASC, created_at ASC, id ASC
+                """
+
+INSERT_CONTINUITY_OBJECT_EVIDENCE_LINK_SQL = """
+                INSERT INTO continuity_object_evidence_links (
+                  user_id,
+                  continuity_object_id,
+                  artifact_id,
+                  artifact_copy_id,
+                  artifact_segment_id,
+                  relationship
+                )
+                VALUES (
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s
+                )
+                RETURNING
+                  id,
+                  user_id,
+                  continuity_object_id,
+                  artifact_id,
+                  artifact_copy_id,
+                  artifact_segment_id,
+                  relationship,
+                  created_at
+                """
+
+LIST_CONTINUITY_OBJECT_EVIDENCE_SQL = """
+                SELECT
+                  links.id,
+                  links.user_id,
+                  links.continuity_object_id,
+                  links.artifact_id,
+                  links.artifact_copy_id,
+                  links.artifact_segment_id,
+                  links.relationship,
+                  links.created_at,
+                  artifacts.source_kind,
+                  artifacts.import_source_path,
+                  artifacts.relative_path,
+                  artifacts.display_name,
+                  artifacts.media_type,
+                  artifacts.created_at AS artifact_created_at,
+                  copies.checksum_sha256 AS artifact_copy_checksum_sha256,
+                  copies.content_text AS artifact_copy_content_text,
+                  copies.content_length_bytes AS artifact_copy_content_length_bytes,
+                  copies.content_encoding AS artifact_copy_content_encoding,
+                  copies.created_at AS artifact_copy_created_at,
+                  segments.source_item_id AS segment_source_item_id,
+                  segments.sequence_no AS segment_sequence_no,
+                  segments.segment_kind,
+                  segments.locator AS segment_locator,
+                  segments.raw_content AS segment_raw_content,
+                  segments.checksum_sha256 AS segment_checksum_sha256,
+                  segments.created_at AS segment_created_at
+                FROM continuity_object_evidence_links AS links
+                JOIN continuity_artifacts AS artifacts
+                  ON artifacts.id = links.artifact_id
+                 AND artifacts.user_id = links.user_id
+                JOIN continuity_artifact_copies AS copies
+                  ON copies.id = links.artifact_copy_id
+                 AND copies.user_id = links.user_id
+                LEFT JOIN continuity_artifact_segments AS segments
+                  ON segments.id = links.artifact_segment_id
+                 AND segments.user_id = links.user_id
+                WHERE links.continuity_object_id = %s
+                ORDER BY links.created_at ASC, links.id ASC
+                """
+
 UPDATE_CONTINUITY_OBJECT_SQL = """
                 UPDATE continuity_objects
                 SET status = %s,
@@ -4820,6 +5192,180 @@ class ContinuityStore:
 
     def list_continuity_recall_candidates(self) -> list[ContinuityRecallCandidateRow]:
         return self._fetch_all(LIST_CONTINUITY_RECALL_CANDIDATES_SQL)
+
+    def upsert_continuity_artifact(
+        self,
+        *,
+        source_kind: str,
+        import_source_path: str,
+        relative_path: str,
+        display_name: str,
+        media_type: str,
+    ) -> ContinuityArtifactRow:
+        created = self._fetch_optional_one(
+            UPSERT_CONTINUITY_ARTIFACT_SQL,
+            (
+                source_kind,
+                import_source_path,
+                relative_path,
+                display_name,
+                media_type,
+            ),
+        )
+        if created is not None:
+            return created
+        existing = self._fetch_optional_one(
+            GET_CONTINUITY_ARTIFACT_BY_SOURCE_SQL,
+            (source_kind, import_source_path, relative_path),
+        )
+        if existing is None:
+            raise ContinuityStoreInvariantError(
+                "upsert_continuity_artifact did not return or reveal an artifact row",
+            )
+        return existing
+
+    def get_continuity_artifact_optional(
+        self,
+        artifact_id: UUID,
+    ) -> ContinuityArtifactRow | None:
+        return self._fetch_optional_one(
+            GET_CONTINUITY_ARTIFACT_SQL,
+            (artifact_id,),
+        )
+
+    def upsert_continuity_artifact_copy(
+        self,
+        *,
+        artifact_id: UUID,
+        checksum_sha256: str,
+        content_text: str,
+        content_length_bytes: int,
+        content_encoding: str,
+    ) -> ContinuityArtifactCopyRow:
+        created = self._fetch_optional_one(
+            UPSERT_CONTINUITY_ARTIFACT_COPY_SQL,
+            (
+                artifact_id,
+                checksum_sha256,
+                content_text,
+                content_length_bytes,
+                content_encoding,
+            ),
+        )
+        if created is not None:
+            return created
+        existing = self._fetch_optional_one(
+            GET_CONTINUITY_ARTIFACT_COPY_BY_CHECKSUM_SQL,
+            (artifact_id, checksum_sha256),
+        )
+        if existing is None:
+            raise ContinuityStoreInvariantError(
+                "upsert_continuity_artifact_copy did not return or reveal an artifact copy row",
+            )
+        return existing
+
+    def get_continuity_artifact_copy_optional(
+        self,
+        artifact_copy_id: UUID,
+    ) -> ContinuityArtifactCopyRow | None:
+        return self._fetch_optional_one(
+            GET_CONTINUITY_ARTIFACT_COPY_SQL,
+            (artifact_copy_id,),
+        )
+
+    def list_continuity_artifact_copies(
+        self,
+        artifact_id: UUID,
+    ) -> list[ContinuityArtifactCopyRow]:
+        return self._fetch_all(
+            LIST_CONTINUITY_ARTIFACT_COPIES_SQL,
+            (artifact_id,),
+        )
+
+    def upsert_continuity_artifact_segment(
+        self,
+        *,
+        artifact_id: UUID,
+        artifact_copy_id: UUID,
+        source_item_id: str,
+        sequence_no: int,
+        segment_kind: str,
+        locator: JsonObject,
+        raw_content: str,
+        checksum_sha256: str,
+    ) -> ContinuityArtifactSegmentRow:
+        created = self._fetch_optional_one(
+            UPSERT_CONTINUITY_ARTIFACT_SEGMENT_SQL,
+            (
+                artifact_id,
+                artifact_copy_id,
+                source_item_id,
+                sequence_no,
+                segment_kind,
+                Jsonb(locator),
+                raw_content,
+                checksum_sha256,
+            ),
+        )
+        if created is not None:
+            return created
+        existing = self._fetch_optional_one(
+            GET_CONTINUITY_ARTIFACT_SEGMENT_BY_SOURCE_ITEM_SQL,
+            (artifact_copy_id, source_item_id),
+        )
+        if existing is None:
+            raise ContinuityStoreInvariantError(
+                "upsert_continuity_artifact_segment did not return or reveal a segment row",
+            )
+        return existing
+
+    def get_continuity_artifact_segment_optional(
+        self,
+        artifact_segment_id: UUID,
+    ) -> ContinuityArtifactSegmentRow | None:
+        return self._fetch_optional_one(
+            GET_CONTINUITY_ARTIFACT_SEGMENT_SQL,
+            (artifact_segment_id,),
+        )
+
+    def list_continuity_artifact_segments(
+        self,
+        artifact_id: UUID,
+    ) -> list[ContinuityArtifactSegmentRow]:
+        return self._fetch_all(
+            LIST_CONTINUITY_ARTIFACT_SEGMENTS_SQL,
+            (artifact_id,),
+        )
+
+    def create_continuity_object_evidence_link(
+        self,
+        *,
+        continuity_object_id: UUID,
+        artifact_id: UUID,
+        artifact_copy_id: UUID,
+        artifact_segment_id: UUID | None,
+        relationship: str,
+    ) -> ContinuityObjectEvidenceLinkRow:
+        return self._fetch_one(
+            "create_continuity_object_evidence_link",
+            INSERT_CONTINUITY_OBJECT_EVIDENCE_LINK_SQL,
+            (
+                continuity_object_id,
+                artifact_id,
+                artifact_copy_id,
+                artifact_segment_id,
+                relationship,
+            ),
+        )
+
+    def list_continuity_object_evidence(
+        self,
+        continuity_object_id: UUID,
+    ) -> list[ContinuityObjectEvidenceRow]:
+        return self._fetch_all(
+            LIST_CONTINUITY_OBJECT_EVIDENCE_SQL,
+            (continuity_object_id,),
+        )
 
     def update_continuity_object_optional(
         self,

--- a/tests/integration/test_chatgpt_import.py
+++ b/tests/integration/test_chatgpt_import.py
@@ -60,6 +60,8 @@ def test_chatgpt_import_supports_recall_resumption_and_idempotent_dedupe(migrate
             item["provenance"].get("chatgpt_workspace_id") == "chatgpt-workspace-demo-001"
             for item in recall["items"]
         )
+        assert all(item["provenance"].get("artifact_id") is not None for item in recall["items"])
+        assert all(item["provenance"].get("artifact_segment_id") is not None for item in recall["items"])
 
         resumption = compile_continuity_resumption_brief(
             store,

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -9,6 +9,7 @@ import sys
 from uuid import UUID, uuid4
 
 from alicebot_api.db import user_connection
+from alicebot_api.markdown_import import import_markdown_source
 from alicebot_api.store import ContinuityStore
 
 
@@ -293,3 +294,24 @@ def test_cli_command_surface_and_correction_flow(migrated_database_urls) -> None
     )
     assert resume_override_fact_result.returncode == 0
     assert "Memory Fact: searchable but not promotable" in resume_override_fact_result.stdout
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        imported = import_markdown_source(
+            ContinuityStore(conn),
+            user_id=user_id,
+            source=REPO_ROOT / "fixtures" / "importers" / "markdown" / "workspace_v1.md",
+        )
+        imported_object_id = imported["imported_object_ids"][0]
+        evidence_rows = ContinuityStore(conn).list_continuity_object_evidence(UUID(imported_object_id))
+        artifact_id = evidence_rows[0]["artifact_id"]
+
+    explain_result = run_cli(["explain", imported_object_id], env=env)
+    assert explain_result.returncode == 0
+    assert "evidence_links: 1" in explain_result.stdout
+    assert "raw_evidence=" in explain_result.stdout
+
+    artifact_result = run_cli(["evidence", "artifact", str(artifact_id)], env=env)
+    assert artifact_result.returncode == 0
+    assert "artifact detail" in artifact_result.stdout
+    assert "copies: 1" in artifact_result.stdout
+    assert "segments:" in artifact_result.stdout

--- a/tests/integration/test_markdown_import.py
+++ b/tests/integration/test_markdown_import.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 from uuid import UUID, uuid4
 
+import pytest
+
+from alicebot_api.continuity_evidence import build_continuity_explain
 from alicebot_api.continuity_recall import query_continuity_recall
 from alicebot_api.continuity_resumption import compile_continuity_resumption_brief
 from alicebot_api.contracts import ContinuityRecallQueryInput, ContinuityResumptionBriefRequestInput
 from alicebot_api.db import user_connection
-from alicebot_api.markdown_import import import_markdown_source
+from alicebot_api.markdown_import import MarkdownImportValidationError, import_markdown_source
 from alicebot_api.store import ContinuityStore
 
 
@@ -60,6 +63,22 @@ def test_markdown_import_supports_recall_resumption_and_idempotent_dedupe(migrat
             item["provenance"].get("markdown_workspace_id") == "markdown-workspace-demo-001"
             for item in recall["items"]
         )
+        assert all(item["provenance"].get("artifact_id") is not None for item in recall["items"])
+        assert all(item["provenance"].get("artifact_segment_id") is not None for item in recall["items"])
+
+        explain = build_continuity_explain(
+            store,
+            user_id=user_id,
+            continuity_object_id=UUID(first_import["imported_object_ids"][0]),
+        )
+        assert len(explain["explain"]["evidence_chain"]) == 1
+        assert explain["explain"]["evidence_chain"][0]["artifact"]["source_kind"] == "markdown_import"
+        assert explain["explain"]["evidence_chain"][0]["artifact_segment"] is not None
+        assert (
+            explain["explain"]["evidence_chain"][0]["artifact_segment"]["segment_kind"]
+            == "markdown_line"
+        )
+        assert explain["explain"]["evidence_chain"][0]["artifact_copy"]["content_text"] != ""
 
         resumption = compile_continuity_resumption_brief(
             store,
@@ -89,3 +108,30 @@ def test_markdown_import_supports_recall_resumption_and_idempotent_dedupe(migrat
         assert second_import["total_candidates"] == 5
         assert second_import["imported_count"] == 0
         assert second_import["skipped_duplicates"] == 5
+
+
+def test_markdown_import_archives_source_before_failed_extraction(migrated_database_urls, tmp_path: Path) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="markdown-import-failure@example.com")
+    broken_source = tmp_path / "broken.md"
+    broken_source.write_text("---\nfixture_id: broken\n- Decision: missing frontmatter close\n", encoding="utf-8")
+
+    with pytest.raises(MarkdownImportValidationError, match="frontmatter"):
+        with user_connection(migrated_database_urls["app"], user_id) as conn:
+            import_markdown_source(
+                ContinuityStore(conn),
+                user_id=user_id,
+                source=broken_source,
+            )
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT relative_path FROM continuity_artifacts ORDER BY relative_path ASC")
+            artifacts = cur.fetchall()
+            cur.execute("SELECT content_text FROM continuity_artifact_copies ORDER BY created_at ASC, id ASC")
+            copies = cur.fetchall()
+            cur.execute("SELECT COUNT(*) AS count FROM continuity_artifact_segments")
+            segments_row = cur.fetchone()
+
+    assert artifacts == [{"relative_path": "broken.md"}]
+    assert copies == [{"content_text": broken_source.read_text(encoding="utf-8")}]
+    assert segments_row == {"count": 0}

--- a/tests/integration/test_openclaw_import.py
+++ b/tests/integration/test_openclaw_import.py
@@ -93,6 +93,8 @@ def test_openclaw_import_supports_recall_resumption_and_idempotent_dedupe(
             item["provenance"].get("openclaw_workspace_id") == expected_workspace_id
             for item in recall["items"]
         )
+        assert all(item["provenance"].get("artifact_id") is not None for item in recall["items"])
+        assert all(item["provenance"].get("artifact_segment_id") is not None for item in recall["items"])
 
         resumption = compile_continuity_resumption_brief(
             store,

--- a/tests/unit/test_20260410_0050_archive_first_evidence_pipeline.py
+++ b/tests/unit/test_20260410_0050_archive_first_evidence_pipeline.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260410_0050_archive_first_evidence_pipeline"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == list(module._UPGRADE_STATEMENTS)
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -21,6 +21,8 @@ def test_parser_routes_required_commands() -> None:
         (["review", "queue"], "_run_review_queue"),
         (["review", "show", continuity_object_id], "_run_review_show"),
         (["review", "apply", continuity_object_id, "--action", "confirm"], "_run_review_apply"),
+        (["explain", continuity_object_id], "_run_explain"),
+        (["evidence", "artifact", continuity_object_id], "_run_evidence_artifact"),
         (["status"], "_run_status"),
     ]
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -134,6 +134,8 @@ def test_healthcheck_route_is_registered() -> None:
     assert "/v0/memory-embeddings/{memory_embedding_id}" in route_paths
     assert "/v0/admin/debug/continuity/lifecycle" in route_paths
     assert "/v0/admin/debug/continuity/lifecycle/{continuity_object_id}" in route_paths
+    assert "/v0/admin/debug/continuity/artifacts/{artifact_id}" in route_paths
+    assert "/v0/continuity/explain/{continuity_object_id}" in route_paths
     assert "/v0/task-artifact-chunk-embeddings" in route_paths
     assert "/v0/task-artifacts/{task_artifact_id}/chunk-embeddings" in route_paths
     assert "/v0/task-artifact-chunks/{task_artifact_chunk_id}/embeddings" in route_paths


### PR DESCRIPTION
## Summary
This PR builds an archive-first evidence pipeline for imported continuity data.

Imported source material is now preserved before extraction, stored as first-class artifacts with immutable copies and extracted segments, and linked directly to promoted continuity objects. The continuity explain and inspection surfaces were extended so every promoted fact can be traced back to the raw artifact and the exact segment it came from.

## What Changed
- added continuity artifact, artifact copy, artifact segment, and continuity object evidence-link tables
- updated the shared importer pipeline so raw source files are archived before extraction and segment-level evidence is recorded during import
- preserved evidence chains across supersession so corrected facts keep their source lineage
- added API, CLI, and MCP inspection paths for explain and archived artifact lookup
- added migration, importer, CLI, and integration coverage for the new evidence workflow

## Why
The previous importer flow stored extracted continuity objects, but it did not preserve raw source material as a durable first-class record before extraction.

That meant provenance was partially represented in JSON metadata instead of a concrete evidence chain, and a failed extraction path could not reliably prove the original source had been retained.

This change makes archival durability explicit and gives downstream explain tooling a real raw-evidence chain instead of an inferred one.

## Acceptance Criteria
This change satisfies the requested behavior:
- every imported artifact is preserved before extraction
- every promoted fact can trace back to its source artifact and extracted segment
- failed extraction does not destroy source material
- alice explain can show the raw evidence chain

## Validation
The following focused suite passed on the staged tree:

```bash
python3 -m pytest tests/unit/test_20260410_0050_archive_first_evidence_pipeline.py tests/unit/test_cli.py tests/unit/test_main.py tests/unit/test_importers.py tests/integration/test_markdown_import.py tests/integration/test_chatgpt_import.py tests/integration/test_openclaw_import.py tests/integration/test_cli_integration.py tests/integration/test_mcp_cli_parity.py -q
```

Result: 78 passed in 8.69s
