### PR TITLE
Security hardening: Hermes Alice provider endpoint, identity, and error hygiene

### DIFF
--- a/docs/integrations/hermes-memory-provider.md
+++ b/docs/integrations/hermes-memory-provider.md
@@ -53,6 +53,12 @@ Select `alice` and provide:
 - `base_url`: Alice API base URL (example `http://127.0.0.1:8000`)
 - `user_id`: Alice user UUID scope
 
+Security rules enforced by the provider:
+
+- `https://` is required for non-loopback hosts.
+- `http://` is only allowed for loopback/local development hosts (`localhost`, `127.0.0.1`, `::1`).
+- the provider sends user scope in `X-AliceBot-User-Id` header (not URL query params).
+
 Config is saved to:
 
 - `$HERMES_HOME/alice_memory_provider.json`

--- a/docs/integrations/hermes-memory-provider/plugins/memory/alice/README.md
+++ b/docs/integrations/hermes-memory-provider/plugins/memory/alice/README.md
@@ -35,6 +35,12 @@ The provider reads and writes:
 - `auto_capture` (bool, default `false`)
 - `mirror_memory_writes` (bool, default `false`)
 
+## Transport and Identity Safety
+
+- non-loopback `base_url` values must use `https://`
+- `http://` is allowed only for loopback development hosts
+- provider requests carry user scope in `X-AliceBot-User-Id`
+
 ## Activation
 
 ```bash

--- a/docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py
+++ b/docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py
@@ -12,6 +12,7 @@ Design goals:
 from __future__ import annotations
 
 import json
+import ipaddress
 import logging
 import os
 import threading
@@ -43,6 +44,15 @@ _OPEN_LOOP_LIMIT_MAX = 50
 
 _RECENT_CHANGES_MIN = 0
 _RECENT_CHANGES_MAX = 25
+
+_AUTH_USER_HEADER = "X-AliceBot-User-Id"
+_SAFE_TOOL_ERROR_MESSAGES = (
+    "internal provider error",
+    "provider is not initialized",
+    "provider configuration is invalid",
+    "Alice API connection failed",
+    "Alice API returned an invalid response payload",
+)
 
 
 ALICE_RECALL_TOOL = {
@@ -154,7 +164,41 @@ def _normalize_base_url(value: str) -> str:
     normalized = value.strip().rstrip("/")
     if normalized.endswith("/v0"):
         normalized = normalized[:-3]
-    return normalized
+    parsed = urllib.parse.urlsplit(normalized)
+    scheme = parsed.scheme.lower()
+    hostname = (parsed.hostname or "").strip().lower()
+    if scheme not in {"http", "https"}:
+        raise ValueError("base_url must start with http:// or https://")
+    if parsed.netloc.strip() == "":
+        raise ValueError("base_url must include a host")
+    if parsed.query or parsed.fragment:
+        raise ValueError("base_url must not include query parameters or fragments")
+    if scheme != "https" and not _is_loopback_host(hostname):
+        raise ValueError("base_url must use https:// unless host is loopback")
+    return urllib.parse.urlunsplit((scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
+def _is_loopback_host(hostname: str) -> bool:
+    if hostname == "":
+        return False
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _sanitize_tool_exception_message(error: Exception) -> str:
+    message = str(error).strip()
+    if message == "":
+        return "internal provider error"
+    for prefix in _SAFE_TOOL_ERROR_MESSAGES:
+        if message.startswith(prefix):
+            return message
+    if message.startswith("Alice API request failed with HTTP status "):
+        return message
+    return "internal provider error"
 
 
 def _config_path(hermes_home: str) -> Path:
@@ -218,40 +262,11 @@ def _load_config(hermes_home: str) -> Dict[str, Any]:
         except Exception:
             logger.debug("Failed to parse %s", path, exc_info=True)
 
-    config["base_url"] = _normalize_base_url(str(config.get("base_url", _DEFAULT_BASE_URL)))
-    config["user_id"] = str(config.get("user_id", "")).strip()
-    config["timeout_seconds"] = _parse_float(
-        config.get("timeout_seconds"),
-        default=_DEFAULT_TIMEOUT_SECONDS,
-        min_value=0.5,
-        max_value=30.0,
-    )
-    config["prefetch_limit"] = _parse_int(
-        config.get("prefetch_limit"),
-        default=_DEFAULT_PREFETCH_LIMIT,
-        min_value=_RECALL_LIMIT_MIN,
-        max_value=_RECALL_LIMIT_MAX,
-    )
-    config["max_recent_changes"] = _parse_int(
-        config.get("max_recent_changes"),
-        default=_DEFAULT_MAX_RECENT_CHANGES,
-        min_value=_RECENT_CHANGES_MIN,
-        max_value=_RECENT_CHANGES_MAX,
-    )
-    config["max_open_loops"] = _parse_int(
-        config.get("max_open_loops"),
-        default=_DEFAULT_MAX_OPEN_LOOPS,
-        min_value=_RECENT_CHANGES_MIN,
-        max_value=_RECENT_CHANGES_MAX,
-    )
-    config["include_non_promotable_facts"] = _parse_bool(
-        config.get("include_non_promotable_facts"),
-        default=False,
-    )
-    config["auto_capture"] = _parse_bool(config.get("auto_capture"), default=False)
-    config["mirror_memory_writes"] = _parse_bool(config.get("mirror_memory_writes"), default=False)
-
-    return config
+    try:
+        return _load_config_dict_from_values(config)
+    except ValueError:
+        logger.warning("Invalid Alice memory provider config; falling back to defaults", exc_info=True)
+        return _load_config_dict_from_values(_default_config())
 
 
 def _validate_uuid(value: str) -> bool:
@@ -286,10 +301,15 @@ class AliceMemoryProvider(MemoryProvider):
     def is_available(self) -> bool:
         from hermes_constants import get_hermes_home
 
-        cfg = _load_config(str(get_hermes_home()))
+        try:
+            cfg = _load_config(str(get_hermes_home()))
+        except ValueError:
+            return False
         base_url = str(cfg.get("base_url", "")).strip()
         user_id = str(cfg.get("user_id", "")).strip()
-        if not (base_url.startswith("http://") or base_url.startswith("https://")):
+        try:
+            _normalize_base_url(base_url)
+        except ValueError:
             return False
         return _validate_uuid(user_id)
 
@@ -464,7 +484,8 @@ class AliceMemoryProvider(MemoryProvider):
                 return tool_error(f"unknown tool: {tool_name}")
             return json.dumps(payload)
         except Exception as exc:
-            return tool_error(f"{tool_name} failed: {exc}")
+            logger.debug("Alice provider tool call failed for %s", tool_name, exc_info=True)
+            return tool_error(f"{tool_name} failed: {_sanitize_tool_exception_message(exc)}")
 
     def shutdown(self) -> None:
         with self._prefetch_lock:
@@ -571,7 +592,6 @@ class AliceMemoryProvider(MemoryProvider):
 
     def _post_capture(self, raw_content: str) -> None:
         payload = {
-            "user_id": self._config.get("user_id", ""),
             "raw_content": raw_content[:_DEFAULT_CAPTURE_CHAR_LIMIT],
         }
         self._request_json("POST", "/v0/continuity/captures", payload=payload)
@@ -605,16 +625,24 @@ class AliceMemoryProvider(MemoryProvider):
             raise RuntimeError("provider is not initialized")
 
         query = dict(params or {})
-        query["user_id"] = self._config.get("user_id", "")
+        user_id = str(self._config.get("user_id", "")).strip()
+        if not _validate_uuid(user_id):
+            raise RuntimeError("provider configuration is invalid")
 
-        base_url = self._config.get("base_url", _DEFAULT_BASE_URL)
+        try:
+            base_url = _normalize_base_url(str(self._config.get("base_url", _DEFAULT_BASE_URL)))
+        except ValueError as exc:
+            raise RuntimeError("provider configuration is invalid") from exc
         encoded = urllib.parse.urlencode(query, doseq=True)
         url = f"{base_url}{path}"
         if encoded:
             url = f"{url}?{encoded}"
 
         data = None
-        headers = {"Accept": "application/json"}
+        headers = {
+            "Accept": "application/json",
+            _AUTH_USER_HEADER: user_id,
+        }
         if payload is not None:
             headers["Content-Type"] = "application/json"
             data = json.dumps(payload).encode("utf-8")
@@ -624,35 +652,18 @@ class AliceMemoryProvider(MemoryProvider):
         timeout = float(self._config.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS))
 
         try:
-            with urllib.request.urlopen(request, timeout=timeout) as response:
+            with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310
                 body = response.read().decode("utf-8", errors="replace")
                 if not body:
                     return {}
                 decoded = json.loads(body)
                 if isinstance(decoded, dict):
                     return decoded
-                raise RuntimeError("unexpected non-object response from Alice API")
+                raise RuntimeError("Alice API returned an invalid response payload")
         except urllib.error.HTTPError as exc:
-            detail = _decode_error_detail(exc)
-            raise RuntimeError(f"Alice API HTTP {exc.code}: {detail}") from exc
+            raise RuntimeError(f"Alice API request failed with HTTP status {exc.code}") from exc
         except urllib.error.URLError as exc:
-            raise RuntimeError(f"Alice API connection failed: {exc.reason}") from exc
-
-
-def _decode_error_detail(error: urllib.error.HTTPError) -> str:
-    try:
-        body = error.read().decode("utf-8", errors="replace")
-    except Exception:
-        return "request failed"
-    try:
-        payload = json.loads(body)
-    except Exception:
-        return body.strip() or "request failed"
-    if isinstance(payload, dict):
-        detail = payload.get("detail")
-        if isinstance(detail, str) and detail.strip():
-            return detail
-    return body.strip() or "request failed"
+            raise RuntimeError("Alice API connection failed") from exc
 
 
 def _load_config_dict_from_values(values: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/unit/test_hermes_memory_provider.py
+++ b/tests/unit/test_hermes_memory_provider.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+from pathlib import Path
+import sys
+import types
+import urllib.error
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROVIDER_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "integrations"
+    / "hermes-memory-provider"
+    / "plugins"
+    / "memory"
+    / "alice"
+    / "__init__.py"
+)
+
+
+def _load_provider_module(monkeypatch: pytest.MonkeyPatch):
+    agent_pkg = types.ModuleType("agent")
+    memory_provider_pkg = types.ModuleType("agent.memory_provider")
+
+    class _MemoryProvider:
+        pass
+
+    memory_provider_pkg.MemoryProvider = _MemoryProvider
+
+    tools_pkg = types.ModuleType("tools")
+    tools_registry_pkg = types.ModuleType("tools.registry")
+
+    def _tool_error(message: str) -> str:
+        return f"tool_error:{message}"
+
+    tools_registry_pkg.tool_error = _tool_error
+
+    monkeypatch.setitem(sys.modules, "agent", agent_pkg)
+    monkeypatch.setitem(sys.modules, "agent.memory_provider", memory_provider_pkg)
+    monkeypatch.setitem(sys.modules, "tools", tools_pkg)
+    monkeypatch.setitem(sys.modules, "tools.registry", tools_registry_pkg)
+
+    module_name = "alice_memory_provider_test_module"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, PROVIDER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalize_base_url_enforces_https_for_non_loopback(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_provider_module(monkeypatch)
+
+    with pytest.raises(ValueError, match="https://"):
+        module._normalize_base_url("http://example.com")
+
+    assert module._normalize_base_url("http://127.0.0.1:8000") == "http://127.0.0.1:8000"
+    assert module._normalize_base_url("https://alice.example.com/v0") == "https://alice.example.com"
+
+
+def test_request_json_sends_user_scope_in_header_not_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_provider_module(monkeypatch)
+    provider = module.AliceMemoryProvider()
+    provider._config = {
+        "base_url": "http://127.0.0.1:8000",
+        "user_id": "00000000-0000-0000-0000-000000000001",
+        "timeout_seconds": 8.0,
+    }
+
+    captured: dict[str, object] = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            del exc_type, exc, tb
+            return None
+
+        def read(self) -> bytes:
+            return b'{"ok": true}'
+
+    def _fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]
+        captured["url"] = request.full_url
+        captured["headers"] = dict(request.header_items())
+        captured["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", _fake_urlopen)
+
+    result = provider._request_json(
+        "GET",
+        "/v0/continuity/recall",
+        params={"query": "release gating"},
+    )
+
+    assert result == {"ok": True}
+    assert "user_id=" not in str(captured["url"])
+
+    headers = {str(key).lower(): str(value) for key, value in dict(captured["headers"]).items()}
+    assert headers["x-alicebot-user-id"] == "00000000-0000-0000-0000-000000000001"
+
+
+def test_handle_tool_call_sanitizes_unexpected_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_provider_module(monkeypatch)
+    provider = module.AliceMemoryProvider()
+
+    def _raise_unexpected(_args):  # type: ignore[no-untyped-def]
+        raise RuntimeError("database password leaked from /private/tmp/creds.txt")
+
+    monkeypatch.setattr(provider, "_tool_recall", _raise_unexpected)
+
+    response = provider.handle_tool_call("alice_recall", {})
+    assert "internal provider error" in response
+    assert "password" not in response
+    assert "/private/tmp" not in response
+
+
+def test_handle_tool_call_sanitizes_http_error_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_provider_module(monkeypatch)
+    provider = module.AliceMemoryProvider()
+    provider._config = {
+        "base_url": "http://127.0.0.1:8000",
+        "user_id": "00000000-0000-0000-0000-000000000001",
+        "timeout_seconds": 8.0,
+    }
+
+    def _fake_urlopen(_request, timeout=0):  # type: ignore[no-untyped-def]
+        del timeout
+        raise urllib.error.HTTPError(
+            url="http://127.0.0.1:8000/v0/continuity/recall",
+            code=500,
+            msg="internal error",
+            hdrs=None,
+            fp=io.BytesIO(b'{"detail":"db password leaked"}'),
+        )
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", _fake_urlopen)
+    response = provider.handle_tool_call("alice_recall", {"query": "foo"})
+
+    assert "HTTP status 500" in response
+    assert "password leaked" not in response
+


### PR DESCRIPTION
## Summary
Remediates the security findings from the latest sprint scan for the Hermes Alice external memory provider integration.

## Fixes applied
1. **Transport and endpoint guardrails**
   - Enforced `http://` or `https://` scheme validation for `base_url`.
   - Rejected query/fragment-bearing base URLs.
   - Required `https://` for non-loopback hosts (loopback-only exception for local dev).

2. **Tool-visible error sanitization**
   - Removed propagation of raw upstream HTTP error bodies/details into tool responses.
   - Added sanitized, bounded tool error messaging (`internal provider error` fallback).
   - Kept detailed internals only in debug logs.

3. **User scope handling hardening**
   - Stopped sending `user_id` in request query strings.
   - Switched provider requests to `X-AliceBot-User-Id` header for identity scope.
   - Removed explicit `user_id` from capture payload body.

4. **Documentation + tests**
   - Updated Hermes provider docs with transport and identity safety behavior.
   - Added unit tests for URL policy enforcement, header-only user scope, and error sanitization.

## Validation
- `python3 -m pytest -q tests/unit/test_hermes_memory_provider.py tests/unit/test_archive_maintenance.py tests/unit/test_cli.py`
  - `16 passed`
- `./.venv/bin/bandit -r docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py scripts/install_hermes_alice_memory_provider.py scripts/run_hermes_memory_provider_smoke.py`
  - `No issues identified` (one justified `# nosec B310` suppression after strict scheme/host validation)
- `python3 scripts/run_hermes_memory_provider_smoke.py`
  - structural smoke pass

## PII check
No personally identifiable information was introduced in changed files.