### PR TITLE
P11-S2: local provider adapters

### DIFF
--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,105 +1,82 @@
 # BUILD_REPORT
 
 ## sprint objective
-Implement Phase 11 Sprint 1 (`P11-S1`) provider abstraction, provider registry, OpenAI-compatible base adapter, capability discovery, and normalized `v1` provider/runtime APIs while preserving existing `v0/responses` behavior.
+Implement Phase 11 Sprint 2 (`P11-S2`) local-provider support by shipping Ollama and llama.cpp adapters behind the existing provider abstraction, including registration, model enumeration + health posture snapshots, and normalized runtime invoke through existing `v1` seams.
 
 ## completed work
-- Added provider runtime abstraction in `apps/api/src/alicebot_api/provider_runtime.py`:
-  - provider adapter protocol
-  - provider adapter registry
-  - OpenAI-compatible adapter implementation
-  - capability snapshot normalization
-  - provider test model request builder
-- Added provider secret-reference storage and runtime resolution in `apps/api/src/alicebot_api/provider_secrets.py`:
-  - file-backed secret refs for provider API keys
-  - backward-compatible plaintext fallback resolver
-- Extended response-generation seam in `apps/api/src/alicebot_api/response_generation.py`:
-  - extracted OpenAI-compatible transport config/invoker
-  - preserved `invoke_model` wrapper behavior for existing flow
-  - added runtime override + model invoker injection in `generate_response`
-- Added provider/runtime contracts in `apps/api/src/alicebot_api/contracts.py`.
-- Added persistence model + capability storage in `apps/api/src/alicebot_api/store.py`:
-  - `ModelProviderRow`, `ProviderCapabilityRow`
-  - workspace-scoped provider CRUD/query methods
-  - capability upsert/query methods
-- Added migration `apps/api/alembic/versions/20260411_0052_phase11_provider_runtime_base.py` with:
-  - `model_providers`
-  - `provider_capabilities`
-- Added `v1` APIs in `apps/api/src/alicebot_api/main.py`:
-  - `POST /v1/providers`
-  - `GET /v1/providers`
-  - `GET /v1/providers/{provider_id}`
+- Added local provider transport helpers in `apps/api/src/alicebot_api/local_provider_helpers.py`:
+  - auth header handling (`bearer`/`none`)
+  - deterministic JSON request helper
+  - Ollama/llama.cpp model enumeration parsers
+  - Ollama/llama.cpp invoke response normalization
+- Extended provider runtime adapters in `apps/api/src/alicebot_api/provider_runtime.py`:
+  - added `ollama` and `llamacpp` adapter keys and implementations
+  - registered both adapters in the existing provider registry
+  - added deterministic capability snapshot fields for local health/model posture
+  - preserved normalized runtime provider seam (`openai_responses`)
+- Added additive model provider config fields in persistence:
+  - migration `apps/api/alembic/versions/20260411_0053_phase11_local_provider_config_fields.py`
+  - store/runtime wiring for `auth_mode`, `model_list_path`, `healthcheck_path`, `invoke_path`
+- Updated API contract and serialization surfaces:
+  - `apps/api/src/alicebot_api/contracts.py`
+  - `apps/api/src/alicebot_api/store.py`
+  - `apps/api/src/alicebot_api/main.py`
+- Added new registration APIs in `apps/api/src/alicebot_api/main.py`:
+  - `POST /v1/providers/ollama/register`
+  - `POST /v1/providers/llamacpp/register`
+- Kept existing in-scope APIs working with local adapters:
   - `POST /v1/providers/test`
   - `POST /v1/runtime/invoke`
-- Added registration conflict handling (`409` on duplicate workspace display name) in `/v1/providers`.
-- Added/updated sprint verification tests:
+  - `GET /v1/providers`
+  - `GET /v1/providers/{provider_id}`
+- Added failure-safe capability behavior:
+  - registration stores failed discovery posture when local provider is unreachable
+  - provider test stores failed discovery posture when capability discovery fails
+- Added sprint verification tests:
   - `tests/unit/test_provider_runtime.py`
-  - `tests/unit/test_provider_secrets.py`
-  - `tests/unit/test_20260411_0052_phase11_provider_runtime_base.py`
+  - `tests/unit/test_20260411_0053_phase11_local_provider_config_fields.py`
   - `tests/integration/test_phase11_provider_runtime_api.py`
-- Fixed baseline regression blockers so required backend verification is green:
-  - resilience fixes in continuity explainability/review/semantic retrieval
-  - fact pattern/playbook upsert RETURNING stability
-  - chief-of-staff note visibility for searchable lifecycle/routing/outcome events
-  - OpenClaw demo pre-committed user bootstrap and archive behavior preservation
-- Updated public control-doc truth markers in:
-  - `README.md`
-  - `ROADMAP.md`
-  - `RULES.md`
-- Verified existing active control state already reflects `P11-S1` in:
-  - `.ai/active/SPRINT_PACKET.md`
-  - `.ai/handoff/CURRENT_STATE.md`
+- Added local setup docs and runnable example paths:
+  - `docs/integrations/phase11-local-provider-adapters.md`
+  - `scripts/run_phase11_local_provider_e2e.py`
+- Updated control-doc truth checker markers for current sprint state:
+  - `scripts/check_control_doc_truth.py`
+  - linked new integration doc from `README.md`
 
 ## incomplete work
-- None for `P11-S1` acceptance and required verification commands.
+- None for `P11-S2` acceptance criteria and required verification commands.
 
 ## files changed
-- apps/api/alembic/versions/20260411_0052_phase11_provider_runtime_base.py
-- apps/api/src/alicebot_api/provider_runtime.py
-- apps/api/src/alicebot_api/provider_secrets.py
-- apps/api/src/alicebot_api/response_generation.py
-- apps/api/src/alicebot_api/contracts.py
-- apps/api/src/alicebot_api/store.py
-- apps/api/src/alicebot_api/main.py
-- apps/api/src/alicebot_api/chief_of_staff.py
-- apps/api/src/alicebot_api/config.py
-- apps/api/src/alicebot_api/continuity_explainability.py
-- apps/api/src/alicebot_api/continuity_review.py
-- apps/api/src/alicebot_api/semantic_retrieval.py
-- scripts/use_alice_with_openclaw.py
-- tests/integration/test_phase11_provider_runtime_api.py
-- tests/unit/test_20260411_0052_phase11_provider_runtime_base.py
-- tests/unit/test_provider_runtime.py
-- tests/unit/test_provider_secrets.py
-- tests/unit/test_entity_store.py
-- README.md
-- ROADMAP.md
-- RULES.md
-- BUILD_REPORT.md
-- REVIEW_REPORT.md
+- `apps/api/src/alicebot_api/local_provider_helpers.py`
+- `apps/api/src/alicebot_api/provider_runtime.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/store.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/alembic/versions/20260411_0053_phase11_local_provider_config_fields.py`
+- `tests/unit/test_provider_runtime.py`
+- `tests/unit/test_20260411_0053_phase11_local_provider_config_fields.py`
+- `tests/integration/test_phase11_provider_runtime_api.py`
+- `docs/integrations/phase11-local-provider-adapters.md`
+- `scripts/run_phase11_local_provider_e2e.py`
+- `scripts/check_control_doc_truth.py`
+- `README.md`
+- `BUILD_REPORT.md`
+- `REVIEW_REPORT.md`
 
 ## tests run
-- Required command:
-  - `python3 scripts/check_control_doc_truth.py`
+- `python3 scripts/check_control_doc_truth.py`
   - Result: `PASS`
-- Required command:
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-  - Result: `PASS` (`1112 passed in 195.60s (0:03:15)`)
-- Required command:
-  - `pnpm --dir apps/web test`
-  - Result: `PASS` (`62 passed` files, `199 passed` tests, duration `5.14s`)
-- Sprint-targeted API/runtime verification:
-  - `./.venv/bin/python -m pytest tests/integration/test_phase11_provider_runtime_api.py tests/unit/test_provider_runtime.py tests/unit/test_provider_secrets.py -q`
-  - Result: `PASS` (`8 passed`)
+- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
+  - Result: `PASS` (`1118 passed in 183.14s (0:03:03)`)
+- `pnpm --dir apps/web test`
+  - Result: `PASS` (`62 files`, `199 tests`, duration `4.82s`)
+- Sprint-targeted subset:
+  - `./.venv/bin/python -m pytest tests/unit/test_provider_runtime.py tests/unit/test_20260411_0053_phase11_local_provider_config_fields.py tests/integration/test_phase11_provider_runtime_api.py -q`
+  - Result: `PASS` (`12 passed in 2.50s`)
 
 ## blockers/issues
-- No active blockers for `P11-S1` acceptance criteria.
-
-## merge-scope notes
-- Existing local control-doc drafts remain dirty in working tree but are explicitly out of sprint-owned merge scope:
-  - `ARCHITECTURE.md`
-  - `PRODUCT_BRIEF.md`
+- No active implementation blockers.
 
 ## recommended next step
-1. Open PR for `codex/phase11-sprint-1-provider-abstraction-openai-base` with this verification evidence.
-2. Keep `ARCHITECTURE.md` and `PRODUCT_BRIEF.md` edits scoped to separate planning/docs PR.
+1. Open a sprint PR from `codex/phase11-sprint-2-ollama-llamacpp-adapters` with this report and required test evidence.
+2. Keep pre-existing dirty local docs (`ARCHITECTURE.md`, `PRODUCT_BRIEF.md`) excluded from sprint merge scope.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The current open-source surface includes:
 - shared explainability across recall, resume, open-loop review, and explain surfaces
 - scheduled archive maintenance, ops status reporting, and failure alerting
 - Hermes external memory provider for always-on continuity prefetch and Alice memory tools inside Hermes
-- provider runtime abstraction with workspace-scoped provider registration, capability snapshots, and an OpenAI-compatible base adapter
+- provider runtime abstraction with workspace-scoped provider registration, capability snapshots, an OpenAI-compatible base adapter, and local Ollama/llama.cpp adapters
 - importers for OpenClaw, Markdown, and ChatGPT exports
 - OpenClaw adapter and demo path
 - evaluation harness and integration docs
@@ -205,6 +205,7 @@ See:
 - [docs/integrations/hermes.md](docs/integrations/hermes.md)
 - [docs/integrations/hermes-memory-provider.md](docs/integrations/hermes-memory-provider.md)
 - [docs/integrations/hermes-skill-pack.md](docs/integrations/hermes-skill-pack.md)
+- [docs/integrations/phase11-local-provider-adapters.md](docs/integrations/phase11-local-provider-adapters.md)
 
 Hermes runtime smoke test:
 

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,48 +4,50 @@
 PASS
 
 ## criteria met
-- `P11-S1` in-scope API surface is implemented and verified:
-  - `POST /v1/providers`
-  - `GET /v1/providers`
-  - `GET /v1/providers/{provider_id}`
+- `P11-S2` local provider registration APIs are implemented and functioning:
+  - `POST /v1/providers/ollama/register`
+  - `POST /v1/providers/llamacpp/register`
+- Existing in-scope APIs are functioning with local adapters:
   - `POST /v1/providers/test`
   - `POST /v1/runtime/invoke`
-- Provider abstraction and registry are present with an OpenAI-compatible base adapter (`apps/api/src/alicebot_api/provider_runtime.py`).
-- Required data additions are present and migrated:
-  - `model_providers`
-  - `provider_capabilities`
-- Runtime invoke flows through the provider abstraction and returns normalized assistant/usage payloads.
-- Existing `v0/responses` seam remains intact (response-generation regression tests pass).
-- Provider config/capability access is workspace-scoped and integration-tested.
-- Provider credential handling no longer stores plaintext API keys in provider rows; registration stores secret references and runtime resolves secrets (`apps/api/src/alicebot_api/provider_secrets.py`, `apps/api/src/alicebot_api/main.py`).
-- Required verification commands pass:
+  - `GET /v1/providers`
+  - `GET /v1/providers/{provider_id}`
+- Ollama and llama.cpp adapters are integrated through the shipped provider abstraction and registry.
+- Capability snapshots include deterministic local model enumeration and health posture fields.
+- Additive provider config fields are migrated and wired (`auth_mode`, `model_list_path`, `healthcheck_path`, `invoke_path`).
+- Local setup documentation and runnable e2e example path are present.
+- Regression fix validated: legacy `/v1/providers` path now correctly passes `store` into shared registration helper (`apps/api/src/alicebot_api/main.py:6174-6177`).
+- Credential handling tightened: `auth_mode="none"` now rejects non-empty `api_key`, preventing plaintext persistence (`apps/api/src/alicebot_api/main.py:1562-1568`).
+- New regression coverage added:
+  - OpenAI-compatible registration still works and stores secret ref, not plaintext (`tests/integration/test_phase11_provider_runtime_api.py:470-491`).
+  - `auth_mode="none"` rejects provided `api_key` (`tests/integration/test_phase11_provider_runtime_api.py:494-514`).
+- Required verification commands pass on the current branch head:
   - `python3 scripts/check_control_doc_truth.py` -> PASS
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> PASS (`1112 passed in 195.60s`)
-  - `pnpm --dir apps/web test` -> PASS (`62 files`, `199 tests`, duration `5.14s`)
+  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> PASS (`1118 passed in 183.14s`)
+  - `pnpm --dir apps/web test` -> PASS (`62 files`, `199 tests`, duration `4.82s`)
 
 ## criteria missed
-- None for `P11-S1` acceptance criteria.
+- None identified for `P11-S2` acceptance criteria.
 
 ## quality issues
-- No blocking implementation quality issues found in sprint-owned scope.
-- Registration now returns deterministic `409` for duplicate provider display names within a workspace.
+- No blocking quality issues remain in sprint-owned scope after fixes.
 
 ## regression risks
-- Low after full required backend+web test pass.
-- Chief-of-staff, import/archive, and CLI regression paths that were previously red are now green.
+- Low. Full required verification is passing, including new regression tests for the previously broken path.
+- Residual operational risk remains external local-provider availability (Ollama/llama.cpp process reachability), which is surfaced via explicit discovery/test failure posture.
 
 ## docs issues
-- Control-doc truth markers are green, with sprint-owned updates in `README.md`, `ROADMAP.md`, and `RULES.md`.
-- No local machine paths/usernames found in reviewed sprint-owned code/docs/report files.
-- `ARCHITECTURE.md` and `PRODUCT_BRIEF.md` remain locally dirty and out of sprint merge scope; keep them excluded from this sprint PR.
+- No local identifiers (local computer paths, names) were found in sprint-owned changed code/docs reviewed here.
+- Out-of-scope dirty local docs remain and should stay excluded from sprint merge scope:
+  - `ARCHITECTURE.md`
+  - `PRODUCT_BRIEF.md`
 
 ## should anything be added to RULES.md?
-- Already addressed in current updates: explicit credential handling and provider/runtime security/reliability guardrails are present.
-- No additional rule required for this sprint merge.
+- Optional improvement: require backward-compat regression tests for already-shipped endpoints whenever shared registration/runtime helpers are refactored.
 
 ## should anything update ARCHITECTURE.md?
-- Optional follow-up only: add a tightly scoped `P11-S1 shipped` subsection when the docs-only planning edits are split into their own PR.
+- Optional improvement: add a concise note clarifying auth-mode credential invariants (`bearer` uses secret refs; `none` must not persist API keys).
 
 ## recommended next action
-1. Merge `P11-S1` code/test/doc-truth fixes as the sprint PR.
-2. Split `ARCHITECTURE.md` and `PRODUCT_BRIEF.md` planning edits into a separate non-sprint docs PR.
+1. Ready for Control Tower merge approval with the updated build and review evidence on this branch head.
+2. Keep `ARCHITECTURE.md` and `PRODUCT_BRIEF.md` excluded from the sprint PR.

--- a/apps/api/alembic/versions/20260411_0053_phase11_local_provider_config_fields.py
+++ b/apps/api/alembic/versions/20260411_0053_phase11_local_provider_config_fields.py
@@ -1,0 +1,62 @@
+"""Add local-provider configuration fields to model_providers."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260411_0053"
+down_revision = "20260411_0052"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_STATEMENTS = (
+    "ALTER TABLE model_providers ADD COLUMN auth_mode text NOT NULL DEFAULT 'bearer'",
+    "ALTER TABLE model_providers ADD COLUMN model_list_path text NOT NULL DEFAULT ''",
+    "ALTER TABLE model_providers ADD COLUMN healthcheck_path text NOT NULL DEFAULT ''",
+    "ALTER TABLE model_providers ADD COLUMN invoke_path text NOT NULL DEFAULT ''",
+    (
+        "ALTER TABLE model_providers "
+        "ADD CONSTRAINT model_providers_auth_mode_check "
+        "CHECK (auth_mode IN ('bearer', 'none'))"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "ADD CONSTRAINT model_providers_model_list_path_length_check "
+        "CHECK (char_length(model_list_path) <= 200)"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "ADD CONSTRAINT model_providers_healthcheck_path_length_check "
+        "CHECK (char_length(healthcheck_path) <= 200)"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "ADD CONSTRAINT model_providers_invoke_path_length_check "
+        "CHECK (char_length(invoke_path) <= 200)"
+    ),
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "ALTER TABLE model_providers DROP CONSTRAINT IF EXISTS model_providers_invoke_path_length_check",
+    "ALTER TABLE model_providers DROP CONSTRAINT IF EXISTS model_providers_healthcheck_path_length_check",
+    "ALTER TABLE model_providers DROP CONSTRAINT IF EXISTS model_providers_model_list_path_length_check",
+    "ALTER TABLE model_providers DROP CONSTRAINT IF EXISTS model_providers_auth_mode_check",
+    "ALTER TABLE model_providers DROP COLUMN IF EXISTS invoke_path",
+    "ALTER TABLE model_providers DROP COLUMN IF EXISTS healthcheck_path",
+    "ALTER TABLE model_providers DROP COLUMN IF EXISTS model_list_path",
+    "ALTER TABLE model_providers DROP COLUMN IF EXISTS auth_mode",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -189,7 +189,7 @@ ToolAllowlistDecision = Literal["allowed", "denied", "approval_required"]
 ToolRoutingDecision = Literal["ready", "denied", "approval_required"]
 PromptSectionName = Literal["system", "developer", "context", "conversation"]
 ModelProvider = Literal["openai_responses"]
-ProviderAdapterKey = Literal["openai_compatible"]
+ProviderAdapterKey = Literal["openai_compatible", "ollama", "llamacpp"]
 ModelProviderStatus = Literal["active"]
 ProviderCapabilityDiscoveryStatus = Literal["ready", "failed"]
 ModelFinishReason = Literal["completed", "incomplete"]
@@ -1547,8 +1547,12 @@ class ModelProviderRecord(TypedDict):
     model_provider: ModelProvider
     display_name: str
     base_url: str
+    auth_mode: str
     default_model: str
     status: ModelProviderStatus
+    model_list_path: str
+    healthcheck_path: str
+    invoke_path: str
     metadata: JsonObject
     created_at: str
     updated_at: str

--- a/apps/api/src/alicebot_api/local_provider_helpers.py
+++ b/apps/api/src/alicebot_api/local_provider_helpers.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from alicebot_api.contracts import ModelInvocationRequest, ModelInvocationResponse, ModelUsagePayload
+from alicebot_api.response_generation import ModelInvocationError
+
+
+def build_auth_headers(*, auth_mode: str, api_key: str) -> dict[str, str]:
+    mode = auth_mode.strip().lower()
+    if mode == "none":
+        return {}
+    if mode == "bearer":
+        token = api_key.strip()
+        if token == "":
+            raise ModelInvocationError("provider api_key is required when auth_mode is bearer")
+        return {"Authorization": f"Bearer {token}"}
+    raise ModelInvocationError(f"unsupported provider auth_mode: {auth_mode}")
+
+
+def request_json(
+    *,
+    method: str,
+    base_url: str,
+    path: str,
+    timeout_seconds: int,
+    headers: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    endpoint = base_url.rstrip("/") + normalized_path
+    request_headers = {"Accept": "application/json"}
+    if headers:
+        request_headers.update(headers)
+    body = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+    request = Request(endpoint, data=body, headers=request_headers, method=method)
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            raw_payload = response.read()
+    except HTTPError as exc:
+        detail = _extract_http_error_detail(exc)
+        if detail is not None:
+            raise ModelInvocationError(detail) from exc
+        raise ModelInvocationError(f"model provider returned HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise ModelInvocationError(f"model provider request failed: {exc.reason}") from exc
+
+    try:
+        parsed_payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        raise ModelInvocationError("model provider returned invalid JSON") from exc
+
+    if not isinstance(parsed_payload, dict):
+        raise ModelInvocationError("model provider returned invalid JSON")
+    return parsed_payload
+
+
+def prompt_sections_to_messages(request: ModelInvocationRequest) -> list[dict[str, str]]:
+    sections = {section.name: section.content for section in request.prompt.sections}
+    return [
+        {"role": "system", "content": sections["system"]},
+        {"role": "developer", "content": sections["developer"]},
+        {"role": "user", "content": f"[CONTEXT]\n{sections['context']}"},
+        {"role": "user", "content": f"[CONVERSATION]\n{sections['conversation']}"},
+    ]
+
+
+def parse_ollama_models(payload: dict[str, Any]) -> list[str]:
+    models_payload = payload.get("models")
+    if not isinstance(models_payload, list):
+        raise ModelInvocationError("ollama model enumeration payload is invalid")
+    model_names: set[str] = set()
+    for model_payload in models_payload:
+        if not isinstance(model_payload, dict):
+            continue
+        raw_name = model_payload.get("name")
+        if isinstance(raw_name, str) and raw_name.strip():
+            model_names.add(raw_name.strip())
+    return sorted(model_names)
+
+
+def parse_llamacpp_models(payload: dict[str, Any]) -> list[str]:
+    data_payload = payload.get("data")
+    if not isinstance(data_payload, list):
+        raise ModelInvocationError("llamacpp model enumeration payload is invalid")
+    model_names: set[str] = set()
+    for model_payload in data_payload:
+        if not isinstance(model_payload, dict):
+            continue
+        raw_name = model_payload.get("id")
+        if isinstance(raw_name, str) and raw_name.strip():
+            model_names.add(raw_name.strip())
+    return sorted(model_names)
+
+
+def parse_ollama_invoke_response(*, request: ModelInvocationRequest, payload: dict[str, Any]) -> ModelInvocationResponse:
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        raise ModelInvocationError("ollama response did not include message payload")
+    output_text = message.get("content")
+    if not isinstance(output_text, str) or output_text.strip() == "":
+        raise ModelInvocationError("ollama response did not include assistant output text")
+    done = payload.get("done")
+    finish_reason = "completed" if done is True else "incomplete"
+    prompt_tokens = payload.get("prompt_eval_count")
+    completion_tokens = payload.get("eval_count")
+    total_tokens = (
+        prompt_tokens + completion_tokens
+        if isinstance(prompt_tokens, int) and isinstance(completion_tokens, int)
+        else None
+    )
+    usage: ModelUsagePayload = {
+        "input_tokens": prompt_tokens if isinstance(prompt_tokens, int) else None,
+        "output_tokens": completion_tokens if isinstance(completion_tokens, int) else None,
+        "total_tokens": total_tokens,
+    }
+    return ModelInvocationResponse(
+        provider=request.provider,
+        model=request.model,
+        response_id=None,
+        finish_reason=finish_reason,
+        output_text=output_text,
+        usage=usage,
+    )
+
+
+def parse_llamacpp_invoke_response(
+    *,
+    request: ModelInvocationRequest,
+    payload: dict[str, Any],
+) -> ModelInvocationResponse:
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or len(choices) == 0:
+        raise ModelInvocationError("llamacpp response did not include choices")
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        raise ModelInvocationError("llamacpp response did not include choices")
+    message = first_choice.get("message")
+    if not isinstance(message, dict):
+        raise ModelInvocationError("llamacpp response did not include message payload")
+    output_text = message.get("content")
+    if not isinstance(output_text, str) or output_text.strip() == "":
+        raise ModelInvocationError("llamacpp response did not include assistant output text")
+    raw_finish_reason = first_choice.get("finish_reason")
+    finish_reason = "completed" if raw_finish_reason in {"stop", "completed", "eos"} else "incomplete"
+    usage_payload = payload.get("usage")
+    if isinstance(usage_payload, dict):
+        usage: ModelUsagePayload = {
+            "input_tokens": (
+                usage_payload.get("prompt_tokens")
+                if isinstance(usage_payload.get("prompt_tokens"), int)
+                else None
+            ),
+            "output_tokens": (
+                usage_payload.get("completion_tokens")
+                if isinstance(usage_payload.get("completion_tokens"), int)
+                else None
+            ),
+            "total_tokens": (
+                usage_payload.get("total_tokens")
+                if isinstance(usage_payload.get("total_tokens"), int)
+                else None
+            ),
+        }
+    else:
+        usage = {"input_tokens": None, "output_tokens": None, "total_tokens": None}
+    response_id = payload.get("id") if isinstance(payload.get("id"), str) else None
+    return ModelInvocationResponse(
+        provider=request.provider,
+        model=request.model,
+        response_id=response_id,
+        finish_reason=finish_reason,
+        output_text=output_text,
+        usage=usage,
+    )
+
+
+def _extract_http_error_detail(exc: HTTPError) -> str | None:
+    raw_body = exc.read().decode("utf-8", errors="replace")
+    try:
+        parsed_error = json.loads(raw_body)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(parsed_error, dict):
+        return None
+
+    error = parsed_error.get("error")
+    if isinstance(error, dict):
+        detail = error.get("message")
+        if isinstance(detail, str) and detail.strip():
+            return detail
+    detail = parsed_error.get("detail")
+    if isinstance(detail, str) and detail.strip():
+        return detail
+    return None

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -599,10 +599,15 @@ from alicebot_api.proxy_execution import (
     execute_approved_proxy_request,
 )
 from alicebot_api.provider_runtime import (
+    LLAMACPP_ADAPTER_KEY,
+    OLLAMA_ADAPTER_KEY,
+    OPENAI_COMPATIBLE_ADAPTER_KEY,
+    OPENAI_RESPONSES_PROVIDER,
     ProviderAdapterNotFoundError,
     RuntimeProviderConfig,
     build_provider_test_model_request,
     make_provider_adapter_registry,
+    normalized_capability_snapshot,
     resolve_runtime_provider_config_secrets,
 )
 from alicebot_api.provider_secrets import (
@@ -1427,8 +1432,12 @@ def _serialize_model_provider(provider: ModelProviderRow) -> dict[str, object]:
         "model_provider": provider["model_provider"],
         "display_name": provider["display_name"],
         "base_url": provider["base_url"],
+        "auth_mode": provider["auth_mode"],
         "default_model": provider["default_model"],
         "status": provider["status"],
+        "model_list_path": provider["model_list_path"],
+        "healthcheck_path": provider["healthcheck_path"],
+        "invoke_path": provider["invoke_path"],
         "metadata": provider["metadata"],
         "created_at": provider["created_at"].isoformat(),
         "updated_at": provider["updated_at"].isoformat(),
@@ -1468,6 +1477,154 @@ def _runtime_provider_config_or_none(
         config=RuntimeProviderConfig.from_row(row),
         settings=settings,
     )
+
+
+def _normalize_provider_path(*, field_name: str, value: str) -> str:
+    path = value.strip()
+    if path == "":
+        raise ValueError(f"{field_name} is required")
+    return path if path.startswith("/") else f"/{path}"
+
+
+def _fallback_provider_capability_snapshot(
+    *,
+    adapter_key: str,
+    runtime_provider: str,
+    model_list_path: str,
+    healthcheck_path: str,
+    invoke_path: str,
+) -> dict[str, object]:
+    snapshot = normalized_capability_snapshot(
+        adapter_key=adapter_key,
+        runtime_provider=runtime_provider,
+        supports_tool_calls=False,
+        supports_streaming=False,
+        supports_store=False,
+        supports_vision_input=False,
+        supports_audio_input=False,
+    )
+    snapshot.update(
+        {
+            "health_status": "unreachable",
+            "health_endpoint": healthcheck_path,
+            "models_endpoint": model_list_path,
+            "invoke_endpoint": invoke_path,
+            "model_count": 0,
+            "models": [],
+        }
+    )
+    return snapshot
+
+
+def _register_workspace_provider(
+    *,
+    settings: Settings,
+    store: ContinuityStore,
+    workspace_id: UUID,
+    created_by_user_account_id: UUID,
+    provider_key: str,
+    display_name: str,
+    base_url: str,
+    api_key: str,
+    auth_mode: str,
+    default_model: str,
+    model_list_path: str,
+    healthcheck_path: str,
+    invoke_path: str,
+    metadata: dict[str, object],
+) -> tuple[ModelProviderRow, ProviderCapabilityRow]:
+    normalized_display_name = display_name.strip()
+    normalized_base_url = base_url.strip()
+    normalized_api_key = api_key.strip()
+    normalized_default_model = default_model.strip()
+    normalized_auth_mode = auth_mode.strip().lower()
+    normalized_model_list_path = _normalize_provider_path(
+        field_name="model_list_path",
+        value=model_list_path,
+    )
+    normalized_healthcheck_path = _normalize_provider_path(
+        field_name="healthcheck_path",
+        value=healthcheck_path,
+    )
+    normalized_invoke_path = _normalize_provider_path(
+        field_name="invoke_path",
+        value=invoke_path,
+    )
+
+    if normalized_display_name == "":
+        raise ValueError("display_name is required")
+    if normalized_base_url == "":
+        raise ValueError("base_url is required")
+    if normalized_default_model == "":
+        raise ValueError("default_model is required")
+    if normalized_auth_mode not in {"bearer", "none"}:
+        raise ValueError(f"unsupported auth_mode: {auth_mode}")
+    if normalized_auth_mode == "bearer" and normalized_api_key == "":
+        raise ValueError("api_key is required when auth_mode is bearer")
+    if normalized_auth_mode == "none" and normalized_api_key != "":
+        raise ValueError("api_key must be empty when auth_mode is none")
+
+    encoded_api_key = "auth_mode_none"
+    if normalized_auth_mode == "bearer":
+        secret_ref = build_provider_secret_ref(workspace_id=workspace_id)
+        write_provider_api_key(
+            settings=settings,
+            secret_ref=secret_ref,
+            api_key=normalized_api_key,
+        )
+        encoded_api_key = encode_provider_secret_ref(secret_ref=secret_ref)
+
+    provider = store.create_model_provider(
+        workspace_id=workspace_id,
+        created_by_user_account_id=created_by_user_account_id,
+        provider_key=provider_key,
+        model_provider=OPENAI_RESPONSES_PROVIDER,
+        display_name=normalized_display_name,
+        base_url=normalized_base_url,
+        api_key=encoded_api_key,
+        default_model=normalized_default_model,
+        status="active",
+        metadata=metadata,
+        auth_mode=normalized_auth_mode,
+        model_list_path=normalized_model_list_path,
+        healthcheck_path=normalized_healthcheck_path,
+        invoke_path=normalized_invoke_path,
+    )
+
+    runtime_provider = resolve_runtime_provider_config_secrets(
+        config=RuntimeProviderConfig.from_row(provider),
+        settings=settings,
+    )
+    adapter = provider_adapter_registry.resolve(runtime_provider.provider_key)
+    discovery_status: str = "ready"
+    discovery_error: str | None = None
+
+    try:
+        capability_snapshot = adapter.discover_capabilities(
+            config=runtime_provider,
+            settings=settings,
+        )
+    except ModelInvocationError as exc:
+        capability_snapshot = _fallback_provider_capability_snapshot(
+            adapter_key=adapter.adapter_key,
+            runtime_provider=adapter.runtime_provider,
+            model_list_path=normalized_model_list_path,
+            healthcheck_path=normalized_healthcheck_path,
+            invoke_path=normalized_invoke_path,
+        )
+        discovery_status = "failed"
+        discovery_error = str(exc)
+
+    capability = store.upsert_provider_capability(
+        workspace_id=workspace_id,
+        provider_id=provider["id"],
+        discovered_by_user_account_id=created_by_user_account_id,
+        adapter_key=adapter.adapter_key,
+        discovery_status=discovery_status,
+        capability_snapshot=capability_snapshot,
+        discovery_error=discovery_error,
+    )
+    return provider, capability
 
 
 def redact_url_credentials(raw_url: str) -> str:
@@ -1882,11 +2039,43 @@ class HostedRolloutFlagsPatchRequest(BaseModel):
 class RegisterProviderRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    provider_key: Literal["openai_compatible"] = "openai_compatible"
+    provider_key: Literal["openai_compatible"] = OPENAI_COMPATIBLE_ADAPTER_KEY
     display_name: str = Field(min_length=1, max_length=120)
     base_url: str = Field(min_length=1, max_length=500)
     api_key: str = Field(min_length=1, max_length=8000)
+    auth_mode: Literal["bearer"] = "bearer"
     default_model: str = Field(min_length=1, max_length=200)
+    model_list_path: str = Field(default="/models", min_length=1, max_length=200)
+    healthcheck_path: str = Field(default="/models", min_length=1, max_length=200)
+    invoke_path: str = Field(default="/responses", min_length=1, max_length=200)
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class RegisterOllamaProviderRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str = Field(min_length=1, max_length=120)
+    base_url: str = Field(default="http://127.0.0.1:11434", min_length=1, max_length=500)
+    api_key: str | None = Field(default=None, max_length=8000)
+    auth_mode: Literal["bearer", "none"] = "none"
+    default_model: str = Field(min_length=1, max_length=200)
+    model_list_path: str = Field(default="/api/tags", min_length=1, max_length=200)
+    healthcheck_path: str = Field(default="/api/version", min_length=1, max_length=200)
+    invoke_path: str = Field(default="/api/chat", min_length=1, max_length=200)
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class RegisterLlamaCppProviderRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str = Field(min_length=1, max_length=120)
+    base_url: str = Field(default="http://127.0.0.1:8080", min_length=1, max_length=500)
+    api_key: str | None = Field(default=None, max_length=8000)
+    auth_mode: Literal["bearer", "none"] = "none"
+    default_model: str = Field(min_length=1, max_length=200)
+    model_list_path: str = Field(default="/v1/models", min_length=1, max_length=200)
+    healthcheck_path: str = Field(default="/health", min_length=1, max_length=200)
+    invoke_path: str = Field(default="/v1/chat/completions", min_length=1, max_length=200)
     metadata: dict[str, object] = Field(default_factory=dict)
 
 
@@ -5981,57 +6170,146 @@ def register_v1_provider(request: Request, body: RegisterProviderRequest) -> JSO
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
 
-                display_name = body.display_name.strip()
-                base_url = body.base_url.strip()
-                api_key = body.api_key.strip()
-                default_model = body.default_model.strip()
-                if display_name == "":
-                    raise ValueError("display_name is required")
-                if base_url == "":
-                    raise ValueError("base_url is required")
-                if api_key == "":
-                    raise ValueError("api_key is required")
-                if default_model == "":
-                    raise ValueError("default_model is required")
-
-                secret_ref = build_provider_secret_ref(workspace_id=workspace["id"])
-                write_provider_api_key(
-                    settings=settings,
-                    secret_ref=secret_ref,
-                    api_key=api_key,
-                )
-
                 store = ContinuityStore(conn)
-                provider = store.create_model_provider(
+                provider, capability = _register_workspace_provider(
+                    settings=settings,
+                    store=store,
                     workspace_id=workspace["id"],
                     created_by_user_account_id=resolution["user_account"]["id"],
                     provider_key=body.provider_key,
-                    model_provider="openai_responses",
-                    display_name=display_name,
-                    base_url=base_url,
-                    api_key=encode_provider_secret_ref(secret_ref=secret_ref),
-                    default_model=default_model,
-                    status="active",
+                    display_name=body.display_name,
+                    base_url=body.base_url,
+                    api_key=body.api_key,
+                    auth_mode=body.auth_mode,
+                    default_model=body.default_model,
+                    model_list_path=body.model_list_path,
+                    healthcheck_path=body.healthcheck_path,
+                    invoke_path=body.invoke_path,
                     metadata=body.metadata,
                 )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except psycopg.errors.UniqueViolation:
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "provider display_name must be unique within the workspace"},
+        )
+    except ProviderAdapterNotFoundError as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
+    except ProviderSecretManagerError as exc:
+        return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
 
-                runtime_provider = resolve_runtime_provider_config_secrets(
-                    config=RuntimeProviderConfig.from_row(provider),
-                    settings=settings,
+    return JSONResponse(
+        status_code=201,
+        content=jsonable_encoder(
+            {
+                "provider": _serialize_model_provider(provider),
+                "capabilities": _serialize_provider_capability(capability),
+            }
+        ),
+    )
+
+
+@app.post("/v1/providers/ollama/register")
+def register_v1_ollama_provider(
+    request: Request,
+    body: RegisterOllamaProviderRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                workspace = get_current_workspace(
+                    conn,
+                    user_account_id=resolution["user_account"]["id"],
+                    preferred_workspace_id=resolution["session"]["workspace_id"],
                 )
-                adapter = provider_adapter_registry.resolve(runtime_provider.provider_key)
-                capability_snapshot = adapter.discover_capabilities(
-                    config=runtime_provider,
+                if workspace is None:
+                    return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+
+                store = ContinuityStore(conn)
+                provider, capability = _register_workspace_provider(
                     settings=settings,
-                )
-                capability = store.upsert_provider_capability(
+                    store=store,
                     workspace_id=workspace["id"],
-                    provider_id=provider["id"],
-                    discovered_by_user_account_id=resolution["user_account"]["id"],
-                    adapter_key=adapter.adapter_key,
-                    discovery_status="ready",
-                    capability_snapshot=capability_snapshot,
-                    discovery_error=None,
+                    created_by_user_account_id=resolution["user_account"]["id"],
+                    provider_key=OLLAMA_ADAPTER_KEY,
+                    display_name=body.display_name,
+                    base_url=body.base_url,
+                    api_key=body.api_key or "",
+                    auth_mode=body.auth_mode,
+                    default_model=body.default_model,
+                    model_list_path=body.model_list_path,
+                    healthcheck_path=body.healthcheck_path,
+                    invoke_path=body.invoke_path,
+                    metadata=body.metadata,
+                )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except psycopg.errors.UniqueViolation:
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "provider display_name must be unique within the workspace"},
+        )
+    except ProviderAdapterNotFoundError as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
+    except ProviderSecretManagerError as exc:
+        return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=201,
+        content=jsonable_encoder(
+            {
+                "provider": _serialize_model_provider(provider),
+                "capabilities": _serialize_provider_capability(capability),
+            }
+        ),
+    )
+
+
+@app.post("/v1/providers/llamacpp/register")
+def register_v1_llamacpp_provider(
+    request: Request,
+    body: RegisterLlamaCppProviderRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                workspace = get_current_workspace(
+                    conn,
+                    user_account_id=resolution["user_account"]["id"],
+                    preferred_workspace_id=resolution["session"]["workspace_id"],
+                )
+                if workspace is None:
+                    return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+
+                store = ContinuityStore(conn)
+                provider, capability = _register_workspace_provider(
+                    settings=settings,
+                    store=store,
+                    workspace_id=workspace["id"],
+                    created_by_user_account_id=resolution["user_account"]["id"],
+                    provider_key=LLAMACPP_ADAPTER_KEY,
+                    display_name=body.display_name,
+                    base_url=body.base_url,
+                    api_key=body.api_key or "",
+                    auth_mode=body.auth_mode,
+                    default_model=body.default_model,
+                    model_list_path=body.model_list_path,
+                    healthcheck_path=body.healthcheck_path,
+                    invoke_path=body.invoke_path,
+                    metadata=body.metadata,
                 )
     except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
         return JSONResponse(status_code=401, content={"detail": str(exc)})
@@ -6176,10 +6454,37 @@ def test_v1_provider(request: Request, body: TestProviderRequest) -> JSONRespons
                 if model_name == "":
                     raise ValueError("model is required")
 
-                capability_snapshot = adapter.discover_capabilities(
-                    config=runtime_provider,
-                    settings=settings,
-                )
+                try:
+                    capability_snapshot = adapter.discover_capabilities(
+                        config=runtime_provider,
+                        settings=settings,
+                    )
+                except ModelInvocationError as exc:
+                    capability = store.upsert_provider_capability(
+                        workspace_id=workspace["id"],
+                        provider_id=runtime_provider.provider_id,
+                        discovered_by_user_account_id=resolution["user_account"]["id"],
+                        adapter_key=adapter.adapter_key,
+                        discovery_status="failed",
+                        capability_snapshot=_fallback_provider_capability_snapshot(
+                            adapter_key=adapter.adapter_key,
+                            runtime_provider=adapter.runtime_provider,
+                            model_list_path=runtime_provider.model_list_path,
+                            healthcheck_path=runtime_provider.healthcheck_path,
+                            invoke_path=runtime_provider.invoke_path,
+                        ),
+                        discovery_error=str(exc),
+                    )
+                    return JSONResponse(
+                        status_code=502,
+                        content=jsonable_encoder(
+                            {
+                                "detail": str(exc),
+                                "provider": _serialize_model_provider(provider),
+                                "capabilities": _serialize_provider_capability(capability),
+                            }
+                        ),
+                    )
                 model_request = build_provider_test_model_request(
                     runtime_provider=runtime_provider.model_provider,
                     model=model_name,

--- a/apps/api/src/alicebot_api/provider_runtime.py
+++ b/apps/api/src/alicebot_api/provider_runtime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 import json
-from typing import Protocol, TypedDict
+from typing import NotRequired, Protocol, TypedDict
 from uuid import UUID
 
 from alicebot_api.config import Settings
@@ -11,6 +11,15 @@ from alicebot_api.contracts import (
     ModelInvocationResponse,
     PromptAssemblyResult,
     PromptSection,
+)
+from alicebot_api.local_provider_helpers import (
+    build_auth_headers,
+    parse_llamacpp_invoke_response,
+    parse_llamacpp_models,
+    parse_ollama_invoke_response,
+    parse_ollama_models,
+    prompt_sections_to_messages,
+    request_json,
 )
 from alicebot_api.response_generation import (
     ModelInvocationError,
@@ -21,6 +30,8 @@ from alicebot_api.provider_secrets import resolve_provider_api_key
 from alicebot_api.store import JsonObject
 
 OPENAI_COMPATIBLE_ADAPTER_KEY = "openai_compatible"
+OLLAMA_ADAPTER_KEY = "ollama"
+LLAMACPP_ADAPTER_KEY = "llamacpp"
 OPENAI_RESPONSES_PROVIDER = "openai_responses"
 PROVIDER_CAPABILITY_VERSION_V1 = "provider_capability_v1"
 
@@ -44,6 +55,12 @@ class ProviderCapabilitySnapshot(TypedDict):
     supports_store: bool
     supports_vision_input: bool
     supports_audio_input: bool
+    health_status: NotRequired[str]
+    health_endpoint: NotRequired[str]
+    models_endpoint: NotRequired[str]
+    invoke_endpoint: NotRequired[str]
+    model_count: NotRequired[int]
+    models: NotRequired[list[str]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,8 +73,12 @@ class RuntimeProviderConfig:
     model_provider: str
     base_url: str
     api_key: str
+    auth_mode: str
     default_model: str
     status: str
+    model_list_path: str
+    healthcheck_path: str
+    invoke_path: str
     metadata: JsonObject
 
     @classmethod
@@ -71,8 +92,12 @@ class RuntimeProviderConfig:
             model_provider=str(row["model_provider"]),
             base_url=str(row["base_url"]),
             api_key=str(row["api_key"]),
+            auth_mode=str(row.get("auth_mode", "bearer")),
             default_model=str(row["default_model"]),
             status=str(row["status"]),
+            model_list_path=str(row.get("model_list_path", "")),
+            healthcheck_path=str(row.get("healthcheck_path", "")),
+            invoke_path=str(row.get("invoke_path", "")),
             metadata=row["metadata"],  # type: ignore[assignment]
         )
 
@@ -185,9 +210,165 @@ class OpenAICompatibleAdapter:
         )
 
 
+class OllamaAdapter:
+    adapter_key = OLLAMA_ADAPTER_KEY
+    runtime_provider = OPENAI_RESPONSES_PROVIDER
+    default_healthcheck_path = "/api/version"
+    default_model_list_path = "/api/tags"
+    default_invoke_path = "/api/chat"
+
+    def discover_capabilities(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderCapabilitySnapshot:
+        headers = build_auth_headers(auth_mode=config.auth_mode, api_key=config.api_key)
+        healthcheck_path = config.healthcheck_path or self.default_healthcheck_path
+        model_list_path = config.model_list_path or self.default_model_list_path
+        request_json(
+            method="GET",
+            base_url=config.base_url,
+            path=healthcheck_path,
+            timeout_seconds=settings.healthcheck_timeout_seconds,
+            headers=headers,
+        )
+        model_payload = request_json(
+            method="GET",
+            base_url=config.base_url,
+            path=model_list_path,
+            timeout_seconds=settings.healthcheck_timeout_seconds,
+            headers=headers,
+        )
+        models = parse_ollama_models(model_payload)
+        snapshot = normalized_capability_snapshot(
+            adapter_key=self.adapter_key,
+            runtime_provider=self.runtime_provider,
+            supports_tool_calls=False,
+            supports_streaming=False,
+            supports_store=False,
+            supports_vision_input=False,
+            supports_audio_input=False,
+        )
+        snapshot.update(
+            {
+                "health_status": "ok",
+                "health_endpoint": healthcheck_path,
+                "models_endpoint": model_list_path,
+                "invoke_endpoint": config.invoke_path or self.default_invoke_path,
+                "model_count": len(models),
+                "models": models,
+            }
+        )
+        return snapshot
+
+    def invoke(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+        request: ModelInvocationRequest,
+    ) -> ModelInvocationResponse:
+        if request.provider != self.runtime_provider:
+            raise ModelInvocationError(f"unsupported model provider: {request.provider}")
+        headers = build_auth_headers(auth_mode=config.auth_mode, api_key=config.api_key)
+        payload = request_json(
+            method="POST",
+            base_url=config.base_url,
+            path=config.invoke_path or self.default_invoke_path,
+            timeout_seconds=settings.model_timeout_seconds,
+            headers=headers,
+            payload={
+                "model": request.model,
+                "stream": False,
+                "messages": prompt_sections_to_messages(request),
+            },
+        )
+        return parse_ollama_invoke_response(request=request, payload=payload)
+
+
+class LlamaCppAdapter:
+    adapter_key = LLAMACPP_ADAPTER_KEY
+    runtime_provider = OPENAI_RESPONSES_PROVIDER
+    default_healthcheck_path = "/health"
+    default_model_list_path = "/v1/models"
+    default_invoke_path = "/v1/chat/completions"
+
+    def discover_capabilities(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderCapabilitySnapshot:
+        headers = build_auth_headers(auth_mode=config.auth_mode, api_key=config.api_key)
+        healthcheck_path = config.healthcheck_path or self.default_healthcheck_path
+        model_list_path = config.model_list_path or self.default_model_list_path
+        request_json(
+            method="GET",
+            base_url=config.base_url,
+            path=healthcheck_path,
+            timeout_seconds=settings.healthcheck_timeout_seconds,
+            headers=headers,
+        )
+        model_payload = request_json(
+            method="GET",
+            base_url=config.base_url,
+            path=model_list_path,
+            timeout_seconds=settings.healthcheck_timeout_seconds,
+            headers=headers,
+        )
+        models = parse_llamacpp_models(model_payload)
+        snapshot = normalized_capability_snapshot(
+            adapter_key=self.adapter_key,
+            runtime_provider=self.runtime_provider,
+            supports_tool_calls=False,
+            supports_streaming=False,
+            supports_store=False,
+            supports_vision_input=False,
+            supports_audio_input=False,
+        )
+        snapshot.update(
+            {
+                "health_status": "ok",
+                "health_endpoint": healthcheck_path,
+                "models_endpoint": model_list_path,
+                "invoke_endpoint": config.invoke_path or self.default_invoke_path,
+                "model_count": len(models),
+                "models": models,
+            }
+        )
+        return snapshot
+
+    def invoke(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+        request: ModelInvocationRequest,
+    ) -> ModelInvocationResponse:
+        if request.provider != self.runtime_provider:
+            raise ModelInvocationError(f"unsupported model provider: {request.provider}")
+        headers = build_auth_headers(auth_mode=config.auth_mode, api_key=config.api_key)
+        payload = request_json(
+            method="POST",
+            base_url=config.base_url,
+            path=config.invoke_path or self.default_invoke_path,
+            timeout_seconds=settings.model_timeout_seconds,
+            headers=headers,
+            payload={
+                "model": request.model,
+                "stream": False,
+                "messages": prompt_sections_to_messages(request),
+            },
+        )
+        return parse_llamacpp_invoke_response(request=request, payload=payload)
+
+
 def make_provider_adapter_registry() -> ProviderAdapterRegistry:
     registry = ProviderAdapterRegistry()
     registry.register(OpenAICompatibleAdapter())
+    registry.register(OllamaAdapter())
+    registry.register(LlamaCppAdapter())
     return registry
 
 

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -348,8 +348,12 @@ class ModelProviderRow(TypedDict):
     display_name: str
     base_url: str
     api_key: str
+    auth_mode: str
     default_model: str
     status: str
+    model_list_path: str
+    healthcheck_path: str
+    invoke_path: str
     metadata: JsonObject
     created_at: datetime
     updated_at: datetime
@@ -2056,13 +2060,34 @@ INSERT_MODEL_PROVIDER_SQL = """
                   display_name,
                   base_url,
                   api_key,
+                  auth_mode,
                   default_model,
                   status,
+                  model_list_path,
+                  healthcheck_path,
+                  invoke_path,
                   metadata,
                   created_at,
                   updated_at
                 )
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, clock_timestamp(), clock_timestamp())
+                VALUES (
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  clock_timestamp(),
+                  clock_timestamp()
+                )
                 RETURNING
                   id,
                   workspace_id,
@@ -2072,8 +2097,12 @@ INSERT_MODEL_PROVIDER_SQL = """
                   display_name,
                   base_url,
                   api_key,
+                  auth_mode,
                   default_model,
                   status,
+                  model_list_path,
+                  healthcheck_path,
+                  invoke_path,
                   metadata,
                   created_at,
                   updated_at
@@ -2089,8 +2118,12 @@ GET_MODEL_PROVIDER_FOR_WORKSPACE_SQL = """
                   display_name,
                   base_url,
                   api_key,
+                  auth_mode,
                   default_model,
                   status,
+                  model_list_path,
+                  healthcheck_path,
+                  invoke_path,
                   metadata,
                   created_at,
                   updated_at
@@ -2109,8 +2142,12 @@ LIST_MODEL_PROVIDERS_FOR_WORKSPACE_SQL = """
                   display_name,
                   base_url,
                   api_key,
+                  auth_mode,
                   default_model,
                   status,
+                  model_list_path,
+                  healthcheck_path,
+                  invoke_path,
                   metadata,
                   created_at,
                   updated_at
@@ -5958,6 +5995,10 @@ class ContinuityStore:
         default_model: str,
         status: str,
         metadata: JsonObject,
+        auth_mode: str = "bearer",
+        model_list_path: str = "",
+        healthcheck_path: str = "",
+        invoke_path: str = "",
     ) -> ModelProviderRow:
         return self._fetch_one(
             "create_model_provider",
@@ -5970,8 +6011,12 @@ class ContinuityStore:
                 display_name,
                 base_url,
                 api_key,
+                auth_mode,
                 default_model,
                 status,
+                model_list_path,
+                healthcheck_path,
+                invoke_path,
                 Jsonb(metadata),
             ),
         )

--- a/docs/integrations/phase11-local-provider-adapters.md
+++ b/docs/integrations/phase11-local-provider-adapters.md
@@ -1,0 +1,103 @@
+# Phase 11 Local Provider Adapters (P11-S2)
+
+This guide covers the sprint-owned local provider paths:
+
+- `POST /v1/providers/ollama/register`
+- `POST /v1/providers/llamacpp/register`
+- `POST /v1/providers/test`
+- `POST /v1/runtime/invoke`
+- `GET /v1/providers`
+- `GET /v1/providers/{provider_id}`
+
+Scope note: this page documents Ollama and llama.cpp only.
+
+## Prerequisites
+
+1. Start Alice API and data services.
+2. Authenticate and obtain a hosted session bearer token.
+3. Have a thread ID available for runtime invoke.
+4. Run at least one local model backend:
+   - Ollama server (default `http://127.0.0.1:11434`)
+   - llama.cpp server (default `http://127.0.0.1:8080`)
+
+## Register Ollama
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers/ollama/register" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "Ollama Local",
+    "base_url": "http://127.0.0.1:11434",
+    "default_model": "llama3.2:latest"
+  }'
+```
+
+## Register llama.cpp / llama-server
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers/llamacpp/register" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "llama.cpp Local",
+    "base_url": "http://127.0.0.1:8080",
+    "default_model": "Meta-Llama-3.1-8B-Instruct"
+  }'
+```
+
+## Test Provider Connectivity
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers/test" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_id": "'"$PROVIDER_ID"'",
+    "prompt": "Reply with one sentence confirming local connectivity."
+  }'
+```
+
+Capability snapshots include deterministic local model enumeration and health posture fields:
+
+- `health_status`
+- `health_endpoint`
+- `models_endpoint`
+- `invoke_endpoint`
+- `model_count`
+- `models`
+
+## Invoke Through Normalized Runtime Seam
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/runtime/invoke" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_id": "'"$PROVIDER_ID"'",
+    "thread_id": "'"$THREAD_ID"'",
+    "message": "Summarize current runtime status in one sentence."
+  }'
+```
+
+## Runnable End-to-End Script
+
+Use the sprint helper script for a full register/test/invoke flow:
+
+```bash
+./scripts/run_phase11_local_provider_e2e.py \
+  --session-token "$SESSION_TOKEN" \
+  --thread-id "$THREAD_ID" \
+  --provider ollama \
+  --model llama3.2:latest
+```
+
+Or for llama.cpp:
+
+```bash
+./scripts/run_phase11_local_provider_e2e.py \
+  --session-token "$SESSION_TOKEN" \
+  --thread-id "$THREAD_ID" \
+  --provider llamacpp \
+  --model Meta-Llama-3.1-8B-Instruct
+```

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -18,38 +18,38 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
     ControlDocTruthRule(
         relative_path="README.md",
         required_markers=(
-            "Phase 9 is complete.",
-            "Alice Connect is the planned Phase 10 product layer",
+            "Phase 10 is complete and shipped.",
+            "`P11-S2` Ollama + llama.cpp Adapters is the active sprint",
             "Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md]",
         ),
     ),
     ControlDocTruthRule(
         relative_path="ROADMAP.md",
         required_markers=(
-            "Phase 10 is the next delivery phase: Alice Connect.",
-            "P10-S1: Identity + Workspace Bootstrap",
+            "Phase 10 is complete and shipped baseline truth.",
+            "P11-S2: Ollama + llama.cpp Adapters",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Phase 10 Sprint 1 (P10-S1): Identity + Workspace Bootstrap",
-            "Phase 9 shipped scope is baseline truth, not sprint work",
+            "Phase 11 Sprint 2 (P11-S2): Ollama + llama.cpp Adapters",
+            "Phase 10 and `P11-S1` shipped scope remain baseline truth and are not reopened as sprint work",
         ),
     ),
     ControlDocTruthRule(
         relative_path="RULES.md",
         required_markers=(
-            "Phase 10 must not fork semantics between local, CLI, MCP, and Telegram.",
-            "Do not rewrite shipped Phase 9 capabilities as future roadmap items.",
+            "Never fork continuity semantics by provider, model, or runtime.",
+            "Provider-specific quirks belong in adapters or declarative packs, not core semantics.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/handoff/CURRENT_STATE.md",
         required_markers=(
             "Phase 9 is complete and shipped.",
-            "Phase 10 planning is defined as Alice Connect.",
-            "P10-S1 (Identity + Workspace Bootstrap) is the first execution sprint packet.",
+            "Phase 10 is complete and shipped.",
+            "`P11-S2` (Ollama + llama.cpp Adapters) is the active execution sprint packet.",
         ),
     ),
     ControlDocTruthRule(

--- a/scripts/run_phase11_local_provider_e2e.py
+++ b/scripts/run_phase11_local_provider_e2e.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Run a local-provider e2e flow for P11-S2.
+
+Flow:
+1) Register local provider (Ollama or llama.cpp)
+2) Run provider test
+3) Run runtime invoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def _request_json(
+    *,
+    method: str,
+    url: str,
+    bearer_token: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = Request(
+        url=url,
+        method=method,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {bearer_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            raw_payload = response.read()
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed with HTTP {exc.code}: {error_body}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"{method} {url} failed: {exc.reason}") from exc
+
+    try:
+        parsed = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{method} {url} returned invalid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"{method} {url} returned invalid payload shape")
+    return parsed
+
+
+def _provider_defaults(provider: str) -> tuple[str, str]:
+    if provider == "ollama":
+        return ("http://127.0.0.1:11434", "/v1/providers/ollama/register")
+    return ("http://127.0.0.1:8080", "/v1/providers/llamacpp/register")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="run_phase11_local_provider_e2e.py",
+        description="Register and invoke a local provider through the P11-S2 runtime paths.",
+    )
+    parser.add_argument(
+        "--api-base-url",
+        default="http://127.0.0.1:8000",
+        help="Alice API base URL (default: http://127.0.0.1:8000).",
+    )
+    parser.add_argument(
+        "--session-token",
+        required=True,
+        help="Hosted session bearer token.",
+    )
+    parser.add_argument(
+        "--thread-id",
+        required=True,
+        help="Thread ID to use for /v1/runtime/invoke.",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=("ollama", "llamacpp"),
+        required=True,
+        help="Local provider adapter to exercise.",
+    )
+    parser.add_argument(
+        "--display-name",
+        default="Local Provider E2E",
+        help="Provider display name.",
+    )
+    parser.add_argument(
+        "--provider-base-url",
+        default=None,
+        help="Local provider base URL. Defaults to adapter standard local URL.",
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Model name to register/test/invoke.",
+    )
+    parser.add_argument(
+        "--test-prompt",
+        default="Reply with one sentence confirming connectivity.",
+        help="Prompt used for /v1/providers/test.",
+    )
+    parser.add_argument(
+        "--message",
+        default="Give a concise runtime confirmation.",
+        help="Message used for /v1/runtime/invoke.",
+    )
+    args = parser.parse_args()
+
+    default_provider_base_url, register_path = _provider_defaults(args.provider)
+    provider_base_url = (args.provider_base_url or default_provider_base_url).strip()
+
+    register_payload = {
+        "display_name": args.display_name,
+        "base_url": provider_base_url,
+        "default_model": args.model,
+        "metadata": {"source": "phase11_local_provider_e2e"},
+    }
+    register_response = _request_json(
+        method="POST",
+        url=f"{args.api_base_url.rstrip('/')}{register_path}",
+        bearer_token=args.session_token,
+        payload=register_payload,
+    )
+    provider_id = register_response["provider"]["id"]
+
+    test_response = _request_json(
+        method="POST",
+        url=f"{args.api_base_url.rstrip('/')}/v1/providers/test",
+        bearer_token=args.session_token,
+        payload={
+            "provider_id": provider_id,
+            "model": args.model,
+            "prompt": args.test_prompt,
+        },
+    )
+
+    invoke_response = _request_json(
+        method="POST",
+        url=f"{args.api_base_url.rstrip('/')}/v1/runtime/invoke",
+        bearer_token=args.session_token,
+        payload={
+            "provider_id": provider_id,
+            "thread_id": args.thread_id,
+            "message": args.message,
+            "model": args.model,
+        },
+    )
+
+    result = {
+        "provider": register_response["provider"],
+        "capabilities": register_response["capabilities"],
+        "test_result": test_response["result"],
+        "runtime_assistant": invoke_response["assistant"],
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_phase11_provider_runtime_api.py
+++ b/tests/integration/test_phase11_provider_runtime_api.py
@@ -97,7 +97,7 @@ def _bootstrap_workspace_session(email: str) -> tuple[str, str, str]:
         "/v1/auth/magic-link/verify",
         payload={
             "challenge_token": start_payload["challenge"]["challenge_token"],
-            "device_label": "P11-S1 Device",
+            "device_label": "P11-S2 Device",
             "device_key": f"device-{email}",
         },
     )
@@ -108,7 +108,7 @@ def _bootstrap_workspace_session(email: str) -> tuple[str, str, str]:
     create_workspace_status, create_workspace_payload = invoke_request(
         "POST",
         "/v1/workspaces",
-        payload={"name": "P11 Provider Workspace"},
+        payload={"name": "P11 Local Provider Workspace"},
         headers=auth_header(session_token),
     )
     assert create_workspace_status == 201
@@ -137,138 +137,37 @@ def _seed_thread_for_user(*, admin_db_url: str, user_id: str, email: str) -> str
                 SET email = EXCLUDED.email,
                     display_name = EXCLUDED.display_name
                 """,
-                (user_id, email, "Provider Runtime User"),
+                (user_id, email, "Local Provider Runtime User"),
             )
             cur.execute(
                 """
                 INSERT INTO threads (id, user_id, title)
                 VALUES (%s, %s, %s)
                 """,
-                (thread_id, user_id, "Provider Runtime Thread"),
+                (thread_id, user_id, "Local Provider Runtime Thread"),
             )
         conn.commit()
     return thread_id
 
 
-def test_phase11_provider_registration_list_and_detail(migrated_database_urls, monkeypatch) -> None:
+class FakeHTTPResponse:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+
+    def __enter__(self) -> "FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def test_phase11_local_provider_registration_list_and_detail(migrated_database_urls, monkeypatch) -> None:
     _configure_settings(migrated_database_urls, monkeypatch)
-    session_token, workspace_id, _ = _bootstrap_workspace_session("provider-reg@example.com")
-
-    create_status, create_payload = invoke_request(
-        "POST",
-        "/v1/providers",
-        payload={
-            "provider_key": "openai_compatible",
-            "display_name": "Primary OpenAI",
-            "base_url": "https://provider.example/v1",
-            "api_key": "provider-secret-key",
-            "default_model": "gpt-5-mini",
-            "metadata": {"tier": "test"},
-        },
-        headers=auth_header(session_token),
-    )
-    assert create_status == 201
-    provider_id = create_payload["provider"]["id"]
-    assert create_payload["provider"]["provider_key"] == "openai_compatible"
-    assert create_payload["provider"]["model_provider"] == "openai_responses"
-    assert create_payload["capabilities"]["discovery_status"] == "ready"
-    assert create_payload["capabilities"]["snapshot"]["runtime_provider"] == "openai_responses"
-
-    with psycopg.connect(migrated_database_urls["admin"]) as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT api_key
-                FROM model_providers
-                WHERE id = %s
-                  AND workspace_id = %s
-                """,
-                (provider_id, workspace_id),
-            )
-            stored_api_key_row = cur.fetchone()
-    assert stored_api_key_row is not None
-    assert stored_api_key_row[0] != "provider-secret-key"
-    assert stored_api_key_row[0].startswith("provider_secret_ref:")
-
-    duplicate_status, duplicate_payload = invoke_request(
-        "POST",
-        "/v1/providers",
-        payload={
-            "provider_key": "openai_compatible",
-            "display_name": "Primary OpenAI",
-            "base_url": "https://provider.example/v1",
-            "api_key": "provider-secret-key",
-            "default_model": "gpt-5-mini",
-        },
-        headers=auth_header(session_token),
-    )
-    assert duplicate_status == 409
-    assert "display_name" in duplicate_payload["detail"]
-
-    list_status, list_payload = invoke_request(
-        "GET",
-        "/v1/providers",
-        headers=auth_header(session_token),
-    )
-    assert list_status == 200
-    assert list_payload["summary"]["total_count"] == 1
-    assert list_payload["items"][0]["id"] == provider_id
-
-    detail_status, detail_payload = invoke_request(
-        "GET",
-        f"/v1/providers/{provider_id}",
-        headers=auth_header(session_token),
-    )
-    assert detail_status == 200
-    assert detail_payload["provider"]["id"] == provider_id
-    assert detail_payload["capabilities"]["provider_id"] == provider_id
-
-
-def test_phase11_provider_test_runtime_invoke_and_workspace_isolation(
-    migrated_database_urls,
-    monkeypatch,
-) -> None:
-    _configure_settings(migrated_database_urls, monkeypatch)
-    session_token_a, _, user_account_id_a = _bootstrap_workspace_session("provider-a@example.com")
-    session_token_b, _, _ = _bootstrap_workspace_session("provider-b@example.com")
-
-    create_status, create_payload = invoke_request(
-        "POST",
-        "/v1/providers",
-        payload={
-            "provider_key": "openai_compatible",
-            "display_name": "Shared Runtime",
-            "base_url": "https://provider.example/v1",
-            "api_key": "provider-secret-key",
-            "default_model": "gpt-5-mini",
-        },
-        headers=auth_header(session_token_a),
-    )
-    assert create_status == 201
-    provider_id = create_payload["provider"]["id"]
-
-    detail_other_status, detail_other_payload = invoke_request(
-        "GET",
-        f"/v1/providers/{provider_id}",
-        headers=auth_header(session_token_b),
-    )
-    assert detail_other_status == 404
-    assert "was not found" in detail_other_payload["detail"]
-
+    session_token, _, _ = _bootstrap_workspace_session("provider-local-reg@example.com")
     captured_requests: list[dict[str, object]] = []
-
-    class FakeHTTPResponse:
-        def __init__(self, body: bytes) -> None:
-            self.body = body
-
-        def __enter__(self) -> "FakeHTTPResponse":
-            return self
-
-        def __exit__(self, exc_type, exc, tb) -> None:
-            return None
-
-        def read(self) -> bytes:
-            return self.body
 
     def fake_urlopen(request, timeout):
         captured_requests.append(
@@ -276,68 +175,340 @@ def test_phase11_provider_test_runtime_invoke_and_workspace_isolation(
                 "url": request.full_url,
                 "timeout": timeout,
                 "headers": dict(request.header_items()),
-                "body": json.loads(request.data.decode("utf-8")),
+                "body": None if request.data is None else json.loads(request.data.decode("utf-8")),
             }
         )
-        return FakeHTTPResponse(
-            json.dumps(
-                {
-                    "id": f"resp_{len(captured_requests)}",
-                    "status": "completed",
-                    "output": [
-                        {
-                            "type": "message",
-                            "content": [{"type": "output_text", "text": "Provider response"}],
-                        }
-                    ],
-                    "usage": {
-                        "input_tokens": 11,
-                        "output_tokens": 5,
-                        "total_tokens": 16,
-                    },
-                }
-            ).encode("utf-8")
-        )
+        url = request.full_url
+        if url.endswith("/api/version"):
+            return FakeHTTPResponse(json.dumps({"version": "0.4.0"}).encode("utf-8"))
+        if url.endswith("/api/tags"):
+            return FakeHTTPResponse(
+                json.dumps({"models": [{"name": "llama3.2:latest"}, {"name": "qwen2.5:latest"}]}).encode("utf-8")
+            )
+        if url.endswith("/health"):
+            return FakeHTTPResponse(json.dumps({"status": "ok"}).encode("utf-8"))
+        if url.endswith("/v1/models"):
+            return FakeHTTPResponse(json.dumps({"data": [{"id": "Meta-Llama-3.1-8B-Instruct"}]}).encode("utf-8"))
+        raise AssertionError(f"unexpected local provider URL: {url}")
 
-    monkeypatch.setattr("alicebot_api.response_generation.urlopen", fake_urlopen)
+    monkeypatch.setattr("alicebot_api.local_provider_helpers.urlopen", fake_urlopen)
 
-    test_status, test_payload = invoke_request(
+    ollama_status, ollama_payload = invoke_request(
         "POST",
-        "/v1/providers/test",
+        "/v1/providers/ollama/register",
         payload={
-            "provider_id": provider_id,
-            "prompt": "Validate provider test path.",
+            "display_name": "Ollama Local",
+            "base_url": "http://127.0.0.1:11434",
+            "default_model": "llama3.2:latest",
+            "metadata": {"kind": "local"},
+        },
+        headers=auth_header(session_token),
+    )
+    assert ollama_status == 201
+    ollama_provider_id = ollama_payload["provider"]["id"]
+    assert ollama_payload["provider"]["provider_key"] == "ollama"
+    assert ollama_payload["provider"]["model_provider"] == "openai_responses"
+    assert ollama_payload["provider"]["auth_mode"] == "none"
+    assert ollama_payload["provider"]["model_list_path"] == "/api/tags"
+    assert ollama_payload["provider"]["healthcheck_path"] == "/api/version"
+    assert ollama_payload["provider"]["invoke_path"] == "/api/chat"
+    assert ollama_payload["capabilities"]["discovery_status"] == "ready"
+    assert ollama_payload["capabilities"]["snapshot"]["health_status"] == "ok"
+    assert ollama_payload["capabilities"]["snapshot"]["models"] == [
+        "llama3.2:latest",
+        "qwen2.5:latest",
+    ]
+
+    llamacpp_status, llamacpp_payload = invoke_request(
+        "POST",
+        "/v1/providers/llamacpp/register",
+        payload={
+            "display_name": "llama.cpp Local",
+            "base_url": "http://127.0.0.1:8080",
+            "default_model": "Meta-Llama-3.1-8B-Instruct",
+            "metadata": {"kind": "local"},
+        },
+        headers=auth_header(session_token),
+    )
+    assert llamacpp_status == 201
+    llamacpp_provider_id = llamacpp_payload["provider"]["id"]
+    assert llamacpp_payload["provider"]["provider_key"] == "llamacpp"
+    assert llamacpp_payload["provider"]["model_provider"] == "openai_responses"
+    assert llamacpp_payload["provider"]["auth_mode"] == "none"
+    assert llamacpp_payload["provider"]["model_list_path"] == "/v1/models"
+    assert llamacpp_payload["provider"]["healthcheck_path"] == "/health"
+    assert llamacpp_payload["provider"]["invoke_path"] == "/v1/chat/completions"
+    assert llamacpp_payload["capabilities"]["discovery_status"] == "ready"
+    assert llamacpp_payload["capabilities"]["snapshot"]["health_status"] == "ok"
+    assert llamacpp_payload["capabilities"]["snapshot"]["models"] == ["Meta-Llama-3.1-8B-Instruct"]
+
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v1/providers",
+        headers=auth_header(session_token),
+    )
+    assert list_status == 200
+    assert list_payload["summary"]["total_count"] == 2
+    listed_provider_ids = [item["id"] for item in list_payload["items"]]
+    assert listed_provider_ids == [ollama_provider_id, llamacpp_provider_id]
+
+    ollama_detail_status, ollama_detail_payload = invoke_request(
+        "GET",
+        f"/v1/providers/{ollama_provider_id}",
+        headers=auth_header(session_token),
+    )
+    assert ollama_detail_status == 200
+    assert ollama_detail_payload["provider"]["id"] == ollama_provider_id
+    assert ollama_detail_payload["capabilities"]["provider_id"] == ollama_provider_id
+
+    llamacpp_detail_status, llamacpp_detail_payload = invoke_request(
+        "GET",
+        f"/v1/providers/{llamacpp_provider_id}",
+        headers=auth_header(session_token),
+    )
+    assert llamacpp_detail_status == 200
+    assert llamacpp_detail_payload["provider"]["id"] == llamacpp_provider_id
+    assert llamacpp_detail_payload["capabilities"]["provider_id"] == llamacpp_provider_id
+
+    captured_urls = [record["url"] for record in captured_requests]
+    assert "http://127.0.0.1:11434/api/version" in captured_urls
+    assert "http://127.0.0.1:11434/api/tags" in captured_urls
+    assert "http://127.0.0.1:8080/health" in captured_urls
+    assert "http://127.0.0.1:8080/v1/models" in captured_urls
+
+
+def test_phase11_local_provider_test_runtime_invoke_and_workspace_isolation(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token_a, _, user_account_id_a = _bootstrap_workspace_session("provider-local-a@example.com")
+    session_token_b, _, _ = _bootstrap_workspace_session("provider-local-b@example.com")
+
+    captured_requests: list[dict[str, object]] = []
+
+    def fake_urlopen(request, timeout):
+        body = None if request.data is None else json.loads(request.data.decode("utf-8"))
+        captured_requests.append(
+            {
+                "url": request.full_url,
+                "timeout": timeout,
+                "headers": dict(request.header_items()),
+                "body": body,
+            }
+        )
+        url = request.full_url
+        if url.endswith("/api/version"):
+            return FakeHTTPResponse(json.dumps({"version": "0.4.0"}).encode("utf-8"))
+        if url.endswith("/api/tags"):
+            return FakeHTTPResponse(json.dumps({"models": [{"name": "llama3.2:latest"}]}).encode("utf-8"))
+        if url.endswith("/api/chat"):
+            return FakeHTTPResponse(
+                json.dumps(
+                    {
+                        "model": "llama3.2:latest",
+                        "done": True,
+                        "message": {"role": "assistant", "content": "Ollama runtime response"},
+                        "prompt_eval_count": 12,
+                        "eval_count": 5,
+                    }
+                ).encode("utf-8")
+            )
+        if url.endswith("/health"):
+            return FakeHTTPResponse(json.dumps({"status": "ok"}).encode("utf-8"))
+        if url.endswith("/v1/models"):
+            return FakeHTTPResponse(json.dumps({"data": [{"id": "Meta-Llama-3.1-8B-Instruct"}]}).encode("utf-8"))
+        if url.endswith("/v1/chat/completions"):
+            return FakeHTTPResponse(
+                json.dumps(
+                    {
+                        "id": "chatcmpl-local-2",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": "llama.cpp runtime response"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {
+                            "prompt_tokens": 13,
+                            "completion_tokens": 4,
+                            "total_tokens": 17,
+                        },
+                    }
+                ).encode("utf-8")
+            )
+        raise AssertionError(f"unexpected local provider URL: {url}")
+
+    monkeypatch.setattr("alicebot_api.local_provider_helpers.urlopen", fake_urlopen)
+
+    create_ollama_status, create_ollama_payload = invoke_request(
+        "POST",
+        "/v1/providers/ollama/register",
+        payload={
+            "display_name": "Ollama Runtime",
+            "base_url": "http://127.0.0.1:11434",
+            "default_model": "llama3.2:latest",
         },
         headers=auth_header(session_token_a),
     )
-    assert test_status == 200
-    assert test_payload["result"]["text"] == "Provider response"
-    assert test_payload["result"]["usage"]["total_tokens"] == 16
-    assert captured_requests[0]["url"] == "https://provider.example/v1/responses"
-    assert captured_requests[0]["headers"]["Authorization"] == "Bearer provider-secret-key"
+    assert create_ollama_status == 201
+    ollama_provider_id = create_ollama_payload["provider"]["id"]
+
+    create_llamacpp_status, create_llamacpp_payload = invoke_request(
+        "POST",
+        "/v1/providers/llamacpp/register",
+        payload={
+            "display_name": "llama.cpp Runtime",
+            "base_url": "http://127.0.0.1:8080",
+            "default_model": "Meta-Llama-3.1-8B-Instruct",
+        },
+        headers=auth_header(session_token_a),
+    )
+    assert create_llamacpp_status == 201
+    llamacpp_provider_id = create_llamacpp_payload["provider"]["id"]
+
+    detail_other_status, detail_other_payload = invoke_request(
+        "GET",
+        f"/v1/providers/{ollama_provider_id}",
+        headers=auth_header(session_token_b),
+    )
+    assert detail_other_status == 404
+    assert "was not found" in detail_other_payload["detail"]
 
     thread_id = _seed_thread_for_user(
         admin_db_url=migrated_database_urls["admin"],
         user_id=user_account_id_a,
-        email="provider-a@example.com",
+        email="provider-local-a@example.com",
     )
 
-    runtime_status, runtime_payload = invoke_request(
+    ollama_test_status, ollama_test_payload = invoke_request(
         "POST",
-        "/v1/runtime/invoke",
+        "/v1/providers/test",
         payload={
-            "provider_id": provider_id,
-            "thread_id": thread_id,
-            "message": "What is the runtime status?",
+            "provider_id": ollama_provider_id,
+            "prompt": "Validate local ollama path.",
         },
         headers=auth_header(session_token_a),
     )
-    assert runtime_status == 200
-    assert runtime_payload["assistant"]["provider_id"] == provider_id
-    assert runtime_payload["assistant"]["provider_key"] == "openai_compatible"
-    assert runtime_payload["assistant"]["model_provider"] == "openai_responses"
-    assert runtime_payload["assistant"]["text"] == "Provider response"
-    assert runtime_payload["assistant"]["usage"]["total_tokens"] == 16
-    assert captured_requests[1]["url"] == "https://provider.example/v1/responses"
-    assert captured_requests[1]["headers"]["Authorization"] == "Bearer provider-secret-key"
-    assert UUID(runtime_payload["assistant"]["event_id"])
+    assert ollama_test_status == 200
+    assert ollama_test_payload["result"]["text"] == "Ollama runtime response"
+    assert ollama_test_payload["result"]["usage"]["total_tokens"] == 17
+
+    ollama_runtime_status, ollama_runtime_payload = invoke_request(
+        "POST",
+        "/v1/runtime/invoke",
+        payload={
+            "provider_id": ollama_provider_id,
+            "thread_id": thread_id,
+            "message": "How is ollama runtime?",
+        },
+        headers=auth_header(session_token_a),
+    )
+    assert ollama_runtime_status == 200
+    assert ollama_runtime_payload["assistant"]["provider_id"] == ollama_provider_id
+    assert ollama_runtime_payload["assistant"]["provider_key"] == "ollama"
+    assert ollama_runtime_payload["assistant"]["model_provider"] == "openai_responses"
+    assert ollama_runtime_payload["assistant"]["text"] == "Ollama runtime response"
+    assert ollama_runtime_payload["assistant"]["usage"]["total_tokens"] == 17
+    assert UUID(ollama_runtime_payload["assistant"]["event_id"])
+
+    llamacpp_test_status, llamacpp_test_payload = invoke_request(
+        "POST",
+        "/v1/providers/test",
+        payload={
+            "provider_id": llamacpp_provider_id,
+            "prompt": "Validate local llamacpp path.",
+        },
+        headers=auth_header(session_token_a),
+    )
+    assert llamacpp_test_status == 200
+    assert llamacpp_test_payload["result"]["text"] == "llama.cpp runtime response"
+    assert llamacpp_test_payload["result"]["usage"]["total_tokens"] == 17
+
+    llamacpp_runtime_status, llamacpp_runtime_payload = invoke_request(
+        "POST",
+        "/v1/runtime/invoke",
+        payload={
+            "provider_id": llamacpp_provider_id,
+            "thread_id": thread_id,
+            "message": "How is llamacpp runtime?",
+        },
+        headers=auth_header(session_token_a),
+    )
+    assert llamacpp_runtime_status == 200
+    assert llamacpp_runtime_payload["assistant"]["provider_id"] == llamacpp_provider_id
+    assert llamacpp_runtime_payload["assistant"]["provider_key"] == "llamacpp"
+    assert llamacpp_runtime_payload["assistant"]["model_provider"] == "openai_responses"
+    assert llamacpp_runtime_payload["assistant"]["text"] == "llama.cpp runtime response"
+    assert llamacpp_runtime_payload["assistant"]["usage"]["total_tokens"] == 17
+    assert UUID(llamacpp_runtime_payload["assistant"]["event_id"])
+
+    captured_urls = [record["url"] for record in captured_requests]
+    assert "http://127.0.0.1:11434/api/chat" in captured_urls
+    assert "http://127.0.0.1:8080/v1/chat/completions" in captured_urls
+
+
+def test_phase11_openai_compatible_registration_still_works(migrated_database_urls, monkeypatch) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, workspace_id, _ = _bootstrap_workspace_session("provider-openai-reg@example.com")
+
+    create_status, create_payload = invoke_request(
+        "POST",
+        "/v1/providers",
+        payload={
+            "provider_key": "openai_compatible",
+            "display_name": "Primary OpenAI",
+            "base_url": "https://provider.example/v1",
+            "api_key": "provider-secret-key",
+            "default_model": "gpt-5-mini",
+        },
+        headers=auth_header(session_token),
+    )
+    assert create_status == 201
+    provider_id = create_payload["provider"]["id"]
+    assert create_payload["provider"]["provider_key"] == "openai_compatible"
+    assert create_payload["provider"]["auth_mode"] == "bearer"
+    assert create_payload["capabilities"]["discovery_status"] == "ready"
+    assert create_payload["capabilities"]["snapshot"]["runtime_provider"] == "openai_responses"
+
+    with psycopg.connect(migrated_database_urls["admin"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT api_key, auth_mode
+                FROM model_providers
+                WHERE id = %s
+                  AND workspace_id = %s
+                """,
+                (provider_id, workspace_id),
+            )
+            stored_row = cur.fetchone()
+    assert stored_row is not None
+    stored_api_key, stored_auth_mode = stored_row
+    assert stored_auth_mode == "bearer"
+    assert stored_api_key != "provider-secret-key"
+    assert stored_api_key.startswith("provider_secret_ref:")
+
+
+def test_phase11_local_provider_rejects_api_key_when_auth_mode_none(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, _, _ = _bootstrap_workspace_session("provider-local-authmode-none@example.com")
+
+    status, payload = invoke_request(
+        "POST",
+        "/v1/providers/ollama/register",
+        payload={
+            "display_name": "Ollama Invalid Auth",
+            "base_url": "http://127.0.0.1:11434",
+            "auth_mode": "none",
+            "api_key": "should-not-be-stored",
+            "default_model": "llama3.2:latest",
+        },
+        headers=auth_header(session_token),
+    )
+    assert status == 400
+    assert payload["detail"] == "api_key must be empty when auth_mode is none"

--- a/tests/unit/test_20260411_0053_phase11_local_provider_config_fields.py
+++ b/tests/unit/test_20260411_0053_phase11_local_provider_config_fields.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260411_0053_phase11_local_provider_config_fields"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == list(module._UPGRADE_STATEMENTS)
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)

--- a/tests/unit/test_provider_runtime.py
+++ b/tests/unit/test_provider_runtime.py
@@ -5,6 +5,8 @@ from uuid import uuid4
 
 from apps.api.src.alicebot_api.config import Settings
 from alicebot_api.provider_runtime import (
+    LLAMACPP_ADAPTER_KEY,
+    OLLAMA_ADAPTER_KEY,
     OPENAI_COMPATIBLE_ADAPTER_KEY,
     OPENAI_RESPONSES_PROVIDER,
     ProviderAdapterNotFoundError,
@@ -28,18 +30,31 @@ class FakeHTTPResponse:
         return self.body
 
 
-def make_runtime_provider_config() -> RuntimeProviderConfig:
+def make_runtime_provider_config(
+    *,
+    provider_key: str = OPENAI_COMPATIBLE_ADAPTER_KEY,
+    base_url: str = "https://provider.example/v1",
+    api_key: str = "provider-secret-key",
+    auth_mode: str = "bearer",
+    model_list_path: str = "/models",
+    healthcheck_path: str = "/models",
+    invoke_path: str = "/responses",
+) -> RuntimeProviderConfig:
     return RuntimeProviderConfig(
         provider_id=uuid4(),
         workspace_id=uuid4(),
         created_by_user_account_id=uuid4(),
-        provider_key=OPENAI_COMPATIBLE_ADAPTER_KEY,
+        provider_key=provider_key,
         display_name="Primary Provider",
         model_provider=OPENAI_RESPONSES_PROVIDER,
-        base_url="https://provider.example/v1",
-        api_key="provider-secret-key",
+        base_url=base_url,
+        api_key=api_key,
+        auth_mode=auth_mode,
         default_model="gpt-5-mini",
         status="active",
+        model_list_path=model_list_path,
+        healthcheck_path=healthcheck_path,
+        invoke_path=invoke_path,
         metadata={},
     )
 
@@ -48,10 +63,18 @@ def test_provider_registry_resolves_registered_adapter() -> None:
     registry = make_provider_adapter_registry()
 
     adapter = registry.resolve(OPENAI_COMPATIBLE_ADAPTER_KEY)
+    ollama_adapter = registry.resolve(OLLAMA_ADAPTER_KEY)
+    llamacpp_adapter = registry.resolve(LLAMACPP_ADAPTER_KEY)
 
     assert adapter.adapter_key == OPENAI_COMPATIBLE_ADAPTER_KEY
     assert adapter.runtime_provider == OPENAI_RESPONSES_PROVIDER
-    assert registry.keys() == [OPENAI_COMPATIBLE_ADAPTER_KEY]
+    assert ollama_adapter.adapter_key == OLLAMA_ADAPTER_KEY
+    assert llamacpp_adapter.adapter_key == LLAMACPP_ADAPTER_KEY
+    assert registry.keys() == [
+        LLAMACPP_ADAPTER_KEY,
+        OLLAMA_ADAPTER_KEY,
+        OPENAI_COMPATIBLE_ADAPTER_KEY,
+    ]
 
 
 def test_provider_registry_rejects_unknown_adapter() -> None:
@@ -133,3 +156,158 @@ def test_openai_compatible_adapter_invokes_registered_transport(monkeypatch) -> 
     assert response.provider == OPENAI_RESPONSES_PROVIDER
     assert response.model == "gpt-5-mini"
     assert response.output_text == "Provider online"
+
+
+def test_ollama_adapter_discovers_capabilities_and_invokes(monkeypatch) -> None:
+    captured: list[dict[str, object]] = []
+    registry = make_provider_adapter_registry()
+    adapter = registry.resolve(OLLAMA_ADAPTER_KEY)
+    runtime_provider = make_runtime_provider_config(
+        provider_key=OLLAMA_ADAPTER_KEY,
+        base_url="http://127.0.0.1:11434",
+        api_key="",
+        auth_mode="none",
+        model_list_path="/api/tags",
+        healthcheck_path="/api/version",
+        invoke_path="/api/chat",
+    )
+
+    def fake_urlopen(request, timeout):
+        body = None if request.data is None else json.loads(request.data.decode("utf-8"))
+        captured.append(
+            {
+                "url": request.full_url,
+                "timeout": timeout,
+                "headers": dict(request.header_items()),
+                "body": body,
+            }
+        )
+        if request.full_url.endswith("/api/version"):
+            return FakeHTTPResponse(json.dumps({"version": "0.4.0"}).encode("utf-8"))
+        if request.full_url.endswith("/api/tags"):
+            return FakeHTTPResponse(
+                json.dumps(
+                    {
+                        "models": [
+                            {"name": "llama3.2:latest"},
+                            {"name": "qwen2.5:latest"},
+                        ]
+                    }
+                ).encode("utf-8")
+            )
+        return FakeHTTPResponse(
+            json.dumps(
+                {
+                    "model": "llama3.2:latest",
+                    "done": True,
+                    "message": {"role": "assistant", "content": "Local Ollama reply"},
+                    "prompt_eval_count": 20,
+                    "eval_count": 6,
+                }
+            ).encode("utf-8")
+        )
+
+    monkeypatch.setattr("alicebot_api.local_provider_helpers.urlopen", fake_urlopen)
+
+    capabilities = adapter.discover_capabilities(
+        config=runtime_provider,
+        settings=Settings(healthcheck_timeout_seconds=5),
+    )
+    response = adapter.invoke(
+        config=runtime_provider,
+        settings=Settings(model_timeout_seconds=11),
+        request=build_provider_test_model_request(
+            runtime_provider=OPENAI_RESPONSES_PROVIDER,
+            model="llama3.2:latest",
+            prompt_text="Reply from local ollama",
+        ),
+    )
+
+    assert capabilities["adapter_key"] == OLLAMA_ADAPTER_KEY
+    assert capabilities["health_status"] == "ok"
+    assert capabilities["model_count"] == 2
+    assert capabilities["models"] == ["llama3.2:latest", "qwen2.5:latest"]
+    assert response.output_text == "Local Ollama reply"
+    assert response.usage["input_tokens"] == 20
+    assert response.usage["output_tokens"] == 6
+    assert captured[0]["url"] == "http://127.0.0.1:11434/api/version"
+    assert captured[1]["url"] == "http://127.0.0.1:11434/api/tags"
+    assert captured[2]["url"] == "http://127.0.0.1:11434/api/chat"
+
+
+def test_llamacpp_adapter_discovers_capabilities_and_invokes(monkeypatch) -> None:
+    captured: list[dict[str, object]] = []
+    registry = make_provider_adapter_registry()
+    adapter = registry.resolve(LLAMACPP_ADAPTER_KEY)
+    runtime_provider = make_runtime_provider_config(
+        provider_key=LLAMACPP_ADAPTER_KEY,
+        base_url="http://127.0.0.1:8080",
+        api_key="",
+        auth_mode="none",
+        model_list_path="/v1/models",
+        healthcheck_path="/health",
+        invoke_path="/v1/chat/completions",
+    )
+
+    def fake_urlopen(request, timeout):
+        body = None if request.data is None else json.loads(request.data.decode("utf-8"))
+        captured.append(
+            {
+                "url": request.full_url,
+                "timeout": timeout,
+                "headers": dict(request.header_items()),
+                "body": body,
+            }
+        )
+        if request.full_url.endswith("/health"):
+            return FakeHTTPResponse(json.dumps({"status": "ok"}).encode("utf-8"))
+        if request.full_url.endswith("/v1/models"):
+            return FakeHTTPResponse(
+                json.dumps({"data": [{"id": "Llama-3.2-3B-Instruct-Q4_K_M"}]}).encode("utf-8")
+            )
+        return FakeHTTPResponse(
+            json.dumps(
+                {
+                    "id": "chatcmpl-local-1",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "llama.cpp says hi"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 18,
+                        "completion_tokens": 4,
+                        "total_tokens": 22,
+                    },
+                }
+            ).encode("utf-8")
+        )
+
+    monkeypatch.setattr("alicebot_api.local_provider_helpers.urlopen", fake_urlopen)
+
+    capabilities = adapter.discover_capabilities(
+        config=runtime_provider,
+        settings=Settings(healthcheck_timeout_seconds=5),
+    )
+    response = adapter.invoke(
+        config=runtime_provider,
+        settings=Settings(model_timeout_seconds=11),
+        request=build_provider_test_model_request(
+            runtime_provider=OPENAI_RESPONSES_PROVIDER,
+            model="Llama-3.2-3B-Instruct-Q4_K_M",
+            prompt_text="Reply from local llamacpp",
+        ),
+    )
+
+    assert capabilities["adapter_key"] == LLAMACPP_ADAPTER_KEY
+    assert capabilities["health_status"] == "ok"
+    assert capabilities["model_count"] == 1
+    assert capabilities["models"] == ["Llama-3.2-3B-Instruct-Q4_K_M"]
+    assert response.output_text == "llama.cpp says hi"
+    assert response.response_id == "chatcmpl-local-1"
+    assert response.usage["total_tokens"] == 22
+    assert captured[0]["url"] == "http://127.0.0.1:8080/health"
+    assert captured[1]["url"] == "http://127.0.0.1:8080/v1/models"
+    assert captured[2]["url"] == "http://127.0.0.1:8080/v1/chat/completions"


### PR DESCRIPTION
## Summary
This PR delivers Phase 11 Sprint 2 by adding Ollama and llama.cpp local-provider support on top of the shipped provider abstraction from `P11-S1`.

## What changed
- adds local provider transport helpers plus Ollama and llama.cpp adapter implementations behind the existing provider registry
- adds local-provider registration flows for `POST /v1/providers/ollama/register` and `POST /v1/providers/llamacpp/register`
- keeps `POST /v1/providers/test`, `POST /v1/runtime/invoke`, `GET /v1/providers`, and `GET /v1/providers/{provider_id}` working through the shipped normalized runtime seam
- adds additive provider config and capability snapshot fields for local model enumeration, healthchecks, and invoke path wiring
- adds local setup docs and a runnable end-to-end helper script for local builder paths
- updates build/review evidence and control-doc truth checks to match the committed `P11-S2` payload

## Verification
- `python3 scripts/check_control_doc_truth.py`
  - PASS
- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
  - PASS (`1118 passed in 183.14s`)
- `pnpm --dir apps/web test`
  - PASS (`62 passed` files, `199 passed` tests)
- `./.venv/bin/python -m pytest tests/unit/test_provider_runtime.py tests/unit/test_20260411_0053_phase11_local_provider_config_fields.py tests/integration/test_phase11_provider_runtime_api.py -q`
  - PASS (`12 passed in 2.50s`)

## Merge Scope Notes
- `ARCHITECTURE.md` and `PRODUCT_BRIEF.md` remain locally dirty and are explicitly excluded from this sprint merge scope.