### PR TITLE
Security hardening: pin archive-maintenance actions and tighten report/path safety

### DIFF
--- a/.github/workflows/archive-maintenance.yml
+++ b/.github/workflows/archive-maintenance.yml
@@ -51,10 +51,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload maintenance artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: archive-maintenance-${{ github.run_id }}
           if-no-files-found: warn
@@ -132,7 +132,7 @@ jobs:
 
       - name: Create failure alert issue
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/scripts/run_archive_maintenance.py
+++ b/scripts/run_archive_maintenance.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import sys
 import time
 from typing import Literal
@@ -68,6 +69,7 @@ DEFAULT_STALE_MARKERS_PATH = REPO_ROOT / "artifacts" / "ops" / "stale_fact_marke
 DEFAULT_PHASE9_REPORT_PATH = REPO_ROOT / "eval" / "reports" / "phase9_eval_latest.json"
 DEFAULT_USER_EMAIL = "maintenance-bot@example.invalid"
 DEFAULT_USER_DISPLAY_NAME = "Maintenance Bot"
+_MAX_SANITIZED_REPORT_MESSAGE_CHARS = 200
 
 JOB_STATUS = Literal["pass", "warn", "fail", "skipped"]
 
@@ -107,6 +109,33 @@ def _resolve_path(path_value: str | Path) -> Path:
     return (REPO_ROOT / candidate).resolve()
 
 
+def _path_within_root(*, path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _allowed_archive_root(index_path: Path) -> Path:
+    resolved_index = index_path.expanduser().resolve()
+    parent = resolved_index.parent
+    # `.../archive/index.json` should allow paths under `.../`.
+    return parent.parent if parent.parent != parent else parent
+
+
+def _sanitize_report_message(message: object, *, fallback: str) -> str:
+    if not isinstance(message, str):
+        return fallback
+    normalized = re.sub(r"\s+", " ", message).strip()
+    if normalized == "":
+        return fallback
+    normalized = re.sub(r"(?:(?:[A-Za-z]:)?[/\\\\][^\s]+)", "[path]", normalized)
+    if len(normalized) > _MAX_SANITIZED_REPORT_MESSAGE_CHARS:
+        normalized = normalized[:_MAX_SANITIZED_REPORT_MESSAGE_CHARS]
+    return normalized
+
+
 def _sha256_for_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -125,6 +154,7 @@ def _load_json_object(path: Path) -> dict[str, object]:
 def _collect_archive_paths(index_path: Path) -> tuple[set[Path], list[str]]:
     paths: set[Path] = {index_path}
     errors: list[str] = []
+    allowed_root = _allowed_archive_root(index_path)
 
     if not index_path.exists():
         return paths, [f"archive index missing: {_repo_relative(index_path)}"]
@@ -136,7 +166,11 @@ def _collect_archive_paths(index_path: Path) -> tuple[set[Path], list[str]]:
 
     latest_summary = index_payload.get("latest_summary_path")
     if isinstance(latest_summary, str) and latest_summary.strip():
-        paths.add(_resolve_path(latest_summary))
+        latest_summary_path = _resolve_path(latest_summary)
+        if _path_within_root(path=latest_summary_path, root=allowed_root):
+            paths.add(latest_summary_path)
+        else:
+            errors.append("archive index latest_summary_path points outside allowed archive root")
     else:
         errors.append("archive index latest_summary_path is missing or invalid")
 
@@ -153,7 +187,11 @@ def _collect_archive_paths(index_path: Path) -> tuple[set[Path], list[str]]:
         if not isinstance(archive_artifact_path, str) or not archive_artifact_path.strip():
             errors.append(f"entries[{idx}].archive_artifact_path is missing or invalid")
             continue
-        paths.add(_resolve_path(archive_artifact_path))
+        archive_artifact = _resolve_path(archive_artifact_path)
+        if not _path_within_root(path=archive_artifact, root=allowed_root):
+            errors.append(f"entries[{idx}].archive_artifact_path points outside allowed archive root")
+            continue
+        paths.add(archive_artifact)
 
     return paths, errors
 
@@ -205,17 +243,23 @@ def _run_job(
         job_payload = operation()
     except Exception as exc:  # pragma: no cover - defensive boundary
         status = "fail"
-        errors.append(str(exc))
+        errors.append(f"unhandled_exception:{exc.__class__.__name__}")
         job_payload = {}
 
     if isinstance(job_payload, dict):
         details = dict(job_payload.get("details", {})) if isinstance(job_payload.get("details"), dict) else {}
         payload_warnings = job_payload.get("warnings")
         if isinstance(payload_warnings, list):
-            warnings = [str(item) for item in payload_warnings]
+            warnings = [
+                _sanitize_report_message(item, fallback="maintenance_job_warning")
+                for item in payload_warnings
+            ]
         payload_errors = job_payload.get("errors")
         if isinstance(payload_errors, list):
-            errors.extend(str(item) for item in payload_errors)
+            errors.extend(
+                _sanitize_report_message(item, fallback="maintenance_job_error")
+                for item in payload_errors
+            )
         payload_status = job_payload.get("status")
         if payload_status in {"pass", "warn", "fail", "skipped"}:
             status = payload_status

--- a/tests/unit/test_archive_maintenance.py
+++ b/tests/unit/test_archive_maintenance.py
@@ -94,6 +94,35 @@ def test_verify_archive_checksums_detects_manifest_drift(tmp_path: Path) -> None
     assert any("archive checksum mismatch" in message for message in second["errors"])
 
 
+def test_collect_archive_paths_rejects_outside_allowed_root(tmp_path: Path) -> None:
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir(parents=True)
+    index_path = archive_dir / "index.json"
+    in_scope_summary = archive_dir / "in_scope_summary.json"
+    out_of_scope_summary = tmp_path.parent / "outside_summary.json"
+
+    _write_go_summary(in_scope_summary)
+    _write_archive_index(index_path, in_scope_summary, out_of_scope_summary)
+
+    paths, errors = maintenance._collect_archive_paths(index_path)  # type: ignore[attr-defined]
+    assert any("outside allowed archive root" in message for message in errors)
+    assert out_of_scope_summary.resolve() not in paths
+    assert in_scope_summary.resolve() in paths
+
+
+def test_run_job_sanitizes_unhandled_exception_message() -> None:
+    def _failing_operation() -> dict[str, object]:
+        raise RuntimeError("db password leaked at /private/tmp/secret.txt\nsecond line")
+
+    result = maintenance._run_job(  # type: ignore[attr-defined]
+        job_key="sanitization_test",
+        operation=_failing_operation,
+    )
+
+    assert result.status == "fail"
+    assert result.errors == ["unhandled_exception:RuntimeError"]
+
+
 class _StaleStoreStub:
     def __init__(self, rows: list[dict[str, object]]) -> None:
         self._rows = rows


### PR DESCRIPTION
## Summary
This PR remediates the latest sprint security-scan findings for the archive maintenance pipeline.

## Fixes implemented
1. **Pinned GitHub Actions to immutable SHAs** in `.github/workflows/archive-maintenance.yml` (checkout, setup-python, upload-artifact, github-script).
2. **Sanitized maintenance report errors/warnings** to avoid leaking raw exception text to step summary/artifacts. Unhandled exceptions now emit class-only codes (for example `unhandled_exception:RuntimeError`).
3. **Enforced archive path boundary checks** when reading archive index paths so out-of-scope paths are rejected before hashing.

## Tests
- `python3 -m pytest -q tests/unit/test_archive_maintenance.py tests/unit/test_cli.py`
  - Result: `12 passed`

## Notes
- No feature behavior changes outside maintenance hardening.
- No personally identifiable information was added to modified files.