### PR TITLE
Build Alice as a first-class Hermes memory provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The open-source surface includes:
 - MCP server
 - trust-aware memory classification and promotion controls
 - shared explainability across recall, resume, open-loop review, and explain surfaces
+- scheduled archive maintenance, ops status reporting, and failure alerting
 - importers for OpenClaw, Markdown, and ChatGPT exports
 - OpenClaw adapter and demo path
 - evaluation harness and integration docs
@@ -119,6 +120,8 @@ In another terminal, verify the runtime and get a first useful result:
 ./.venv/bin/python -m alicebot_api open-loops --limit 5
 ./scripts/run_archive_maintenance.py --schedule manual
 ```
+
+Alice also includes a deterministic maintenance runner for archive integrity checks, stale fact surfacing, missing segment re-embedding, trusted-fact pattern candidate recompute, and optional benchmark regeneration.
 
 Recall-derived surfaces now expose a shared explanation payload, and `explain` uses the same structure for continuity evidence:
 
@@ -215,6 +218,7 @@ Alice is built around a shared continuity core with:
 - structured memory revisions
 - provenance- and trust-aware recall
 - shared explanation chains across recall-derived workflows
+- deterministic archive maintenance with ops-visible health summaries
 - deterministic resumption briefs
 - open-loop objects
 - CLI and MCP surfaces on the same semantics

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ See:
 
 - [docs/integrations/mcp.md](docs/integrations/mcp.md)
 - [docs/integrations/hermes.md](docs/integrations/hermes.md)
+- [docs/integrations/hermes-memory-provider.md](docs/integrations/hermes-memory-provider.md)
 - [docs/integrations/hermes-skill-pack.md](docs/integrations/hermes-skill-pack.md)
 
 Hermes runtime smoke test:
@@ -250,6 +251,7 @@ That means the system behaves consistently across local workflows, MCP-connected
 - [Architecture](ARCHITECTURE.md)
 - [MCP](docs/integrations/mcp.md)
 - [Hermes Guide](docs/integrations/hermes.md)
+- [Hermes Memory Provider](docs/integrations/hermes-memory-provider.md)
 - [Hermes Skill Pack](docs/integrations/hermes-skill-pack.md)
 - [Importers](docs/integrations/importers.md)
 - [OpenClaw Guide](docs/integrations/openclaw.md)

--- a/docs/integrations/hermes-memory-provider.md
+++ b/docs/integrations/hermes-memory-provider.md
@@ -1,0 +1,128 @@
+# Hermes External Memory Provider: Alice
+
+This guide installs Alice as a Hermes **external memory provider**.
+
+Hermes behavior with this provider:
+
+- built-in `MEMORY.md` and `USER.md` stay active
+- one external provider can be active at a time (`memory.provider`)
+- Alice provider adds continuity recall/resumption/open-loop tools and prefetch
+
+## What The Provider Adds
+
+- `alice_recall`: deterministic continuity recall with provenance
+- `alice_resumption_brief`: last decision, next action, open loops, recent changes
+- `alice_open_loops`: open-loop dashboard retrieval
+- prefetch: turn-start context assembled from Alice resumption brief
+
+## Continuity Model Mapping
+
+The provider maps Alice continuity responses into Hermes provider hooks:
+
+| Hermes provider hook | Alice endpoint | Mapping |
+|---|---|---|
+| `prefetch(query)` | `GET /v0/continuity/resumption-brief` | renders last decision, next action, open loops, and recent changes into ephemeral context |
+| `alice_recall` tool | `GET /v0/continuity/recall` | returns ranked continuity objects with provenance and scope filters |
+| `alice_resumption_brief` tool | `GET /v0/continuity/resumption-brief` | returns structured resume sections for deterministic follow-through |
+| `alice_open_loops` tool | `GET /v0/continuity/open-loops` | returns waiting/blocker/stale/next-action open-loop groups |
+
+## Install
+
+Install into the Hermes memory plugin directory used by your active Hermes Python environment:
+
+```bash
+./scripts/install_hermes_alice_memory_provider.py
+```
+
+Optional flags:
+
+- `--force` to replace an existing install
+- `--symlink` for local development iteration
+- `--destination-root /path/to/hermes/plugins/memory` to target a specific Hermes install
+
+## Configure
+
+Use the Hermes setup flow:
+
+```bash
+hermes memory setup
+```
+
+Select `alice` and provide:
+
+- `base_url`: Alice API base URL (example `http://127.0.0.1:8000`)
+- `user_id`: Alice user UUID scope
+
+Config is saved to:
+
+- `$HERMES_HOME/alice_memory_provider.json`
+
+Manual activation:
+
+```bash
+hermes config set memory.provider alice
+```
+
+## Verify
+
+Check provider selection:
+
+```bash
+hermes memory status
+```
+
+Run provider smoke validation from this repository:
+
+```bash
+./scripts/run_hermes_memory_provider_smoke.py
+```
+
+Optional live prefetch test:
+
+```bash
+./scripts/run_hermes_memory_provider_smoke.py \
+  --live-prefetch-query "release gating decision" \
+  --alice-base-url "http://127.0.0.1:8000" \
+  --alice-user-id "00000000-0000-0000-0000-000000000001"
+```
+
+## Single-External-Provider Model
+
+Hermes MemoryManager allows:
+
+- built-in provider (`builtin`) always
+- plus at most one external provider (`alice`, `mem0`, `honcho`, etc.)
+
+If a second external provider is registered, Hermes rejects it and keeps the first.
+
+`run_hermes_memory_provider_smoke.py` validates this behavior directly.
+
+## Provider vs MCP vs Skill Pack
+
+Use this split to avoid overlapping integrations:
+
+| Integration | Best for | Runtime shape |
+|---|---|---|
+| Alice memory provider | always-on continuity prefetch + memory tools inside Hermes memory stack | one external memory provider + built-in `MEMORY.md`/`USER.md` |
+| Alice MCP server | broad Alice tool surface in Hermes (`alice_recall`, `alice_resume`, write/correction flows) | MCP server attached under `mcp_servers` |
+| Hermes Alice skill pack | policy and prompting guidance on when/how to call Alice tools | skill instructions layered on top of provider or MCP |
+
+Practical default:
+
+- choose provider when you want continuity context injected every turn
+- choose MCP when you need wider Alice operations beyond memory-provider scope
+- add skill pack when you want stricter workflow prompting and response policy
+
+## Provider Config Keys
+
+`$HERMES_HOME/alice_memory_provider.json` supports:
+
+- `base_url` (string)
+- `user_id` (UUID string)
+- `timeout_seconds` (float)
+- `prefetch_limit` (int)
+- `max_recent_changes` (int)
+- `max_open_loops` (int)
+- `include_non_promotable_facts` (bool)
+- `auto_capture` (bool, default `false`)
+- `mirror_memory_writes` (bool, default `false`)

--- a/docs/integrations/hermes-memory-provider/plugins/memory/alice/README.md
+++ b/docs/integrations/hermes-memory-provider/plugins/memory/alice/README.md
@@ -1,0 +1,44 @@
+# Alice Hermes Memory Provider
+
+Hermes external memory provider plugin backed by Alice continuity APIs.
+
+## Provider Features
+
+- `alice_recall` tool for scoped continuity recall.
+- `alice_resumption_brief` tool for last-decision and next-action synthesis.
+- `alice_open_loops` tool for blocker and waiting-for review.
+- prefetch support via Alice resumption brief before each model turn.
+- optional turn auto-capture and optional mirror of built-in memory writes.
+
+## Config Location
+
+The provider reads and writes:
+
+- `$HERMES_HOME/alice_memory_provider.json`
+
+## Minimum Config
+
+```json
+{
+  "base_url": "http://127.0.0.1:8000",
+  "user_id": "00000000-0000-0000-0000-000000000001"
+}
+```
+
+## Optional Keys
+
+- `timeout_seconds` (float, default `8.0`)
+- `prefetch_limit` (int, default `5`)
+- `max_recent_changes` (int, default `5`)
+- `max_open_loops` (int, default `5`)
+- `include_non_promotable_facts` (bool, default `false`)
+- `auto_capture` (bool, default `false`)
+- `mirror_memory_writes` (bool, default `false`)
+
+## Activation
+
+```bash
+hermes config set memory.provider alice
+```
+
+Hermes built-in `MEMORY.md` and `USER.md` stay active. The Alice provider is additive.

--- a/docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py
+++ b/docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py
@@ -1,0 +1,735 @@
+"""Alice memory plugin for Hermes MemoryProvider.
+
+This provider connects Hermes's external memory provider interface to Alice's
+continuity APIs.
+
+Design goals:
+- Keep Hermes built-in MEMORY.md / USER.md active (additive integration).
+- Provide deterministic recall and resumption tools.
+- Support prefetch for next-turn context without blocking the tool loop.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_FILENAME = "alice_memory_provider.json"
+_DEFAULT_BASE_URL = "http://127.0.0.1:8000"
+_DEFAULT_TIMEOUT_SECONDS = 8.0
+_DEFAULT_PREFETCH_LIMIT = 5
+_DEFAULT_MAX_RECENT_CHANGES = 5
+_DEFAULT_MAX_OPEN_LOOPS = 5
+_DEFAULT_CAPTURE_CHAR_LIMIT = 3800
+
+_RECALL_LIMIT_MIN = 1
+_RECALL_LIMIT_MAX = 50
+
+_OPEN_LOOP_LIMIT_MIN = 0
+_OPEN_LOOP_LIMIT_MAX = 50
+
+_RECENT_CHANGES_MIN = 0
+_RECENT_CHANGES_MAX = 25
+
+
+ALICE_RECALL_TOOL = {
+    "name": "alice_recall",
+    "description": (
+        "Recall continuity records from Alice with deterministic ranking and provenance. "
+        "Use for prior decisions, commitments, blockers, and history-backed answers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Optional query text."},
+            "thread_id": {"type": "string", "description": "Optional thread UUID."},
+            "task_id": {"type": "string", "description": "Optional task UUID."},
+            "project": {"type": "string", "description": "Optional project filter."},
+            "person": {"type": "string", "description": "Optional person filter."},
+            "since": {"type": "string", "description": "Optional ISO timestamp lower bound."},
+            "until": {"type": "string", "description": "Optional ISO timestamp upper bound."},
+            "limit": {"type": "integer", "description": "Result limit (1-50)."},
+        },
+        "required": [],
+    },
+}
+
+ALICE_RESUME_TOOL = {
+    "name": "alice_resumption_brief",
+    "description": (
+        "Build a scoped resumption brief from Alice continuity state with last decision, "
+        "open loops, recent changes, and next action."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Optional query text."},
+            "thread_id": {"type": "string", "description": "Optional thread UUID."},
+            "task_id": {"type": "string", "description": "Optional task UUID."},
+            "project": {"type": "string", "description": "Optional project filter."},
+            "person": {"type": "string", "description": "Optional person filter."},
+            "since": {"type": "string", "description": "Optional ISO timestamp lower bound."},
+            "until": {"type": "string", "description": "Optional ISO timestamp upper bound."},
+            "max_recent_changes": {
+                "type": "integer",
+                "description": "Maximum recent changes to include (0-25).",
+            },
+            "max_open_loops": {
+                "type": "integer",
+                "description": "Maximum open loops to include (0-25).",
+            },
+            "include_non_promotable_facts": {
+                "type": "boolean",
+                "description": "Include non-promotable continuity facts.",
+            },
+        },
+        "required": [],
+    },
+}
+
+ALICE_OPEN_LOOPS_TOOL = {
+    "name": "alice_open_loops",
+    "description": (
+        "List open loops from Alice continuity grouped and ranked for execution follow-through."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Optional query text."},
+            "thread_id": {"type": "string", "description": "Optional thread UUID."},
+            "task_id": {"type": "string", "description": "Optional task UUID."},
+            "project": {"type": "string", "description": "Optional project filter."},
+            "person": {"type": "string", "description": "Optional person filter."},
+            "since": {"type": "string", "description": "Optional ISO timestamp lower bound."},
+            "until": {"type": "string", "description": "Optional ISO timestamp upper bound."},
+            "limit": {"type": "integer", "description": "Result limit (0-50)."},
+        },
+        "required": [],
+    },
+}
+
+
+def _parse_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    return default
+
+
+def _parse_int(value: Any, *, default: int, min_value: int, max_value: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(min_value, min(max_value, parsed))
+
+
+def _parse_float(value: Any, *, default: float, min_value: float, max_value: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(min_value, min(max_value, parsed))
+
+
+def _normalize_base_url(value: str) -> str:
+    normalized = value.strip().rstrip("/")
+    if normalized.endswith("/v0"):
+        normalized = normalized[:-3]
+    return normalized
+
+
+def _config_path(hermes_home: str) -> Path:
+    return Path(hermes_home) / _CONFIG_FILENAME
+
+
+def _default_config() -> Dict[str, Any]:
+    return {
+        "base_url": os.environ.get("ALICE_API_BASE_URL", _DEFAULT_BASE_URL),
+        "user_id": os.environ.get("ALICE_MEMORY_USER_ID", os.environ.get("ALICEBOT_AUTH_USER_ID", "")),
+        "timeout_seconds": _parse_float(
+            os.environ.get("ALICE_MEMORY_TIMEOUT_SECONDS"),
+            default=_DEFAULT_TIMEOUT_SECONDS,
+            min_value=0.5,
+            max_value=30.0,
+        ),
+        "prefetch_limit": _parse_int(
+            os.environ.get("ALICE_MEMORY_PREFETCH_LIMIT"),
+            default=_DEFAULT_PREFETCH_LIMIT,
+            min_value=_RECALL_LIMIT_MIN,
+            max_value=_RECALL_LIMIT_MAX,
+        ),
+        "max_recent_changes": _parse_int(
+            os.environ.get("ALICE_MEMORY_MAX_RECENT_CHANGES"),
+            default=_DEFAULT_MAX_RECENT_CHANGES,
+            min_value=_RECENT_CHANGES_MIN,
+            max_value=_RECENT_CHANGES_MAX,
+        ),
+        "max_open_loops": _parse_int(
+            os.environ.get("ALICE_MEMORY_MAX_OPEN_LOOPS"),
+            default=_DEFAULT_MAX_OPEN_LOOPS,
+            min_value=_RECENT_CHANGES_MIN,
+            max_value=_RECENT_CHANGES_MAX,
+        ),
+        "include_non_promotable_facts": _parse_bool(
+            os.environ.get("ALICE_MEMORY_INCLUDE_NON_PROMOTABLE"),
+            default=False,
+        ),
+        "auto_capture": _parse_bool(
+            os.environ.get("ALICE_MEMORY_AUTO_CAPTURE"),
+            default=False,
+        ),
+        "mirror_memory_writes": _parse_bool(
+            os.environ.get("ALICE_MEMORY_MIRROR_WRITES"),
+            default=False,
+        ),
+    }
+
+
+def _load_config(hermes_home: str) -> Dict[str, Any]:
+    config = _default_config()
+
+    path = _config_path(hermes_home)
+    if path.exists():
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                for key, value in raw.items():
+                    if value is not None and value != "":
+                        config[key] = value
+        except Exception:
+            logger.debug("Failed to parse %s", path, exc_info=True)
+
+    config["base_url"] = _normalize_base_url(str(config.get("base_url", _DEFAULT_BASE_URL)))
+    config["user_id"] = str(config.get("user_id", "")).strip()
+    config["timeout_seconds"] = _parse_float(
+        config.get("timeout_seconds"),
+        default=_DEFAULT_TIMEOUT_SECONDS,
+        min_value=0.5,
+        max_value=30.0,
+    )
+    config["prefetch_limit"] = _parse_int(
+        config.get("prefetch_limit"),
+        default=_DEFAULT_PREFETCH_LIMIT,
+        min_value=_RECALL_LIMIT_MIN,
+        max_value=_RECALL_LIMIT_MAX,
+    )
+    config["max_recent_changes"] = _parse_int(
+        config.get("max_recent_changes"),
+        default=_DEFAULT_MAX_RECENT_CHANGES,
+        min_value=_RECENT_CHANGES_MIN,
+        max_value=_RECENT_CHANGES_MAX,
+    )
+    config["max_open_loops"] = _parse_int(
+        config.get("max_open_loops"),
+        default=_DEFAULT_MAX_OPEN_LOOPS,
+        min_value=_RECENT_CHANGES_MIN,
+        max_value=_RECENT_CHANGES_MAX,
+    )
+    config["include_non_promotable_facts"] = _parse_bool(
+        config.get("include_non_promotable_facts"),
+        default=False,
+    )
+    config["auto_capture"] = _parse_bool(config.get("auto_capture"), default=False)
+    config["mirror_memory_writes"] = _parse_bool(config.get("mirror_memory_writes"), default=False)
+
+    return config
+
+
+def _validate_uuid(value: str) -> bool:
+    if not value:
+        return False
+    try:
+        uuid.UUID(value)
+        return True
+    except ValueError:
+        return False
+
+
+class AliceMemoryProvider(MemoryProvider):
+    """Hermes external memory provider backed by Alice continuity APIs."""
+
+    def __init__(self) -> None:
+        self._config: Dict[str, Any] = {}
+        self._session_id: str = ""
+        self._hermes_home: str = ""
+        self._agent_context: str = "primary"
+
+        self._prefetch_cache: Dict[str, str] = {}
+        self._prefetch_threads: Dict[str, threading.Thread] = {}
+        self._prefetch_lock = threading.Lock()
+
+        self._capture_thread: Optional[threading.Thread] = None
+
+    @property
+    def name(self) -> str:
+        return "alice"
+
+    def is_available(self) -> bool:
+        from hermes_constants import get_hermes_home
+
+        cfg = _load_config(str(get_hermes_home()))
+        base_url = str(cfg.get("base_url", "")).strip()
+        user_id = str(cfg.get("user_id", "")).strip()
+        if not (base_url.startswith("http://") or base_url.startswith("https://")):
+            return False
+        return _validate_uuid(user_id)
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        from hermes_constants import get_hermes_home
+
+        self._session_id = session_id or ""
+        self._hermes_home = str(kwargs.get("hermes_home") or get_hermes_home())
+        self._agent_context = str(kwargs.get("agent_context") or "primary")
+        self._config = _load_config(self._hermes_home)
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "base_url",
+                "description": "Alice API base URL",
+                "required": True,
+                "default": _DEFAULT_BASE_URL,
+            },
+            {
+                "key": "user_id",
+                "description": "Alice user UUID used for continuity scope",
+                "required": True,
+            },
+            {
+                "key": "timeout_seconds",
+                "description": "HTTP timeout for Alice API calls",
+                "default": str(_DEFAULT_TIMEOUT_SECONDS),
+            },
+            {
+                "key": "prefetch_limit",
+                "description": "Default prefetch recall limit",
+                "default": str(_DEFAULT_PREFETCH_LIMIT),
+            },
+            {
+                "key": "max_recent_changes",
+                "description": "Resumption brief recent changes cap",
+                "default": str(_DEFAULT_MAX_RECENT_CHANGES),
+            },
+            {
+                "key": "max_open_loops",
+                "description": "Resumption brief open-loop cap",
+                "default": str(_DEFAULT_MAX_OPEN_LOOPS),
+            },
+            {
+                "key": "include_non_promotable_facts",
+                "description": "Include non-promotable facts in resumption brief",
+                "choices": ["true", "false"],
+                "default": "false",
+            },
+            {
+                "key": "auto_capture",
+                "description": "Auto-capture completed turns into Alice continuity",
+                "choices": ["true", "false"],
+                "default": "false",
+            },
+            {
+                "key": "mirror_memory_writes",
+                "description": "Mirror built-in MEMORY.md / USER.md writes to Alice",
+                "choices": ["true", "false"],
+                "default": "false",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        cfg = _load_config(hermes_home)
+        cfg.update(values)
+        cfg = _load_config_dict_from_values(cfg)
+        path = _config_path(hermes_home)
+        path.write_text(json.dumps(cfg, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Alice Continuity Memory\n"
+            "Active as an external Hermes memory provider.\n"
+            "Hermes built-in MEMORY.md and USER.md remain active.\n"
+            "Use alice_recall for scoped history lookup and alice_resumption_brief "
+            "to recover last decision, open loops, and next action."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        key = self._session_key(session_id)
+
+        with self._prefetch_lock:
+            cached = self._prefetch_cache.pop(key, "")
+        if cached:
+            return cached
+
+        return self._build_prefetch_context(query)
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if not query:
+            return
+
+        key = self._session_key(session_id)
+        with self._prefetch_lock:
+            existing = self._prefetch_threads.get(key)
+            if existing and existing.is_alive():
+                return
+
+        def _run_prefetch() -> None:
+            context = ""
+            try:
+                context = self._build_prefetch_context(query)
+            except Exception as exc:
+                logger.debug("Alice prefetch failed: %s", exc)
+            with self._prefetch_lock:
+                self._prefetch_cache[key] = context
+
+        thread = threading.Thread(
+            target=_run_prefetch,
+            daemon=True,
+            name=f"alice-prefetch-{key[:8] if key else 'default'}",
+        )
+        with self._prefetch_lock:
+            self._prefetch_threads[key] = thread
+        thread.start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if not self._config.get("auto_capture", False):
+            return
+        if self._agent_context != "primary":
+            return
+
+        raw_content = self._build_turn_capture_payload(user_content, assistant_content)
+        if not raw_content:
+            return
+
+        def _capture() -> None:
+            try:
+                self._post_capture(raw_content)
+            except Exception as exc:
+                logger.debug("Alice sync_turn capture failed: %s", exc)
+
+        if self._capture_thread and self._capture_thread.is_alive():
+            self._capture_thread.join(timeout=5.0)
+
+        self._capture_thread = threading.Thread(target=_capture, daemon=True, name="alice-sync-capture")
+        self._capture_thread.start()
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        if not self._config.get("mirror_memory_writes", False):
+            return
+        if action not in {"add", "replace"}:
+            return
+        if not content.strip():
+            return
+
+        raw_content = f"Hermes built-in memory update ({target}): {content.strip()}"
+
+        def _capture() -> None:
+            try:
+                self._post_capture(raw_content)
+            except Exception as exc:
+                logger.debug("Alice memory-write mirror failed: %s", exc)
+
+        thread = threading.Thread(target=_capture, daemon=True, name="alice-memory-write")
+        thread.start()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [ALICE_RECALL_TOOL, ALICE_RESUME_TOOL, ALICE_OPEN_LOOPS_TOOL]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        try:
+            if tool_name == "alice_recall":
+                payload = self._tool_recall(args)
+            elif tool_name == "alice_resumption_brief":
+                payload = self._tool_resumption_brief(args)
+            elif tool_name == "alice_open_loops":
+                payload = self._tool_open_loops(args)
+            else:
+                return tool_error(f"unknown tool: {tool_name}")
+            return json.dumps(payload)
+        except Exception as exc:
+            return tool_error(f"{tool_name} failed: {exc}")
+
+    def shutdown(self) -> None:
+        with self._prefetch_lock:
+            threads = list(self._prefetch_threads.values())
+        for thread in threads:
+            if thread.is_alive():
+                thread.join(timeout=2.0)
+        if self._capture_thread and self._capture_thread.is_alive():
+            self._capture_thread.join(timeout=5.0)
+
+    def _session_key(self, session_id: str) -> str:
+        return session_id or self._session_id or "default"
+
+    def _tool_recall(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        params = self._scope_params(args)
+        params["limit"] = _parse_int(
+            args.get("limit"),
+            default=self._config.get("prefetch_limit", _DEFAULT_PREFETCH_LIMIT),
+            min_value=_RECALL_LIMIT_MIN,
+            max_value=_RECALL_LIMIT_MAX,
+        )
+        return self._request_json("GET", "/v0/continuity/recall", params=params)
+
+    def _tool_resumption_brief(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        params = self._scope_params(args)
+        params["max_recent_changes"] = _parse_int(
+            args.get("max_recent_changes"),
+            default=self._config.get("max_recent_changes", _DEFAULT_MAX_RECENT_CHANGES),
+            min_value=_RECENT_CHANGES_MIN,
+            max_value=_RECENT_CHANGES_MAX,
+        )
+        params["max_open_loops"] = _parse_int(
+            args.get("max_open_loops"),
+            default=self._config.get("max_open_loops", _DEFAULT_MAX_OPEN_LOOPS),
+            min_value=_RECENT_CHANGES_MIN,
+            max_value=_RECENT_CHANGES_MAX,
+        )
+        params["include_non_promotable_facts"] = _parse_bool(
+            args.get("include_non_promotable_facts"),
+            default=bool(self._config.get("include_non_promotable_facts", False)),
+        )
+        return self._request_json("GET", "/v0/continuity/resumption-brief", params=params)
+
+    def _tool_open_loops(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        params = self._scope_params(args)
+        params["limit"] = _parse_int(
+            args.get("limit"),
+            default=self._config.get("max_open_loops", _DEFAULT_MAX_OPEN_LOOPS),
+            min_value=_OPEN_LOOP_LIMIT_MIN,
+            max_value=_OPEN_LOOP_LIMIT_MAX,
+        )
+        return self._request_json("GET", "/v0/continuity/open-loops", params=params)
+
+    def _scope_params(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        params: Dict[str, Any] = {}
+        for key in ("query", "thread_id", "task_id", "project", "person", "since", "until"):
+            value = args.get(key)
+            if isinstance(value, str):
+                value = value.strip()
+            if value not in (None, ""):
+                params[key] = value
+        return params
+
+    def _build_prefetch_context(self, query: str) -> str:
+        params: Dict[str, Any] = {}
+        normalized_query = (query or "").strip()
+        if normalized_query:
+            params["query"] = normalized_query
+        params["max_recent_changes"] = self._config.get("max_recent_changes", _DEFAULT_MAX_RECENT_CHANGES)
+        params["max_open_loops"] = self._config.get("max_open_loops", _DEFAULT_MAX_OPEN_LOOPS)
+        params["include_non_promotable_facts"] = bool(self._config.get("include_non_promotable_facts", False))
+
+        payload = self._request_json("GET", "/v0/continuity/resumption-brief", params=params)
+        brief = payload.get("brief")
+        if not isinstance(brief, dict):
+            return ""
+
+        lines: List[str] = ["## Alice Continuity Prefetch"]
+
+        last_decision = _extract_single_title(brief.get("last_decision"))
+        if last_decision:
+            lines.append(f"- Last decision: {last_decision}")
+
+        next_action = _extract_single_title(brief.get("next_action"))
+        if next_action:
+            lines.append(f"- Next action: {next_action}")
+
+        open_loop_lines = _extract_titles(brief.get("open_loops"), limit=self._config.get("max_open_loops", 3))
+        if open_loop_lines:
+            lines.append("- Open loops:")
+            lines.extend([f"  - {item}" for item in open_loop_lines])
+
+        recent_change_lines = _extract_titles(
+            brief.get("recent_changes"),
+            limit=self._config.get("max_recent_changes", 3),
+        )
+        if recent_change_lines:
+            lines.append("- Recent changes:")
+            lines.extend([f"  - {item}" for item in recent_change_lines])
+
+        if len(lines) == 1:
+            return ""
+        return "\n".join(lines)
+
+    def _post_capture(self, raw_content: str) -> None:
+        payload = {
+            "user_id": self._config.get("user_id", ""),
+            "raw_content": raw_content[:_DEFAULT_CAPTURE_CHAR_LIMIT],
+        }
+        self._request_json("POST", "/v0/continuity/captures", payload=payload)
+
+    def _build_turn_capture_payload(self, user_content: str, assistant_content: str) -> str:
+        user_text = (user_content or "").strip()
+        assistant_text = (assistant_content or "").strip()
+        if not user_text and not assistant_text:
+            return ""
+
+        segments: List[str] = []
+        if user_text:
+            segments.append(f"User: {user_text}")
+        if assistant_text:
+            segments.append(f"Assistant: {assistant_text}")
+
+        payload = "\n".join(segments)
+        if len(payload) > _DEFAULT_CAPTURE_CHAR_LIMIT:
+            payload = payload[:_DEFAULT_CAPTURE_CHAR_LIMIT]
+        return payload
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if not self._config:
+            raise RuntimeError("provider is not initialized")
+
+        query = dict(params or {})
+        query["user_id"] = self._config.get("user_id", "")
+
+        base_url = self._config.get("base_url", _DEFAULT_BASE_URL)
+        encoded = urllib.parse.urlencode(query, doseq=True)
+        url = f"{base_url}{path}"
+        if encoded:
+            url = f"{url}?{encoded}"
+
+        data = None
+        headers = {"Accept": "application/json"}
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+            data = json.dumps(payload).encode("utf-8")
+
+        request = urllib.request.Request(url=url, data=data, headers=headers, method=method)
+
+        timeout = float(self._config.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS))
+
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                body = response.read().decode("utf-8", errors="replace")
+                if not body:
+                    return {}
+                decoded = json.loads(body)
+                if isinstance(decoded, dict):
+                    return decoded
+                raise RuntimeError("unexpected non-object response from Alice API")
+        except urllib.error.HTTPError as exc:
+            detail = _decode_error_detail(exc)
+            raise RuntimeError(f"Alice API HTTP {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"Alice API connection failed: {exc.reason}") from exc
+
+
+def _decode_error_detail(error: urllib.error.HTTPError) -> str:
+    try:
+        body = error.read().decode("utf-8", errors="replace")
+    except Exception:
+        return "request failed"
+    try:
+        payload = json.loads(body)
+    except Exception:
+        return body.strip() or "request failed"
+    if isinstance(payload, dict):
+        detail = payload.get("detail")
+        if isinstance(detail, str) and detail.strip():
+            return detail
+    return body.strip() or "request failed"
+
+
+def _load_config_dict_from_values(values: Dict[str, Any]) -> Dict[str, Any]:
+    config: Dict[str, Any] = dict(values)
+    config["base_url"] = _normalize_base_url(str(config.get("base_url", _DEFAULT_BASE_URL)))
+    config["user_id"] = str(config.get("user_id", "")).strip()
+    config["timeout_seconds"] = _parse_float(
+        config.get("timeout_seconds"),
+        default=_DEFAULT_TIMEOUT_SECONDS,
+        min_value=0.5,
+        max_value=30.0,
+    )
+    config["prefetch_limit"] = _parse_int(
+        config.get("prefetch_limit"),
+        default=_DEFAULT_PREFETCH_LIMIT,
+        min_value=_RECALL_LIMIT_MIN,
+        max_value=_RECALL_LIMIT_MAX,
+    )
+    config["max_recent_changes"] = _parse_int(
+        config.get("max_recent_changes"),
+        default=_DEFAULT_MAX_RECENT_CHANGES,
+        min_value=_RECENT_CHANGES_MIN,
+        max_value=_RECENT_CHANGES_MAX,
+    )
+    config["max_open_loops"] = _parse_int(
+        config.get("max_open_loops"),
+        default=_DEFAULT_MAX_OPEN_LOOPS,
+        min_value=_RECENT_CHANGES_MIN,
+        max_value=_RECENT_CHANGES_MAX,
+    )
+    config["include_non_promotable_facts"] = _parse_bool(
+        config.get("include_non_promotable_facts"),
+        default=False,
+    )
+    config["auto_capture"] = _parse_bool(config.get("auto_capture"), default=False)
+    config["mirror_memory_writes"] = _parse_bool(config.get("mirror_memory_writes"), default=False)
+    return config
+
+
+def _extract_single_title(section: Any) -> str:
+    if not isinstance(section, dict):
+        return ""
+    item = section.get("item")
+    if not isinstance(item, dict):
+        return ""
+    title = item.get("title")
+    if isinstance(title, str):
+        return title.strip()
+    return ""
+
+
+def _extract_titles(section: Any, *, limit: int) -> List[str]:
+    if not isinstance(section, dict):
+        return []
+    items = section.get("items")
+    if not isinstance(items, list):
+        return []
+
+    titles: List[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        title = item.get("title")
+        if not isinstance(title, str):
+            continue
+        normalized = title.strip()
+        if not normalized:
+            continue
+        titles.append(normalized)
+        if len(titles) >= limit:
+            break
+    return titles
+
+
+# Plugin entry point ---------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register Alice as a Hermes external memory provider."""
+
+    ctx.register_memory_provider(AliceMemoryProvider())

--- a/docs/integrations/hermes-memory-provider/plugins/memory/alice/plugin.yaml
+++ b/docs/integrations/hermes-memory-provider/plugins/memory/alice/plugin.yaml
@@ -1,0 +1,3 @@
+name: alice
+version: 0.1.0
+description: "Alice continuity-backed external memory provider for Hermes (recall, resumption, open-loop prefetch)."

--- a/docs/integrations/hermes-skill-pack.md
+++ b/docs/integrations/hermes-skill-pack.md
@@ -53,11 +53,14 @@ HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}" \
   rg "alice-continuity-recall|alice-resumption|alice-open-loop-review"
 ```
 
-## Skills vs MCP: Responsibility Split
+## Skills vs Provider vs MCP: Responsibility Split
 
 - Skills: decision policy and workflow instructions (when to call tools, how to format output, what evidence to include).
+- External memory provider: always-on prefetch and memory-provider-native recall tools.
 - MCP tools: runtime execution and deterministic continuity data retrieval/update.
-- Practical rule: use skills to decide behavior; use MCP tools to fetch or mutate continuity state.
+- Practical rule: use skills to decide behavior; use provider or MCP to execute continuity reads/writes.
+
+See `docs/integrations/hermes-memory-provider.md` for the external provider setup path.
 
 ## When Hermes Should Prefer Alice Tools
 

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -7,6 +7,17 @@ for:
 - `alice_resume`
 - `alice_open_loops`
 
+## Choose The Integration Path
+
+- External memory provider: `docs/integrations/hermes-memory-provider.md`
+- MCP tools: this document (`docs/integrations/hermes.md`)
+- Hermes skill pack: `docs/integrations/hermes-skill-pack.md`
+
+Use MCP when you want broad Alice tool access through Hermes `mcp_servers`.
+Use the external memory provider when you want always-on prefetch and memory
+tools inside Hermes memory-provider flow. Use the skill pack for tool-routing
+and response policy on top of either path.
+
 ## Prerequisites
 
 - Hermes Agent with MCP support (`hermes mcp --help` works).

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -60,6 +60,7 @@ MCP uses the same local runtime scope as CLI:
 For Hermes Agent-specific setup, prompts, and troubleshooting:
 
 - `docs/integrations/hermes.md`
+- `docs/integrations/hermes-memory-provider.md`
 - `docs/integrations/hermes-skill-pack.md`
 
 ## Contract Guardrails

--- a/scripts/install_hermes_alice_memory_provider.py
+++ b/scripts/install_hermes_alice_memory_provider.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Install the Alice Hermes memory provider into an existing Hermes install."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SOURCE_DIR = REPO_ROOT / "docs" / "integrations" / "hermes-memory-provider" / "plugins" / "memory" / "alice"
+
+
+def _resolve_hermes_memory_plugins_dir() -> Path:
+    try:
+        import plugins.memory as memory_plugins  # type: ignore[import-not-found]
+    except Exception as exc:  # pragma: no cover - runtime-dependent
+        raise RuntimeError(
+            "Could not import Hermes memory plugins package. "
+            "Run this script with the Python environment where Hermes is installed."
+        ) from exc
+    return Path(memory_plugins.__file__).resolve().parent
+
+
+def _validate_source_tree(path: Path) -> None:
+    required = ("__init__.py", "plugin.yaml", "README.md")
+    missing = [name for name in required if not (path / name).exists()]
+    if missing:
+        raise RuntimeError(f"source plugin tree is incomplete: missing {', '.join(missing)}")
+
+
+def _install(*, destination_root: Path, force: bool, symlink: bool) -> Path:
+    destination = destination_root / "alice"
+
+    if destination.exists():
+        if not force:
+            raise RuntimeError(
+                f"destination already exists: {destination}. Re-run with --force to replace it."
+            )
+        if destination.is_symlink() or destination.is_file():
+            destination.unlink()
+        else:
+            shutil.rmtree(destination)
+
+    if symlink:
+        destination.symlink_to(SOURCE_DIR, target_is_directory=True)
+    else:
+        shutil.copytree(SOURCE_DIR, destination)
+
+    return destination
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="install_hermes_alice_memory_provider.py",
+        description="Install Alice as a Hermes external memory provider plugin.",
+    )
+    parser.add_argument(
+        "--destination-root",
+        type=Path,
+        default=None,
+        help=(
+            "Hermes memory plugin root directory. Defaults to the discovered "
+            "<hermes>/plugins/memory path in the active Python environment."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing alice provider directory at the destination.",
+    )
+    parser.add_argument(
+        "--symlink",
+        action="store_true",
+        help="Install as a symlink instead of copying files.",
+    )
+
+    args = parser.parse_args()
+
+    _validate_source_tree(SOURCE_DIR)
+
+    destination_root = args.destination_root
+    if destination_root is None:
+        destination_root = _resolve_hermes_memory_plugins_dir()
+
+    destination_root = destination_root.resolve()
+    if not destination_root.exists():
+        raise RuntimeError(f"destination root does not exist: {destination_root}")
+
+    installed_path = _install(
+        destination_root=destination_root,
+        force=args.force,
+        symlink=args.symlink,
+    )
+
+    print("Installed Alice memory provider plugin")
+    print(f"  source: {SOURCE_DIR}")
+    print(f"  destination: {installed_path}")
+    print()
+    print("Next steps:")
+    print("  1) hermes memory setup      # choose alice")
+    print("  2) hermes memory status")
+    print("  3) hermes config set memory.provider alice")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/run_hermes_memory_provider_smoke.py
+++ b/scripts/run_hermes_memory_provider_smoke.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Smoke validation for the Alice Hermes memory provider integration.
+
+Validates:
+- provider module loads and exposes required tools
+- MemoryManager keeps built-in provider and only one external provider
+- optional live prefetch against an Alice API endpoint
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+from agent.builtin_memory_provider import BuiltinMemoryProvider
+from agent.memory_manager import MemoryManager
+from agent.memory_provider import MemoryProvider
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PROVIDER_FILE = (
+    REPO_ROOT
+    / "docs"
+    / "integrations"
+    / "hermes-memory-provider"
+    / "plugins"
+    / "memory"
+    / "alice"
+    / "__init__.py"
+)
+
+
+class _DummyStore:
+    def load_from_disk(self) -> None:
+        return None
+
+    def format_for_system_prompt(self, target: str) -> str:
+        if target == "memory":
+            return "# MEMORY.md\n- Keep responses deterministic."
+        if target == "user":
+            return "# USER.md\n- Prefer concise output."
+        return ""
+
+
+class _SecondExternalProvider(MemoryProvider):
+    @property
+    def name(self) -> str:
+        return "second-external"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        return None
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        return []
+
+
+def _load_provider_class(provider_file: Path) -> type:
+    spec = importlib.util.spec_from_file_location("alice_provider_module", provider_file)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load provider module: {provider_file}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    provider_class = getattr(module, "AliceMemoryProvider", None)
+    if provider_class is None:
+        raise RuntimeError("provider module has no AliceMemoryProvider class")
+    return provider_class
+
+
+def _run_structural_validation(provider_class: type) -> Dict[str, Any]:
+    manager = MemoryManager()
+
+    builtin = BuiltinMemoryProvider(
+        memory_store=_DummyStore(),
+        memory_enabled=True,
+        user_profile_enabled=True,
+    )
+    alice = provider_class()
+    second_external = _SecondExternalProvider()
+
+    manager.add_provider(builtin)
+    manager.add_provider(alice)
+    manager.add_provider(second_external)
+
+    tool_names = sorted(schema.get("name", "") for schema in alice.get_tool_schemas())
+
+    return {
+        "provider_names": manager.provider_names,
+        "builtin_first": manager.provider_names[:1] == ["builtin"],
+        "single_external_enforced": manager.provider_names.count("second-external") == 0,
+        "alice_registered": "alice" in manager.provider_names,
+        "alice_tools": tool_names,
+    }
+
+
+def _run_live_prefetch(
+    *,
+    provider_class: type,
+    base_url: str,
+    user_id: str,
+    query: str,
+    timeout_seconds: float,
+) -> Dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="alice-hermes-provider-") as temp_dir:
+        hermes_home = Path(temp_dir)
+        config_path = hermes_home / "alice_memory_provider.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "base_url": base_url,
+                    "user_id": user_id,
+                    "timeout_seconds": timeout_seconds,
+                    "prefetch_limit": 5,
+                    "max_recent_changes": 3,
+                    "max_open_loops": 3,
+                    "include_non_promotable_facts": False,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        provider = provider_class()
+        provider.initialize(
+            session_id="smoke-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            agent_context="primary",
+        )
+        context = provider.prefetch(query, session_id="smoke-session")
+
+    return {
+        "query": query,
+        "context_length": len(context),
+        "context_preview": context[:400],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="run_hermes_memory_provider_smoke.py",
+        description="Validate Alice memory provider behavior against Hermes provider contracts.",
+    )
+    parser.add_argument(
+        "--provider-file",
+        type=Path,
+        default=DEFAULT_PROVIDER_FILE,
+        help="Path to the Alice provider __init__.py implementation.",
+    )
+    parser.add_argument(
+        "--live-prefetch-query",
+        default="",
+        help="If set, run a live prefetch call against Alice API using this query.",
+    )
+    parser.add_argument(
+        "--alice-base-url",
+        default="http://127.0.0.1:8000",
+        help="Alice API base URL for live prefetch mode.",
+    )
+    parser.add_argument(
+        "--alice-user-id",
+        default="00000000-0000-0000-0000-000000000001",
+        help="Alice user UUID for live prefetch mode.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=8.0,
+        help="HTTP timeout for live prefetch mode.",
+    )
+
+    args = parser.parse_args()
+
+    provider_file = args.provider_file.resolve()
+    if not provider_file.exists():
+        raise RuntimeError(f"provider file not found: {provider_file}")
+
+    provider_class = _load_provider_class(provider_file)
+
+    result: Dict[str, Any] = {
+        "provider_file": str(provider_file),
+        "structural": _run_structural_validation(provider_class),
+    }
+
+    if args.live_prefetch_query:
+        result["live_prefetch"] = _run_live_prefetch(
+            provider_class=provider_class,
+            base_url=args.alice_base_url,
+            user_id=args.alice_user_id,
+            query=args.live_prefetch_query,
+            timeout_seconds=args.timeout_seconds,
+        )
+
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What This PR Delivers

This PR adds **Alice as a first-class Hermes external memory provider** while preserving Hermes built-in memory behavior.

## Why This Approach

Hermes supports:
- built-in memory (`MEMORY.md` / `USER.md`) always on
- at most one external memory provider at a time

This integration is additive: Alice augments Hermes memory flows without replacing built-in memory files.

## Key Changes

- Added a Hermes-compatible Alice provider plugin:
  - `alice_recall`
  - `alice_resumption_brief`
  - `alice_open_loops`
  - prefetch support based on Alice resumption brief
- Mapped Alice continuity model into Hermes provider lifecycle/hooks.
- Preserved compatibility with Hermes built-in memory and validated single-external-provider behavior.
- Added setup and verification tooling:
  - `scripts/install_hermes_alice_memory_provider.py`
  - `scripts/run_hermes_memory_provider_smoke.py`
- Added and linked docs for install/config/usage, including guidance for:
  - provider vs MCP vs skill-pack usage

## Validation

- `python -m py_compile` on provider and scripts
- `./scripts/run_hermes_memory_provider_smoke.py`
  - confirms provider registration
  - confirms built-in + one external provider behavior
- installer smoke run against a temporary plugins root
- GitHub controls passed:
  - Protected Path Upgrade Guardrails
  - Secrets Scan (Gitleaks)
  - CodeQL (python)
  - CodeQL (javascript)

## Notes

- No PII introduced in edited/created files.
