### PR TITLE
Security remediation: post-sprint scan fixes (abuse controls, evidence minimization, CI pinning)

### DIFF
--- a/.github/workflows/protected-path-guardrails.yml
+++ b/.github/workflows/protected-path-guardrails.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
 

--- a/apps/api/src/alicebot_api/continuity_evidence.py
+++ b/apps/api/src/alicebot_api/continuity_evidence.py
@@ -36,6 +36,9 @@ class ContinuityEvidenceNotFoundError(LookupError):
     """Raised when a continuity evidence resource is not visible in scope."""
 
 
+_REDACTED_EVIDENCE_CONTENT = "[redacted]"
+
+
 @dataclass(frozen=True, slots=True)
 class SourceArtifactArchiveInput:
     relative_path: str
@@ -170,8 +173,20 @@ def _serialize_artifact_segment(
     }
 
 
+def _sensitive_evidence_content(
+    value: str,
+    *,
+    include_raw_content: bool,
+) -> str:
+    if include_raw_content:
+        return value
+    return _REDACTED_EVIDENCE_CONTENT
+
+
 def serialize_continuity_evidence_rows(
     rows: list[ContinuityObjectEvidenceRow],
+    *,
+    include_raw_content: bool = True,
 ) -> list[ContinuityEvidenceLinkRecord]:
     serialized: list[ContinuityEvidenceLinkRecord] = []
     for row in rows:
@@ -189,7 +204,10 @@ def serialize_continuity_evidence_rows(
             "checksum_sha256": row["artifact_copy_checksum_sha256"],
             "content_length_bytes": row["artifact_copy_content_length_bytes"],
             "content_encoding": row["artifact_copy_content_encoding"],
-            "content_text": row["artifact_copy_content_text"],
+            "content_text": _sensitive_evidence_content(
+                row["artifact_copy_content_text"],
+                include_raw_content=include_raw_content,
+            ),
             "created_at": row["artifact_copy_created_at"].isoformat(),
         }
         artifact_segment = None
@@ -200,7 +218,10 @@ def serialize_continuity_evidence_rows(
                 "sequence_no": row["segment_sequence_no"] or 0,
                 "segment_kind": row["segment_kind"] or "unknown",
                 "locator": row["segment_locator"] or {},
-                "raw_content": row["segment_raw_content"] or "",
+                "raw_content": _sensitive_evidence_content(
+                    row["segment_raw_content"] or "",
+                    include_raw_content=include_raw_content,
+                ),
                 "checksum_sha256": row["segment_checksum_sha256"] or "",
                 "created_at": (
                     row["segment_created_at"].isoformat()
@@ -226,6 +247,7 @@ def build_continuity_explain(
     *,
     user_id: UUID,
     continuity_object_id: UUID,
+    include_raw_content: bool = True,
 ) -> ContinuityExplainResponse:
     del user_id
 
@@ -253,7 +275,8 @@ def build_continuity_explain(
             updated_at=continuity_object["updated_at"],
         ),
         "evidence_chain": serialize_continuity_evidence_rows(
-            store.list_continuity_object_evidence(continuity_object_id)
+            store.list_continuity_object_evidence(continuity_object_id),
+            include_raw_content=include_raw_content,
         ),
     }
     return {"explain": explain}
@@ -264,6 +287,7 @@ def get_continuity_artifact_detail(
     *,
     user_id: UUID,
     artifact_id: UUID,
+    include_raw_content: bool = True,
 ) -> ContinuityArtifactDetailResponse:
     del user_id
 
@@ -274,11 +298,23 @@ def get_continuity_artifact_detail(
     detail: ContinuityArtifactDetailRecord = {
         "artifact": _serialize_artifact(artifact),
         "copies": [
-            _serialize_artifact_copy(copy)
+            {
+                **_serialize_artifact_copy(copy),
+                "content_text": _sensitive_evidence_content(
+                    copy["content_text"],
+                    include_raw_content=include_raw_content,
+                ),
+            }
             for copy in store.list_continuity_artifact_copies(artifact_id)
         ],
         "segments": [
-            _serialize_artifact_segment(segment)
+            {
+                **_serialize_artifact_segment(segment),
+                "raw_content": _sensitive_evidence_content(
+                    segment["raw_content"],
+                    include_raw_content=include_raw_content,
+                ),
+            }
             for segment in store.list_continuity_artifact_segments(artifact_id)
         ],
     }

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import hmac
 import hashlib
 import json
+import logging
 import threading
 import time
 from typing import Annotated, Awaitable, Callable, Literal, TypedDict
@@ -608,6 +609,8 @@ from alicebot_api.traces import (
     list_trace_event_records,
     list_trace_records,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 
 app = FastAPI(title="AliceBot API", version="0.1.0")
@@ -1885,6 +1888,25 @@ def _ensure_hosted_admin_access(conn, *, user_account_id: UUID) -> None:
         raise PermissionError(
             "hosted admin access requires hosted_admin_read and hosted_admin_operator flags"
         )
+
+
+def _allow_raw_evidence_debug_access(settings: Settings) -> bool:
+    return settings.app_env in {"development", "test"}
+
+
+def _audit_raw_evidence_access(
+    *,
+    request: Request,
+    settings: Settings,
+    route: str,
+    user_id: UUID,
+) -> None:
+    LOGGER.info(
+        "raw evidence content requested route=%s user_id=%s client=%s",
+        route,
+        user_id,
+        _request_client_identifier(request, settings),
+    )
 
 
 def _record_workspace_onboarding_failure(
@@ -4260,6 +4282,7 @@ def get_continuity_explain_endpoint(
                 ContinuityStore(conn),
                 user_id=user_id,
                 continuity_object_id=continuity_object_id,
+                include_raw_content=False,
             )
     except ContinuityEvidenceNotFoundError as exc:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
@@ -4431,10 +4454,25 @@ def get_trusted_fact_playbook_endpoint(
 
 @app.get("/v0/admin/debug/continuity/artifacts/{artifact_id}")
 def get_continuity_artifact_detail_endpoint(
+    request: Request,
     artifact_id: UUID,
     user_id: UUID,
+    include_raw_content: bool = Query(default=False),
 ) -> JSONResponse:
     settings = get_settings()
+    if include_raw_content and not _allow_raw_evidence_debug_access(settings):
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "raw evidence content access is restricted to development/test"},
+        )
+
+    if include_raw_content:
+        _audit_raw_evidence_access(
+            request=request,
+            settings=settings,
+            route="/v0/admin/debug/continuity/artifacts/{artifact_id}",
+            user_id=user_id,
+        )
 
     try:
         with user_connection(settings.database_url, user_id) as conn:
@@ -4442,6 +4480,7 @@ def get_continuity_artifact_detail_endpoint(
                 ContinuityStore(conn),
                 user_id=user_id,
                 artifact_id=artifact_id,
+                include_raw_content=include_raw_content,
             )
     except ContinuityEvidenceNotFoundError as exc:
         return JSONResponse(status_code=404, content={"detail": str(exc)})

--- a/apps/api/src/alicebot_api/mcp_tools.py
+++ b/apps/api/src/alicebot_api/mcp_tools.py
@@ -61,6 +61,7 @@ from alicebot_api.contracts import (
     TemporalStateAtQueryInput,
     TemporalTimelineQueryInput,
 )
+from alicebot_api.config import get_settings
 from alicebot_api.db import user_connection
 from alicebot_api.store import ContinuityStore, JsonObject
 from alicebot_api.temporal_state import (
@@ -552,11 +553,17 @@ def _handle_alice_explain(context: MCPRuntimeContext, arguments: Mapping[str, ob
             )
     if continuity_object_id is None:
         raise MCPToolError("alice_explain requires continuity_object_id or entity_id")
+
+    include_raw_content = _parse_bool(arguments, key="include_raw_content", default=False)
+    if include_raw_content and get_settings().app_env not in {"development", "test"}:
+        raise MCPToolError("include_raw_content is restricted to development/test environments")
+
     with _store_context(context) as store:
         return build_continuity_explain(
             store,
             user_id=context.user_id,
             continuity_object_id=continuity_object_id,
+            include_raw_content=include_raw_content,
         )
 
 
@@ -564,11 +571,16 @@ def _handle_alice_artifact_inspect(
     context: MCPRuntimeContext,
     arguments: Mapping[str, object],
 ) -> JsonObject:
+    include_raw_content = _parse_bool(arguments, key="include_raw_content", default=False)
+    if include_raw_content and get_settings().app_env not in {"development", "test"}:
+        raise MCPToolError("include_raw_content is restricted to development/test environments")
+
     with _store_context(context) as store:
         return get_continuity_artifact_detail(
             store,
             user_id=context.user_id,
             artifact_id=_parse_required_uuid(arguments, "artifact_id"),
+            include_raw_content=include_raw_content,
         )
 
 
@@ -827,6 +839,7 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
                 "continuity_object_id": {"type": "string", "format": "uuid"},
                 "entity_id": {"type": "string", "format": "uuid"},
                 "at": {"type": "string", "format": "date-time"},
+                "include_raw_content": {"type": "boolean"},
             },
         },
     },
@@ -839,6 +852,7 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
             "required": ["artifact_id"],
             "properties": {
                 "artifact_id": {"type": "string", "format": "uuid"},
+                "include_raw_content": {"type": "boolean"},
             },
         },
     },

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -1612,6 +1612,15 @@ UPSERT_FACT_PATTERN_SQL = """
                   evidence_chain = EXCLUDED.evidence_chain,
                   explanation = EXCLUDED.explanation,
                   updated_at = clock_timestamp()
+                WHERE
+                  fact_patterns.id IS DISTINCT FROM EXCLUDED.id
+                  OR fact_patterns.title IS DISTINCT FROM EXCLUDED.title
+                  OR fact_patterns.memory_type IS DISTINCT FROM EXCLUDED.memory_type
+                  OR fact_patterns.namespace_key IS DISTINCT FROM EXCLUDED.namespace_key
+                  OR fact_patterns.fact_count IS DISTINCT FROM EXCLUDED.fact_count
+                  OR fact_patterns.source_fact_ids IS DISTINCT FROM EXCLUDED.source_fact_ids
+                  OR fact_patterns.evidence_chain IS DISTINCT FROM EXCLUDED.evidence_chain
+                  OR fact_patterns.explanation IS DISTINCT FROM EXCLUDED.explanation
                 RETURNING
                   id,
                   user_id,
@@ -1723,6 +1732,16 @@ UPSERT_FACT_PLAYBOOK_SQL = """
                   steps = EXCLUDED.steps,
                   explanation = EXCLUDED.explanation,
                   updated_at = clock_timestamp()
+                WHERE
+                  fact_playbooks.id IS DISTINCT FROM EXCLUDED.id
+                  OR fact_playbooks.pattern_id IS DISTINCT FROM EXCLUDED.pattern_id
+                  OR fact_playbooks.pattern_key IS DISTINCT FROM EXCLUDED.pattern_key
+                  OR fact_playbooks.title IS DISTINCT FROM EXCLUDED.title
+                  OR fact_playbooks.memory_type IS DISTINCT FROM EXCLUDED.memory_type
+                  OR fact_playbooks.source_fact_ids IS DISTINCT FROM EXCLUDED.source_fact_ids
+                  OR fact_playbooks.source_pattern_ids IS DISTINCT FROM EXCLUDED.source_pattern_ids
+                  OR fact_playbooks.steps IS DISTINCT FROM EXCLUDED.steps
+                  OR fact_playbooks.explanation IS DISTINCT FROM EXCLUDED.explanation
                 RETURNING
                   id,
                   user_id,

--- a/apps/api/src/alicebot_api/trusted_fact_promotions.py
+++ b/apps/api/src/alicebot_api/trusted_fact_promotions.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from collections import defaultdict
 import json
+from threading import Lock
+import time
 from typing import cast
 from uuid import NAMESPACE_URL, UUID, uuid5
 
@@ -30,6 +32,9 @@ from alicebot_api.store import (
 )
 
 _TRUSTED_PATTERN_CLASSES = frozenset({"deterministic", "llm_corroborated", "human_curated"})
+_PROMOTION_SYNC_MIN_INTERVAL_SECONDS = 30.0
+_promotion_sync_lock = Lock()
+_last_promotion_sync_at_by_user: dict[UUID, float] = {}
 _ACTION_TYPE_BY_MEMORY_TYPE = {
     "preference": "prefer",
     "working_style": "work_with",
@@ -257,13 +262,37 @@ def sync_trusted_fact_promotions(
     store.delete_fact_patterns_not_in(pattern_ids)
 
 
+def _sync_trusted_fact_promotions_if_due(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+) -> None:
+    now = time.monotonic()
+    with _promotion_sync_lock:
+        last_sync_at = _last_promotion_sync_at_by_user.get(user_id)
+        if (
+            last_sync_at is not None
+            and now - last_sync_at < _PROMOTION_SYNC_MIN_INTERVAL_SECONDS
+        ):
+            return
+        _last_promotion_sync_at_by_user[user_id] = now
+
+    try:
+        sync_trusted_fact_promotions(store, user_id=user_id)
+    except Exception:
+        # A failed sync should not suppress future retries.
+        with _promotion_sync_lock:
+            _last_promotion_sync_at_by_user.pop(user_id, None)
+        raise
+
+
 def list_trusted_fact_patterns(
     store: ContinuityStore,
     *,
     user_id: UUID,
     request: TrustedFactPatternListQueryInput,
 ) -> TrustedFactPatternListResponse:
-    sync_trusted_fact_promotions(store, user_id=user_id)
+    _sync_trusted_fact_promotions_if_due(store, user_id=user_id)
     rows = store.list_fact_patterns(limit=request.limit)
     total_count = store.count_fact_patterns()
     return {
@@ -283,7 +312,7 @@ def get_trusted_fact_pattern(
     user_id: UUID,
     pattern_id: UUID,
 ) -> TrustedFactPatternExplainResponse:
-    sync_trusted_fact_promotions(store, user_id=user_id)
+    _sync_trusted_fact_promotions_if_due(store, user_id=user_id)
     row = store.get_fact_pattern_optional(pattern_id)
     if row is None:
         raise TrustedFactPromotionNotFoundError(f"pattern {pattern_id} was not found")
@@ -296,7 +325,7 @@ def list_trusted_fact_playbooks(
     user_id: UUID,
     request: TrustedFactPlaybookListQueryInput,
 ) -> TrustedFactPlaybookListResponse:
-    sync_trusted_fact_promotions(store, user_id=user_id)
+    _sync_trusted_fact_promotions_if_due(store, user_id=user_id)
     rows = store.list_fact_playbooks(limit=request.limit)
     total_count = store.count_fact_playbooks()
     return {
@@ -316,7 +345,7 @@ def get_trusted_fact_playbook(
     user_id: UUID,
     playbook_id: UUID,
 ) -> TrustedFactPlaybookExplainResponse:
-    sync_trusted_fact_promotions(store, user_id=user_id)
+    _sync_trusted_fact_promotions_if_due(store, user_id=user_id)
     row = store.get_fact_playbook_optional(playbook_id)
     if row is None:
         raise TrustedFactPromotionNotFoundError(f"playbook {playbook_id} was not found")


### PR DESCRIPTION
## Summary
This PR implements the three approved security remediations from the latest sprint rescan.

## What Changed
1. Reduced write amplification on trusted-fact read paths
- Added a per-user sync throttle in `trusted_fact_promotions.py` to prevent repeated expensive recomputation on rapid GET/MCP polling.
- Updated fact-pattern/playbook UPSERT SQL to only perform `DO UPDATE` when row values actually changed.

2. Minimized raw evidence exposure by default
- `continuity_explain` and artifact inspection now support raw-content redaction controls.
- `/v0/continuity/explain/{continuity_object_id}` now returns redacted evidence-chain content by default.
- `/v0/admin/debug/continuity/artifacts/{artifact_id}` now defaults to redacted content and requires explicit `include_raw_content=true`.
- Raw-content access is restricted to `development`/`test` environments and emits an audit log line when used.
- MCP tools `alice_explain` and `alice_artifact_inspect` now accept `include_raw_content` but enforce the same environment restriction.

3. Hardened CI supply-chain pinning
- Pinned the new protected-path guardrails checkout action to an immutable commit SHA.

## Validation
- `python3 -m pytest -q tests/unit/test_trusted_fact_promotions.py tests/unit/test_mcp.py tests/unit/test_main.py`
- `python3 -m pytest -q tests/integration/test_temporal_state_mcp_cli.py tests/integration/test_trusted_fact_promotions_api.py`
- `python3 -m pytest -q tests/integration/test_markdown_import.py`

All passed.

## PII/Sensitive Data Check
- Reviewed all modified files and diff content for personally identifiable information.
- No new PII or secrets were introduced in this PR.
