### PR TITLE
Add archive maintenance jobs, ops status reporting, and failure alerts

### DIFF
--- a/.github/workflows/archive-maintenance.yml
+++ b/.github/workflows/archive-maintenance.yml
@@ -1,0 +1,156 @@
+name: Archive Maintenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      schedule:
+        description: Schedule metadata for this maintenance run.
+        required: true
+        default: manual
+        type: choice
+        options:
+          - nightly
+          - weekly
+          - manual
+      include_benchmark:
+        description: Run benchmark regeneration during this run.
+        required: true
+        default: false
+        type: boolean
+  schedule:
+    - cron: "17 2 * * *"
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: archive-maintenance
+  cancel-in-progress: false
+
+jobs:
+  archive-maintenance:
+    name: Archive Maintenance
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/alicebot
+      ALICEBOT_AUTH_USER_ID: 00000000-0000-0000-0000-000000000001
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'
+
+      - name: Prepare database
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -c "CREATE DATABASE alicebot;"
+          psql -h localhost -U postgres -d alicebot -f infra/postgres/init/001_roles.sql
+          python -m alembic -c apps/api/alembic.ini upgrade head
+
+      - name: Resolve schedule mode
+        id: schedule
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            resolved_schedule="${{ inputs.schedule }}"
+            include_benchmark="${{ inputs.include_benchmark }}"
+          elif [[ "${{ github.event.schedule }}" == "23 4 * * 1" ]]; then
+            resolved_schedule="weekly"
+            include_benchmark="true"
+          else
+            resolved_schedule="nightly"
+            include_benchmark="false"
+          fi
+
+          echo "schedule=${resolved_schedule}" >> "$GITHUB_OUTPUT"
+          echo "include_benchmark=${include_benchmark}" >> "$GITHUB_OUTPUT"
+
+      - name: Run archive maintenance
+        run: |
+          args=(
+            --schedule "${{ steps.schedule.outputs.schedule }}"
+            --database-url "$DATABASE_URL"
+            --user-id "$ALICEBOT_AUTH_USER_ID"
+          )
+
+          if [[ "${{ steps.schedule.outputs.include_benchmark }}" == "true" ]]; then
+            args+=(--include-benchmark)
+          fi
+
+          python scripts/run_archive_maintenance.py "${args[@]}"
+
+      - name: Publish maintenance summary
+        if: always()
+        run: |
+          if [[ -f artifacts/ops/maintenance_status_latest.json ]]; then
+            {
+              echo "### Archive maintenance"
+              echo
+              echo '```json'
+              cat artifacts/ops/maintenance_status_latest.json
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "maintenance report not found" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload maintenance artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: archive-maintenance-${{ github.run_id }}
+          if-no-files-found: warn
+          path: |
+            artifacts/ops/maintenance_status_latest.json
+            artifacts/ops/archive_checksum_manifest.json
+            artifacts/ops/stale_fact_markers_latest.json
+            artifacts/ops/history/*.json
+            eval/reports/phase9_eval_latest.json
+
+      - name: Create failure alert issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const schedule = `${{ steps.schedule.outputs.schedule }}`;
+            const title = `[ops] archive maintenance failure (${schedule})`;
+            const body = [
+              'Archive maintenance job failed.',
+              '',
+              `- schedule: ${schedule}`,
+              `- workflow run: ${runUrl}`,
+              `- commit: ${context.sha}`,
+              '',
+              'Please inspect the uploaded maintenance artifacts and logs.'
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ In another terminal, verify the runtime and get a first useful result:
 ./.venv/bin/python -m alicebot_api recall --query local-first --limit 5
 ./.venv/bin/python -m alicebot_api resume --max-recent-changes 5 --max-open-loops 5
 ./.venv/bin/python -m alicebot_api open-loops --limit 5
+./scripts/run_archive_maintenance.py --schedule manual
 ```
 
 Recall-derived surfaces now expose a shared explanation payload, and `explain` uses the same structure for continuity evidence:

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import json
 import os
+from pathlib import Path
 import sys
 from uuid import UUID
 
@@ -122,6 +123,10 @@ from alicebot_api.trusted_fact_promotions import (
 )
 
 DEFAULT_CLI_USER_ID = "00000000-0000-0000-0000-000000000001"
+MAINTENANCE_REPORT_PATH_ENV = "ALICEBOT_MAINTENANCE_REPORT_PATH"
+DEFAULT_MAINTENANCE_REPORT_PATH = (
+    Path(__file__).resolve().parents[4] / "artifacts" / "ops" / "maintenance_status_latest.json"
+)
 REVIEW_STATUS_CHOICES = ("correction_ready", "active", "stale", "superseded", "deleted", "all")
 
 
@@ -192,6 +197,90 @@ def _build_context(args: argparse.Namespace) -> CLIContext:
 def _store_context(ctx: CLIContext) -> Iterator[ContinuityStore]:
     with user_connection(ctx.database_url, ctx.user_id) as conn:
         yield ContinuityStore(conn)
+
+
+def _parse_maintenance_status_payload(payload: object) -> dict[str, object]:
+    default_snapshot: dict[str, object] = {
+        "maintenance_status": "unknown",
+        "maintenance_schedule": "unknown",
+        "maintenance_last_run_at": "unknown",
+        "maintenance_failure_count": 0,
+        "maintenance_warning_count": 0,
+        "maintenance_stale_fact_count": 0,
+        "maintenance_reembedded_segment_count": 0,
+        "maintenance_pattern_candidate_count": 0,
+        "maintenance_benchmark_status": "unknown",
+    }
+
+    if not isinstance(payload, dict):
+        return default_snapshot
+
+    summary = payload.get("summary")
+    if isinstance(summary, dict):
+        status = summary.get("status")
+        if isinstance(status, str):
+            default_snapshot["maintenance_status"] = status
+        schedule = summary.get("schedule")
+        if isinstance(schedule, str):
+            default_snapshot["maintenance_schedule"] = schedule
+        completed_at = summary.get("run_completed_at")
+        if isinstance(completed_at, str):
+            default_snapshot["maintenance_last_run_at"] = completed_at
+        failure_count = summary.get("failure_count")
+        if isinstance(failure_count, int):
+            default_snapshot["maintenance_failure_count"] = failure_count
+        warning_count = summary.get("warning_count")
+        if isinstance(warning_count, int):
+            default_snapshot["maintenance_warning_count"] = warning_count
+
+    jobs = payload.get("jobs")
+    if not isinstance(jobs, list):
+        return default_snapshot
+
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        job_key = job.get("job_key")
+        details = job.get("details")
+        if not isinstance(job_key, str) or not isinstance(details, dict):
+            continue
+        if job_key == "stale_fact_marking":
+            stale_fact_count = details.get("stale_fact_count")
+            if isinstance(stale_fact_count, int):
+                default_snapshot["maintenance_stale_fact_count"] = stale_fact_count
+        elif job_key == "reembed_missing_segments":
+            reembedded_segment_count = details.get("reembedded_segment_count")
+            if isinstance(reembedded_segment_count, int):
+                default_snapshot["maintenance_reembedded_segment_count"] = reembedded_segment_count
+        elif job_key == "pattern_candidate_recompute":
+            pattern_candidate_count = details.get("pattern_candidate_count")
+            if isinstance(pattern_candidate_count, int):
+                default_snapshot["maintenance_pattern_candidate_count"] = pattern_candidate_count
+        elif job_key == "benchmark_regeneration":
+            benchmark_status = details.get("benchmark_status")
+            if isinstance(benchmark_status, str):
+                default_snapshot["maintenance_benchmark_status"] = benchmark_status
+
+    return default_snapshot
+
+
+def _load_maintenance_status_snapshot() -> dict[str, object]:
+    raw_path = os.getenv(MAINTENANCE_REPORT_PATH_ENV)
+    if raw_path is None or raw_path.strip() == "":
+        report_path = DEFAULT_MAINTENANCE_REPORT_PATH
+    else:
+        candidate = Path(raw_path.strip()).expanduser()
+        report_path = candidate if candidate.is_absolute() else (Path.cwd() / candidate).resolve()
+
+    if not report_path.exists():
+        return _parse_maintenance_status_payload({})
+
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return _parse_maintenance_status_payload({})
+
+    return _parse_maintenance_status_payload(payload)
 
 
 def _run_capture(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -451,6 +540,7 @@ def _run_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
         ctx.database_url,
         timeout_seconds=ctx.settings.healthcheck_timeout_seconds,
     )
+    maintenance_status = _load_maintenance_status_snapshot()
 
     status_payload: dict[str, object] = {
         "user_id": str(ctx.user_id),
@@ -478,6 +568,15 @@ def _run_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
         "retrieval_eval_status": "unknown",
         "retrieval_precision_at_k_mean": "0.000",
         "retrieval_precision_at_1_mean": "0.000",
+        "maintenance_status": maintenance_status["maintenance_status"],
+        "maintenance_schedule": maintenance_status["maintenance_schedule"],
+        "maintenance_last_run_at": maintenance_status["maintenance_last_run_at"],
+        "maintenance_failure_count": maintenance_status["maintenance_failure_count"],
+        "maintenance_warning_count": maintenance_status["maintenance_warning_count"],
+        "maintenance_stale_fact_count": maintenance_status["maintenance_stale_fact_count"],
+        "maintenance_reembedded_segment_count": maintenance_status["maintenance_reembedded_segment_count"],
+        "maintenance_pattern_candidate_count": maintenance_status["maintenance_pattern_candidate_count"],
+        "maintenance_benchmark_status": maintenance_status["maintenance_benchmark_status"],
     }
     if not database_reachable:
         return format_status_output(status_payload)

--- a/apps/api/src/alicebot_api/cli_formatting.py
+++ b/apps/api/src/alicebot_api/cli_formatting.py
@@ -858,6 +858,18 @@ def format_status_output(status: Mapping[str, object]) -> str:
             f"next_action={status['open_loops_next_action']}"
         ),
         (
+            "maintenance: "
+            f"status={status['maintenance_status']} "
+            f"schedule={status['maintenance_schedule']} "
+            f"last_run={status['maintenance_last_run_at']} "
+            f"failures={status['maintenance_failure_count']} "
+            f"warnings={status['maintenance_warning_count']} "
+            f"stale_facts={status['maintenance_stale_fact_count']} "
+            f"reembedded_segments={status['maintenance_reembedded_segment_count']} "
+            f"pattern_candidates={status['maintenance_pattern_candidate_count']} "
+            f"benchmark={status['maintenance_benchmark_status']}"
+        ),
+        (
             "retrieval_eval: "
             f"status={status['retrieval_eval_status']} "
             f"precision_at_k_mean={status['retrieval_precision_at_k_mean']} "

--- a/scripts/run_archive_maintenance.py
+++ b/scripts/run_archive_maintenance.py
@@ -1,0 +1,782 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import time
+from typing import Literal
+from uuid import UUID
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_VENV_REEXEC_ENV = "ALICEBOT_ARCHIVE_MAINTENANCE_REEXEC"
+
+
+def _maybe_reexec_into_repo_venv() -> None:
+    if os.getenv(_VENV_REEXEC_ENV) == "1":
+        return
+
+    venv_python = (REPO_ROOT / ".venv" / "bin" / "python").resolve()
+    if not venv_python.exists():
+        return
+
+    current_python = Path(sys.executable).expanduser().resolve()
+    if current_python == venv_python:
+        return
+
+    os.environ[_VENV_REEXEC_ENV] = "1"
+    os.execv(
+        str(venv_python),
+        [
+            str(venv_python),
+            str(Path(__file__).resolve()),
+            *sys.argv[1:],
+        ],
+    )
+
+
+_maybe_reexec_into_repo_venv()
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+API_SRC = REPO_ROOT / "apps" / "api" / "src"
+if str(API_SRC) not in sys.path:
+    sys.path.insert(0, str(API_SRC))
+
+from alicebot_api.db import user_connection
+from alicebot_api.retrieval_evaluation import run_phase9_evaluation, write_phase9_evaluation_report
+from alicebot_api.store import ContinuityStore
+from alicebot_api.trusted_fact_promotions import sync_trusted_fact_promotions
+
+import scripts.verify_phase4_rc_archive as verify_rc_archive
+
+
+DEFAULT_DATABASE_URL = "postgresql://alicebot_app:alicebot_app@localhost:5432/alicebot"
+DEFAULT_AUTH_USER_ID = "00000000-0000-0000-0000-000000000001"
+DEFAULT_REPORT_PATH = REPO_ROOT / "artifacts" / "ops" / "maintenance_status_latest.json"
+DEFAULT_HISTORY_DIR = REPO_ROOT / "artifacts" / "ops" / "history"
+DEFAULT_ARCHIVE_INDEX_PATH = REPO_ROOT / "artifacts" / "release" / "archive" / "index.json"
+DEFAULT_CHECKSUM_MANIFEST_PATH = REPO_ROOT / "artifacts" / "ops" / "archive_checksum_manifest.json"
+DEFAULT_STALE_MARKERS_PATH = REPO_ROOT / "artifacts" / "ops" / "stale_fact_markers_latest.json"
+DEFAULT_PHASE9_REPORT_PATH = REPO_ROOT / "eval" / "reports" / "phase9_eval_latest.json"
+DEFAULT_USER_EMAIL = "maintenance-bot@example.invalid"
+DEFAULT_USER_DISPLAY_NAME = "Maintenance Bot"
+
+JOB_STATUS = Literal["pass", "warn", "fail", "skipped"]
+
+
+@dataclass(frozen=True, slots=True)
+class MaintenanceJobResult:
+    job_key: str
+    status: JOB_STATUS
+    started_at: str
+    completed_at: str
+    duration_seconds: float
+    details: dict[str, object]
+    warnings: list[str]
+    errors: list[str]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso8601_utc(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _repo_relative(path: Path) -> str:
+    resolved = path.expanduser().resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _resolve_path(path_value: str | Path) -> Path:
+    candidate = Path(path_value).expanduser()
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (REPO_ROOT / candidate).resolve()
+
+
+def _sha256_for_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 64), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _load_json_object(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return payload
+
+
+def _collect_archive_paths(index_path: Path) -> tuple[set[Path], list[str]]:
+    paths: set[Path] = {index_path}
+    errors: list[str] = []
+
+    if not index_path.exists():
+        return paths, [f"archive index missing: {_repo_relative(index_path)}"]
+
+    try:
+        index_payload = _load_json_object(index_path)
+    except Exception as exc:  # pragma: no cover - defensive IO guard
+        return paths, [f"failed to parse archive index: {exc}"]
+
+    latest_summary = index_payload.get("latest_summary_path")
+    if isinstance(latest_summary, str) and latest_summary.strip():
+        paths.add(_resolve_path(latest_summary))
+    else:
+        errors.append("archive index latest_summary_path is missing or invalid")
+
+    entries = index_payload.get("entries")
+    if not isinstance(entries, list):
+        errors.append("archive index entries must be a JSON array")
+        return paths, errors
+
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            errors.append(f"entries[{idx}] must be a JSON object")
+            continue
+        archive_artifact_path = entry.get("archive_artifact_path")
+        if not isinstance(archive_artifact_path, str) or not archive_artifact_path.strip():
+            errors.append(f"entries[{idx}].archive_artifact_path is missing or invalid")
+            continue
+        paths.add(_resolve_path(archive_artifact_path))
+
+    return paths, errors
+
+
+def _deterministic_embedding_vector(*, text: str, dimensions: int) -> list[float]:
+    if dimensions <= 0:
+        raise ValueError("dimensions must be greater than zero")
+
+    seed = text.encode("utf-8")
+    if not seed:
+        seed = b"\x00"
+
+    values: list[float] = []
+    nonce = 0
+    while len(values) < dimensions:
+        hasher = hashlib.sha256()
+        hasher.update(seed)
+        hasher.update(nonce.to_bytes(4, byteorder="big", signed=False))
+        digest = hasher.digest()
+        nonce += 1
+        for byte_value in digest:
+            normalized = (float(byte_value) / 127.5) - 1.0
+            values.append(normalized)
+            if len(values) == dimensions:
+                break
+
+    magnitude = sum(value * value for value in values) ** 0.5
+    if magnitude == 0.0:
+        # Deterministic fallback to avoid storing zero-magnitude vectors.
+        values[0] = 1.0
+        magnitude = 1.0
+
+    return [value / magnitude for value in values]
+
+
+def _run_job(
+    *,
+    job_key: str,
+    operation,
+) -> MaintenanceJobResult:
+    started = _utc_now()
+    started_monotonic = time.monotonic()
+    warnings: list[str] = []
+    errors: list[str] = []
+    details: dict[str, object] = {}
+    status: JOB_STATUS = "pass"
+
+    try:
+        job_payload = operation()
+    except Exception as exc:  # pragma: no cover - defensive boundary
+        status = "fail"
+        errors.append(str(exc))
+        job_payload = {}
+
+    if isinstance(job_payload, dict):
+        details = dict(job_payload.get("details", {})) if isinstance(job_payload.get("details"), dict) else {}
+        payload_warnings = job_payload.get("warnings")
+        if isinstance(payload_warnings, list):
+            warnings = [str(item) for item in payload_warnings]
+        payload_errors = job_payload.get("errors")
+        if isinstance(payload_errors, list):
+            errors.extend(str(item) for item in payload_errors)
+        payload_status = job_payload.get("status")
+        if payload_status in {"pass", "warn", "fail", "skipped"}:
+            status = payload_status
+
+    if errors:
+        status = "fail"
+    elif status == "pass" and warnings:
+        status = "warn"
+
+    completed = _utc_now()
+    duration_seconds = round(time.monotonic() - started_monotonic, 6)
+    return MaintenanceJobResult(
+        job_key=job_key,
+        status=status,
+        started_at=_iso8601_utc(started),
+        completed_at=_iso8601_utc(completed),
+        duration_seconds=duration_seconds,
+        details=details,
+        warnings=warnings,
+        errors=errors,
+    )
+
+
+def _verify_archive_checksums(
+    *,
+    index_path: Path,
+    checksum_manifest_path: Path,
+) -> dict[str, object]:
+    errors = verify_rc_archive.verify_archive_index(index_path=index_path)
+    archive_paths, collection_errors = _collect_archive_paths(index_path)
+    errors.extend(collection_errors)
+
+    checksums: dict[str, str] = {}
+    for archive_path in sorted(archive_paths):
+        if not archive_path.exists():
+            errors.append(f"archive file missing: {_repo_relative(archive_path)}")
+            continue
+        checksums[_repo_relative(archive_path)] = _sha256_for_file(archive_path)
+
+    manifest_mismatch_count = 0
+    previous_count = 0
+    if checksum_manifest_path.exists():
+        try:
+            previous_manifest = _load_json_object(checksum_manifest_path)
+            previous_checksums = previous_manifest.get("checksums")
+            if isinstance(previous_checksums, dict):
+                previous_count = len(previous_checksums)
+                for relative_path, expected_checksum in sorted(previous_checksums.items()):
+                    if not isinstance(relative_path, str) or not isinstance(expected_checksum, str):
+                        continue
+                    actual_checksum = checksums.get(relative_path)
+                    if actual_checksum is None:
+                        errors.append(
+                            "archive checksum manifest references missing file in current index: "
+                            f"{relative_path}"
+                        )
+                        manifest_mismatch_count += 1
+                        continue
+                    if actual_checksum != expected_checksum:
+                        errors.append(
+                            "archive checksum mismatch for "
+                            f"{relative_path}: manifest={expected_checksum} current={actual_checksum}"
+                        )
+                        manifest_mismatch_count += 1
+            else:
+                errors.append("existing archive checksum manifest is invalid")
+        except Exception as exc:  # pragma: no cover - defensive IO guard
+            errors.append(f"failed to read checksum manifest: {exc}")
+
+    if not errors:
+        checksum_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        checksum_manifest_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "archive_checksum_manifest.v1",
+                    "generated_at": _iso8601_utc(_utc_now()),
+                    "index_path": _repo_relative(index_path),
+                    "entry_count": len(checksums),
+                    "checksums": checksums,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    details = {
+        "verified_file_count": len(checksums),
+        "previous_manifest_file_count": previous_count,
+        "manifest_mismatch_count": manifest_mismatch_count,
+        "checksum_manifest_path": _repo_relative(checksum_manifest_path),
+        "archive_index_path": _repo_relative(index_path),
+    }
+    return {
+        "status": "pass" if not errors else "fail",
+        "details": details,
+        "errors": errors,
+    }
+
+
+def _collect_stale_fact_markers(store: ContinuityStore) -> tuple[list[str], int, int]:
+    active_count = store.count_memories(status="active")
+    if active_count == 0:
+        return [], 0, 0
+
+    active_memories = store.list_review_memories(status="active", limit=active_count)
+    stale_ids: list[str] = []
+    contested_count = 0
+    valid_to_count = 0
+
+    for memory in active_memories:
+        is_contested = memory.get("confirmation_status") == "contested"
+        has_valid_to = memory.get("valid_to") is not None
+        if is_contested:
+            contested_count += 1
+        if has_valid_to:
+            valid_to_count += 1
+        if is_contested or has_valid_to:
+            stale_ids.append(str(memory["id"]))
+
+    return sorted(stale_ids), contested_count, valid_to_count
+
+
+def _mark_stale_facts(
+    *,
+    store: ContinuityStore,
+    stale_markers_path: Path,
+) -> dict[str, object]:
+    stale_ids, contested_count, valid_to_count = _collect_stale_fact_markers(store)
+    stale_markers_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_markers_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "stale_fact_markers.v1",
+                "generated_at": _iso8601_utc(_utc_now()),
+                "stale_fact_count": len(stale_ids),
+                "contested_count": contested_count,
+                "valid_to_count": valid_to_count,
+                "stale_fact_ids": stale_ids,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    warnings: list[str] = []
+    if stale_ids:
+        warnings.append(
+            "stale facts detected; deterministic marker file updated for review queue triage"
+        )
+
+    return {
+        "status": "warn" if warnings else "pass",
+        "details": {
+            "stale_fact_count": len(stale_ids),
+            "contested_count": contested_count,
+            "valid_to_count": valid_to_count,
+            "stale_markers_path": _repo_relative(stale_markers_path),
+        },
+        "warnings": warnings,
+    }
+
+
+def _reembed_missing_segments(
+    *,
+    store: ContinuityStore,
+) -> dict[str, object]:
+    configs = store.list_embedding_configs()
+    if not configs:
+        return {
+            "status": "warn",
+            "details": {
+                "artifact_count": 0,
+                "chunk_count": 0,
+                "missing_segment_count": 0,
+                "reembedded_segment_count": 0,
+                "embedding_config_id": None,
+            },
+            "warnings": ["no embedding configs exist; re-embedding skipped"],
+        }
+
+    target_config = next((config for config in configs if config["status"] == "active"), configs[0])
+    target_config_id = target_config["id"]
+    target_dimensions = int(target_config["dimensions"])
+
+    artifacts = [
+        artifact
+        for artifact in store.list_task_artifacts()
+        if artifact["ingestion_status"] == "ingested"
+    ]
+
+    total_chunks = 0
+    missing_chunks = 0
+    reembedded_chunks = 0
+
+    for artifact in artifacts:
+        artifact_id = artifact["id"]
+        chunks = store.list_task_artifact_chunks(artifact_id)
+        total_chunks += len(chunks)
+
+        embeddings = store.list_task_artifact_chunk_embeddings_for_artifact(artifact_id)
+        embedded_chunk_ids = {
+            embedding["task_artifact_chunk_id"]
+            for embedding in embeddings
+            if embedding["embedding_config_id"] == target_config_id
+        }
+
+        ordered_chunks = sorted(
+            chunks,
+            key=lambda chunk: (chunk["sequence_no"], chunk["created_at"], chunk["id"]),
+        )
+
+        for chunk in ordered_chunks:
+            if chunk["id"] in embedded_chunk_ids:
+                continue
+
+            missing_chunks += 1
+            existing = store.get_task_artifact_chunk_embedding_by_chunk_and_config_optional(
+                task_artifact_chunk_id=chunk["id"],
+                embedding_config_id=target_config_id,
+            )
+            if existing is not None:
+                continue
+
+            vector = _deterministic_embedding_vector(
+                text=str(chunk["text"]),
+                dimensions=target_dimensions,
+            )
+            store.create_task_artifact_chunk_embedding(
+                task_artifact_chunk_id=chunk["id"],
+                embedding_config_id=target_config_id,
+                dimensions=target_dimensions,
+                vector=vector,
+            )
+            reembedded_chunks += 1
+
+    return {
+        "status": "pass",
+        "details": {
+            "artifact_count": len(artifacts),
+            "chunk_count": total_chunks,
+            "missing_segment_count": missing_chunks,
+            "reembedded_segment_count": reembedded_chunks,
+            "embedding_config_id": str(target_config_id),
+            "embedding_dimensions": target_dimensions,
+            "embedding_source": "deterministic_hash_vector",
+        },
+    }
+
+
+def _recompute_pattern_candidates(
+    *,
+    store: ContinuityStore,
+    user_id: UUID,
+) -> dict[str, object]:
+    sync_trusted_fact_promotions(store, user_id=user_id)
+    pattern_count = store.count_fact_patterns()
+    playbook_count = store.count_fact_playbooks()
+
+    return {
+        "status": "pass",
+        "details": {
+            "pattern_candidate_count": pattern_count,
+            "playbook_count": playbook_count,
+        },
+    }
+
+
+def _regenerate_benchmarks(
+    *,
+    store: ContinuityStore,
+    user_id: UUID,
+    include_benchmark: bool,
+    benchmark_report_path: Path,
+) -> dict[str, object]:
+    if not include_benchmark:
+        return {
+            "status": "skipped",
+            "details": {
+                "benchmark_status": "skipped",
+                "benchmark_report_path": _repo_relative(benchmark_report_path),
+                "reason": "benchmark regeneration is scheduled weekly or via explicit opt-in",
+            },
+        }
+
+    report = run_phase9_evaluation(store, user_id=user_id)
+    output_path = write_phase9_evaluation_report(
+        report=report,
+        report_path=benchmark_report_path,
+    )
+
+    summary = report.get("summary", {})
+    benchmark_status = summary.get("status", "unknown")
+    warnings: list[str] = []
+    status: JOB_STATUS = "pass"
+    if benchmark_status != "pass":
+        warnings.append(f"benchmark summary status is {benchmark_status}")
+        status = "warn"
+
+    return {
+        "status": status,
+        "details": {
+            "benchmark_status": benchmark_status,
+            "benchmark_report_path": _repo_relative(output_path),
+            "benchmark_summary": summary,
+        },
+        "warnings": warnings,
+    }
+
+
+def _ensure_user(store: ContinuityStore, *, user_id: UUID, email: str, display_name: str) -> None:
+    with store.conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM users WHERE id = %s", (user_id,))
+        exists = cur.fetchone() is not None
+    if exists:
+        return
+    store.create_user(user_id, email, display_name)
+
+
+def _serialize_job(job: MaintenanceJobResult) -> dict[str, object]:
+    return {
+        "job_key": job.job_key,
+        "status": job.status,
+        "started_at": job.started_at,
+        "completed_at": job.completed_at,
+        "duration_seconds": job.duration_seconds,
+        "details": job.details,
+        "warnings": job.warnings,
+        "errors": job.errors,
+    }
+
+
+def _write_maintenance_report(
+    *,
+    report_path: Path,
+    history_dir: Path,
+    schedule: str,
+    run_started_at: str,
+    run_completed_at: str,
+    jobs: list[MaintenanceJobResult],
+) -> tuple[Path, Path, dict[str, object]]:
+    failures = [job for job in jobs if job.status == "fail"]
+    warnings = [job for job in jobs if job.status == "warn"]
+
+    if failures:
+        overall_status: JOB_STATUS = "fail"
+    elif warnings:
+        overall_status = "warn"
+    else:
+        overall_status = "pass"
+
+    summary = {
+        "status": overall_status,
+        "schedule": schedule,
+        "run_started_at": run_started_at,
+        "run_completed_at": run_completed_at,
+        "job_count": len(jobs),
+        "failure_count": len(failures),
+        "warning_count": len(warnings),
+    }
+
+    payload = {
+        "schema_version": "archive_maintenance_report.v1",
+        "generated_at": run_completed_at,
+        "summary": summary,
+        "jobs": [_serialize_job(job) for job in jobs],
+        "alerts": [
+            {
+                "severity": "error",
+                "job_key": job.job_key,
+                "message": message,
+            }
+            for job in failures
+            for message in (job.errors or ["job failed without error detail"])
+        ]
+        + [
+            {
+                "severity": "warning",
+                "job_key": job.job_key,
+                "message": message,
+            }
+            for job in warnings
+            for message in (job.warnings or ["job reported warning"])
+        ],
+    }
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    history_dir.mkdir(parents=True, exist_ok=True)
+    timestamp_slug = run_completed_at.replace(":", "").replace("-", "").replace(".", "")
+    history_path = history_dir / f"maintenance_status_{timestamp_slug}.json"
+    history_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return report_path, history_path, summary
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run deterministic archive maintenance jobs (checksum verification, stale fact surfacing, "
+            "segment re-embedding, pattern recompute, and benchmark regeneration)."
+        )
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("DATABASE_URL", DEFAULT_DATABASE_URL),
+        help="Database URL used for maintenance jobs that require continuity state.",
+    )
+    parser.add_argument(
+        "--user-id",
+        default=os.getenv("ALICEBOT_AUTH_USER_ID", DEFAULT_AUTH_USER_ID),
+        help="User ID used for maintenance state reads/writes.",
+    )
+    parser.add_argument(
+        "--schedule",
+        choices=("nightly", "weekly", "manual"),
+        default="manual",
+        help="Schedule slot metadata for ops status reporting.",
+    )
+    parser.add_argument(
+        "--report-path",
+        default=str(DEFAULT_REPORT_PATH),
+        help="Path for the latest maintenance report JSON output.",
+    )
+    parser.add_argument(
+        "--history-dir",
+        default=str(DEFAULT_HISTORY_DIR),
+        help="Directory for timestamped maintenance report history files.",
+    )
+    parser.add_argument(
+        "--archive-index-path",
+        default=str(DEFAULT_ARCHIVE_INDEX_PATH),
+        help="Path to the archive index file used for integrity verification.",
+    )
+    parser.add_argument(
+        "--checksum-manifest-path",
+        default=str(DEFAULT_CHECKSUM_MANIFEST_PATH),
+        help="Path to the archive checksum baseline manifest.",
+    )
+    parser.add_argument(
+        "--stale-markers-path",
+        default=str(DEFAULT_STALE_MARKERS_PATH),
+        help="Path to write deterministic stale fact markers.",
+    )
+    parser.add_argument(
+        "--benchmark-report-path",
+        default=str(DEFAULT_PHASE9_REPORT_PATH),
+        help="Path for regenerated benchmark output.",
+    )
+    parser.add_argument(
+        "--include-benchmark",
+        action="store_true",
+        help="Run benchmark regeneration during this maintenance invocation.",
+    )
+    parser.add_argument(
+        "--user-email",
+        default=DEFAULT_USER_EMAIL,
+        help="Email for auto-created maintenance user when --user-id does not exist.",
+    )
+    parser.add_argument(
+        "--display-name",
+        default=DEFAULT_USER_DISPLAY_NAME,
+        help="Display name for auto-created maintenance user when --user-id does not exist.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    user_id = UUID(str(args.user_id))
+
+    report_path = _resolve_path(str(args.report_path))
+    history_dir = _resolve_path(str(args.history_dir))
+    archive_index_path = _resolve_path(str(args.archive_index_path))
+    checksum_manifest_path = _resolve_path(str(args.checksum_manifest_path))
+    stale_markers_path = _resolve_path(str(args.stale_markers_path))
+    benchmark_report_path = _resolve_path(str(args.benchmark_report_path))
+
+    run_started = _iso8601_utc(_utc_now())
+    jobs: list[MaintenanceJobResult] = []
+
+    jobs.append(
+        _run_job(
+            job_key="checksum_verification",
+            operation=lambda: _verify_archive_checksums(
+                index_path=archive_index_path,
+                checksum_manifest_path=checksum_manifest_path,
+            ),
+        )
+    )
+
+    with user_connection(str(args.database_url), user_id) as conn:
+        store = ContinuityStore(conn)
+        _ensure_user(
+            store,
+            user_id=user_id,
+            email=str(args.user_email),
+            display_name=str(args.display_name),
+        )
+
+        jobs.append(
+            _run_job(
+                job_key="stale_fact_marking",
+                operation=lambda: _mark_stale_facts(
+                    store=store,
+                    stale_markers_path=stale_markers_path,
+                ),
+            )
+        )
+        jobs.append(
+            _run_job(
+                job_key="reembed_missing_segments",
+                operation=lambda: _reembed_missing_segments(store=store),
+            )
+        )
+        jobs.append(
+            _run_job(
+                job_key="pattern_candidate_recompute",
+                operation=lambda: _recompute_pattern_candidates(store=store, user_id=user_id),
+            )
+        )
+        jobs.append(
+            _run_job(
+                job_key="benchmark_regeneration",
+                operation=lambda: _regenerate_benchmarks(
+                    store=store,
+                    user_id=user_id,
+                    include_benchmark=bool(args.include_benchmark),
+                    benchmark_report_path=benchmark_report_path,
+                ),
+            )
+        )
+
+    run_completed = _iso8601_utc(_utc_now())
+    latest_report_path, history_report_path, summary = _write_maintenance_report(
+        report_path=report_path,
+        history_dir=history_dir,
+        schedule=str(args.schedule),
+        run_started_at=run_started,
+        run_completed_at=run_completed,
+        jobs=jobs,
+    )
+
+    output = {
+        "status": summary["status"],
+        "schedule": summary["schedule"],
+        "failure_count": summary["failure_count"],
+        "warning_count": summary["warning_count"],
+        "latest_report_path": _repo_relative(latest_report_path),
+        "history_report_path": _repo_relative(history_report_path),
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+
+    if summary["status"] == "fail":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_archive_maintenance.py
+++ b/tests/unit/test_archive_maintenance.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import scripts.run_archive_maintenance as maintenance
+
+
+def _write_go_summary(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "artifact_version": "phase4_rc_summary.v1",
+                "artifact_path": str(path),
+                "final_decision": "GO",
+                "summary_exit_code": 0,
+                "failing_steps": [],
+                "ordered_steps": ["phase4_acceptance", "phase4_validation_matrix"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_archive_index(path: Path, summary_path: Path, latest_path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "archive_dir": str(path.parent),
+                "artifact_version": "phase4_rc_archive_index.v1",
+                "entries": [
+                    {
+                        "archive_artifact_path": str(summary_path),
+                        "command_mode": "default",
+                        "created_at": "2026-03-29T05:49:50Z",
+                        "failing_steps": [],
+                        "final_decision": "GO",
+                        "summary_exit_code": 0,
+                    }
+                ],
+                "latest_summary_path": str(latest_path),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_verify_archive_checksums_detects_manifest_drift(tmp_path: Path) -> None:
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir(parents=True)
+
+    archived_summary_path = archive_dir / "20260329T054950Z_phase4_rc_summary.json"
+    latest_summary_path = tmp_path / "phase4_rc_summary.json"
+    index_path = archive_dir / "index.json"
+    manifest_path = tmp_path / "archive_checksum_manifest.json"
+
+    _write_go_summary(archived_summary_path)
+    _write_go_summary(latest_summary_path)
+    _write_archive_index(index_path, archived_summary_path, latest_summary_path)
+
+    first = maintenance._verify_archive_checksums(  # type: ignore[attr-defined]
+        index_path=index_path,
+        checksum_manifest_path=manifest_path,
+    )
+    assert first["status"] == "pass"
+    assert first["errors"] == []
+
+    archived_summary_path.write_text(
+        json.dumps(
+            {
+                "artifact_version": "phase4_rc_summary.v1",
+                "artifact_path": str(archived_summary_path),
+                "final_decision": "GO",
+                "summary_exit_code": 0,
+                "failing_steps": [],
+                "ordered_steps": ["phase4_acceptance", "phase4_validation_matrix"],
+                "revision": "unexpected-change",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    second = maintenance._verify_archive_checksums(  # type: ignore[attr-defined]
+        index_path=index_path,
+        checksum_manifest_path=manifest_path,
+    )
+    assert second["status"] == "fail"
+    assert second["details"]["manifest_mismatch_count"] == 1
+    assert any("archive checksum mismatch" in message for message in second["errors"])
+
+
+class _StaleStoreStub:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+
+    def count_memories(self, *, status: str | None = None) -> int:
+        if status == "active":
+            return len(self._rows)
+        return len(self._rows)
+
+    def list_review_memories(self, *, status: str | None = None, limit: int | None = None) -> list[dict[str, object]]:
+        del status
+        del limit
+        return list(self._rows)
+
+
+def test_collect_stale_fact_markers_is_deterministic() -> None:
+    stale_id = uuid4()
+    contested_id = uuid4()
+    fresh_id = uuid4()
+
+    store = _StaleStoreStub(
+        [
+            {
+                "id": stale_id,
+                "confirmation_status": "confirmed",
+                "valid_to": datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
+            },
+            {
+                "id": contested_id,
+                "confirmation_status": "contested",
+                "valid_to": None,
+            },
+            {
+                "id": fresh_id,
+                "confirmation_status": "confirmed",
+                "valid_to": None,
+            },
+        ]
+    )
+
+    stale_ids, contested_count, valid_to_count = maintenance._collect_stale_fact_markers(  # type: ignore[attr-defined]
+        store
+    )
+
+    assert stale_ids == sorted([str(stale_id), str(contested_id)])
+    assert contested_count == 1
+    assert valid_to_count == 1
+
+
+class _EmbeddingStoreStub:
+    def __init__(self) -> None:
+        self.config_id = UUID("22222222-2222-4222-8222-222222222222")
+        self.artifact_id = UUID("33333333-3333-4333-8333-333333333333")
+        self.first_chunk_id = UUID("44444444-4444-4444-8444-444444444444")
+        self.second_chunk_id = UUID("55555555-5555-4555-8555-555555555555")
+        self._created_embeddings: list[dict[str, object]] = []
+
+    def list_embedding_configs(self) -> list[dict[str, object]]:
+        return [
+            {
+                "id": self.config_id,
+                "status": "active",
+                "dimensions": 8,
+            }
+        ]
+
+    def list_task_artifacts(self) -> list[dict[str, object]]:
+        return [
+            {
+                "id": self.artifact_id,
+                "ingestion_status": "ingested",
+            }
+        ]
+
+    def list_task_artifact_chunks(self, task_artifact_id: UUID) -> list[dict[str, object]]:
+        assert task_artifact_id == self.artifact_id
+        return [
+            {
+                "id": self.first_chunk_id,
+                "sequence_no": 1,
+                "created_at": datetime(2026, 4, 1, 9, 0, tzinfo=UTC),
+                "text": "alpha",
+            },
+            {
+                "id": self.second_chunk_id,
+                "sequence_no": 2,
+                "created_at": datetime(2026, 4, 1, 9, 1, tzinfo=UTC),
+                "text": "beta",
+            },
+        ]
+
+    def list_task_artifact_chunk_embeddings_for_artifact(self, task_artifact_id: UUID) -> list[dict[str, object]]:
+        assert task_artifact_id == self.artifact_id
+        rows = [
+            {
+                "task_artifact_chunk_id": self.first_chunk_id,
+                "embedding_config_id": self.config_id,
+            }
+        ]
+        rows.extend(
+            {
+                "task_artifact_chunk_id": embedding["task_artifact_chunk_id"],
+                "embedding_config_id": embedding["embedding_config_id"],
+            }
+            for embedding in self._created_embeddings
+        )
+        return rows
+
+    def get_task_artifact_chunk_embedding_by_chunk_and_config_optional(
+        self,
+        *,
+        task_artifact_chunk_id: UUID,
+        embedding_config_id: UUID,
+    ) -> dict[str, object] | None:
+        for embedding in self._created_embeddings:
+            if (
+                embedding["task_artifact_chunk_id"] == task_artifact_chunk_id
+                and embedding["embedding_config_id"] == embedding_config_id
+            ):
+                return embedding
+        return None
+
+    def create_task_artifact_chunk_embedding(
+        self,
+        *,
+        task_artifact_chunk_id: UUID,
+        embedding_config_id: UUID,
+        dimensions: int,
+        vector: list[float],
+    ) -> dict[str, object]:
+        record = {
+            "id": uuid4(),
+            "task_artifact_chunk_id": task_artifact_chunk_id,
+            "embedding_config_id": embedding_config_id,
+            "dimensions": dimensions,
+            "vector": vector,
+        }
+        self._created_embeddings.append(record)
+        return record
+
+
+def test_reembed_missing_segments_backfills_only_uncovered_chunks() -> None:
+    store = _EmbeddingStoreStub()
+
+    first = maintenance._reembed_missing_segments(store=store)  # type: ignore[attr-defined]
+    assert first["status"] == "pass"
+    assert first["details"]["missing_segment_count"] == 1
+    assert first["details"]["reembedded_segment_count"] == 1
+    assert len(store._created_embeddings) == 1
+
+    second = maintenance._reembed_missing_segments(store=store)  # type: ignore[attr-defined]
+    assert second["status"] == "pass"
+    assert second["details"]["missing_segment_count"] == 0
+    assert second["details"]["reembedded_segment_count"] == 0
+    assert len(store._created_embeddings) == 1

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from uuid import UUID, uuid4
 
 import alicebot_api.cli as cli_module
@@ -217,6 +219,64 @@ def test_status_command_returns_unreachable_without_db_connection(monkeypatch, c
     assert exit_code == 0
     assert "database: unreachable" in captured.out
     assert f"user_id: {user_id}" in captured.out
+
+
+def test_status_command_surfaces_latest_maintenance_snapshot(monkeypatch, capsys, tmp_path: Path) -> None:
+    user_id = UUID("44444444-4444-4444-8444-444444444444")
+    maintenance_report_path = tmp_path / "maintenance_status_latest.json"
+    maintenance_report_path.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "status": "warn",
+                    "schedule": "nightly",
+                    "run_completed_at": "2026-04-11T01:00:00Z",
+                    "failure_count": 0,
+                    "warning_count": 2,
+                },
+                "jobs": [
+                    {
+                        "job_key": "stale_fact_marking",
+                        "details": {"stale_fact_count": 3},
+                    },
+                    {
+                        "job_key": "reembed_missing_segments",
+                        "details": {"reembedded_segment_count": 5},
+                    },
+                    {
+                        "job_key": "pattern_candidate_recompute",
+                        "details": {"pattern_candidate_count": 8},
+                    },
+                    {
+                        "job_key": "benchmark_regeneration",
+                        "details": {"benchmark_status": "pass"},
+                    },
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv(cli_module.MAINTENANCE_REPORT_PATH_ENV, str(maintenance_report_path))
+    monkeypatch.setattr(
+        cli_module,
+        "get_settings",
+        lambda: Settings(
+            database_url="postgresql://db",
+            healthcheck_timeout_seconds=2,
+            auth_user_id=str(user_id),
+        ),
+    )
+    monkeypatch.setattr(cli_module, "ping_database", lambda *_args, **_kwargs: False)
+
+    exit_code = cli_module.main(["status"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "maintenance: status=warn schedule=nightly" in captured.out
+    assert "last_run=2026-04-11T01:00:00Z" in captured.out
+    assert "failures=0 warnings=2 stale_facts=3 reembedded_segments=5 pattern_candidates=8 benchmark=pass" in captured.out
 
 
 def test_recall_formatting_renders_provenance_source_label_when_present() -> None:


### PR DESCRIPTION
## Summary
This PR adds a deterministic maintenance pipeline for archive and memory hygiene, plus visible ops reporting and automated alerting.

## What’s included
- Adds `scripts/run_archive_maintenance.py` with scheduled maintenance jobs for:
  - archive checksum/integrity verification
  - stale fact surfacing/marking
  - re-embedding missing artifact segments
  - trusted fact pattern candidate recompute
  - benchmark regeneration (weekly or manual opt-in)
- Adds GitHub Actions workflow `.github/workflows/archive-maintenance.yml`:
  - nightly and weekly schedules
  - manual trigger inputs
  - artifact upload for maintenance outputs
  - automatic GitHub issue creation when maintenance fails
- Extends `alicebot status` to include maintenance status fields from the latest maintenance report.
- Adds unit tests for maintenance logic and CLI maintenance status rendering.
- Updates README quickstart command list with a maintenance run example.

## Why this helps
- Archive integrity is now verified automatically.
- Stale memories are surfaced via deterministic marker output.
- Pattern candidates are recomputed without manual intervention.
- Nightly/weekly maintenance health is visible in ops status output.
- Failures now create actionable notifications through GitHub issues.

## Validation
- `python3 -m pytest tests/unit/test_archive_maintenance.py tests/unit/test_cli.py`
- Result: passing
