### PR TITLE
[codex] Add trusted fact patterns and playbooks

### DIFF
--- a/apps/api/alembic/versions/20260410_0051_trusted_fact_patterns_playbooks.py
+++ b/apps/api/alembic/versions/20260410_0051_trusted_fact_patterns_playbooks.py
@@ -1,0 +1,138 @@
+"""Add derived trusted-fact pattern and playbook tables."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260410_0051"
+down_revision = "20260410_0050"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_STATEMENTS = (
+    """
+        CREATE TABLE fact_patterns (
+          id uuid PRIMARY KEY,
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          pattern_key text NOT NULL,
+          title text NOT NULL,
+          memory_type text NOT NULL,
+          namespace_key text NOT NULL,
+          fact_count integer NOT NULL,
+          source_fact_ids jsonb NOT NULL,
+          evidence_chain jsonb NOT NULL,
+          explanation text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (id, user_id),
+          UNIQUE (user_id, pattern_key),
+          CONSTRAINT fact_patterns_pattern_key_length_check
+            CHECK (char_length(pattern_key) >= 1 AND char_length(pattern_key) <= 280),
+          CONSTRAINT fact_patterns_title_length_check
+            CHECK (char_length(title) >= 1 AND char_length(title) <= 280),
+          CONSTRAINT fact_patterns_memory_type_length_check
+            CHECK (char_length(memory_type) >= 1 AND char_length(memory_type) <= 100),
+          CONSTRAINT fact_patterns_namespace_key_length_check
+            CHECK (char_length(namespace_key) >= 1 AND char_length(namespace_key) <= 280),
+          CONSTRAINT fact_patterns_fact_count_positive_check
+            CHECK (fact_count >= 1)
+        );
+        """,
+    """
+        CREATE TABLE fact_playbooks (
+          id uuid PRIMARY KEY,
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          playbook_key text NOT NULL,
+          pattern_id uuid NOT NULL,
+          pattern_key text NOT NULL,
+          title text NOT NULL,
+          memory_type text NOT NULL,
+          source_fact_ids jsonb NOT NULL,
+          source_pattern_ids jsonb NOT NULL,
+          steps jsonb NOT NULL,
+          explanation text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (id, user_id),
+          UNIQUE (user_id, playbook_key),
+          CONSTRAINT fact_playbooks_pattern_fkey
+            FOREIGN KEY (pattern_id, user_id)
+            REFERENCES fact_patterns(id, user_id)
+            ON DELETE CASCADE,
+          CONSTRAINT fact_playbooks_playbook_key_length_check
+            CHECK (char_length(playbook_key) >= 1 AND char_length(playbook_key) <= 280),
+          CONSTRAINT fact_playbooks_pattern_key_length_check
+            CHECK (char_length(pattern_key) >= 1 AND char_length(pattern_key) <= 280),
+          CONSTRAINT fact_playbooks_title_length_check
+            CHECK (char_length(title) >= 1 AND char_length(title) <= 280),
+          CONSTRAINT fact_playbooks_memory_type_length_check
+            CHECK (char_length(memory_type) >= 1 AND char_length(memory_type) <= 100)
+        );
+        """,
+    """
+        CREATE INDEX fact_patterns_user_memory_type_namespace_idx
+          ON fact_patterns (user_id, memory_type, namespace_key, id);
+        CREATE INDEX fact_playbooks_user_memory_type_pattern_idx
+          ON fact_playbooks (user_id, memory_type, pattern_key, id);
+        """,
+    "GRANT SELECT, INSERT, UPDATE, DELETE ON fact_patterns TO alicebot_app",
+    "GRANT SELECT, INSERT, UPDATE, DELETE ON fact_playbooks TO alicebot_app",
+    "ALTER TABLE fact_patterns ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE fact_patterns FORCE ROW LEVEL SECURITY",
+    "ALTER TABLE fact_playbooks ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE fact_playbooks FORCE ROW LEVEL SECURITY",
+    """
+        CREATE POLICY fact_patterns_read_own ON fact_patterns
+          FOR SELECT
+          USING (user_id = app.current_user_id());
+
+        CREATE POLICY fact_patterns_insert_own ON fact_patterns
+          FOR INSERT
+          WITH CHECK (user_id = app.current_user_id());
+
+        CREATE POLICY fact_patterns_update_own ON fact_patterns
+          FOR UPDATE
+          USING (user_id = app.current_user_id())
+          WITH CHECK (user_id = app.current_user_id());
+
+        CREATE POLICY fact_patterns_delete_own ON fact_patterns
+          FOR DELETE
+          USING (user_id = app.current_user_id());
+
+        CREATE POLICY fact_playbooks_read_own ON fact_playbooks
+          FOR SELECT
+          USING (user_id = app.current_user_id());
+
+        CREATE POLICY fact_playbooks_insert_own ON fact_playbooks
+          FOR INSERT
+          WITH CHECK (user_id = app.current_user_id());
+
+        CREATE POLICY fact_playbooks_update_own ON fact_playbooks
+          FOR UPDATE
+          USING (user_id = app.current_user_id())
+          WITH CHECK (user_id = app.current_user_id());
+
+        CREATE POLICY fact_playbooks_delete_own ON fact_playbooks
+          FOR DELETE
+          USING (user_id = app.current_user_id());
+        """,
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP TABLE IF EXISTS fact_playbooks",
+    "DROP TABLE IF EXISTS fact_patterns",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -28,6 +28,10 @@ from alicebot_api.cli_formatting import (
     format_temporal_explain_output,
     format_temporal_state_output,
     format_temporal_timeline_output,
+    format_trusted_fact_pattern_explain_output,
+    format_trusted_fact_pattern_list_output,
+    format_trusted_fact_playbook_explain_output,
+    format_trusted_fact_playbook_list_output,
 )
 from alicebot_api.config import Settings, get_settings
 from alicebot_api.continuity_capture import (
@@ -78,6 +82,7 @@ from alicebot_api.contracts import (
     DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
     DEFAULT_CONTINUITY_REVIEW_LIMIT,
     DEFAULT_TEMPORAL_TIMELINE_LIMIT,
+    DEFAULT_TRUSTED_FACT_PROMOTION_LIMIT,
     MAX_CONTINUITY_OPEN_LOOP_LIMIT,
     MAX_CONTINUITY_RECALL_LIMIT,
     MAX_CONTINUITY_LIFECYCLE_LIMIT,
@@ -85,6 +90,7 @@ from alicebot_api.contracts import (
     MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
     MAX_CONTINUITY_REVIEW_LIMIT,
     MAX_TEMPORAL_TIMELINE_LIMIT,
+    MAX_TRUSTED_FACT_PROMOTION_LIMIT,
     ContinuityCaptureCreateInput,
     ContinuityCorrectionInput,
     ContinuityLifecycleQueryInput,
@@ -95,6 +101,8 @@ from alicebot_api.contracts import (
     TemporalExplainQueryInput,
     TemporalStateAtQueryInput,
     TemporalTimelineQueryInput,
+    TrustedFactPatternListQueryInput,
+    TrustedFactPlaybookListQueryInput,
 )
 from alicebot_api.db import ping_database, user_connection
 from alicebot_api.retrieval_evaluation import get_retrieval_evaluation_summary
@@ -104,6 +112,13 @@ from alicebot_api.temporal_state import (
     get_temporal_explain,
     get_temporal_state_at,
     get_temporal_timeline,
+)
+from alicebot_api.trusted_fact_promotions import (
+    TrustedFactPromotionNotFoundError,
+    get_trusted_fact_pattern,
+    get_trusted_fact_playbook,
+    list_trusted_fact_patterns,
+    list_trusted_fact_playbooks,
 )
 
 DEFAULT_CLI_USER_ID = "00000000-0000-0000-0000-000000000001"
@@ -389,6 +404,46 @@ def _run_evidence_artifact(ctx: CLIContext, args: argparse.Namespace) -> str:
             artifact_id=args.artifact_id,
         )
     return format_artifact_detail_output(payload)
+
+
+def _run_pattern_list(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = list_trusted_fact_patterns(
+            store,
+            user_id=ctx.user_id,
+            request=TrustedFactPatternListQueryInput(limit=args.limit),
+        )
+    return format_trusted_fact_pattern_list_output(payload)
+
+
+def _run_pattern_explain(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = get_trusted_fact_pattern(
+            store,
+            user_id=ctx.user_id,
+            pattern_id=args.pattern_id,
+        )
+    return format_trusted_fact_pattern_explain_output(payload)
+
+
+def _run_playbook_list(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = list_trusted_fact_playbooks(
+            store,
+            user_id=ctx.user_id,
+            request=TrustedFactPlaybookListQueryInput(limit=args.limit),
+        )
+    return format_trusted_fact_playbook_list_output(payload)
+
+
+def _run_playbook_explain(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = get_trusted_fact_playbook(
+            store,
+            user_id=ctx.user_id,
+            playbook_id=args.playbook_id,
+        )
+    return format_trusted_fact_playbook_explain_output(payload)
 
 
 def _run_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
@@ -735,6 +790,34 @@ def build_parser() -> argparse.ArgumentParser:
     evidence_artifact_parser.add_argument("artifact_id", type=_parse_uuid, help="Continuity artifact UUID.")
     evidence_artifact_parser.set_defaults(handler=_run_evidence_artifact)
 
+    patterns_parser = subparsers.add_parser("patterns", help="List and explain trusted fact patterns.")
+    patterns_subparsers = patterns_parser.add_subparsers(dest="patterns_command", required=True)
+    patterns_list_parser = patterns_subparsers.add_parser("list", help="List trusted fact patterns.")
+    patterns_list_parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_TRUSTED_FACT_PROMOTION_LIMIT,
+        help=f"Max pattern results (1-{MAX_TRUSTED_FACT_PROMOTION_LIMIT}).",
+    )
+    patterns_list_parser.set_defaults(handler=_run_pattern_list)
+    patterns_explain_parser = patterns_subparsers.add_parser("explain", help="Explain one trusted fact pattern.")
+    patterns_explain_parser.add_argument("pattern_id", type=_parse_uuid, help="Pattern UUID.")
+    patterns_explain_parser.set_defaults(handler=_run_pattern_explain)
+
+    playbooks_parser = subparsers.add_parser("playbooks", help="List and explain trusted fact playbooks.")
+    playbooks_subparsers = playbooks_parser.add_subparsers(dest="playbooks_command", required=True)
+    playbooks_list_parser = playbooks_subparsers.add_parser("list", help="List trusted fact playbooks.")
+    playbooks_list_parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_TRUSTED_FACT_PROMOTION_LIMIT,
+        help=f"Max playbook results (1-{MAX_TRUSTED_FACT_PROMOTION_LIMIT}).",
+    )
+    playbooks_list_parser.set_defaults(handler=_run_playbook_list)
+    playbooks_explain_parser = playbooks_subparsers.add_parser("explain", help="Explain one trusted fact playbook.")
+    playbooks_explain_parser.add_argument("playbook_id", type=_parse_uuid, help="Playbook UUID.")
+    playbooks_explain_parser.set_defaults(handler=_run_playbook_explain)
+
     status_parser = subparsers.add_parser("status", help="Show local continuity runtime status.")
     status_parser.set_defaults(handler=_run_status)
 
@@ -795,6 +878,20 @@ def _validate_arguments(args: argparse.Namespace) -> None:
             minimum=1,
             maximum=MAX_CONTINUITY_REVIEW_LIMIT,
         )
+    elif args.command == "patterns" and args.patterns_command == "list":
+        _validate_limit(
+            args.limit,
+            option_name="--limit",
+            minimum=1,
+            maximum=MAX_TRUSTED_FACT_PROMOTION_LIMIT,
+        )
+    elif args.command == "playbooks" and args.playbooks_command == "list":
+        _validate_limit(
+            args.limit,
+            option_name="--limit",
+            minimum=1,
+            maximum=MAX_TRUSTED_FACT_PROMOTION_LIMIT,
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -819,6 +916,7 @@ def main(argv: list[str] | None = None) -> int:
         ContinuityReviewNotFoundError,
         ContinuityEvidenceNotFoundError,
         TemporalStateValidationError,
+        TrustedFactPromotionNotFoundError,
     ) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/apps/api/src/alicebot_api/cli_formatting.py
+++ b/apps/api/src/alicebot_api/cli_formatting.py
@@ -19,6 +19,10 @@ from alicebot_api.contracts import (
     TemporalExplainResponse,
     TemporalStateAtResponse,
     TemporalTimelineResponse,
+    TrustedFactPatternExplainResponse,
+    TrustedFactPatternListResponse,
+    TrustedFactPlaybookExplainResponse,
+    TrustedFactPlaybookListResponse,
 )
 
 
@@ -507,6 +511,123 @@ def format_temporal_explain_output(payload: TemporalExplainResponse) -> str:
                     f"    supersession_chain={_format_json(edge['supersession_chain'])}",
                 ]
             )
+    return "\n".join(lines)
+
+
+def format_trusted_fact_pattern_list_output(payload: TrustedFactPatternListResponse) -> str:
+    summary = payload["summary"]
+    lines = [
+        "patterns",
+        f"returned: {summary['returned_count']}/{summary['total_count']} (limit={summary['limit']})",
+        f"order: {', '.join(summary['order'])}",
+    ]
+    if len(payload["items"]) == 0:
+        lines.append("empty: no trusted fact patterns.")
+        return "\n".join(lines)
+
+    for index, item in enumerate(payload["items"], start=1):
+        lines.extend(
+            [
+                f"{index}. {item['title']}",
+                f"   id={item['id']} pattern_key={item['pattern_key']}",
+                (
+                    f"   memory_type={item['memory_type']} "
+                    f"namespace_key={item['namespace_key']} fact_count={item['fact_count']}"
+                ),
+                f"   source_fact_ids={','.join(item['source_fact_ids'])}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def format_trusted_fact_pattern_explain_output(payload: TrustedFactPatternExplainResponse) -> str:
+    pattern = payload["pattern"]
+    lines = [
+        "pattern",
+        f"id: {pattern['id']}",
+        f"pattern_key: {pattern['pattern_key']}",
+        f"title: {pattern['title']}",
+        f"memory_type: {pattern['memory_type']}",
+        f"namespace_key: {pattern['namespace_key']}",
+        f"fact_count: {pattern['fact_count']}",
+        f"source_fact_ids: {','.join(pattern['source_fact_ids'])}",
+        f"explanation: {pattern['explanation']}",
+    ]
+    if len(pattern["evidence_chain"]) == 0:
+        lines.append("evidence_chain: none")
+        return "\n".join(lines)
+
+    lines.append("evidence_chain:")
+    for index, link in enumerate(pattern["evidence_chain"], start=1):
+        lines.extend(
+            [
+                f"  {index}. fact_id={link['fact_id']} memory_key={link['memory_key']}",
+                (
+                    f"    trust_class={link['trust']['trust_class']} "
+                    f"promotion={link['promotion_eligibility']} "
+                    f"evidence_count={link['evidence_count']} "
+                    f"independent_source_count={link['independent_source_count']}"
+                ),
+                f"    source_event_ids={','.join(link['source_event_ids'])}",
+                f"    revision={_format_json({'sequence_no': link['revision_sequence_no'], 'action': link['revision_action'], 'created_at': link['revision_created_at']})}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def format_trusted_fact_playbook_list_output(payload: TrustedFactPlaybookListResponse) -> str:
+    summary = payload["summary"]
+    lines = [
+        "playbooks",
+        f"returned: {summary['returned_count']}/{summary['total_count']} (limit={summary['limit']})",
+        f"order: {', '.join(summary['order'])}",
+    ]
+    if len(payload["items"]) == 0:
+        lines.append("empty: no trusted fact playbooks.")
+        return "\n".join(lines)
+
+    for index, item in enumerate(payload["items"], start=1):
+        lines.extend(
+            [
+                f"{index}. {item['title']}",
+                f"   id={item['id']} playbook_key={item['playbook_key']}",
+                (
+                    f"   memory_type={item['memory_type']} pattern_key={item['pattern_key']} "
+                    f"step_count={len(item['steps'])}"
+                ),
+                f"   source_fact_ids={','.join(item['source_fact_ids'])}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def format_trusted_fact_playbook_explain_output(payload: TrustedFactPlaybookExplainResponse) -> str:
+    playbook = payload["playbook"]
+    lines = [
+        "playbook",
+        f"id: {playbook['id']}",
+        f"playbook_key: {playbook['playbook_key']}",
+        f"pattern_id: {playbook['pattern_id']}",
+        f"pattern_key: {playbook['pattern_key']}",
+        f"title: {playbook['title']}",
+        f"memory_type: {playbook['memory_type']}",
+        f"source_fact_ids: {','.join(playbook['source_fact_ids'])}",
+        f"source_pattern_ids: {','.join(playbook['source_pattern_ids'])}",
+        f"explanation: {playbook['explanation']}",
+    ]
+    if len(playbook["steps"]) == 0:
+        lines.append("steps: none")
+        return "\n".join(lines)
+
+    lines.append("steps:")
+    for step in playbook["steps"]:
+        lines.extend(
+            [
+                f"  {step['step_no']}. [{step['action_type']}] {step['instruction']}",
+                f"    fact_id={step['fact_id']} memory_key={step['memory_key']}",
+                f"    trust={_format_json(step['trust'])}",
+            ]
+        )
     return "\n".join(lines)
 
 

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -466,6 +466,8 @@ DEFAULT_MEMORY_TRUST_CLASS: MemoryTrustClass = "deterministic"
 DEFAULT_MEMORY_PROMOTION_ELIGIBILITY: MemoryPromotionEligibility = "promotable"
 DEFAULT_CONTINUITY_LIFECYCLE_LIMIT = 50
 MAX_CONTINUITY_LIFECYCLE_LIMIT = 200
+DEFAULT_TRUSTED_FACT_PROMOTION_LIMIT = 50
+MAX_TRUSTED_FACT_PROMOTION_LIMIT = 200
 ENTITY_TYPES = [
     "person",
     "merchant",
@@ -476,6 +478,8 @@ ENTITY_TYPES = [
 ENTITY_LIST_ORDER = ["created_at_asc", "id_asc"]
 ENTITY_EDGE_LIST_ORDER = ["created_at_asc", "id_asc"]
 TEMPORAL_TIMELINE_ORDER = ["occurred_at_asc", "event_type_asc", "id_asc"]
+TRUSTED_FACT_PATTERN_ORDER = ["memory_type_asc", "namespace_key_asc", "title_asc", "id_asc"]
+TRUSTED_FACT_PLAYBOOK_ORDER = ["memory_type_asc", "pattern_key_asc", "title_asc", "id_asc"]
 EMBEDDING_CONFIG_LIST_ORDER = ["created_at_asc", "id_asc"]
 MEMORY_EMBEDDING_LIST_ORDER = ["created_at_asc", "id_asc"]
 SEMANTIC_MEMORY_RETRIEVAL_ORDER = ["score_desc", "created_at_asc", "id_asc"]
@@ -2064,6 +2068,26 @@ class TemporalExplainQueryInput:
         return {
             "entity_id": str(self.entity_id),
             "at": isoformat_or_none(self.at),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedFactPatternListQueryInput:
+    limit: int = DEFAULT_TRUSTED_FACT_PROMOTION_LIMIT
+
+    def as_payload(self) -> JsonObject:
+        return {
+            "limit": self.limit,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedFactPlaybookListQueryInput:
+    limit: int = DEFAULT_TRUSTED_FACT_PROMOTION_LIMIT
+
+    def as_payload(self) -> JsonObject:
+        return {
+            "limit": self.limit,
         }
 
 
@@ -3974,6 +3998,93 @@ class TemporalExplainRecord(TypedDict):
 
 class TemporalExplainResponse(TypedDict):
     explain: TemporalExplainRecord
+
+
+class TrustedFactEvidenceLinkRecord(TypedDict):
+    fact_id: str
+    memory_key: str
+    memory_type: str
+    value: JsonValue
+    trust: TemporalTrustRecord
+    promotion_eligibility: MemoryPromotionEligibility
+    evidence_count: int | None
+    independent_source_count: int | None
+    extracted_by_model: str | None
+    source_event_ids: list[str]
+    revision_sequence_no: int | None
+    revision_action: str | None
+    revision_created_at: str | None
+
+
+class TrustedFactPatternRecord(TypedDict):
+    id: str
+    pattern_key: str
+    title: str
+    memory_type: str
+    namespace_key: str
+    fact_count: int
+    source_fact_ids: list[str]
+    evidence_chain: list[TrustedFactEvidenceLinkRecord]
+    explanation: str
+    created_at: str
+    updated_at: str
+
+
+class TrustedFactPatternListSummary(TypedDict):
+    returned_count: int
+    total_count: int
+    limit: int
+    order: list[str]
+
+
+class TrustedFactPatternListResponse(TypedDict):
+    items: list[TrustedFactPatternRecord]
+    summary: TrustedFactPatternListSummary
+
+
+class TrustedFactPatternExplainResponse(TypedDict):
+    pattern: TrustedFactPatternRecord
+
+
+class TrustedFactPlaybookStepRecord(TypedDict):
+    step_no: int
+    fact_id: str
+    memory_key: str
+    action_type: str
+    instruction: str
+    value: JsonValue
+    trust: TemporalTrustRecord
+
+
+class TrustedFactPlaybookRecord(TypedDict):
+    id: str
+    playbook_key: str
+    pattern_id: str
+    pattern_key: str
+    title: str
+    memory_type: str
+    source_fact_ids: list[str]
+    source_pattern_ids: list[str]
+    steps: list[TrustedFactPlaybookStepRecord]
+    explanation: str
+    created_at: str
+    updated_at: str
+
+
+class TrustedFactPlaybookListSummary(TypedDict):
+    returned_count: int
+    total_count: int
+    limit: int
+    order: list[str]
+
+
+class TrustedFactPlaybookListResponse(TypedDict):
+    items: list[TrustedFactPlaybookRecord]
+    summary: TrustedFactPlaybookListSummary
+
+
+class TrustedFactPlaybookExplainResponse(TypedDict):
+    playbook: TrustedFactPlaybookRecord
 
 
 class EmbeddingConfigRecord(TypedDict):

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -56,6 +56,7 @@ from alicebot_api.contracts import (
     DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
     DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
     DEFAULT_TEMPORAL_TIMELINE_LIMIT,
+    DEFAULT_TRUSTED_FACT_PROMOTION_LIMIT,
     DEFAULT_CHIEF_OF_STAFF_PRIORITY_LIMIT,
     DEFAULT_MAX_EVENTS,
     DEFAULT_MAX_ENTITY_EDGES,
@@ -86,6 +87,7 @@ from alicebot_api.contracts import (
     MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
     MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
     MAX_TEMPORAL_TIMELINE_LIMIT,
+    MAX_TRUSTED_FACT_PROMOTION_LIMIT,
     MAX_CHIEF_OF_STAFF_PRIORITY_LIMIT,
     MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
     ContextCompilerLimits,
@@ -115,6 +117,12 @@ from alicebot_api.contracts import (
     TemporalStateAtResponse,
     TemporalTimelineQueryInput,
     TemporalTimelineResponse,
+    TrustedFactPatternExplainResponse,
+    TrustedFactPatternListQueryInput,
+    TrustedFactPatternListResponse,
+    TrustedFactPlaybookExplainResponse,
+    TrustedFactPlaybookListQueryInput,
+    TrustedFactPlaybookListResponse,
     ChiefOfStaffPriorityBriefRequestInput,
     ChiefOfStaffPriorityBriefResponse,
     ChiefOfStaffExecutionRoutingActionInput,
@@ -374,6 +382,13 @@ from alicebot_api.temporal_state import (
     get_temporal_explain,
     get_temporal_state_at,
     get_temporal_timeline,
+)
+from alicebot_api.trusted_fact_promotions import (
+    TrustedFactPromotionNotFoundError,
+    get_trusted_fact_pattern,
+    get_trusted_fact_playbook,
+    list_trusted_fact_patterns,
+    list_trusted_fact_playbooks,
 )
 from alicebot_api.continuity_lifecycle import (
     ContinuityLifecycleNotFoundError,
@@ -4330,6 +4345,86 @@ def get_temporal_explain_endpoint(
     except (TemporalStateNotFoundError, TemporalStateValidationError) as exc:
         status_code = 404 if isinstance(exc, TemporalStateNotFoundError) else 400
         return JSONResponse(status_code=status_code, content={"detail": str(exc)})
+
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.get("/v0/patterns")
+def list_trusted_fact_patterns_endpoint(
+    user_id: UUID,
+    limit: int = Query(
+        default=DEFAULT_TRUSTED_FACT_PROMOTION_LIMIT,
+        ge=1,
+        le=MAX_TRUSTED_FACT_PROMOTION_LIMIT,
+    ),
+) -> JSONResponse:
+    settings = get_settings()
+
+    with user_connection(settings.database_url, user_id) as conn:
+        payload: TrustedFactPatternListResponse = list_trusted_fact_patterns(
+            ContinuityStore(conn),
+            user_id=user_id,
+            request=TrustedFactPatternListQueryInput(limit=limit),
+        )
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.get("/v0/patterns/{pattern_id}")
+def get_trusted_fact_pattern_endpoint(
+    pattern_id: UUID,
+    user_id: UUID,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: TrustedFactPatternExplainResponse = get_trusted_fact_pattern(
+                ContinuityStore(conn),
+                user_id=user_id,
+                pattern_id=pattern_id,
+            )
+    except TrustedFactPromotionNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.get("/v0/playbooks")
+def list_trusted_fact_playbooks_endpoint(
+    user_id: UUID,
+    limit: int = Query(
+        default=DEFAULT_TRUSTED_FACT_PROMOTION_LIMIT,
+        ge=1,
+        le=MAX_TRUSTED_FACT_PROMOTION_LIMIT,
+    ),
+) -> JSONResponse:
+    settings = get_settings()
+
+    with user_connection(settings.database_url, user_id) as conn:
+        payload: TrustedFactPlaybookListResponse = list_trusted_fact_playbooks(
+            ContinuityStore(conn),
+            user_id=user_id,
+            request=TrustedFactPlaybookListQueryInput(limit=limit),
+        )
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.get("/v0/playbooks/{playbook_id}")
+def get_trusted_fact_playbook_endpoint(
+    playbook_id: UUID,
+    user_id: UUID,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: TrustedFactPlaybookExplainResponse = get_trusted_fact_playbook(
+                ContinuityStore(conn),
+                user_id=user_id,
+                playbook_id=playbook_id,
+            )
+    except TrustedFactPromotionNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
 
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -131,6 +131,37 @@ class MemoryRevisionRow(TypedDict):
     created_at: datetime
 
 
+class FactPatternRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    pattern_key: str
+    title: str
+    memory_type: str
+    namespace_key: str
+    fact_count: int
+    source_fact_ids: list[str]
+    evidence_chain: JsonValue
+    explanation: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class FactPlaybookRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    playbook_key: str
+    pattern_id: UUID
+    pattern_key: str
+    title: str
+    memory_type: str
+    source_fact_ids: list[str]
+    source_pattern_ids: list[str]
+    steps: JsonValue
+    explanation: str
+    created_at: datetime
+    updated_at: datetime
+
+
 class MemoryReviewLabelRow(TypedDict):
     id: UUID
     user_id: UUID
@@ -1539,6 +1570,228 @@ LIST_LIMITED_MEMORY_REVISIONS_SQL = """
                 WHERE memory_id = %s
                 ORDER BY sequence_no ASC
                 LIMIT %s
+                """
+
+UPSERT_FACT_PATTERN_SQL = """
+                INSERT INTO fact_patterns (
+                  id,
+                  user_id,
+                  pattern_key,
+                  title,
+                  memory_type,
+                  namespace_key,
+                  fact_count,
+                  source_fact_ids,
+                  evidence_chain,
+                  explanation,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  %s,
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  clock_timestamp(),
+                  clock_timestamp()
+                )
+                ON CONFLICT (user_id, pattern_key)
+                DO UPDATE SET
+                  id = EXCLUDED.id,
+                  title = EXCLUDED.title,
+                  memory_type = EXCLUDED.memory_type,
+                  namespace_key = EXCLUDED.namespace_key,
+                  fact_count = EXCLUDED.fact_count,
+                  source_fact_ids = EXCLUDED.source_fact_ids,
+                  evidence_chain = EXCLUDED.evidence_chain,
+                  explanation = EXCLUDED.explanation,
+                  updated_at = clock_timestamp()
+                RETURNING
+                  id,
+                  user_id,
+                  pattern_key,
+                  title,
+                  memory_type,
+                  namespace_key,
+                  fact_count,
+                  source_fact_ids,
+                  evidence_chain,
+                  explanation,
+                  created_at,
+                  updated_at
+                """
+
+LIST_FACT_PATTERNS_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  pattern_key,
+                  title,
+                  memory_type,
+                  namespace_key,
+                  fact_count,
+                  source_fact_ids,
+                  evidence_chain,
+                  explanation,
+                  created_at,
+                  updated_at
+                FROM fact_patterns
+                ORDER BY memory_type ASC, namespace_key ASC, title ASC, id ASC
+                LIMIT %s
+                """
+
+COUNT_FACT_PATTERNS_SQL = """
+                SELECT COUNT(*) AS count
+                FROM fact_patterns
+                """
+
+GET_FACT_PATTERN_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  pattern_key,
+                  title,
+                  memory_type,
+                  namespace_key,
+                  fact_count,
+                  source_fact_ids,
+                  evidence_chain,
+                  explanation,
+                  created_at,
+                  updated_at
+                FROM fact_patterns
+                WHERE id = %s
+                """
+
+DELETE_FACT_PATTERNS_NOT_IN_SQL = """
+                DELETE FROM fact_patterns
+                WHERE user_id = app.current_user_id()
+                  AND NOT (id = ANY(%s))
+                """
+
+DELETE_ALL_FACT_PATTERNS_SQL = """
+                DELETE FROM fact_patterns
+                WHERE user_id = app.current_user_id()
+                """
+
+UPSERT_FACT_PLAYBOOK_SQL = """
+                INSERT INTO fact_playbooks (
+                  id,
+                  user_id,
+                  playbook_key,
+                  pattern_id,
+                  pattern_key,
+                  title,
+                  memory_type,
+                  source_fact_ids,
+                  source_pattern_ids,
+                  steps,
+                  explanation,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  %s,
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  clock_timestamp(),
+                  clock_timestamp()
+                )
+                ON CONFLICT (user_id, playbook_key)
+                DO UPDATE SET
+                  id = EXCLUDED.id,
+                  pattern_id = EXCLUDED.pattern_id,
+                  pattern_key = EXCLUDED.pattern_key,
+                  title = EXCLUDED.title,
+                  memory_type = EXCLUDED.memory_type,
+                  source_fact_ids = EXCLUDED.source_fact_ids,
+                  source_pattern_ids = EXCLUDED.source_pattern_ids,
+                  steps = EXCLUDED.steps,
+                  explanation = EXCLUDED.explanation,
+                  updated_at = clock_timestamp()
+                RETURNING
+                  id,
+                  user_id,
+                  playbook_key,
+                  pattern_id,
+                  pattern_key,
+                  title,
+                  memory_type,
+                  source_fact_ids,
+                  source_pattern_ids,
+                  steps,
+                  explanation,
+                  created_at,
+                  updated_at
+                """
+
+LIST_FACT_PLAYBOOKS_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  playbook_key,
+                  pattern_id,
+                  pattern_key,
+                  title,
+                  memory_type,
+                  source_fact_ids,
+                  source_pattern_ids,
+                  steps,
+                  explanation,
+                  created_at,
+                  updated_at
+                FROM fact_playbooks
+                ORDER BY memory_type ASC, pattern_key ASC, title ASC, id ASC
+                LIMIT %s
+                """
+
+COUNT_FACT_PLAYBOOKS_SQL = """
+                SELECT COUNT(*) AS count
+                FROM fact_playbooks
+                """
+
+GET_FACT_PLAYBOOK_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  playbook_key,
+                  pattern_id,
+                  pattern_key,
+                  title,
+                  memory_type,
+                  source_fact_ids,
+                  source_pattern_ids,
+                  steps,
+                  explanation,
+                  created_at,
+                  updated_at
+                FROM fact_playbooks
+                WHERE id = %s
+                """
+
+DELETE_FACT_PLAYBOOKS_NOT_IN_SQL = """
+                DELETE FROM fact_playbooks
+                WHERE user_id = app.current_user_id()
+                  AND NOT (id = ANY(%s))
+                """
+
+DELETE_ALL_FACT_PLAYBOOKS_SQL = """
+                DELETE FROM fact_playbooks
+                WHERE user_id = app.current_user_id()
                 """
 
 INSERT_MEMORY_REVIEW_LABEL_SQL = """
@@ -4668,6 +4921,16 @@ class ContinuityStore:
 
         return cast(CountRow, row)["count"]
 
+    def _execute(
+        self,
+        operation_name: str,
+        query: str,
+        params: tuple[object, ...] | None = None,
+    ) -> None:
+        del operation_name
+        with self.conn.cursor() as cur:
+            cur.execute(query, params)
+
     @staticmethod
     def _vector_literal(vector: list[float]) -> str:
         return "[" + ",".join(repr(value) for value in vector) + "]"
@@ -4956,6 +5219,96 @@ class ContinuityStore:
         if limit is None:
             return self._fetch_all(LIST_MEMORY_REVISIONS_SQL, (memory_id,))
         return self._fetch_all(LIST_LIMITED_MEMORY_REVISIONS_SQL, (memory_id, limit))
+
+    def upsert_fact_pattern(
+        self,
+        *,
+        pattern_id: UUID,
+        pattern_key: str,
+        title: str,
+        memory_type: str,
+        namespace_key: str,
+        fact_count: int,
+        source_fact_ids: list[str],
+        evidence_chain: JsonValue,
+        explanation: str,
+    ) -> FactPatternRow:
+        return self._fetch_one(
+            "upsert_fact_pattern",
+            UPSERT_FACT_PATTERN_SQL,
+            (
+                pattern_id,
+                pattern_key,
+                title,
+                memory_type,
+                namespace_key,
+                fact_count,
+                Jsonb(source_fact_ids),
+                Jsonb(evidence_chain),
+                explanation,
+            ),
+        )
+
+    def list_fact_patterns(self, *, limit: int) -> list[FactPatternRow]:
+        return self._fetch_all(LIST_FACT_PATTERNS_SQL, (limit,))
+
+    def count_fact_patterns(self) -> int:
+        return self._fetch_count(COUNT_FACT_PATTERNS_SQL)
+
+    def get_fact_pattern_optional(self, pattern_id: UUID) -> FactPatternRow | None:
+        return self._fetch_optional_one(GET_FACT_PATTERN_SQL, (pattern_id,))
+
+    def delete_fact_patterns_not_in(self, pattern_ids: list[UUID]) -> None:
+        if not pattern_ids:
+            self._execute("delete_all_fact_patterns", DELETE_ALL_FACT_PATTERNS_SQL)
+            return
+        self._execute("delete_fact_patterns_not_in", DELETE_FACT_PATTERNS_NOT_IN_SQL, (pattern_ids,))
+
+    def upsert_fact_playbook(
+        self,
+        *,
+        playbook_id: UUID,
+        playbook_key: str,
+        pattern_id: UUID,
+        pattern_key: str,
+        title: str,
+        memory_type: str,
+        source_fact_ids: list[str],
+        source_pattern_ids: list[str],
+        steps: JsonValue,
+        explanation: str,
+    ) -> FactPlaybookRow:
+        return self._fetch_one(
+            "upsert_fact_playbook",
+            UPSERT_FACT_PLAYBOOK_SQL,
+            (
+                playbook_id,
+                playbook_key,
+                pattern_id,
+                pattern_key,
+                title,
+                memory_type,
+                Jsonb(source_fact_ids),
+                Jsonb(source_pattern_ids),
+                Jsonb(steps),
+                explanation,
+            ),
+        )
+
+    def list_fact_playbooks(self, *, limit: int) -> list[FactPlaybookRow]:
+        return self._fetch_all(LIST_FACT_PLAYBOOKS_SQL, (limit,))
+
+    def count_fact_playbooks(self) -> int:
+        return self._fetch_count(COUNT_FACT_PLAYBOOKS_SQL)
+
+    def get_fact_playbook_optional(self, playbook_id: UUID) -> FactPlaybookRow | None:
+        return self._fetch_optional_one(GET_FACT_PLAYBOOK_SQL, (playbook_id,))
+
+    def delete_fact_playbooks_not_in(self, playbook_ids: list[UUID]) -> None:
+        if not playbook_ids:
+            self._execute("delete_all_fact_playbooks", DELETE_ALL_FACT_PLAYBOOKS_SQL)
+            return
+        self._execute("delete_fact_playbooks_not_in", DELETE_FACT_PLAYBOOKS_NOT_IN_SQL, (playbook_ids,))
 
     def create_memory_review_label(
         self,

--- a/apps/api/src/alicebot_api/trusted_fact_promotions.py
+++ b/apps/api/src/alicebot_api/trusted_fact_promotions.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+from collections import defaultdict
+import json
+from typing import cast
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from alicebot_api.contracts import (
+    TRUSTED_FACT_PATTERN_ORDER,
+    TRUSTED_FACT_PLAYBOOK_ORDER,
+    TemporalTrustRecord,
+    TrustedFactEvidenceLinkRecord,
+    TrustedFactPatternExplainResponse,
+    TrustedFactPatternListQueryInput,
+    TrustedFactPatternListResponse,
+    TrustedFactPatternRecord,
+    TrustedFactPlaybookExplainResponse,
+    TrustedFactPlaybookListQueryInput,
+    TrustedFactPlaybookListResponse,
+    TrustedFactPlaybookRecord,
+    TrustedFactPlaybookStepRecord,
+    isoformat_or_none,
+)
+from alicebot_api.store import (
+    ContinuityStore,
+    FactPatternRow,
+    FactPlaybookRow,
+    MemoryRevisionRow,
+    MemoryRow,
+)
+
+_TRUSTED_PATTERN_CLASSES = frozenset({"deterministic", "llm_corroborated", "human_curated"})
+_ACTION_TYPE_BY_MEMORY_TYPE = {
+    "preference": "prefer",
+    "working_style": "work_with",
+    "constraint": "constrain",
+    "routine": "repeat",
+    "commitment": "follow_through",
+    "decision": "apply_decision",
+    "project_fact": "apply_project_fact",
+    "identity_fact": "respect_identity",
+    "relationship_fact": "respect_relationship",
+}
+
+
+class TrustedFactPromotionNotFoundError(LookupError):
+    """Raised when a trusted-fact promotion record is not visible in scope."""
+
+
+def _fact_is_single_source_model_output(memory: MemoryRow) -> bool:
+    extracted_by_model = memory.get("extracted_by_model")
+    if extracted_by_model is None or extracted_by_model == "":
+        return False
+    return (memory.get("independent_source_count") or 0) <= 1
+
+
+def _is_promotable_trusted_fact(memory: MemoryRow) -> bool:
+    if memory["status"] != "active":
+        return False
+    if memory["promotion_eligibility"] != "promotable":
+        return False
+    if memory["trust_class"] not in _TRUSTED_PATTERN_CLASSES:
+        return False
+    # Guardrail: single-source model output cannot become a durable pattern on its own.
+    if _fact_is_single_source_model_output(memory):
+        return False
+    return True
+
+
+def _namespace_key(memory_key: str) -> str:
+    segments = [segment for segment in memory_key.split(".") if segment]
+    if len(segments) <= 1:
+        return memory_key
+    return ".".join(segments[:-1])
+
+
+def _stable_id(user_id: UUID, kind: str, key: str) -> UUID:
+    return uuid5(NAMESPACE_URL, f"alicebot://{user_id}/{kind}/{key}")
+
+
+def _json_inline(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _trust_record(memory: MemoryRow) -> TemporalTrustRecord:
+    return {
+        "trust_class": memory["trust_class"],
+        "trust_reason": memory["trust_reason"],
+        "confirmation_status": memory["confirmation_status"],
+        "confidence": memory["confidence"],
+    }
+
+
+def _latest_revision(memory: MemoryRow, revisions: list[MemoryRevisionRow]) -> MemoryRevisionRow | None:
+    if revisions:
+        return revisions[-1]
+    return None
+
+
+def _evidence_link(memory: MemoryRow, latest_revision: MemoryRevisionRow | None) -> TrustedFactEvidenceLinkRecord:
+    return {
+        "fact_id": str(memory["id"]),
+        "memory_key": memory["memory_key"],
+        "memory_type": memory["memory_type"],
+        "value": memory["value"],
+        "trust": _trust_record(memory),
+        "promotion_eligibility": memory["promotion_eligibility"],
+        "evidence_count": memory["evidence_count"],
+        "independent_source_count": memory["independent_source_count"],
+        "extracted_by_model": memory["extracted_by_model"],
+        "source_event_ids": list(memory["source_event_ids"]),
+        "revision_sequence_no": None if latest_revision is None else latest_revision["sequence_no"],
+        "revision_action": None if latest_revision is None else latest_revision["action"],
+        "revision_created_at": (
+            None if latest_revision is None else isoformat_or_none(latest_revision["created_at"])
+        ),
+    }
+
+
+def _pattern_title(memory_type: str, namespace_key: str) -> str:
+    return f"{memory_type.replace('_', ' ')} pattern: {namespace_key}"
+
+
+def _pattern_explanation(memory_type: str, namespace_key: str, fact_count: int) -> str:
+    return (
+        f"Derived from {fact_count} active promotable trusted facts sharing memory type "
+        f"{memory_type} and namespace {namespace_key}. Evidence links show the source fact IDs, "
+        "source events, and current fact revisions."
+    )
+
+
+def _playbook_instruction(memory: MemoryRow) -> str:
+    action_type = _ACTION_TYPE_BY_MEMORY_TYPE.get(memory["memory_type"], "apply_fact")
+    if action_type in {"prefer", "work_with", "constrain"}:
+        return f"Honor {memory['memory_key']} with value {_json_inline(memory['value'])}."
+    if action_type in {"repeat", "follow_through"}:
+        return f"Carry forward {memory['memory_key']} with value {_json_inline(memory['value'])}."
+    return f"Use {memory['memory_key']} with value {_json_inline(memory['value'])} when acting."
+
+
+def _playbook_explanation(pattern_key: str) -> str:
+    return (
+        f"Transparent rendering of pattern {pattern_key}. Each step maps directly to one trusted "
+        "promotable fact; no opaque synthesis is used."
+    )
+
+
+def _serialize_pattern_row(row: FactPatternRow) -> TrustedFactPatternRecord:
+    return {
+        "id": str(row["id"]),
+        "pattern_key": row["pattern_key"],
+        "title": row["title"],
+        "memory_type": row["memory_type"],
+        "namespace_key": row["namespace_key"],
+        "fact_count": row["fact_count"],
+        "source_fact_ids": cast(list[str], row["source_fact_ids"]),
+        "evidence_chain": cast(list[TrustedFactEvidenceLinkRecord], row["evidence_chain"]),
+        "explanation": row["explanation"],
+        "created_at": row["created_at"].isoformat(),
+        "updated_at": row["updated_at"].isoformat(),
+    }
+
+
+def _serialize_playbook_row(row: FactPlaybookRow) -> TrustedFactPlaybookRecord:
+    return {
+        "id": str(row["id"]),
+        "playbook_key": row["playbook_key"],
+        "pattern_id": str(row["pattern_id"]),
+        "pattern_key": row["pattern_key"],
+        "title": row["title"],
+        "memory_type": row["memory_type"],
+        "source_fact_ids": cast(list[str], row["source_fact_ids"]),
+        "source_pattern_ids": cast(list[str], row["source_pattern_ids"]),
+        "steps": cast(list[TrustedFactPlaybookStepRecord], row["steps"]),
+        "explanation": row["explanation"],
+        "created_at": row["created_at"].isoformat(),
+        "updated_at": row["updated_at"].isoformat(),
+    }
+
+
+def sync_trusted_fact_promotions(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+) -> None:
+    del user_id
+
+    memories = sorted(
+        (memory for memory in store.list_memories() if _is_promotable_trusted_fact(memory)),
+        key=lambda memory: (memory["memory_type"], _namespace_key(memory["memory_key"]), memory["memory_key"], str(memory["id"])),
+    )
+    revisions_by_memory_id = {
+        memory["id"]: store.list_memory_revisions(memory["id"])
+        for memory in memories
+    }
+
+    grouped: dict[tuple[str, str], list[MemoryRow]] = defaultdict(list)
+    for memory in memories:
+        grouped[(memory["memory_type"], _namespace_key(memory["memory_key"]))].append(memory)
+
+    pattern_ids: list[UUID] = []
+    playbook_ids: list[UUID] = []
+    for (memory_type, namespace_key), grouped_memories in sorted(grouped.items()):
+        if not grouped_memories:
+            continue
+
+        group_user_id = grouped_memories[0]["user_id"]
+        pattern_key = f"{memory_type}:{namespace_key}"
+        pattern_id = _stable_id(group_user_id, "fact-pattern", pattern_key)
+        evidence_chain = [
+            _evidence_link(memory, _latest_revision(memory, revisions_by_memory_id[memory["id"]]))
+            for memory in grouped_memories
+        ]
+        store.upsert_fact_pattern(
+            pattern_id=pattern_id,
+            pattern_key=pattern_key,
+            title=_pattern_title(memory_type, namespace_key),
+            memory_type=memory_type,
+            namespace_key=namespace_key,
+            fact_count=len(grouped_memories),
+            source_fact_ids=[str(memory["id"]) for memory in grouped_memories],
+            evidence_chain=evidence_chain,
+            explanation=_pattern_explanation(memory_type, namespace_key, len(grouped_memories)),
+        )
+        pattern_ids.append(pattern_id)
+
+        playbook_key = f"{pattern_key}:playbook"
+        playbook_id = _stable_id(group_user_id, "fact-playbook", playbook_key)
+        steps: list[TrustedFactPlaybookStepRecord] = []
+        for step_no, memory in enumerate(grouped_memories, start=1):
+            steps.append(
+                {
+                    "step_no": step_no,
+                    "fact_id": str(memory["id"]),
+                    "memory_key": memory["memory_key"],
+                    "action_type": _ACTION_TYPE_BY_MEMORY_TYPE.get(memory["memory_type"], "apply_fact"),
+                    "instruction": _playbook_instruction(memory),
+                    "value": memory["value"],
+                    "trust": _trust_record(memory),
+                }
+            )
+        store.upsert_fact_playbook(
+            playbook_id=playbook_id,
+            playbook_key=playbook_key,
+            pattern_id=pattern_id,
+            pattern_key=pattern_key,
+            title=_pattern_title(memory_type, namespace_key).replace("pattern", "playbook", 1),
+            memory_type=memory_type,
+            source_fact_ids=[str(memory["id"]) for memory in grouped_memories],
+            source_pattern_ids=[str(pattern_id)],
+            steps=steps,
+            explanation=_playbook_explanation(pattern_key),
+        )
+        playbook_ids.append(playbook_id)
+
+    store.delete_fact_playbooks_not_in(playbook_ids)
+    store.delete_fact_patterns_not_in(pattern_ids)
+
+
+def list_trusted_fact_patterns(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: TrustedFactPatternListQueryInput,
+) -> TrustedFactPatternListResponse:
+    sync_trusted_fact_promotions(store, user_id=user_id)
+    rows = store.list_fact_patterns(limit=request.limit)
+    total_count = store.count_fact_patterns()
+    return {
+        "items": [_serialize_pattern_row(row) for row in rows],
+        "summary": {
+            "returned_count": len(rows),
+            "total_count": total_count,
+            "limit": request.limit,
+            "order": list(TRUSTED_FACT_PATTERN_ORDER),
+        },
+    }
+
+
+def get_trusted_fact_pattern(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    pattern_id: UUID,
+) -> TrustedFactPatternExplainResponse:
+    sync_trusted_fact_promotions(store, user_id=user_id)
+    row = store.get_fact_pattern_optional(pattern_id)
+    if row is None:
+        raise TrustedFactPromotionNotFoundError(f"pattern {pattern_id} was not found")
+    return {"pattern": _serialize_pattern_row(row)}
+
+
+def list_trusted_fact_playbooks(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: TrustedFactPlaybookListQueryInput,
+) -> TrustedFactPlaybookListResponse:
+    sync_trusted_fact_promotions(store, user_id=user_id)
+    rows = store.list_fact_playbooks(limit=request.limit)
+    total_count = store.count_fact_playbooks()
+    return {
+        "items": [_serialize_playbook_row(row) for row in rows],
+        "summary": {
+            "returned_count": len(rows),
+            "total_count": total_count,
+            "limit": request.limit,
+            "order": list(TRUSTED_FACT_PLAYBOOK_ORDER),
+        },
+    }
+
+
+def get_trusted_fact_playbook(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    playbook_id: UUID,
+) -> TrustedFactPlaybookExplainResponse:
+    sync_trusted_fact_promotions(store, user_id=user_id)
+    row = store.get_fact_playbook_optional(playbook_id)
+    if row is None:
+        raise TrustedFactPromotionNotFoundError(f"playbook {playbook_id} was not found")
+    return {"playbook": _serialize_playbook_row(row)}
+
+
+__all__ = [
+    "TrustedFactPromotionNotFoundError",
+    "get_trusted_fact_pattern",
+    "get_trusted_fact_playbook",
+    "list_trusted_fact_patterns",
+    "list_trusted_fact_playbooks",
+    "sync_trusted_fact_promotions",
+]

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -8,8 +8,10 @@ import subprocess
 import sys
 from uuid import UUID, uuid4
 
+from alicebot_api.contracts import MemoryCandidateInput
 from alicebot_api.db import user_connection
 from alicebot_api.markdown_import import import_markdown_source
+from alicebot_api.memory import admit_memory_candidate
 from alicebot_api.store import ContinuityStore
 
 
@@ -315,3 +317,101 @@ def test_cli_command_surface_and_correction_flow(migrated_database_urls) -> None
     assert "artifact detail" in artifact_result.stdout
     assert "copies: 1" in artifact_result.stdout
     assert "segments:" in artifact_result.stdout
+
+
+def test_cli_lists_and_explains_trusted_fact_promotions(migrated_database_urls) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="trusted-cli@example.invalid")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        thread = store.create_thread("Trusted fact CLI")
+        session = store.create_session(thread["id"], status="active")
+        coffee_event = store.append_event(thread["id"], session["id"], "message.user", {"text": "Coffee"})["id"]
+        tea_event = store.append_event(thread["id"], session["id"], "message.user", {"text": "Tea"})["id"]
+        generated_event = store.append_event(
+            thread["id"], session["id"], "message.user", {"text": "Model suggested mate"}
+        )["id"]
+
+        admit_memory_candidate(
+            store,
+            user_id=user_id,
+            candidate=MemoryCandidateInput(
+                memory_key="user.preference.coffee",
+                value={"drink": "coffee"},
+                source_event_ids=(coffee_event,),
+                memory_type="preference",
+                trust_class="human_curated",
+                promotion_eligibility="promotable",
+                evidence_count=2,
+                independent_source_count=2,
+                trust_reason="owner confirmed",
+            ),
+        )
+        admit_memory_candidate(
+            store,
+            user_id=user_id,
+            candidate=MemoryCandidateInput(
+                memory_key="user.preference.tea",
+                value={"drink": "tea"},
+                source_event_ids=(tea_event,),
+                memory_type="preference",
+                trust_class="deterministic",
+                promotion_eligibility="promotable",
+                evidence_count=1,
+                independent_source_count=1,
+                trust_reason="deterministic capture",
+            ),
+        )
+        admit_memory_candidate(
+            store,
+            user_id=user_id,
+            candidate=MemoryCandidateInput(
+                memory_key="user.preference.generated",
+                value={"drink": "mate"},
+                source_event_ids=(generated_event,),
+                memory_type="preference",
+                trust_class="llm_single_source",
+                promotion_eligibility="promotable",
+                evidence_count=1,
+                independent_source_count=1,
+                extracted_by_model="gpt-5.4-mini",
+                trust_reason="single-source model extraction",
+            ),
+        )
+
+    env = build_cli_env(database_url=migrated_database_urls["app"], user_id=user_id)
+
+    patterns_list = run_cli(["patterns", "list", "--limit", "10"], env=env)
+    assert patterns_list.returncode == 0
+    assert "patterns" in patterns_list.stdout
+    assert "fact_count=2" in patterns_list.stdout
+
+    pattern_id = None
+    for line in patterns_list.stdout.splitlines():
+        if line.strip().startswith("id="):
+            pattern_id = line.split("id=", 1)[1].split()[0]
+            break
+    assert pattern_id is not None
+
+    pattern_explain = run_cli(["patterns", "explain", pattern_id], env=env)
+    assert pattern_explain.returncode == 0
+    assert "evidence_chain:" in pattern_explain.stdout
+    assert "memory_key=user.preference.coffee" in pattern_explain.stdout
+    assert "user.preference.generated" not in pattern_explain.stdout
+
+    playbooks_list = run_cli(["playbooks", "list", "--limit", "10"], env=env)
+    assert playbooks_list.returncode == 0
+    assert "playbooks" in playbooks_list.stdout
+    assert "step_count=2" in playbooks_list.stdout
+
+    playbook_id = None
+    for line in playbooks_list.stdout.splitlines():
+        if line.strip().startswith("id="):
+            playbook_id = line.split("id=", 1)[1].split()[0]
+            break
+    assert playbook_id is not None
+
+    playbook_explain = run_cli(["playbooks", "explain", playbook_id], env=env)
+    assert playbook_explain.returncode == 0
+    assert "steps:" in playbook_explain.stdout
+    assert "[prefer]" in playbook_explain.stdout

--- a/tests/integration/test_trusted_fact_promotions_api.py
+++ b/tests/integration/test_trusted_fact_promotions_api.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import urlencode
+from uuid import uuid4
+
+import anyio
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+from alicebot_api.contracts import MemoryCandidateInput
+from alicebot_api.db import user_connection
+from alicebot_api.memory import admit_memory_candidate
+from alicebot_api.store import ContinuityStore
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+        request_received = True
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def seed_trusted_fact_memories(database_url: str) -> dict[str, str]:
+    user_id = uuid4()
+    with user_connection(database_url, user_id) as conn:
+        store = ContinuityStore(conn)
+        store.create_user(user_id, "trusted-facts@example.invalid", "Trusted Facts")
+        thread = store.create_thread("Trusted fact promotions")
+        session = store.create_session(thread["id"], status="active")
+        coffee_event = store.append_event(
+            thread["id"], session["id"], "message.user", {"text": "Prefer coffee"}
+        )["id"]
+        tea_event = store.append_event(
+            thread["id"], session["id"], "message.user", {"text": "Prefer tea"}
+        )["id"]
+        generated_event = store.append_event(
+            thread["id"], session["id"], "message.user", {"text": "Model guessed mate"}
+        )["id"]
+
+        admit_memory_candidate(
+            store,
+            user_id=user_id,
+            candidate=MemoryCandidateInput(
+                memory_key="user.preference.coffee",
+                value={"drink": "coffee"},
+                source_event_ids=(coffee_event,),
+                memory_type="preference",
+                trust_class="human_curated",
+                promotion_eligibility="promotable",
+                evidence_count=2,
+                independent_source_count=2,
+                trust_reason="owner confirmed",
+            ),
+        )
+        admit_memory_candidate(
+            store,
+            user_id=user_id,
+            candidate=MemoryCandidateInput(
+                memory_key="user.preference.tea",
+                value={"drink": "tea"},
+                source_event_ids=(tea_event,),
+                memory_type="preference",
+                trust_class="deterministic",
+                promotion_eligibility="promotable",
+                evidence_count=1,
+                independent_source_count=1,
+                trust_reason="direct deterministic capture",
+            ),
+        )
+        admit_memory_candidate(
+            store,
+            user_id=user_id,
+            candidate=MemoryCandidateInput(
+                memory_key="user.preference.generated",
+                value={"drink": "mate"},
+                source_event_ids=(generated_event,),
+                memory_type="preference",
+                trust_class="llm_single_source",
+                promotion_eligibility="promotable",
+                evidence_count=1,
+                independent_source_count=1,
+                extracted_by_model="gpt-5.4-mini",
+                trust_reason="single-source model extraction",
+            ),
+        )
+
+    return {
+        "user_id": str(user_id),
+        "coffee_event": str(coffee_event),
+        "tea_event": str(tea_event),
+        "generated_event": str(generated_event),
+    }
+
+
+def test_pattern_and_playbook_endpoints_only_promote_trusted_facts(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    seeded = seed_trusted_fact_memories(migrated_database_urls["app"])
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v0/patterns",
+        query_params={"user_id": seeded["user_id"], "limit": "10"},
+    )
+
+    assert list_status == 200
+    assert list_payload["summary"]["total_count"] == 1
+    pattern = list_payload["items"][0]
+    assert pattern["fact_count"] == 2
+    assert len(pattern["evidence_chain"]) == 2
+    assert seeded["generated_event"] not in [
+        source_event_id
+        for evidence in pattern["evidence_chain"]
+        for source_event_id in evidence["source_event_ids"]
+    ]
+
+    explain_status, explain_payload = invoke_request(
+        "GET",
+        f"/v0/patterns/{pattern['id']}",
+        query_params={"user_id": seeded["user_id"]},
+    )
+    assert explain_status == 200
+    assert explain_payload["pattern"]["source_fact_ids"] == pattern["source_fact_ids"]
+    assert explain_payload["pattern"]["evidence_chain"][0]["revision_action"] == "ADD"
+
+    playbook_list_status, playbook_list_payload = invoke_request(
+        "GET",
+        "/v0/playbooks",
+        query_params={"user_id": seeded["user_id"], "limit": "10"},
+    )
+    assert playbook_list_status == 200
+    assert playbook_list_payload["summary"]["total_count"] == 1
+    playbook = playbook_list_payload["items"][0]
+    assert len(playbook["steps"]) == 2
+    assert "opaque" in playbook["explanation"]
+
+    playbook_explain_status, playbook_explain_payload = invoke_request(
+        "GET",
+        f"/v0/playbooks/{playbook['id']}",
+        query_params={"user_id": seeded["user_id"]},
+    )
+    assert playbook_explain_status == 200
+    assert playbook_explain_payload["playbook"]["source_fact_ids"] == pattern["source_fact_ids"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -26,6 +26,10 @@ def test_parser_routes_required_commands() -> None:
         (["explain", continuity_object_id], "_run_explain"),
         (["explain", "--entity-id", continuity_object_id], "_run_explain"),
         (["evidence", "artifact", continuity_object_id], "_run_evidence_artifact"),
+        (["patterns", "list"], "_run_pattern_list"),
+        (["patterns", "explain", continuity_object_id], "_run_pattern_explain"),
+        (["playbooks", "list"], "_run_playbook_list"),
+        (["playbooks", "explain", continuity_object_id], "_run_playbook_explain"),
         (["status"], "_run_status"),
     ]
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -136,6 +136,10 @@ def test_healthcheck_route_is_registered() -> None:
     assert "/v0/admin/debug/continuity/lifecycle/{continuity_object_id}" in route_paths
     assert "/v0/admin/debug/continuity/artifacts/{artifact_id}" in route_paths
     assert "/v0/continuity/explain/{continuity_object_id}" in route_paths
+    assert "/v0/patterns" in route_paths
+    assert "/v0/patterns/{pattern_id}" in route_paths
+    assert "/v0/playbooks" in route_paths
+    assert "/v0/playbooks/{playbook_id}" in route_paths
     assert "/v0/task-artifact-chunk-embeddings" in route_paths
     assert "/v0/task-artifacts/{task_artifact_id}/chunk-embeddings" in route_paths
     assert "/v0/task-artifact-chunks/{task_artifact_chunk_id}/embeddings" in route_paths

--- a/tests/unit/test_trusted_fact_promotions.py
+++ b/tests/unit/test_trusted_fact_promotions.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+
+from alicebot_api.contracts import TrustedFactPatternListQueryInput, TrustedFactPlaybookListQueryInput
+from alicebot_api.trusted_fact_promotions import (
+    TrustedFactPromotionNotFoundError,
+    get_trusted_fact_pattern,
+    list_trusted_fact_patterns,
+    list_trusted_fact_playbooks,
+    sync_trusted_fact_promotions,
+)
+
+
+class TrustedFactPromotionStoreStub:
+    def __init__(self) -> None:
+        self.memories: list[dict[str, object]] = []
+        self.revisions: dict[UUID, list[dict[str, object]]] = {}
+        self.patterns: dict[UUID, dict[str, object]] = {}
+        self.playbooks: dict[UUID, dict[str, object]] = {}
+        self._base_time = datetime(2026, 4, 10, 9, 0, tzinfo=UTC)
+
+    def list_memories(self) -> list[dict[str, object]]:
+        return list(self.memories)
+
+    def list_memory_revisions(self, memory_id: UUID) -> list[dict[str, object]]:
+        return list(self.revisions.get(memory_id, []))
+
+    def upsert_fact_pattern(self, **kwargs):  # type: ignore[no-untyped-def]
+        pattern_id = kwargs["pattern_id"]
+        existing = self.patterns.get(pattern_id)
+        created_at = self._base_time if existing is None else existing["created_at"]
+        row = {
+            "id": pattern_id,
+            "user_id": self._current_user_id(),
+            "pattern_key": kwargs["pattern_key"],
+            "title": kwargs["title"],
+            "memory_type": kwargs["memory_type"],
+            "namespace_key": kwargs["namespace_key"],
+            "fact_count": kwargs["fact_count"],
+            "source_fact_ids": kwargs["source_fact_ids"],
+            "evidence_chain": kwargs["evidence_chain"],
+            "explanation": kwargs["explanation"],
+            "created_at": created_at,
+            "updated_at": self._base_time + timedelta(minutes=1),
+        }
+        self.patterns[pattern_id] = row
+        return row
+
+    def list_fact_patterns(self, *, limit: int):
+        rows = sorted(
+            self.patterns.values(),
+            key=lambda row: (row["memory_type"], row["namespace_key"], row["title"], str(row["id"])),
+        )
+        return rows[:limit]
+
+    def count_fact_patterns(self) -> int:
+        return len(self.patterns)
+
+    def get_fact_pattern_optional(self, pattern_id: UUID):
+        return self.patterns.get(pattern_id)
+
+    def delete_fact_patterns_not_in(self, pattern_ids: list[UUID]) -> None:
+        keep = set(pattern_ids)
+        self.patterns = {pattern_id: row for pattern_id, row in self.patterns.items() if pattern_id in keep}
+
+    def upsert_fact_playbook(self, **kwargs):  # type: ignore[no-untyped-def]
+        playbook_id = kwargs["playbook_id"]
+        existing = self.playbooks.get(playbook_id)
+        created_at = self._base_time if existing is None else existing["created_at"]
+        row = {
+            "id": playbook_id,
+            "user_id": self._current_user_id(),
+            "playbook_key": kwargs["playbook_key"],
+            "pattern_id": kwargs["pattern_id"],
+            "pattern_key": kwargs["pattern_key"],
+            "title": kwargs["title"],
+            "memory_type": kwargs["memory_type"],
+            "source_fact_ids": kwargs["source_fact_ids"],
+            "source_pattern_ids": kwargs["source_pattern_ids"],
+            "steps": kwargs["steps"],
+            "explanation": kwargs["explanation"],
+            "created_at": created_at,
+            "updated_at": self._base_time + timedelta(minutes=1),
+        }
+        self.playbooks[playbook_id] = row
+        return row
+
+    def list_fact_playbooks(self, *, limit: int):
+        rows = sorted(
+            self.playbooks.values(),
+            key=lambda row: (row["memory_type"], row["pattern_key"], row["title"], str(row["id"])),
+        )
+        return rows[:limit]
+
+    def count_fact_playbooks(self) -> int:
+        return len(self.playbooks)
+
+    def get_fact_playbook_optional(self, playbook_id: UUID):
+        return self.playbooks.get(playbook_id)
+
+    def delete_fact_playbooks_not_in(self, playbook_ids: list[UUID]) -> None:
+        keep = set(playbook_ids)
+        self.playbooks = {
+            playbook_id: row for playbook_id, row in self.playbooks.items() if playbook_id in keep
+        }
+
+    def _current_user_id(self) -> UUID:
+        return UUID(str(self.memories[0]["user_id"]))
+
+
+def _memory(
+    *,
+    memory_id: UUID,
+    user_id: UUID,
+    memory_key: str,
+    value: object,
+    trust_class: str,
+    promotion_eligibility: str = "promotable",
+    extracted_by_model: str | None = None,
+    independent_source_count: int | None = None,
+) -> dict[str, object]:
+    return {
+        "id": memory_id,
+        "user_id": user_id,
+        "agent_profile_id": "assistant_default",
+        "memory_key": memory_key,
+        "value": value,
+        "status": "active",
+        "source_event_ids": [f"event-{memory_key.split('.')[-1]}"],
+        "memory_type": "preference",
+        "confidence": 0.95,
+        "salience": 0.5,
+        "confirmation_status": "confirmed",
+        "trust_class": trust_class,
+        "promotion_eligibility": promotion_eligibility,
+        "evidence_count": 1,
+        "independent_source_count": independent_source_count,
+        "extracted_by_model": extracted_by_model,
+        "trust_reason": "trusted test fact",
+        "valid_from": None,
+        "valid_to": None,
+        "last_confirmed_at": None,
+        "created_at": datetime(2026, 4, 10, 9, 0, tzinfo=UTC),
+        "updated_at": datetime(2026, 4, 10, 9, 1, tzinfo=UTC),
+        "deleted_at": None,
+    }
+
+
+def _revision(*, memory_id: UUID, memory_key: str, sequence_no: int) -> dict[str, object]:
+    return {
+        "id": uuid4(),
+        "user_id": uuid4(),
+        "memory_id": memory_id,
+        "sequence_no": sequence_no,
+        "action": "ADD",
+        "memory_key": memory_key,
+        "previous_value": None,
+        "new_value": {"captured": memory_key},
+        "source_event_ids": [f"event-{memory_key.split('.')[-1]}"],
+        "candidate": {"memory_key": memory_key},
+        "created_at": datetime(2026, 4, 10, 9, sequence_no, tzinfo=UTC),
+    }
+
+
+def test_sync_trusted_fact_promotions_excludes_single_source_llm_facts() -> None:
+    store = TrustedFactPromotionStoreStub()
+    user_id = uuid4()
+    coffee_id = uuid4()
+    tea_id = uuid4()
+    generated_id = uuid4()
+
+    store.memories = [
+        _memory(
+            memory_id=coffee_id,
+            user_id=user_id,
+            memory_key="user.preference.coffee",
+            value={"drink": "coffee"},
+            trust_class="human_curated",
+        ),
+        _memory(
+            memory_id=tea_id,
+            user_id=user_id,
+            memory_key="user.preference.tea",
+            value={"drink": "tea"},
+            trust_class="deterministic",
+        ),
+        _memory(
+            memory_id=generated_id,
+            user_id=user_id,
+            memory_key="user.preference.generated",
+            value={"drink": "mate"},
+            trust_class="llm_corroborated",
+            extracted_by_model="gpt-5.4-mini",
+            independent_source_count=1,
+        ),
+    ]
+    store.revisions = {
+        coffee_id: [_revision(memory_id=coffee_id, memory_key="user.preference.coffee", sequence_no=1)],
+        tea_id: [_revision(memory_id=tea_id, memory_key="user.preference.tea", sequence_no=2)],
+        generated_id: [_revision(memory_id=generated_id, memory_key="user.preference.generated", sequence_no=3)],
+    }
+
+    sync_trusted_fact_promotions(store, user_id=user_id)  # type: ignore[arg-type]
+
+    patterns = list_trusted_fact_patterns(
+        store,  # type: ignore[arg-type]
+        user_id=user_id,
+        request=TrustedFactPatternListQueryInput(limit=10),
+    )
+    assert patterns["summary"]["total_count"] == 1
+    pattern = patterns["items"][0]
+    assert pattern["fact_count"] == 2
+    assert pattern["source_fact_ids"] == [str(coffee_id), str(tea_id)]
+    assert [link["fact_id"] for link in pattern["evidence_chain"]] == [str(coffee_id), str(tea_id)]
+
+    playbooks = list_trusted_fact_playbooks(
+        store,  # type: ignore[arg-type]
+        user_id=user_id,
+        request=TrustedFactPlaybookListQueryInput(limit=10),
+    )
+    assert playbooks["summary"]["total_count"] == 1
+    playbook = playbooks["items"][0]
+    assert playbook["source_fact_ids"] == [str(coffee_id), str(tea_id)]
+    assert len(playbook["steps"]) == 2
+    assert "no opaque synthesis" in playbook["explanation"]
+
+
+def test_get_trusted_fact_pattern_raises_not_found_for_unknown_id() -> None:
+    store = TrustedFactPromotionStoreStub()
+
+    with pytest.raises(TrustedFactPromotionNotFoundError):
+        get_trusted_fact_pattern(
+            store,  # type: ignore[arg-type]
+            user_id=uuid4(),
+            pattern_id=uuid4(),
+        )


### PR DESCRIPTION
## Summary

This PR adds a deterministic trusted-fact promotion pipeline that derives persisted `patterns` and `playbooks` from active memory facts that are both trusted and promotable.

## What Changed

- Added derived storage for trusted-fact promotions:
  - `fact_patterns`
  - `fact_playbooks`
- Added a new `trusted_fact_promotions` module that:
  - syncs derived pattern and playbook rows from current memory state
  - only promotes active facts with trusted classes and `promotion_eligibility = promotable`
  - blocks single-source model-extracted facts from creating patterns or playbooks on their own
- Added API endpoints for listing and explaining:
  - `GET /v0/patterns`
  - `GET /v0/patterns/{pattern_id}`
  - `GET /v0/playbooks`
  - `GET /v0/playbooks/{playbook_id}`
- Added CLI commands for listing and explaining the same resources:
  - `alicebot patterns list`
  - `alicebot patterns explain <pattern-id>`
  - `alicebot playbooks list`
  - `alicebot playbooks explain <playbook-id>`
- Added CLI formatting that makes promotion outputs inspectable rather than opaque:
  - patterns show source fact IDs
  - patterns show evidence-chain entries with trust, source events, and revision metadata
  - playbooks show direct per-fact steps and explicit explanations
- Added migration `20260410_0051_trusted_fact_patterns_playbooks`
- Added unit and integration coverage for the new derivation, API routes, and CLI flow

## Why

The system already tracked trust class, promotion eligibility, and evidence metadata on memories, but it did not have a first-class way to turn that data into reusable promoted structures with strict guardrails and explainability.

This change closes that gap by making promotion deterministic, persisted, and inspectable.

## Root Cause Addressed

Previously there was no dedicated promotion layer for trusted facts, so the codebase had no durable representation of:

- which facts formed a reusable pattern
- how those facts were connected to evidence and revisions
- how to expose derived playbooks without hiding the underlying reasoning

That made it impossible to satisfy the trusted-facts-only promotion rule with a transparent API and CLI surface.

## User and Developer Impact

- Users can now inspect promoted patterns and playbooks directly from the API and CLI.
- Promotion outputs are explainable and traceable back to source facts.
- Single-source LLM facts are prevented from creating patterns by themselves.
- Developers now have explicit persistence and tests around trusted-fact promotion behavior instead of implicit or ad hoc derivation.

## Validation

Ran:

```bash
python3 -m pytest tests/unit/test_trusted_fact_promotions.py tests/unit/test_cli.py tests/unit/test_main.py tests/integration/test_trusted_fact_promotions_api.py tests/integration/test_cli_integration.py
```

Result: `70 passed`

## Notes

- The implementation keeps promotion logic deterministic and avoids opaque synthesis.
- No personal identifiers were added in the edited source or test files.
