### PR TITLE
[codex] add protected path upgrade guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+
+## Validation
+
+## Upgrade Overview
+
+Complete this section when the PR touches a protected path listed in `PROTECTED_PATHS.md`.
+CI enforces this section for protected-path changes.
+
+### Protected Areas
+
+- [ ] memory schema
+- [ ] evidence pipeline
+- [ ] trust rules
+- [ ] promotion logic
+- [ ] continuity APIs
+
+### Compatibility Impact
+
+<!-- Required for protected paths: call out additive-only, behavior-changing, or breaking impact. -->
+
+### Migration / Rollout
+
+<!-- Required for protected paths: include sequencing, backfills, feature flags, and deploy notes. -->
+
+### Operator Action
+
+<!-- Required for protected paths: note any manual steps or explicitly state that none are required. -->
+
+### Validation
+
+<!-- Required for protected paths: include exact tests, smoke checks, and manual verification. -->
+
+### Rollback
+
+<!-- Required for protected paths: explain how the change is reverted or safely contained. -->

--- a/.github/workflows/protected-path-guardrails.yml
+++ b/.github/workflows/protected-path-guardrails.yml
@@ -1,0 +1,27 @@
+name: Protected Path Guardrails
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  protected-path-upgrade-guardrails:
+    name: Protected Path Upgrade Guardrails
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require upgrade metadata for protected paths
+        run: python3 scripts/check_protected_paths.py --event-path "$GITHUB_EVENT_PATH"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ For Phase 9 public-surface changes, also run:
 - Keep PR scope narrow and sprint-aligned.
 - Update docs when behavior or command paths change.
 - Include exact commands executed and pass/fail evidence.
+- Complete the protected-path `Upgrade Overview` when the PR touches paths listed in `PROTECTED_PATHS.md`.
 - Do not introduce claims that outrun shipped functionality.
 
 ## Architecture and Rules
@@ -45,4 +46,5 @@ Read before making non-trivial changes:
 
 - `ARCHITECTURE.md`
 - `RULES.md`
+- `PROTECTED_PATHS.md`
 - active sprint packet (internal/local-only; not published in this repo)

--- a/PROTECTED_PATHS.md
+++ b/PROTECTED_PATHS.md
@@ -1,0 +1,112 @@
+# Protected Paths
+
+These paths gate continuity correctness, upgrade safety, and cross-surface compatibility.
+Changes here must not merge silently. If a pull request touches any protected path, it must include a completed `Upgrade Overview` using [UPGRADE_OVERVIEW_TEMPLATE.md](UPGRADE_OVERVIEW_TEMPLATE.md).
+
+## Why This Exists
+
+The protected surface covers the parts of Alice where a small code change can create hidden breakage:
+
+- schema drift that invalidates stored memory or migrations
+- evidence-chain changes that weaken explainability or provenance
+- trust or promotion changes that quietly alter durable-truth behavior
+- API changes that desynchronize CLI, MCP, HTTP, and web consumers
+
+## Protected Areas
+
+### Memory schema
+
+Protected paths:
+
+- `apps/api/alembic/versions/*.py`
+- `apps/api/src/alicebot_api/store.py`
+- `apps/api/src/alicebot_api/db.py`
+- `apps/api/src/alicebot_api/memory.py`
+- `apps/api/src/alicebot_api/contracts.py`
+
+Invariants:
+
+- existing stored data must remain readable through the upgrade path
+- migrations should be additive-first or explicitly sequenced when destructive work is unavoidable
+- enum, status, and typed-memory contract changes must be reflected across persistence, serialization, and validation
+- schema-affecting changes must state rollout order, backfill needs, and rollback posture
+
+### Evidence pipeline
+
+Protected paths:
+
+- `apps/api/src/alicebot_api/artifacts.py`
+- `apps/api/src/alicebot_api/compiler.py`
+- `apps/api/src/alicebot_api/continuity_capture.py`
+- `apps/api/src/alicebot_api/continuity_evidence.py`
+- `apps/api/src/alicebot_api/continuity_explainability.py`
+- `apps/api/src/alicebot_api/continuity_review.py`
+- `apps/api/src/alicebot_api/importers/*.py`
+
+Invariants:
+
+- evidence links must remain auditable from continuity object back to archived source material
+- archived artifact copies and checksums must stay deterministic for the same input
+- review, explain, and recall surfaces must preserve provenance rather than inventing opaque synthesis
+- importer changes must describe whether previously archived evidence remains valid
+
+### Trust rules
+
+Protected paths:
+
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/memory.py`
+- `apps/api/src/alicebot_api/trusted_fact_promotions.py`
+
+Invariants:
+
+- trust classes, confirmation status, and promotion eligibility must not change meaning silently
+- trust posture visible in retrieval, review, and explain output must stay internally consistent
+- high-risk or contested memories must remain reviewable and visible to operators
+- any trust-rule change must explain how existing stored memories behave after upgrade
+
+### Promotion logic
+
+Protected paths:
+
+- `apps/api/src/alicebot_api/memory.py`
+- `apps/api/src/alicebot_api/trusted_fact_promotions.py`
+
+Invariants:
+
+- single-source model output must not become durable trusted patterns without corroboration
+- trusted fact pattern and playbook generation must remain deterministic and traceable to source facts
+- promotion or cleanup changes must describe how stale patterns, playbooks, or orphaned records are handled
+- promotion behavior changes must include compatibility notes for downstream consumers
+
+### Continuity APIs
+
+Protected paths:
+
+- `apps/api/src/alicebot_api/cli.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/mcp_server.py`
+- `apps/api/src/alicebot_api/mcp_tools.py`
+- `apps/web/lib/api.ts`
+
+Invariants:
+
+- shared request and response contracts across HTTP, CLI, MCP, and web client code must remain aligned
+- non-additive surface changes must be called out explicitly, even for internal consumers
+- defaults, enum values, and limit semantics must not drift across surfaces
+- API-affecting changes must describe caller impact, validation coverage, and rollback posture
+
+## CI Enforcement
+
+GitHub Actions runs `scripts/check_protected_paths.py` on every pull request.
+When a PR touches a protected path, the job requires:
+
+- the matching protected areas to be checked in the PR body
+- explicit notes for compatibility impact
+- explicit notes for migration / rollout
+- explicit notes for operator action
+- explicit notes for validation
+- explicit notes for rollback
+
+If those fields are missing or left as placeholders, the guardrail job fails.

--- a/UPGRADE_OVERVIEW_TEMPLATE.md
+++ b/UPGRADE_OVERVIEW_TEMPLATE.md
@@ -1,0 +1,44 @@
+# Upgrade Overview Template
+
+Use this template in a pull request whenever the change touches a path listed in [PROTECTED_PATHS.md](PROTECTED_PATHS.md).
+The goal is to make compatibility, rollout, and rollback intent explicit before merge.
+
+```md
+## Upgrade Overview
+
+### Protected Areas
+
+- [ ] memory schema
+- [ ] evidence pipeline
+- [ ] trust rules
+- [ ] promotion logic
+- [ ] continuity APIs
+
+### Compatibility Impact
+
+State whether the change is additive-only, behavior-changing, or breaking.
+Call out stored-data impact, contract impact, and any caller-visible changes.
+
+### Migration / Rollout
+
+Describe deploy order, migrations, backfills, feature flags, and any sequencing requirements.
+
+### Operator Action
+
+List required manual steps, or say explicitly that no manual action is required.
+
+### Validation
+
+List exact tests, smoke checks, fixtures, and manual verification performed.
+
+### Rollback
+
+Explain how the change is reverted, contained, or disabled safely if problems appear after deploy.
+```
+
+## Notes
+
+- Check every protected area that the PR actually touches.
+- Do not leave sections blank or as placeholders such as `TBD`, `N/A`, or `none`.
+- If the change is intentionally non-breaking, say why.
+- If rollback is constrained by schema or data movement, say that directly.

--- a/scripts/check_protected_paths.py
+++ b/scripts/check_protected_paths.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class ProtectedArea:
+    label: str
+    patterns: tuple[str, ...]
+
+
+PROTECTED_AREAS: tuple[ProtectedArea, ...] = (
+    ProtectedArea(
+        label="memory schema",
+        patterns=(
+            "apps/api/alembic/versions/*.py",
+            "apps/api/src/alicebot_api/store.py",
+            "apps/api/src/alicebot_api/db.py",
+            "apps/api/src/alicebot_api/memory.py",
+            "apps/api/src/alicebot_api/contracts.py",
+        ),
+    ),
+    ProtectedArea(
+        label="evidence pipeline",
+        patterns=(
+            "apps/api/src/alicebot_api/artifacts.py",
+            "apps/api/src/alicebot_api/compiler.py",
+            "apps/api/src/alicebot_api/continuity_capture.py",
+            "apps/api/src/alicebot_api/continuity_evidence.py",
+            "apps/api/src/alicebot_api/continuity_explainability.py",
+            "apps/api/src/alicebot_api/continuity_review.py",
+            "apps/api/src/alicebot_api/importers/*.py",
+        ),
+    ),
+    ProtectedArea(
+        label="trust rules",
+        patterns=(
+            "apps/api/src/alicebot_api/contracts.py",
+            "apps/api/src/alicebot_api/memory.py",
+            "apps/api/src/alicebot_api/trusted_fact_promotions.py",
+        ),
+    ),
+    ProtectedArea(
+        label="promotion logic",
+        patterns=(
+            "apps/api/src/alicebot_api/memory.py",
+            "apps/api/src/alicebot_api/trusted_fact_promotions.py",
+        ),
+    ),
+    ProtectedArea(
+        label="continuity APIs",
+        patterns=(
+            "apps/api/src/alicebot_api/cli.py",
+            "apps/api/src/alicebot_api/contracts.py",
+            "apps/api/src/alicebot_api/main.py",
+            "apps/api/src/alicebot_api/mcp_server.py",
+            "apps/api/src/alicebot_api/mcp_tools.py",
+            "apps/web/lib/api.ts",
+        ),
+    ),
+)
+
+REQUIRED_NARRATIVE_SECTIONS: tuple[str, ...] = (
+    "compatibility impact",
+    "migration / rollout",
+    "operator action",
+    "validation",
+    "rollback",
+)
+
+PLACEHOLDER_VALUES = {
+    "",
+    "-",
+    "n/a",
+    "na",
+    "none",
+    "not applicable",
+    "same as above",
+    "tbd",
+    "todo",
+    "pending",
+}
+
+_UPGRADE_OVERVIEW_RE = re.compile(
+    r"^## Upgrade Overview\s*$\n(?P<body>.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_SUBSECTION_RE = re.compile(
+    r"^### (?P<title>.+?)\s*$\n(?P<body>.*?)(?=^###\s|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_CHECKBOX_RE = re.compile(r"^- \[(?P<checked>[ xX])\] (?P<label>.+?)\s*$", re.MULTILINE)
+
+
+def _normalize_heading(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+def _matches_pattern(path: str, pattern: str) -> bool:
+    return PurePosixPath(path).match(pattern)
+
+
+def categorize_files(changed_files: Iterable[str]) -> dict[str, list[str]]:
+    matched: dict[str, list[str]] = {}
+    for raw_path in changed_files:
+        path = raw_path.strip()
+        if not path:
+            continue
+        for area in PROTECTED_AREAS:
+            if any(_matches_pattern(path, pattern) for pattern in area.patterns):
+                matched.setdefault(area.label, []).append(path)
+    return matched
+
+
+def _strip_comments(value: str) -> str:
+    return re.sub(r"<!--.*?-->", "", value, flags=re.DOTALL).strip()
+
+
+def _has_meaningful_content(value: str) -> bool:
+    cleaned = _strip_comments(value)
+    collapsed = " ".join(cleaned.split()).strip(" -")
+    if not collapsed:
+        return False
+    if collapsed.lower() in PLACEHOLDER_VALUES:
+        return False
+    return len(re.sub(r"[^a-zA-Z0-9]+", "", collapsed)) >= 8
+
+
+def extract_upgrade_sections(pr_body: str) -> dict[str, str]:
+    match = _UPGRADE_OVERVIEW_RE.search(pr_body)
+    if match is None:
+        return {}
+
+    overview_body = match.group("body").strip()
+    sections: dict[str, str] = {}
+    for subsection in _SUBSECTION_RE.finditer(overview_body):
+        title = _normalize_heading(subsection.group("title"))
+        sections[title] = subsection.group("body").strip()
+    return sections
+
+
+def parse_checked_areas(section_body: str) -> set[str]:
+    checked: set[str] = set()
+    for match in _CHECKBOX_RE.finditer(section_body):
+        if match.group("checked").lower() == "x":
+            checked.add(_normalize_heading(match.group("label")))
+    return checked
+
+
+def validate_upgrade_overview(pr_body: str, touched_areas: dict[str, list[str]]) -> list[str]:
+    if not touched_areas:
+        return []
+
+    sections = extract_upgrade_sections(pr_body)
+    if not sections:
+        return [
+            "Protected paths were modified, but the PR body is missing the required `## Upgrade Overview` section."
+        ]
+
+    errors: list[str] = []
+    protected_area_section = sections.get("protected areas")
+    if protected_area_section is None:
+        errors.append("`### Protected Areas` is missing from `## Upgrade Overview`.")
+    else:
+        checked_areas = parse_checked_areas(protected_area_section)
+        missing_checked = sorted(set(touched_areas) - checked_areas)
+        if missing_checked:
+            errors.append(
+                "The checked protected areas do not cover the touched categories: "
+                + ", ".join(missing_checked)
+                + "."
+            )
+
+    for section_name in REQUIRED_NARRATIVE_SECTIONS:
+        section_body = sections.get(section_name)
+        if section_body is None:
+            errors.append(f"`### {section_name.title()}` is missing from `## Upgrade Overview`.")
+            continue
+        if not _has_meaningful_content(section_body):
+            errors.append(f"`### {section_name.title()}` must contain explicit upgrade notes.")
+
+    return errors
+
+
+def changed_files_between(base_sha: str, head_sha: str) -> list[str]:
+    command = ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"]
+    completed = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+
+
+def load_pull_request_event(event_path: str) -> tuple[str, str, str]:
+    with open(event_path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    pull_request = payload.get("pull_request")
+    if not isinstance(pull_request, dict):
+        raise ValueError("GitHub event payload does not contain a pull_request object.")
+
+    base_sha = pull_request["base"]["sha"]
+    head_sha = pull_request["head"]["sha"]
+    body = pull_request.get("body") or ""
+    return base_sha, head_sha, body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail CI when protected path changes are missing explicit upgrade metadata."
+    )
+    parser.add_argument(
+        "--event-path",
+        required=True,
+        help="Path to the GitHub event payload JSON.",
+    )
+    args = parser.parse_args()
+
+    try:
+        base_sha, head_sha, pr_body = load_pull_request_event(args.event_path)
+        changed_files = changed_files_between(base_sha, head_sha)
+    except Exception as exc:
+        print(f"Unable to evaluate protected-path guardrails: {exc}")
+        return 1
+
+    touched_areas = categorize_files(changed_files)
+    if not touched_areas:
+        print("No protected paths changed; upgrade metadata is not required.")
+        return 0
+
+    errors = validate_upgrade_overview(pr_body, touched_areas)
+    if not errors:
+        print("Protected-path upgrade metadata is present.")
+        for label, files in sorted(touched_areas.items()):
+            print(f"- {label}: {', '.join(sorted(files))}")
+        return 0
+
+    print("Protected-path guardrail failure:")
+    for label, files in sorted(touched_areas.items()):
+        print(f"- touched {label}: {', '.join(sorted(files))}")
+    for error in errors:
+        print(f"- {error}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_protected_path_guardrails.py
+++ b/tests/unit/test_protected_path_guardrails.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "check_protected_paths.py"
+)
+_SPEC = importlib.util.spec_from_file_location("check_protected_paths", _MODULE_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+guardrails = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = guardrails
+_SPEC.loader.exec_module(guardrails)
+
+
+def test_categorize_files_tracks_overlapping_protected_areas() -> None:
+    touched = guardrails.categorize_files(
+        [
+            "apps/api/src/alicebot_api/contracts.py",
+            "apps/api/src/alicebot_api/trusted_fact_promotions.py",
+            "README.md",
+        ]
+    )
+
+    assert sorted(touched) == [
+        "continuity APIs",
+        "memory schema",
+        "promotion logic",
+        "trust rules",
+    ]
+    assert touched["promotion logic"] == [
+        "apps/api/src/alicebot_api/trusted_fact_promotions.py"
+    ]
+
+
+def test_validate_upgrade_overview_skips_non_protected_changes() -> None:
+    assert guardrails.validate_upgrade_overview("", {}) == []
+
+
+def test_validate_upgrade_overview_requires_checked_areas_and_notes() -> None:
+    touched = {
+        "memory schema": ["apps/api/alembic/versions/20260410_9999_example.py"],
+        "continuity APIs": ["apps/api/src/alicebot_api/main.py"],
+    }
+
+    errors = guardrails.validate_upgrade_overview(
+        """
+## Upgrade Overview
+
+### Protected Areas
+
+- [x] memory schema
+
+### Compatibility Impact
+
+TBD
+
+### Migration / Rollout
+
+Pending
+
+### Operator Action
+
+None
+
+### Validation
+
+N/A
+""",
+        touched,
+    )
+
+    assert any("continuity APIs" in error for error in errors)
+    assert any("Compatibility Impact" in error for error in errors)
+    assert any("Rollback" in error for error in errors)
+
+
+def test_validate_upgrade_overview_accepts_complete_metadata() -> None:
+    touched = {
+        "evidence pipeline": ["apps/api/src/alicebot_api/continuity_evidence.py"],
+        "trust rules": ["apps/api/src/alicebot_api/memory.py"],
+    }
+
+    errors = guardrails.validate_upgrade_overview(
+        """
+## Summary
+
+Short summary.
+
+## Upgrade Overview
+
+### Protected Areas
+
+- [x] evidence pipeline
+- [x] trust rules
+
+### Compatibility Impact
+
+Additive internal change only. Existing archived evidence rows stay readable and no API enum changes occur.
+
+### Migration / Rollout
+
+No deploy sequencing beyond the normal application rollout. Existing data remains valid without backfill.
+
+### Operator Action
+
+No manual operator action is required for this change.
+
+### Validation
+
+Ran targeted unit coverage for the guardrail parser and reviewed the protected-path mapping against the touched files.
+
+### Rollback
+
+Revert the change set and redeploy. No irreversible data rewrite occurs in this path.
+""",
+        touched,
+    )
+
+    assert errors == []


### PR DESCRIPTION
## Summary
This PR adds explicit upgrade guardrails around Alice's highest-risk surfaces.

It documents the protected areas that can silently break continuity behavior, adds a reusable upgrade overview template, and makes pull requests fail in CI when they modify protected paths without explicit rollout and compatibility notes.

## What Changed
- added `PROTECTED_PATHS.md` to map protected areas to concrete path globs and list the invariants contributors must preserve
- added `UPGRADE_OVERVIEW_TEMPLATE.md` so upgrade metadata is structured and easy to copy into a PR
- added a pull request template that points contributors at the guarded upgrade fields
- added a GitHub Actions workflow plus `scripts/check_protected_paths.py` to enforce upgrade metadata for protected-path changes
- added unit coverage for the guardrail parser and path matcher
- updated `CONTRIBUTING.md` so contributors see the new expectation before opening a PR

## Why
The repo already has sensitive areas where small changes can alter schema compatibility, evidence provenance, trust posture, promotion behavior, or cross-surface API alignment. Before this change, a contributor could modify those areas without being forced to explain compatibility impact, rollout steps, or rollback posture.

This closes that gap by making the protected surface explicit and by failing the PR when that metadata is missing.

## Contributor Impact
Contributors now have a fast way to identify high-risk paths and the invariants attached to them. When a PR touches one of those paths, the author must describe compatibility impact, migration or rollout, operator action, validation, and rollback before the PR can merge.

## Validation
- `python3 -m pytest tests/unit/test_protected_path_guardrails.py`
- `python3 scripts/check_protected_paths.py --help`
- `git diff --check`
- targeted regex scan of edited files for obvious email or phone-number PII patterns

## Protected Paths
This PR adds the guardrails but does not modify any of the protected runtime paths themselves, so the new CI rule does not require upgrade metadata for this branch.