### PR TITLE
P11-S4: tier-1 model packs

### DIFF
--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,63 +1,69 @@
 # BUILD_REPORT
 
 ## sprint objective
-Implement Phase 11 Sprint 2 (`P11-S2`) local-provider support by shipping Ollama and llama.cpp adapters behind the existing provider abstraction, including registration, model enumeration + health posture snapshots, and normalized runtime invoke through existing `v1` seams.
+Implement Phase 11 Sprint 4 (`P11-S4`) Model Packs Tier 1 by adding a declarative model-pack layer with tier-1 packs (`llama`, `qwen`, `gemma`, `gpt-oss`), pack catalog/versioning APIs, workspace binding APIs, and pack-driven runtime shaping on the existing `POST /v1/runtime/invoke` seam.
 
 ## completed work
-- Added local provider transport helpers in `apps/api/src/alicebot_api/local_provider_helpers.py`:
-  - auth header handling (`bearer`/`none`)
-  - deterministic JSON request helper
-  - Ollama/llama.cpp model enumeration parsers
-  - Ollama/llama.cpp invoke response normalization
-- Extended provider runtime adapters in `apps/api/src/alicebot_api/provider_runtime.py`:
-  - added `ollama` and `llamacpp` adapter keys and implementations
-  - registered both adapters in the existing provider registry
-  - added deterministic capability snapshot fields for local health/model posture
-  - preserved normalized runtime provider seam (`openai_responses`)
-- Added additive model provider config fields in persistence:
-  - migration `apps/api/alembic/versions/20260411_0053_phase11_local_provider_config_fields.py`
-  - store/runtime wiring for `auth_mode`, `model_list_path`, `healthcheck_path`, `invoke_path`
-- Updated API contract and serialization surfaces:
-  - `apps/api/src/alicebot_api/contracts.py`
-  - `apps/api/src/alicebot_api/store.py`
-  - `apps/api/src/alicebot_api/main.py`
-- Added new registration APIs in `apps/api/src/alicebot_api/main.py`:
-  - `POST /v1/providers/ollama/register`
-  - `POST /v1/providers/llamacpp/register`
-- Kept existing in-scope APIs working with local adapters:
-  - `POST /v1/providers/test`
-  - `POST /v1/runtime/invoke`
-  - `GET /v1/providers`
-  - `GET /v1/providers/{provider_id}`
-- Added failure-safe capability behavior:
-  - registration stores failed discovery posture when local provider is unreachable
-  - provider test stores failed discovery posture when capability discovery fails
-- Added sprint verification tests:
-  - `tests/unit/test_provider_runtime.py`
-  - `tests/unit/test_20260411_0053_phase11_local_provider_config_fields.py`
-  - `tests/integration/test_phase11_provider_runtime_api.py`
-- Added local setup docs and runnable example paths:
-  - `docs/integrations/phase11-local-provider-adapters.md`
-  - `scripts/run_phase11_local_provider_e2e.py`
-- Updated control-doc truth checker markers for current sprint state:
+- Added new persistence tables via migration:
+  - `model_packs`
+  - `workspace_model_pack_bindings`
+  - workspace-consistent binding foreign-key integrity (`model_pack_id`, `workspace_id`)
+- Added model-pack domain helper module:
+  - `apps/api/src/alicebot_api/model_packs.py`
+  - contract validation (`model_pack_contract_v1`)
+  - tier-1 pack seeding for workspace scope with concurrency-safe upsert behavior
+  - pack version and family normalization
+  - canonical tier-1 pack key reservation checks
+  - workspace binding vs request override precedence resolution
+  - declarative runtime shaping helpers (context cap shaping + instruction overlays)
+- Extended store layer in `apps/api/src/alicebot_api/store.py`:
+  - typed rows for model packs and bindings
+  - model-pack CRUD/list/get queries
+  - binding create/get-latest queries (workspace-scoped)
+- Extended API contracts in `apps/api/src/alicebot_api/contracts.py`:
+  - model-pack families/status/binding-source literals
+  - model-pack response typed dicts and list order constant
+- Added new v1 model-pack endpoints in `apps/api/src/alicebot_api/main.py`:
+  - `GET /v1/model-packs`
+  - `GET /v1/model-packs/{pack_id}`
+  - `POST /v1/model-packs`
+  - `POST /v1/model-packs/{pack_id}/bind`
+  - `GET /v1/workspaces/{workspace_id}/model-pack-binding`
+- Updated `POST /v1/runtime/invoke` in `apps/api/src/alicebot_api/main.py`:
+  - pack selection precedence: request override > workspace binding > none
+  - pack-driven context cap shaping and instruction overlays
+  - model-pack metadata returned for invoke auditing
+  - no parallel runtime path created; existing provider invoke seam preserved
+- Updated response generation seam in `apps/api/src/alicebot_api/response_generation.py`:
+  - added optional system/developer instruction overrides for runtime shaping
+  - default `v0/responses` behavior remains unchanged
+- Added sprint docs under `docs/`:
+  - `docs/integrations/phase11-model-packs-tier1.md`
+  - `docs/integrations/phase11-model-pack-compatibility.md`
+- Updated control-doc truth markers for active sprint alignment:
   - `scripts/check_control_doc_truth.py`
-  - linked new integration doc from `README.md`
+- Updated active sprint truth markers:
+  - `README.md`
+- Added sprint tests:
+  - unit: `tests/unit/test_model_packs.py`
+  - migration unit: `tests/unit/test_20260412_0054_phase11_model_packs_tier1.py`
+  - integration: `tests/integration/test_phase11_model_packs_api.py`
 
 ## incomplete work
-- None for `P11-S2` acceptance criteria and required verification commands.
+- None identified against `P11-S4` packet acceptance criteria and required API/data scope.
 
 ## files changed
-- `apps/api/src/alicebot_api/local_provider_helpers.py`
-- `apps/api/src/alicebot_api/provider_runtime.py`
-- `apps/api/src/alicebot_api/main.py`
+- `apps/api/alembic/versions/20260412_0054_phase11_model_packs_tier1.py`
+- `apps/api/src/alicebot_api/model_packs.py`
 - `apps/api/src/alicebot_api/store.py`
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/alembic/versions/20260411_0053_phase11_local_provider_config_fields.py`
-- `tests/unit/test_provider_runtime.py`
-- `tests/unit/test_20260411_0053_phase11_local_provider_config_fields.py`
-- `tests/integration/test_phase11_provider_runtime_api.py`
-- `docs/integrations/phase11-local-provider-adapters.md`
-- `scripts/run_phase11_local_provider_e2e.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/response_generation.py`
+- `docs/integrations/phase11-model-packs-tier1.md`
+- `docs/integrations/phase11-model-pack-compatibility.md`
+- `tests/unit/test_model_packs.py`
+- `tests/unit/test_20260412_0054_phase11_model_packs_tier1.py`
+- `tests/integration/test_phase11_model_packs_api.py`
 - `scripts/check_control_doc_truth.py`
 - `README.md`
 - `BUILD_REPORT.md`
@@ -67,16 +73,19 @@ Implement Phase 11 Sprint 2 (`P11-S2`) local-provider support by shipping Ollama
 - `python3 scripts/check_control_doc_truth.py`
   - Result: `PASS`
 - `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-  - Result: `PASS` (`1118 passed in 183.14s (0:03:03)`)
+  - Result: `PASS` (`1133 passed in 188.69s (0:03:08)`)
 - `pnpm --dir apps/web test`
-  - Result: `PASS` (`62 files`, `199 tests`, duration `4.82s`)
-- Sprint-targeted subset:
-  - `./.venv/bin/python -m pytest tests/unit/test_provider_runtime.py tests/unit/test_20260411_0053_phase11_local_provider_config_fields.py tests/integration/test_phase11_provider_runtime_api.py -q`
-  - Result: `PASS` (`12 passed in 2.50s`)
+  - Result: `PASS` (`62` files, `199` tests, duration `4.66s`)
+- Sprint-targeted verification subsets:
+  - `./.venv/bin/python -m pytest tests/unit/test_model_packs.py tests/unit/test_20260412_0054_phase11_model_packs_tier1.py tests/integration/test_phase11_model_packs_api.py -q`
+  - Result: `PASS` (`15 passed in 1.47s`)
+  - `python3 -m pytest tests/unit/test_control_doc_truth.py tests/unit/test_response_generation.py tests/integration/test_phase11_provider_runtime_api.py -q`
+  - Result: `PASS` (`15 passed in 2.25s`)
 
 ## blockers/issues
-- No active implementation blockers.
+- No active blockers.
+- Pre-existing dirty files were present before sprint implementation and were not modified as part of this sprint scope: `ARCHITECTURE.md`, `PRODUCT_BRIEF.md`.
 
 ## recommended next step
-1. Open a sprint PR from `codex/phase11-sprint-2-ollama-llamacpp-adapters` with this report and required test evidence.
-2. Keep pre-existing dirty local docs (`ARCHITECTURE.md`, `PRODUCT_BRIEF.md`) excluded from sprint merge scope.
+1. Open/refresh a sprint PR for `P11-S4` and keep only the sprint-owned files above in merge scope.
+2. Run reviewer pass focused on `P11-S4` acceptance criteria and workspace-isolation/runtime-shaping behavior.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Phase 10 is complete and shipped.
 Phase 11 is now the active planning and execution phase:
 
 - `P11-S1` Provider Abstraction + OpenAI-Compatible Base is shipped
-- `P11-S2` Ollama + llama.cpp Adapters is the active sprint
-- later Phase 11 work adds more provider breadth, model packs, and agent integration guides
+- `P11-S2` Ollama + llama.cpp Adapters is shipped
+- `P11-S3` vLLM Adapter + Self-Hosted Performance Path is shipped
+- `P11-S4` Model Packs Tier 1 is the active sprint
+- later Phase 11 work adds Azure, tier-2 packs, and agent integration guides
 - Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md](docs/archive/planning/2026-04-08-context-compaction/README.md)
 
 ## Why Alice exists

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,50 +4,53 @@
 PASS
 
 ## criteria met
-- `P11-S2` local provider registration APIs are implemented and functioning:
-  - `POST /v1/providers/ollama/register`
-  - `POST /v1/providers/llamacpp/register`
-- Existing in-scope APIs are functioning with local adapters:
-  - `POST /v1/providers/test`
-  - `POST /v1/runtime/invoke`
-  - `GET /v1/providers`
-  - `GET /v1/providers/{provider_id}`
-- Ollama and llama.cpp adapters are integrated through the shipped provider abstraction and registry.
-- Capability snapshots include deterministic local model enumeration and health posture fields.
-- Additive provider config fields are migrated and wired (`auth_mode`, `model_list_path`, `healthcheck_path`, `invoke_path`).
-- Local setup documentation and runnable e2e example path are present.
-- Regression fix validated: legacy `/v1/providers` path now correctly passes `store` into shared registration helper (`apps/api/src/alicebot_api/main.py:6174-6177`).
-- Credential handling tightened: `auth_mode="none"` now rejects non-empty `api_key`, preventing plaintext persistence (`apps/api/src/alicebot_api/main.py:1562-1568`).
-- New regression coverage added:
-  - OpenAI-compatible registration still works and stores secret ref, not plaintext (`tests/integration/test_phase11_provider_runtime_api.py:470-491`).
-  - `auth_mode="none"` rejects provided `api_key` (`tests/integration/test_phase11_provider_runtime_api.py:494-514`).
-- Required verification commands pass on the current branch head:
+- All `P11-S4` in-scope APIs are implemented and exercised:
+  - `GET /v1/model-packs`
+  - `GET /v1/model-packs/{pack_id}`
+  - `POST /v1/model-packs`
+  - `POST /v1/model-packs/{pack_id}/bind`
+  - `GET /v1/workspaces/{workspace_id}/model-pack-binding`
+  - pack-aware shaping on `POST /v1/runtime/invoke`
+- In-scope data additions are implemented:
+  - `model_packs`
+  - `workspace_model_pack_bindings`
+- Tier-1 packs (`llama`, `qwen`, `gemma`, `gpt-oss`) are seeded with declarative contracts and versioning.
+- Runtime selection precedence is implemented as required: request override > workspace binding > none.
+- Pack-driven shaping remains on the existing invoke seam (no parallel runtime path).
+- Previously identified hardening gaps are fixed:
+  - Tier-1 seeding is now concurrency-safe via `ON CONFLICT DO NOTHING` insert path.
+  - Canonical tier-1 pack keys are reserved in create flow.
+  - Migration now enforces workspace-consistent binding integrity for `(model_pack_id, workspace_id)`.
+- Required verification commands pass on current branch state:
   - `python3 scripts/check_control_doc_truth.py` -> PASS
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> PASS (`1118 passed in 183.14s`)
-  - `pnpm --dir apps/web test` -> PASS (`62 files`, `199 tests`, duration `4.82s`)
+  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> PASS (`1133 passed in 188.69s`)
+  - `pnpm --dir apps/web test` -> PASS (`62 files`, `199 tests`, duration `4.66s`)
+- No local identifiers (local computer paths, usernames, etc.) were found in sprint-owned changed code/docs reviewed.
 
 ## criteria missed
-- None identified for `P11-S2` acceptance criteria.
+- None identified for `P11-S4` acceptance criteria.
 
 ## quality issues
-- No blocking quality issues remain in sprint-owned scope after fixes.
+- No blocking quality issues remain in sprint-owned scope after the fix pass.
 
 ## regression risks
-- Low. Full required verification is passing, including new regression tests for the previously broken path.
-- Residual operational risk remains external local-provider availability (Ollama/llama.cpp process reachability), which is surfaced via explicit discovery/test failure posture.
+- Low.
+- Main residual risk is normal operational dependency on provider availability/reachability, which is already surfaced through existing provider/runtime error handling.
 
 ## docs issues
-- No local identifiers (local computer paths, names) were found in sprint-owned changed code/docs reviewed here.
-- Out-of-scope dirty local docs remain and should stay excluded from sprint merge scope:
+- `BUILD_REPORT.md` now aligns with observed sprint-owned changed files (including `README.md` truth-marker update).
+- Out-of-scope dirty files remain in the local working tree and should stay excluded from sprint merge scope:
   - `ARCHITECTURE.md`
   - `PRODUCT_BRIEF.md`
+- No local machine identifiers detected in sprint-owned docs/code reviewed.
 
 ## should anything be added to RULES.md?
-- Optional improvement: require backward-compat regression tests for already-shipped endpoints whenever shared registration/runtime helpers are refactored.
+- Optional improvement only: encode the new practice explicitly (seed/bootstrap paths must be concurrency-safe and idempotent).
 
 ## should anything update ARCHITECTURE.md?
-- Optional improvement: add a concise note clarifying auth-mode credential invariants (`bearer` uses secret refs; `none` must not persist API keys).
+- Optional improvement only: add an explicit line that workspace-pack binding integrity is enforced on `(model_pack_id, workspace_id)`.
 
 ## recommended next action
-1. Ready for Control Tower merge approval with the updated build and review evidence on this branch head.
-2. Keep `ARCHITECTURE.md` and `PRODUCT_BRIEF.md` excluded from the sprint PR.
+1. Prepare/refresh the sprint PR with only sprint-owned files in merge scope.
+2. Keep `ARCHITECTURE.md` and `PRODUCT_BRIEF.md` out of the sprint merge.
+3. Proceed to merge approval for `P11-S4`.

--- a/apps/api/alembic/versions/20260412_0054_phase11_model_packs_tier1.py
+++ b/apps/api/alembic/versions/20260412_0054_phase11_model_packs_tier1.py
@@ -1,0 +1,106 @@
+"""Add Phase 11 model pack catalog and workspace binding tables."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260412_0054"
+down_revision = "20260411_0053"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_STATEMENTS = (
+    """
+        CREATE TABLE model_packs (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          created_by_user_account_id uuid NOT NULL REFERENCES user_accounts(id) ON DELETE RESTRICT,
+          pack_id text NOT NULL,
+          pack_version text NOT NULL,
+          display_name text NOT NULL,
+          family text NOT NULL,
+          description text NOT NULL DEFAULT '',
+          status text NOT NULL DEFAULT 'active',
+          contract jsonb NOT NULL DEFAULT '{}'::jsonb,
+          metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (workspace_id, pack_id, pack_version),
+          UNIQUE (id, workspace_id),
+          CONSTRAINT model_packs_pack_id_length_check
+            CHECK (char_length(pack_id) >= 1 AND char_length(pack_id) <= 80),
+          CONSTRAINT model_packs_pack_version_semver_check
+            CHECK (pack_version ~ '^[0-9]+\\.[0-9]+\\.[0-9]+$'),
+          CONSTRAINT model_packs_display_name_length_check
+            CHECK (char_length(display_name) >= 1 AND char_length(display_name) <= 120),
+          CONSTRAINT model_packs_family_check
+            CHECK (family IN ('llama', 'qwen', 'gemma', 'gpt-oss', 'custom')),
+          CONSTRAINT model_packs_status_check
+            CHECK (status IN ('active')),
+          CONSTRAINT model_packs_contract_object_check
+            CHECK (jsonb_typeof(contract) = 'object'),
+          CONSTRAINT model_packs_metadata_object_check
+            CHECK (jsonb_typeof(metadata) = 'object')
+        )
+        """,
+    (
+        "CREATE INDEX model_packs_workspace_pack_created_idx "
+        "ON model_packs (workspace_id, pack_id, created_at DESC, id DESC)"
+    ),
+    (
+        "CREATE INDEX model_packs_workspace_family_idx "
+        "ON model_packs (workspace_id, family, created_at DESC, id DESC)"
+    ),
+    """
+        CREATE TABLE workspace_model_pack_bindings (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          model_pack_id uuid NOT NULL,
+          bound_by_user_account_id uuid NOT NULL REFERENCES user_accounts(id) ON DELETE RESTRICT,
+          binding_source text NOT NULL DEFAULT 'manual',
+          metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          CONSTRAINT workspace_model_pack_bindings_workspace_pack_fk
+            FOREIGN KEY (model_pack_id, workspace_id)
+            REFERENCES model_packs(id, workspace_id)
+            ON DELETE RESTRICT,
+          CONSTRAINT workspace_model_pack_bindings_source_check
+            CHECK (binding_source IN ('manual', 'runtime_override')),
+          CONSTRAINT workspace_model_pack_bindings_metadata_object_check
+            CHECK (jsonb_typeof(metadata) = 'object')
+        )
+        """,
+    (
+        "CREATE INDEX workspace_model_pack_bindings_workspace_created_idx "
+        "ON workspace_model_pack_bindings (workspace_id, created_at DESC, id DESC)"
+    ),
+    (
+        "CREATE INDEX workspace_model_pack_bindings_pack_created_idx "
+        "ON workspace_model_pack_bindings (model_pack_id, created_at DESC, id DESC)"
+    ),
+)
+
+_UPGRADE_GRANT_STATEMENTS = (
+    "GRANT SELECT, INSERT, UPDATE, DELETE ON model_packs TO alicebot_app",
+    "GRANT SELECT, INSERT, UPDATE, DELETE ON workspace_model_pack_bindings TO alicebot_app",
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP TABLE IF EXISTS workspace_model_pack_bindings",
+    "DROP TABLE IF EXISTS model_packs",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_STATEMENTS)
+    _execute_statements(_UPGRADE_GRANT_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -192,6 +192,9 @@ ModelProvider = Literal["openai_responses"]
 ProviderAdapterKey = Literal["openai_compatible", "ollama", "llamacpp"]
 ModelProviderStatus = Literal["active"]
 ProviderCapabilityDiscoveryStatus = Literal["ready", "failed"]
+ModelPackFamily = Literal["llama", "qwen", "gemma", "gpt-oss", "custom"]
+ModelPackStatus = Literal["active"]
+ModelPackBindingSource = Literal["manual", "runtime_override"]
 ModelFinishReason = Literal["completed", "incomplete"]
 ExplicitPreferencePattern = Literal[
     "i_like",
@@ -377,6 +380,7 @@ COMPILER_VERSION_V0 = "continuity_v0"
 PROMPT_ASSEMBLY_VERSION_V0 = "prompt_assembly_v0"
 RESPONSE_GENERATION_VERSION_V0 = "response_generation_v0"
 PROVIDER_CAPABILITY_VERSION_V1 = "provider_capability_v1"
+MODEL_PACK_CONTRACT_VERSION_V1 = "model_pack_contract_v1"
 TRACE_KIND_CONTEXT_COMPILE = "context.compile"
 TRACE_KIND_RESPONSE_GENERATE = "response.generate"
 TRACE_REVIEW_LIST_ORDER = ["created_at_desc", "id_desc"]
@@ -386,6 +390,7 @@ AGENT_PROFILE_LIST_ORDER = ["id_asc"]
 THREAD_SESSION_LIST_ORDER = ["started_at_asc", "created_at_asc", "id_asc"]
 THREAD_EVENT_LIST_ORDER = ["sequence_no_asc"]
 PROVIDER_LIST_ORDER = ["created_at_asc", "id_asc"]
+MODEL_PACK_LIST_ORDER = ["pack_id_asc", "created_at_desc", "id_desc"]
 DEFAULT_AGENT_PROFILE_ID = "assistant_default"
 RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0 = "resumption_brief_v0"
 CONTINUITY_RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0 = "continuity_resumption_brief_v0"
@@ -1591,6 +1596,51 @@ class ProviderTestResponse(TypedDict):
     provider: ModelProviderRecord
     capabilities: ProviderCapabilityRecord | None
     result: ProviderTestResultRecord
+
+
+class ModelPackRecord(TypedDict):
+    id: str
+    workspace_id: str
+    created_by_user_account_id: str
+    pack_id: str
+    pack_version: str
+    display_name: str
+    family: ModelPackFamily
+    description: str
+    status: ModelPackStatus
+    contract: JsonObject
+    metadata: JsonObject
+    created_at: str
+    updated_at: str
+
+
+class ModelPackListSummary(TypedDict):
+    total_count: int
+    order: list[str]
+
+
+class ModelPackListResponse(TypedDict):
+    items: list[ModelPackRecord]
+    summary: ModelPackListSummary
+
+
+class ModelPackDetailResponse(TypedDict):
+    model_pack: ModelPackRecord
+
+
+class WorkspaceModelPackBindingRecord(TypedDict):
+    id: str
+    workspace_id: str
+    model_pack_id: str
+    bound_by_user_account_id: str
+    binding_source: ModelPackBindingSource
+    metadata: JsonObject
+    created_at: str
+    model_pack: ModelPackRecord
+
+
+class WorkspaceModelPackBindingResponse(TypedDict):
+    binding: WorkspaceModelPackBindingRecord | None
 
 
 class RuntimeInvokeAssistantRecord(TypedDict):

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -161,6 +161,7 @@ from alicebot_api.contracts import (
     MemoryEmbeddingUpsertInput,
     THREAD_EVENT_LIST_ORDER,
     PROVIDER_LIST_ORDER,
+    MODEL_PACK_LIST_ORDER,
     THREAD_LIST_ORDER,
     THREAD_SESSION_LIST_ORDER,
     MemoryReviewLabelValue,
@@ -588,8 +589,10 @@ from alicebot_api.semantic_retrieval import (
     retrieve_task_scoped_semantic_artifact_chunk_records,
 )
 from alicebot_api.response_generation import (
+    DEVELOPER_INSTRUCTION,
     ModelInvocationError,
     ResponseFailure,
+    SYSTEM_INSTRUCTION,
     generate_response,
 )
 from alicebot_api.proxy_execution import (
@@ -610,6 +613,22 @@ from alicebot_api.provider_runtime import (
     normalized_capability_snapshot,
     resolve_runtime_provider_config_secrets,
 )
+from alicebot_api.model_packs import (
+    MODEL_PACK_BINDING_SOURCE_MANUAL,
+    MODEL_PACK_STATUS_ACTIVE,
+    ModelPackNotFoundError,
+    ModelPackValidationError,
+    append_instruction,
+    apply_runtime_limit_caps,
+    build_model_pack_runtime_shape,
+    ensure_tier1_model_packs_for_workspace,
+    is_reserved_tier1_pack_key,
+    normalize_model_pack_contract,
+    normalize_pack_family,
+    normalize_pack_id,
+    normalize_pack_version,
+    resolve_workspace_model_pack_selection,
+)
 from alicebot_api.provider_secrets import (
     ProviderSecretManagerError,
     build_provider_secret_ref,
@@ -620,10 +639,12 @@ from alicebot_api.store import (
     ContinuityStore,
     ContinuityStoreInvariantError,
     EventRow,
+    ModelPackRow,
     ModelProviderRow,
     ProviderCapabilityRow,
     SessionRow,
     ThreadRow,
+    WorkspaceModelPackBindingDetailRow,
 )
 from alicebot_api.traces import (
     TraceNotFoundError,
@@ -1460,6 +1481,54 @@ def _serialize_provider_capability(capability: ProviderCapabilityRow) -> dict[st
     }
 
 
+def _serialize_model_pack(pack: ModelPackRow) -> dict[str, object]:
+    return {
+        "id": str(pack["id"]),
+        "workspace_id": str(pack["workspace_id"]),
+        "created_by_user_account_id": str(pack["created_by_user_account_id"]),
+        "pack_id": pack["pack_id"],
+        "pack_version": pack["pack_version"],
+        "display_name": pack["display_name"],
+        "family": pack["family"],
+        "description": pack["description"],
+        "status": pack["status"],
+        "contract": pack["contract"],
+        "metadata": pack["metadata"],
+        "created_at": pack["created_at"].isoformat(),
+        "updated_at": pack["updated_at"].isoformat(),
+    }
+
+
+def _serialize_workspace_model_pack_binding(
+    binding: WorkspaceModelPackBindingDetailRow,
+) -> dict[str, object]:
+    model_pack: ModelPackRow = {
+        "id": binding["model_pack_id"],
+        "workspace_id": binding["workspace_id"],
+        "created_by_user_account_id": binding["pack_created_by_user_account_id"],
+        "pack_id": binding["pack_id"],
+        "pack_version": binding["pack_version"],
+        "display_name": binding["pack_display_name"],
+        "family": binding["pack_family"],
+        "description": binding["pack_description"],
+        "status": binding["pack_status"],
+        "contract": binding["pack_contract"],
+        "metadata": binding["pack_metadata"],
+        "created_at": binding["pack_created_at"],
+        "updated_at": binding["pack_updated_at"],
+    }
+    return {
+        "id": str(binding["id"]),
+        "workspace_id": str(binding["workspace_id"]),
+        "model_pack_id": str(binding["model_pack_id"]),
+        "bound_by_user_account_id": str(binding["bound_by_user_account_id"]),
+        "binding_source": binding["binding_source"],
+        "metadata": binding["metadata"],
+        "created_at": binding["created_at"].isoformat(),
+        "model_pack": _serialize_model_pack(model_pack),
+    }
+
+
 def _runtime_provider_config_or_none(
     *,
     store: ContinuityStore,
@@ -2091,6 +2160,25 @@ class TestProviderRequest(BaseModel):
     )
 
 
+class CreateModelPackRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pack_id: str = Field(min_length=1, max_length=80)
+    pack_version: str = Field(min_length=1, max_length=40)
+    display_name: str = Field(min_length=1, max_length=120)
+    family: str = Field(min_length=1, max_length=40)
+    description: str = Field(default="", max_length=1000)
+    contract: dict[str, object]
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class BindModelPackRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pack_version: str | None = Field(default=None, min_length=1, max_length=40)
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
 class RuntimeInvokeRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -2098,6 +2186,8 @@ class RuntimeInvokeRequest(BaseModel):
     thread_id: UUID
     message: str = Field(min_length=1, max_length=4000)
     model: str | None = Field(default=None, min_length=1, max_length=200)
+    pack_id: str | None = Field(default=None, min_length=1, max_length=80)
+    pack_version: str | None = Field(default=None, min_length=1, max_length=40)
     max_sessions: int = Field(default=DEFAULT_MAX_SESSIONS, ge=1, le=50)
     max_events: int = Field(default=DEFAULT_MAX_EVENTS, ge=1, le=200)
     max_memories: int = Field(default=DEFAULT_MAX_MEMORIES, ge=1, le=200)
@@ -6555,6 +6645,267 @@ def test_v1_provider(request: Request, body: TestProviderRequest) -> JSONRespons
     )
 
 
+@app.get("/v1/model-packs")
+def list_v1_model_packs(request: Request) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                workspace = get_current_workspace(
+                    conn,
+                    user_account_id=resolution["user_account"]["id"],
+                    preferred_workspace_id=resolution["session"]["workspace_id"],
+                )
+                if workspace is None:
+                    return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+
+                store = ContinuityStore(conn)
+                ensure_tier1_model_packs_for_workspace(
+                    store=store,
+                    workspace_id=workspace["id"],
+                    created_by_user_account_id=resolution["user_account"]["id"],
+                )
+                packs = store.list_model_packs_for_workspace(workspace_id=workspace["id"])
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except ModelPackValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    items = [_serialize_model_pack(pack) for pack in packs]
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(
+            {
+                "items": items,
+                "summary": {
+                    "total_count": len(items),
+                    "order": list(MODEL_PACK_LIST_ORDER),
+                },
+            }
+        ),
+    )
+
+
+@app.get("/v1/model-packs/{pack_id}")
+def get_v1_model_pack(
+    pack_id: str,
+    request: Request,
+    version: Annotated[str | None, Query(min_length=1, max_length=40)] = None,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        normalized_pack_id = normalize_pack_id(pack_id)
+        normalized_version = None if version is None else normalize_pack_version(version)
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                workspace = get_current_workspace(
+                    conn,
+                    user_account_id=resolution["user_account"]["id"],
+                    preferred_workspace_id=resolution["session"]["workspace_id"],
+                )
+                if workspace is None:
+                    return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+
+                store = ContinuityStore(conn)
+                ensure_tier1_model_packs_for_workspace(
+                    store=store,
+                    workspace_id=workspace["id"],
+                    created_by_user_account_id=resolution["user_account"]["id"],
+                )
+                pack = store.get_model_pack_for_workspace_optional(
+                    workspace_id=workspace["id"],
+                    pack_id=normalized_pack_id,
+                    pack_version=normalized_version,
+                )
+                if pack is None:
+                    return JSONResponse(
+                        status_code=404,
+                        content={"detail": f"model pack {normalized_pack_id} was not found"},
+                    )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except ModelPackValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder({"model_pack": _serialize_model_pack(pack)}),
+    )
+
+
+@app.post("/v1/model-packs")
+def create_v1_model_pack(request: Request, body: CreateModelPackRequest) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        normalized_pack_id = normalize_pack_id(body.pack_id)
+        normalized_pack_version = normalize_pack_version(body.pack_version)
+        normalized_family = normalize_pack_family(body.family)
+        normalized_contract = normalize_model_pack_contract(body.contract)
+        normalized_display_name = body.display_name.strip()
+        if normalized_display_name == "":
+            raise ModelPackValidationError("display_name is required")
+
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                workspace = get_current_workspace(
+                    conn,
+                    user_account_id=resolution["user_account"]["id"],
+                    preferred_workspace_id=resolution["session"]["workspace_id"],
+                )
+                if workspace is None:
+                    return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+
+                store = ContinuityStore(conn)
+                ensure_tier1_model_packs_for_workspace(
+                    store=store,
+                    workspace_id=workspace["id"],
+                    created_by_user_account_id=resolution["user_account"]["id"],
+                )
+                if is_reserved_tier1_pack_key(
+                    pack_id=normalized_pack_id,
+                    pack_version=normalized_pack_version,
+                ):
+                    return JSONResponse(
+                        status_code=409,
+                        content={
+                            "detail": (
+                                f"model pack {normalized_pack_id}@{normalized_pack_version} "
+                                "is reserved for tier-1 catalog entries"
+                            )
+                        },
+                    )
+                pack = store.create_model_pack(
+                    workspace_id=workspace["id"],
+                    created_by_user_account_id=resolution["user_account"]["id"],
+                    pack_id=normalized_pack_id,
+                    pack_version=normalized_pack_version,
+                    display_name=normalized_display_name,
+                    family=normalized_family,
+                    description=body.description.strip(),
+                    status=MODEL_PACK_STATUS_ACTIVE,
+                    contract=normalized_contract,
+                    metadata=body.metadata,
+                )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except psycopg.errors.UniqueViolation:
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "model pack pack_id and pack_version must be unique within the workspace"},
+        )
+    except ModelPackValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=201,
+        content=jsonable_encoder({"model_pack": _serialize_model_pack(pack)}),
+    )
+
+
+@app.post("/v1/model-packs/{pack_id}/bind")
+def bind_v1_model_pack(pack_id: str, request: Request, body: BindModelPackRequest) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        normalized_pack_id = normalize_pack_id(pack_id)
+        normalized_pack_version = (
+            None if body.pack_version is None else normalize_pack_version(body.pack_version)
+        )
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                workspace = get_current_workspace(
+                    conn,
+                    user_account_id=resolution["user_account"]["id"],
+                    preferred_workspace_id=resolution["session"]["workspace_id"],
+                )
+                if workspace is None:
+                    return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+
+                store = ContinuityStore(conn)
+                ensure_tier1_model_packs_for_workspace(
+                    store=store,
+                    workspace_id=workspace["id"],
+                    created_by_user_account_id=resolution["user_account"]["id"],
+                )
+                pack = store.get_model_pack_for_workspace_optional(
+                    workspace_id=workspace["id"],
+                    pack_id=normalized_pack_id,
+                    pack_version=normalized_pack_version,
+                )
+                if pack is None:
+                    return JSONResponse(
+                        status_code=404,
+                        content={"detail": f"model pack {normalized_pack_id} was not found"},
+                    )
+                store.create_workspace_model_pack_binding(
+                    workspace_id=workspace["id"],
+                    model_pack_id=pack["id"],
+                    bound_by_user_account_id=resolution["user_account"]["id"],
+                    binding_source=MODEL_PACK_BINDING_SOURCE_MANUAL,
+                    metadata=body.metadata,
+                )
+                binding = store.get_latest_workspace_model_pack_binding_optional(
+                    workspace_id=workspace["id"],
+                )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except ModelPackValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    assert binding is not None
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder({"binding": _serialize_workspace_model_pack_binding(binding)}),
+    )
+
+
+@app.get("/v1/workspaces/{workspace_id}/model-pack-binding")
+def get_v1_workspace_model_pack_binding(workspace_id: UUID, request: Request) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                workspace = get_workspace_for_member(
+                    conn,
+                    workspace_id=workspace_id,
+                    user_account_id=resolution["user_account"]["id"],
+                )
+                if workspace is None:
+                    return JSONResponse(status_code=404, content={"detail": f"workspace {workspace_id} was not found"})
+
+                store = ContinuityStore(conn)
+                binding = store.get_latest_workspace_model_pack_binding_optional(
+                    workspace_id=workspace["id"],
+                )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(
+            {
+                "binding": None
+                if binding is None
+                else _serialize_workspace_model_pack_binding(binding),
+            }
+        ),
+    )
+
+
 @app.post("/v1/runtime/invoke")
 def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONResponse:
     settings = get_settings()
@@ -6562,6 +6913,8 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
     workspace_id: UUID | None = None
     user_account: dict[str, object] | None = None
     runtime_provider: RuntimeProviderConfig | None = None
+    model_pack: ModelPackRow | None = None
+    model_pack_source: str = "none"
 
     try:
         session_token = _extract_bearer_token(request)
@@ -6591,8 +6944,25 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
                         status_code=404,
                         content={"detail": f"provider {body.provider_id} was not found"},
                     )
+                ensure_tier1_model_packs_for_workspace(
+                    store=store,
+                    workspace_id=workspace["id"],
+                    created_by_user_account_id=resolution["user_account"]["id"],
+                )
+                selected_pack = resolve_workspace_model_pack_selection(
+                    store=store,
+                    workspace_id=workspace["id"],
+                    requested_pack_id=body.pack_id,
+                    requested_pack_version=body.pack_version,
+                )
+                model_pack = selected_pack.pack
+                model_pack_source = selected_pack.source
     except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
         return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except ModelPackNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except ModelPackValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
     except ProviderSecretManagerError as exc:
         return JSONResponse(status_code=500, content={"detail": str(exc)})
 
@@ -6603,6 +6973,48 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
     selected_model = (body.model or runtime_provider.default_model).strip()
     if selected_model == "":
         return JSONResponse(status_code=400, content={"detail": "model is required"})
+
+    runtime_limits = ContextCompilerLimits(
+        max_sessions=body.max_sessions,
+        max_events=body.max_events,
+        max_memories=body.max_memories,
+        max_entities=body.max_entities,
+        max_entity_edges=body.max_entity_edges,
+    )
+    runtime_system_instruction = SYSTEM_INSTRUCTION
+    runtime_developer_instruction = DEVELOPER_INSTRUCTION
+
+    if model_pack is not None:
+        runtime_shape = build_model_pack_runtime_shape(model_pack["contract"])
+        (
+            max_sessions,
+            max_events,
+            max_memories,
+            max_entities,
+            max_entity_edges,
+        ) = apply_runtime_limit_caps(
+            max_sessions=runtime_limits.max_sessions,
+            max_events=runtime_limits.max_events,
+            max_memories=runtime_limits.max_memories,
+            max_entities=runtime_limits.max_entities,
+            max_entity_edges=runtime_limits.max_entity_edges,
+            shape=runtime_shape,
+        )
+        runtime_limits = ContextCompilerLimits(
+            max_sessions=max_sessions,
+            max_events=max_events,
+            max_memories=max_memories,
+            max_entities=max_entities,
+            max_entity_edges=max_entity_edges,
+        )
+        runtime_system_instruction = append_instruction(
+            SYSTEM_INSTRUCTION,
+            runtime_shape.system_instruction_append,
+        )
+        runtime_developer_instruction = append_instruction(
+            DEVELOPER_INSTRUCTION,
+            runtime_shape.developer_instruction_append,
+        )
 
     user_account_id = user_account["id"]
     assert isinstance(user_account_id, UUID)
@@ -6621,19 +7033,15 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
                 user_id=user_account_id,
                 thread_id=body.thread_id,
                 message_text=body.message,
-                limits=ContextCompilerLimits(
-                    max_sessions=body.max_sessions,
-                    max_events=body.max_events,
-                    max_memories=body.max_memories,
-                    max_entities=body.max_entities,
-                    max_entity_edges=body.max_entity_edges,
-                ),
+                limits=runtime_limits,
                 runtime_override=(runtime_provider.model_provider, selected_model),
                 model_invoker=lambda model_request: adapter.invoke(
                     config=runtime_provider,
                     settings=settings,
                     request=model_request,
                 ),
+                system_instruction=runtime_system_instruction,
+                developer_instruction=runtime_developer_instruction,
             )
             if isinstance(result, ResponseFailure):
                 return JSONResponse(
@@ -6646,6 +7054,13 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
                                 "workspace_id": str(workspace_id),
                                 "provider_id": str(runtime_provider.provider_id),
                                 "provider_key": runtime_provider.provider_key,
+                                "model_pack": None
+                                if model_pack is None
+                                else {
+                                    "pack_id": model_pack["pack_id"],
+                                    "pack_version": model_pack["pack_version"],
+                                    "source": model_pack_source,
+                                },
                             },
                         }
                     ),
@@ -6696,6 +7111,13 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
                 "trace": result["trace"],
                 "metadata": {
                     "workspace_id": str(workspace_id),
+                    "model_pack": None
+                    if model_pack is None
+                    else {
+                        "pack_id": model_pack["pack_id"],
+                        "pack_version": model_pack["pack_version"],
+                        "source": model_pack_source,
+                    },
                 },
             }
         ),

--- a/apps/api/src/alicebot_api/model_packs.py
+++ b/apps/api/src/alicebot_api/model_packs.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import re
+from typing import Literal
+from uuid import UUID
+
+from alicebot_api.store import ContinuityStore, JsonObject, ModelPackRow
+
+MODEL_PACK_CONTRACT_VERSION_V1 = "model_pack_contract_v1"
+MODEL_PACK_STATUS_ACTIVE = "active"
+MODEL_PACK_BINDING_SOURCE_MANUAL = "manual"
+MODEL_PACK_BINDING_SOURCE_RUNTIME_OVERRIDE = "runtime_override"
+MODEL_PACK_FAMILIES: tuple[str, ...] = ("llama", "qwen", "gemma", "gpt-oss", "custom")
+MAX_CONTEXT_SESSIONS = 50
+MAX_CONTEXT_EVENTS = 200
+MAX_CONTEXT_MEMORIES = 200
+MAX_CONTEXT_ENTITIES = 200
+MAX_CONTEXT_ENTITY_EDGES = 400
+
+_ALLOWED_PROVIDER_KEYS: tuple[str, ...] = ("openai_compatible", "ollama", "llamacpp")
+_ALLOWED_RUNTIME_PROVIDERS: tuple[str, ...] = ("openai_responses",)
+_PACK_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,79}$")
+_PACK_VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+class ModelPackValidationError(ValueError):
+    """Raised when a model-pack request payload is invalid."""
+
+
+class ModelPackNotFoundError(LookupError):
+    """Raised when a model pack cannot be found in the workspace scope."""
+
+
+PackSelectionSource = Literal["none", "request", "workspace_binding"]
+
+
+@dataclass(frozen=True, slots=True)
+class Tier1PackSpec:
+    pack_id: str
+    pack_version: str
+    display_name: str
+    family: str
+    description: str
+    contract: JsonObject
+
+
+@dataclass(frozen=True, slots=True)
+class ModelPackRuntimeShape:
+    max_sessions_cap: int | None
+    max_events_cap: int | None
+    max_memories_cap: int | None
+    max_entities_cap: int | None
+    max_entity_edges_cap: int | None
+    tools_mode: str
+    system_instruction_append: str
+    developer_instruction_append: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedModelPackSelection:
+    source: PackSelectionSource
+    pack: ModelPackRow | None
+
+
+def apply_runtime_limit_caps(
+    *,
+    max_sessions: int,
+    max_events: int,
+    max_memories: int,
+    max_entities: int,
+    max_entity_edges: int,
+    shape: ModelPackRuntimeShape,
+) -> tuple[int, int, int, int, int]:
+    return (
+        max_sessions if shape.max_sessions_cap is None else min(max_sessions, shape.max_sessions_cap),
+        max_events if shape.max_events_cap is None else min(max_events, shape.max_events_cap),
+        max_memories if shape.max_memories_cap is None else min(max_memories, shape.max_memories_cap),
+        max_entities if shape.max_entities_cap is None else min(max_entities, shape.max_entities_cap),
+        max_entity_edges
+        if shape.max_entity_edges_cap is None
+        else min(max_entity_edges, shape.max_entity_edges_cap),
+    )
+
+
+def append_instruction(base_instruction: str, append_instruction_text: str) -> str:
+    suffix = append_instruction_text.strip()
+    if suffix == "":
+        return base_instruction
+    return f"{base_instruction}\n{suffix}"
+
+
+def normalize_pack_id(pack_id: str) -> str:
+    normalized = pack_id.strip().lower()
+    if normalized == "":
+        raise ModelPackValidationError("pack_id is required")
+    if _PACK_ID_PATTERN.fullmatch(normalized) is None:
+        raise ModelPackValidationError(
+            "pack_id must contain only lowercase letters, digits, '.', '_', or '-'"
+        )
+    return normalized
+
+
+def normalize_pack_version(pack_version: str) -> str:
+    normalized = pack_version.strip()
+    if normalized == "":
+        raise ModelPackValidationError("pack_version is required")
+    if _PACK_VERSION_PATTERN.fullmatch(normalized) is None:
+        raise ModelPackValidationError("pack_version must use semver format: MAJOR.MINOR.PATCH")
+    return normalized
+
+
+def normalize_pack_family(family: str) -> str:
+    normalized = family.strip().lower()
+    if normalized not in MODEL_PACK_FAMILIES:
+        raise ModelPackValidationError(f"unsupported model-pack family: {family}")
+    return normalized
+
+
+def _normalize_optional_instruction(*, field_name: str, value: object) -> str:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ModelPackValidationError(f"{field_name} must be a string")
+    normalized = value.strip()
+    if len(normalized) > 2000:
+        raise ModelPackValidationError(f"{field_name} must be at most 2000 characters")
+    return normalized
+
+
+def _normalize_cap(
+    *,
+    context: Mapping[str, object],
+    key: str,
+    maximum: int,
+) -> int | None:
+    value = context.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int):
+        raise ModelPackValidationError(f"context.{key} must be an integer")
+    if value < 1 or value > maximum:
+        raise ModelPackValidationError(f"context.{key} must be between 1 and {maximum}")
+    return value
+
+
+def normalize_model_pack_contract(contract: Mapping[str, object]) -> JsonObject:
+    if not isinstance(contract, Mapping):
+        raise ModelPackValidationError("contract must be an object")
+
+    contract_version = contract.get("contract_version")
+    if contract_version != MODEL_PACK_CONTRACT_VERSION_V1:
+        raise ModelPackValidationError(
+            f"contract.contract_version must equal {MODEL_PACK_CONTRACT_VERSION_V1}"
+        )
+
+    context_raw = contract.get("context", {})
+    if not isinstance(context_raw, Mapping):
+        raise ModelPackValidationError("contract.context must be an object")
+
+    tools_raw = contract.get("tools", {})
+    if not isinstance(tools_raw, Mapping):
+        raise ModelPackValidationError("contract.tools must be an object")
+    tools_mode = tools_raw.get("mode", "none")
+    if tools_mode != "none":
+        raise ModelPackValidationError("contract.tools.mode must be 'none' in P11-S4")
+
+    response_raw = contract.get("response", {})
+    if not isinstance(response_raw, Mapping):
+        raise ModelPackValidationError("contract.response must be an object")
+
+    compatibility_raw = contract.get("compatibility", {})
+    if not isinstance(compatibility_raw, Mapping):
+        raise ModelPackValidationError("contract.compatibility must be an object")
+
+    provider_keys_raw = compatibility_raw.get("provider_keys", [])
+    if not isinstance(provider_keys_raw, list):
+        raise ModelPackValidationError("contract.compatibility.provider_keys must be a list")
+    provider_keys: list[str] = []
+    for key in provider_keys_raw:
+        if not isinstance(key, str) or key.strip() == "":
+            raise ModelPackValidationError("contract.compatibility.provider_keys must contain strings")
+        normalized_key = key.strip()
+        if normalized_key not in _ALLOWED_PROVIDER_KEYS:
+            raise ModelPackValidationError(f"unsupported provider key in compatibility: {normalized_key}")
+        if normalized_key not in provider_keys:
+            provider_keys.append(normalized_key)
+
+    runtime_providers_raw = compatibility_raw.get("runtime_providers", [])
+    if not isinstance(runtime_providers_raw, list):
+        raise ModelPackValidationError("contract.compatibility.runtime_providers must be a list")
+    runtime_providers: list[str] = []
+    for runtime_provider in runtime_providers_raw:
+        if not isinstance(runtime_provider, str) or runtime_provider.strip() == "":
+            raise ModelPackValidationError(
+                "contract.compatibility.runtime_providers must contain strings"
+            )
+        normalized_runtime_provider = runtime_provider.strip()
+        if normalized_runtime_provider not in _ALLOWED_RUNTIME_PROVIDERS:
+            raise ModelPackValidationError(
+                f"unsupported runtime provider in compatibility: {normalized_runtime_provider}"
+            )
+        if normalized_runtime_provider not in runtime_providers:
+            runtime_providers.append(normalized_runtime_provider)
+
+    compatibility_notes_raw = compatibility_raw.get("notes")
+    compatibility_notes = None
+    if compatibility_notes_raw is not None:
+        if not isinstance(compatibility_notes_raw, str):
+            raise ModelPackValidationError("contract.compatibility.notes must be a string")
+        compatibility_notes = compatibility_notes_raw.strip()
+        if len(compatibility_notes) > 500:
+            raise ModelPackValidationError("contract.compatibility.notes must be at most 500 characters")
+
+    max_sessions_cap = _normalize_cap(
+        context=context_raw,
+        key="max_sessions_cap",
+        maximum=MAX_CONTEXT_SESSIONS,
+    )
+    max_events_cap = _normalize_cap(
+        context=context_raw,
+        key="max_events_cap",
+        maximum=MAX_CONTEXT_EVENTS,
+    )
+    max_memories_cap = _normalize_cap(
+        context=context_raw,
+        key="max_memories_cap",
+        maximum=MAX_CONTEXT_MEMORIES,
+    )
+    max_entities_cap = _normalize_cap(
+        context=context_raw,
+        key="max_entities_cap",
+        maximum=MAX_CONTEXT_ENTITIES,
+    )
+    max_entity_edges_cap = _normalize_cap(
+        context=context_raw,
+        key="max_entity_edges_cap",
+        maximum=MAX_CONTEXT_ENTITY_EDGES,
+    )
+
+    system_instruction_append = _normalize_optional_instruction(
+        field_name="contract.response.system_instruction_append",
+        value=response_raw.get("system_instruction_append"),
+    )
+    developer_instruction_append = _normalize_optional_instruction(
+        field_name="contract.response.developer_instruction_append",
+        value=response_raw.get("developer_instruction_append"),
+    )
+
+    normalized_contract: JsonObject = {
+        "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
+        "context": {
+            "max_sessions_cap": max_sessions_cap,
+            "max_events_cap": max_events_cap,
+            "max_memories_cap": max_memories_cap,
+            "max_entities_cap": max_entities_cap,
+            "max_entity_edges_cap": max_entity_edges_cap,
+        },
+        "tools": {
+            "mode": "none",
+        },
+        "response": {
+            "system_instruction_append": system_instruction_append,
+            "developer_instruction_append": developer_instruction_append,
+        },
+        "compatibility": {
+            "provider_keys": provider_keys,
+            "runtime_providers": runtime_providers,
+            "notes": compatibility_notes,
+        },
+    }
+    return normalized_contract
+
+
+def build_model_pack_runtime_shape(contract: Mapping[str, object]) -> ModelPackRuntimeShape:
+    normalized_contract = normalize_model_pack_contract(contract)
+    context = normalized_contract["context"]
+    response = normalized_contract["response"]
+    tools = normalized_contract["tools"]
+
+    assert isinstance(context, dict)
+    assert isinstance(response, dict)
+    assert isinstance(tools, dict)
+
+    return ModelPackRuntimeShape(
+        max_sessions_cap=context.get("max_sessions_cap"),  # type: ignore[arg-type]
+        max_events_cap=context.get("max_events_cap"),  # type: ignore[arg-type]
+        max_memories_cap=context.get("max_memories_cap"),  # type: ignore[arg-type]
+        max_entities_cap=context.get("max_entities_cap"),  # type: ignore[arg-type]
+        max_entity_edges_cap=context.get("max_entity_edges_cap"),  # type: ignore[arg-type]
+        tools_mode=str(tools.get("mode", "none")),
+        system_instruction_append=str(response.get("system_instruction_append", "")),
+        developer_instruction_append=str(response.get("developer_instruction_append", "")),
+    )
+
+
+def _tier1_pack_specs() -> tuple[Tier1PackSpec, ...]:
+    return (
+        Tier1PackSpec(
+            pack_id="llama",
+            pack_version="1.0.0",
+            display_name="Llama Tier 1",
+            family="llama",
+            description="Tier-1 declarative runtime shaping for Llama-family instruct models.",
+            contract=normalize_model_pack_contract(
+                {
+                    "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
+                    "context": {
+                        "max_sessions_cap": 3,
+                        "max_events_cap": 8,
+                        "max_memories_cap": 5,
+                        "max_entities_cap": 5,
+                        "max_entity_edges_cap": 10,
+                    },
+                    "tools": {"mode": "none"},
+                    "response": {
+                        "system_instruction_append": (
+                            "Prefer factual, concise output and surface uncertainty explicitly when context is incomplete."
+                        ),
+                        "developer_instruction_append": (
+                            "Favor grounded continuity facts over stylistic elaboration."
+                        ),
+                    },
+                    "compatibility": {
+                        "provider_keys": ["openai_compatible", "ollama", "llamacpp"],
+                        "runtime_providers": ["openai_responses"],
+                        "notes": "Tier-1 baseline for Llama-family backends.",
+                    },
+                }
+            ),
+        ),
+        Tier1PackSpec(
+            pack_id="qwen",
+            pack_version="1.0.0",
+            display_name="Qwen Tier 1",
+            family="qwen",
+            description="Tier-1 declarative runtime shaping for Qwen-family instruct models.",
+            contract=normalize_model_pack_contract(
+                {
+                    "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
+                    "context": {
+                        "max_sessions_cap": 3,
+                        "max_events_cap": 8,
+                        "max_memories_cap": 4,
+                        "max_entities_cap": 5,
+                        "max_entity_edges_cap": 8,
+                    },
+                    "tools": {"mode": "none"},
+                    "response": {
+                        "system_instruction_append": (
+                            "Respond with deterministic structure and avoid unsupported speculation."
+                        ),
+                        "developer_instruction_append": (
+                            "Keep outputs directly actionable and compact."
+                        ),
+                    },
+                    "compatibility": {
+                        "provider_keys": ["openai_compatible", "ollama", "llamacpp"],
+                        "runtime_providers": ["openai_responses"],
+                        "notes": "Tier-1 baseline for Qwen-family backends.",
+                    },
+                }
+            ),
+        ),
+        Tier1PackSpec(
+            pack_id="gemma",
+            pack_version="1.0.0",
+            display_name="Gemma Tier 1",
+            family="gemma",
+            description="Tier-1 declarative runtime shaping for Gemma-family instruct models.",
+            contract=normalize_model_pack_contract(
+                {
+                    "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
+                    "context": {
+                        "max_sessions_cap": 2,
+                        "max_events_cap": 8,
+                        "max_memories_cap": 4,
+                        "max_entities_cap": 4,
+                        "max_entity_edges_cap": 8,
+                    },
+                    "tools": {"mode": "none"},
+                    "response": {
+                        "system_instruction_append": (
+                            "Maintain directness and prioritize clear, bounded recommendations."
+                        ),
+                        "developer_instruction_append": (
+                            "Prefer concise summaries with explicit next actions."
+                        ),
+                    },
+                    "compatibility": {
+                        "provider_keys": ["openai_compatible", "ollama", "llamacpp"],
+                        "runtime_providers": ["openai_responses"],
+                        "notes": "Tier-1 baseline for Gemma-family backends.",
+                    },
+                }
+            ),
+        ),
+        Tier1PackSpec(
+            pack_id="gpt-oss",
+            pack_version="1.0.0",
+            display_name="gpt-oss Tier 1",
+            family="gpt-oss",
+            description="Tier-1 declarative runtime shaping for gpt-oss-family instruct models.",
+            contract=normalize_model_pack_contract(
+                {
+                    "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
+                    "context": {
+                        "max_sessions_cap": 3,
+                        "max_events_cap": 8,
+                        "max_memories_cap": 6,
+                        "max_entities_cap": 6,
+                        "max_entity_edges_cap": 12,
+                    },
+                    "tools": {"mode": "none"},
+                    "response": {
+                        "system_instruction_append": (
+                            "Use precise language, preserve continuity facts, and avoid narrative filler."
+                        ),
+                        "developer_instruction_append": (
+                            "When uncertain, state the uncertainty and propose the smallest safe next step."
+                        ),
+                    },
+                    "compatibility": {
+                        "provider_keys": ["openai_compatible", "ollama", "llamacpp"],
+                        "runtime_providers": ["openai_responses"],
+                        "notes": "Tier-1 baseline for gpt-oss-family backends.",
+                    },
+                }
+            ),
+        ),
+    )
+
+
+def is_reserved_tier1_pack_key(*, pack_id: str, pack_version: str) -> bool:
+    normalized_pack_id = normalize_pack_id(pack_id)
+    normalized_pack_version = normalize_pack_version(pack_version)
+    return any(
+        spec.pack_id == normalized_pack_id and spec.pack_version == normalized_pack_version
+        for spec in _tier1_pack_specs()
+    )
+
+
+def ensure_tier1_model_packs_for_workspace(
+    *,
+    store: ContinuityStore,
+    workspace_id: UUID,
+    created_by_user_account_id: UUID,
+) -> list[ModelPackRow]:
+    packs: list[ModelPackRow] = []
+    for spec in _tier1_pack_specs():
+        created = store.create_model_pack_if_absent_optional(
+            workspace_id=workspace_id,
+            created_by_user_account_id=created_by_user_account_id,
+            pack_id=spec.pack_id,
+            pack_version=spec.pack_version,
+            display_name=spec.display_name,
+            family=spec.family,
+            description=spec.description,
+            status=MODEL_PACK_STATUS_ACTIVE,
+            contract=spec.contract,
+            metadata={"seed": "tier1", "seed_version": "p11-s4"},
+        )
+        if created is not None:
+            packs.append(created)
+            continue
+
+        existing = store.get_model_pack_for_workspace_optional(
+            workspace_id=workspace_id,
+            pack_id=spec.pack_id,
+            pack_version=spec.pack_version,
+        )
+        if existing is None:
+            raise RuntimeError(
+                f"tier-1 model pack {spec.pack_id}@{spec.pack_version} was expected but missing"
+            )
+        packs.append(existing)
+    return packs
+
+
+def resolve_workspace_model_pack_selection(
+    *,
+    store: ContinuityStore,
+    workspace_id: UUID,
+    requested_pack_id: str | None,
+    requested_pack_version: str | None,
+) -> ResolvedModelPackSelection:
+    if requested_pack_id is not None:
+        normalized_pack_id = normalize_pack_id(requested_pack_id)
+        normalized_pack_version = (
+            None
+            if requested_pack_version is None
+            else normalize_pack_version(requested_pack_version)
+        )
+        selected_pack = store.get_model_pack_for_workspace_optional(
+            workspace_id=workspace_id,
+            pack_id=normalized_pack_id,
+            pack_version=normalized_pack_version,
+        )
+        if selected_pack is None:
+            if normalized_pack_version is None:
+                raise ModelPackNotFoundError(
+                    f"model pack {normalized_pack_id} was not found"
+                )
+            raise ModelPackNotFoundError(
+                f"model pack {normalized_pack_id}@{normalized_pack_version} was not found"
+            )
+        return ResolvedModelPackSelection(source="request", pack=selected_pack)
+
+    binding = store.get_latest_workspace_model_pack_binding_optional(workspace_id=workspace_id)
+    if binding is None:
+        return ResolvedModelPackSelection(source="none", pack=None)
+
+    selected_pack = store.get_model_pack_for_workspace_by_row_id_optional(
+        workspace_id=workspace_id,
+        model_pack_id=binding["model_pack_id"],
+    )
+    if selected_pack is None:
+        return ResolvedModelPackSelection(source="none", pack=None)
+
+    return ResolvedModelPackSelection(source="workspace_binding", pack=selected_pack)

--- a/apps/api/src/alicebot_api/response_generation.py
+++ b/apps/api/src/alicebot_api/response_generation.py
@@ -450,6 +450,8 @@ def generate_response(
     limits: ContextCompilerLimits,
     runtime_override: tuple[str, str] | None = None,
     model_invoker: Callable[[ModelInvocationRequest], ModelInvocationResponse] | None = None,
+    system_instruction: str = SYSTEM_INSTRUCTION,
+    developer_instruction: str = DEVELOPER_INSTRUCTION,
 ) -> GenerateResponseSuccess | ResponseFailure:
     store.get_user(user_id)
     thread = store.get_thread(thread_id)
@@ -469,8 +471,8 @@ def generate_response(
     prompt = assemble_prompt(
         request=PromptAssemblyInput(
             context_pack=compiled_trace.context_pack,
-            system_instruction=SYSTEM_INSTRUCTION,
-            developer_instruction=DEVELOPER_INSTRUCTION,
+            system_instruction=system_instruction,
+            developer_instruction=developer_instruction,
         ),
         compile_trace_id=compiled_trace.trace_id,
     )

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -373,6 +373,53 @@ class ProviderCapabilityRow(TypedDict):
     updated_at: datetime
 
 
+class ModelPackRow(TypedDict):
+    id: UUID
+    workspace_id: UUID
+    created_by_user_account_id: UUID
+    pack_id: str
+    pack_version: str
+    display_name: str
+    family: str
+    description: str
+    status: str
+    contract: JsonObject
+    metadata: JsonObject
+    created_at: datetime
+    updated_at: datetime
+
+
+class WorkspaceModelPackBindingRow(TypedDict):
+    id: UUID
+    workspace_id: UUID
+    model_pack_id: UUID
+    bound_by_user_account_id: UUID
+    binding_source: str
+    metadata: JsonObject
+    created_at: datetime
+
+
+class WorkspaceModelPackBindingDetailRow(TypedDict):
+    id: UUID
+    workspace_id: UUID
+    model_pack_id: UUID
+    bound_by_user_account_id: UUID
+    binding_source: str
+    metadata: JsonObject
+    created_at: datetime
+    pack_id: str
+    pack_version: str
+    pack_display_name: str
+    pack_family: str
+    pack_description: str
+    pack_status: str
+    pack_contract: JsonObject
+    pack_metadata: JsonObject
+    pack_created_by_user_account_id: UUID
+    pack_created_at: datetime
+    pack_updated_at: datetime
+
+
 class MemoryEmbeddingRow(TypedDict):
     id: UUID
     user_id: UUID
@@ -2209,6 +2256,228 @@ GET_PROVIDER_CAPABILITY_FOR_PROVIDER_SQL = """
                 FROM provider_capabilities
                 WHERE provider_id = %s
                   AND workspace_id = %s
+                """
+
+INSERT_MODEL_PACK_SQL = """
+                INSERT INTO model_packs (
+                  workspace_id,
+                  created_by_user_account_id,
+                  pack_id,
+                  pack_version,
+                  display_name,
+                  family,
+                  description,
+                  status,
+                  contract,
+                  metadata,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  clock_timestamp(),
+                  clock_timestamp()
+                )
+                RETURNING
+                  id,
+                  workspace_id,
+                  created_by_user_account_id,
+                  pack_id,
+                  pack_version,
+                  display_name,
+                  family,
+                  description,
+                  status,
+                  contract,
+                  metadata,
+                  created_at,
+                  updated_at
+                """
+
+INSERT_MODEL_PACK_IF_ABSENT_SQL = """
+                INSERT INTO model_packs (
+                  workspace_id,
+                  created_by_user_account_id,
+                  pack_id,
+                  pack_version,
+                  display_name,
+                  family,
+                  description,
+                  status,
+                  contract,
+                  metadata,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  clock_timestamp(),
+                  clock_timestamp()
+                )
+                ON CONFLICT (workspace_id, pack_id, pack_version) DO NOTHING
+                RETURNING
+                  id,
+                  workspace_id,
+                  created_by_user_account_id,
+                  pack_id,
+                  pack_version,
+                  display_name,
+                  family,
+                  description,
+                  status,
+                  contract,
+                  metadata,
+                  created_at,
+                  updated_at
+                """
+
+GET_MODEL_PACK_FOR_WORKSPACE_BY_ID_AND_VERSION_SQL = """
+                SELECT
+                  id,
+                  workspace_id,
+                  created_by_user_account_id,
+                  pack_id,
+                  pack_version,
+                  display_name,
+                  family,
+                  description,
+                  status,
+                  contract,
+                  metadata,
+                  created_at,
+                  updated_at
+                FROM model_packs
+                WHERE workspace_id = %s
+                  AND pack_id = %s
+                  AND pack_version = %s
+                """
+
+GET_LATEST_MODEL_PACK_FOR_WORKSPACE_BY_ID_SQL = """
+                SELECT
+                  id,
+                  workspace_id,
+                  created_by_user_account_id,
+                  pack_id,
+                  pack_version,
+                  display_name,
+                  family,
+                  description,
+                  status,
+                  contract,
+                  metadata,
+                  created_at,
+                  updated_at
+                FROM model_packs
+                WHERE workspace_id = %s
+                  AND pack_id = %s
+                ORDER BY created_at DESC, id DESC
+                LIMIT 1
+                """
+
+GET_MODEL_PACK_FOR_WORKSPACE_BY_ROW_ID_SQL = """
+                SELECT
+                  id,
+                  workspace_id,
+                  created_by_user_account_id,
+                  pack_id,
+                  pack_version,
+                  display_name,
+                  family,
+                  description,
+                  status,
+                  contract,
+                  metadata,
+                  created_at,
+                  updated_at
+                FROM model_packs
+                WHERE workspace_id = %s
+                  AND id = %s
+                """
+
+LIST_MODEL_PACKS_FOR_WORKSPACE_SQL = """
+                SELECT
+                  id,
+                  workspace_id,
+                  created_by_user_account_id,
+                  pack_id,
+                  pack_version,
+                  display_name,
+                  family,
+                  description,
+                  status,
+                  contract,
+                  metadata,
+                  created_at,
+                  updated_at
+                FROM model_packs
+                WHERE workspace_id = %s
+                ORDER BY pack_id ASC, created_at DESC, id DESC
+                """
+
+INSERT_WORKSPACE_MODEL_PACK_BINDING_SQL = """
+                INSERT INTO workspace_model_pack_bindings (
+                  workspace_id,
+                  model_pack_id,
+                  bound_by_user_account_id,
+                  binding_source,
+                  metadata,
+                  created_at
+                )
+                VALUES (%s, %s, %s, %s, %s, clock_timestamp())
+                RETURNING
+                  id,
+                  workspace_id,
+                  model_pack_id,
+                  bound_by_user_account_id,
+                  binding_source,
+                  metadata,
+                  created_at
+                """
+
+GET_LATEST_WORKSPACE_MODEL_PACK_BINDING_SQL = """
+                SELECT
+                  b.id,
+                  b.workspace_id,
+                  b.model_pack_id,
+                  b.bound_by_user_account_id,
+                  b.binding_source,
+                  b.metadata,
+                  b.created_at,
+                  p.pack_id,
+                  p.pack_version,
+                  p.display_name AS pack_display_name,
+                  p.family AS pack_family,
+                  p.description AS pack_description,
+                  p.status AS pack_status,
+                  p.contract AS pack_contract,
+                  p.metadata AS pack_metadata,
+                  p.created_by_user_account_id AS pack_created_by_user_account_id,
+                  p.created_at AS pack_created_at,
+                  p.updated_at AS pack_updated_at
+                FROM workspace_model_pack_bindings AS b
+                INNER JOIN model_packs AS p
+                  ON p.id = b.model_pack_id
+                WHERE b.workspace_id = %s
+                ORDER BY b.created_at DESC, b.id DESC
+                LIMIT 1
                 """
 
 INSERT_EMBEDDING_CONFIG_SQL = """
@@ -6072,6 +6341,132 @@ class ContinuityStore:
         return self._fetch_optional_one(
             GET_PROVIDER_CAPABILITY_FOR_PROVIDER_SQL,
             (provider_id, workspace_id),
+        )
+
+    def create_model_pack(
+        self,
+        *,
+        workspace_id: UUID,
+        created_by_user_account_id: UUID,
+        pack_id: str,
+        pack_version: str,
+        display_name: str,
+        family: str,
+        description: str,
+        status: str,
+        contract: JsonObject,
+        metadata: JsonObject,
+    ) -> ModelPackRow:
+        return self._fetch_one(
+            "create_model_pack",
+            INSERT_MODEL_PACK_SQL,
+            (
+                workspace_id,
+                created_by_user_account_id,
+                pack_id,
+                pack_version,
+                display_name,
+                family,
+                description,
+                status,
+                Jsonb(contract),
+                Jsonb(metadata),
+            ),
+        )
+
+    def create_model_pack_if_absent_optional(
+        self,
+        *,
+        workspace_id: UUID,
+        created_by_user_account_id: UUID,
+        pack_id: str,
+        pack_version: str,
+        display_name: str,
+        family: str,
+        description: str,
+        status: str,
+        contract: JsonObject,
+        metadata: JsonObject,
+    ) -> ModelPackRow | None:
+        return self._fetch_optional_one(
+            INSERT_MODEL_PACK_IF_ABSENT_SQL,
+            (
+                workspace_id,
+                created_by_user_account_id,
+                pack_id,
+                pack_version,
+                display_name,
+                family,
+                description,
+                status,
+                Jsonb(contract),
+                Jsonb(metadata),
+            ),
+        )
+
+    def get_model_pack_for_workspace_optional(
+        self,
+        *,
+        workspace_id: UUID,
+        pack_id: str,
+        pack_version: str | None = None,
+    ) -> ModelPackRow | None:
+        if pack_version is None:
+            return self._fetch_optional_one(
+                GET_LATEST_MODEL_PACK_FOR_WORKSPACE_BY_ID_SQL,
+                (workspace_id, pack_id),
+            )
+        return self._fetch_optional_one(
+            GET_MODEL_PACK_FOR_WORKSPACE_BY_ID_AND_VERSION_SQL,
+            (workspace_id, pack_id, pack_version),
+        )
+
+    def get_model_pack_for_workspace_by_row_id_optional(
+        self,
+        *,
+        workspace_id: UUID,
+        model_pack_id: UUID,
+    ) -> ModelPackRow | None:
+        return self._fetch_optional_one(
+            GET_MODEL_PACK_FOR_WORKSPACE_BY_ROW_ID_SQL,
+            (workspace_id, model_pack_id),
+        )
+
+    def list_model_packs_for_workspace(self, *, workspace_id: UUID) -> list[ModelPackRow]:
+        return self._fetch_all(
+            LIST_MODEL_PACKS_FOR_WORKSPACE_SQL,
+            (workspace_id,),
+        )
+
+    def create_workspace_model_pack_binding(
+        self,
+        *,
+        workspace_id: UUID,
+        model_pack_id: UUID,
+        bound_by_user_account_id: UUID,
+        binding_source: str,
+        metadata: JsonObject,
+    ) -> WorkspaceModelPackBindingRow:
+        return self._fetch_one(
+            "create_workspace_model_pack_binding",
+            INSERT_WORKSPACE_MODEL_PACK_BINDING_SQL,
+            (
+                workspace_id,
+                model_pack_id,
+                bound_by_user_account_id,
+                binding_source,
+                Jsonb(metadata),
+            ),
+        )
+
+    def get_latest_workspace_model_pack_binding_optional(
+        self,
+        *,
+        workspace_id: UUID,
+    ) -> WorkspaceModelPackBindingDetailRow | None:
+        return self._fetch_optional_one(
+            GET_LATEST_WORKSPACE_MODEL_PACK_BINDING_SQL,
+            (workspace_id,),
         )
 
     def create_embedding_config(

--- a/docs/integrations/phase11-model-pack-compatibility.md
+++ b/docs/integrations/phase11-model-pack-compatibility.md
@@ -1,0 +1,16 @@
+# Phase 11 Model Pack Compatibility (P11-S4)
+
+This table is the sprint-owned compatibility reference for tier-1 model packs.
+
+| Pack ID | Version | Family | Runtime Provider | Provider Keys | Tool Mode |
+|---|---|---|---|---|---|
+| `llama` | `1.0.0` | `llama` | `openai_responses` | `openai_compatible`, `ollama`, `llamacpp` | `none` |
+| `qwen` | `1.0.0` | `qwen` | `openai_responses` | `openai_compatible`, `ollama`, `llamacpp` | `none` |
+| `gemma` | `1.0.0` | `gemma` | `openai_responses` | `openai_compatible`, `ollama`, `llamacpp` | `none` |
+| `gpt-oss` | `1.0.0` | `gpt-oss` | `openai_responses` | `openai_compatible`, `ollama`, `llamacpp` | `none` |
+
+## Scope Notes
+
+- This reference is limited to tier-1 packs shipped in `P11-S4`.
+- Azure and tier-2 packs are explicitly out of scope for this sprint.
+- Provider adapter behavior remains in adapters; model-pack behavior remains declarative in pack contracts.

--- a/docs/integrations/phase11-model-packs-tier1.md
+++ b/docs/integrations/phase11-model-packs-tier1.md
@@ -1,0 +1,122 @@
+# Phase 11 Model Packs Tier 1 (P11-S4)
+
+This guide documents the declarative tier-1 model-pack layer introduced in `P11-S4`.
+
+## In-Scope APIs
+
+- `GET /v1/model-packs`
+- `GET /v1/model-packs/{pack_id}`
+- `POST /v1/model-packs`
+- `POST /v1/model-packs/{pack_id}/bind`
+- `GET /v1/workspaces/{workspace_id}/model-pack-binding`
+- `POST /v1/runtime/invoke` (pack-aware shaping)
+
+## Tier-1 Packs
+
+The tier-1 pack catalog is seeded per workspace and includes:
+
+- `llama@1.0.0`
+- `qwen@1.0.0`
+- `gemma@1.0.0`
+- `gpt-oss@1.0.0`
+
+Each tier-1 pack uses `contract_version = model_pack_contract_v1` and keeps behavior declarative in:
+
+- `context` (limit caps)
+- `tools` (mode)
+- `response` (instruction overlays)
+- `compatibility` (provider/runtime compatibility references)
+
+## Runtime Selection Precedence
+
+For `POST /v1/runtime/invoke`, model-pack selection precedence is:
+
+1. request override (`pack_id` + optional `pack_version`)
+2. current workspace binding
+3. no pack
+
+This precedence affects runtime shaping only. It does not change provider adapter semantics.
+
+## Pack-Driven Runtime Shaping
+
+Pack contracts can declaratively shape:
+
+- context compiler caps (`max_sessions`, `max_events`, `max_memories`, `max_entities`, `max_entity_edges`)
+- instruction overlays appended to system/developer instructions
+- tool mode contract (`none` in this sprint)
+
+Shaping is applied on the existing invoke seam (`/v1/runtime/invoke`) and does not create a parallel runtime path.
+
+## Bind A Tier-1 Pack
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/model-packs/gpt-oss/bind" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pack_version": "1.0.0",
+    "metadata": {"reason": "team-default"}
+  }'
+```
+
+## Invoke With Bound Pack
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/runtime/invoke" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_id": "'$PROVIDER_ID'",
+    "thread_id": "'$THREAD_ID'",
+    "message": "Summarize current open loops.",
+    "max_sessions": 10,
+    "max_events": 40,
+    "max_memories": 40,
+    "max_entities": 40,
+    "max_entity_edges": 80
+  }'
+```
+
+The response metadata reports the resolved pack and source when a pack is applied.
+
+## Create A Custom Pack
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/model-packs" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pack_id": "custom-brief",
+    "pack_version": "1.0.0",
+    "display_name": "Custom Brief",
+    "family": "custom",
+    "description": "Workspace custom pack for concise operational briefs.",
+    "contract": {
+      "contract_version": "model_pack_contract_v1",
+      "context": {
+        "max_sessions_cap": 3,
+        "max_events_cap": 8,
+        "max_memories_cap": 5,
+        "max_entities_cap": 5,
+        "max_entity_edges_cap": 10
+      },
+      "tools": {"mode": "none"},
+      "response": {
+        "system_instruction_append": "Keep responses concise and grounded.",
+        "developer_instruction_append": "Prioritize explicit next actions."
+      },
+      "compatibility": {
+        "provider_keys": ["openai_compatible", "ollama", "llamacpp"],
+        "runtime_providers": ["openai_responses"],
+        "notes": "Custom workspace brief style."
+      }
+    },
+    "metadata": {
+      "owner": "workspace-ops"
+    }
+  }'
+```
+
+## Compatibility References
+
+See `docs/integrations/phase11-model-pack-compatibility.md`.

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -19,7 +19,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="README.md",
         required_markers=(
             "Phase 10 is complete and shipped.",
-            "`P11-S2` Ollama + llama.cpp Adapters is the active sprint",
+            "`P11-S4` Model Packs Tier 1 is the active sprint",
             "Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md]",
         ),
     ),
@@ -27,14 +27,14 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="ROADMAP.md",
         required_markers=(
             "Phase 10 is complete and shipped baseline truth.",
-            "P11-S2: Ollama + llama.cpp Adapters",
+            "P11-S4: Model Packs Tier 1",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Phase 11 Sprint 2 (P11-S2): Ollama + llama.cpp Adapters",
-            "Phase 10 and `P11-S1` shipped scope remain baseline truth and are not reopened as sprint work",
+            "Phase 11 Sprint 4 (P11-S4): Model Packs Tier 1",
+            "Phase 10, `P11-S1`, `P11-S2`, and `P11-S3` shipped scope remain baseline truth and are not reopened as sprint work",
         ),
     ),
     ControlDocTruthRule(
@@ -49,7 +49,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "Phase 9 is complete and shipped.",
             "Phase 10 is complete and shipped.",
-            "`P11-S2` (Ollama + llama.cpp Adapters) is the active execution sprint packet.",
+            "`P11-S4` (Model Packs Tier 1) is the active execution sprint packet.",
         ),
     ),
     ControlDocTruthRule(

--- a/scripts/check_protected_paths.py
+++ b/scripts/check_protected_paths.py
@@ -170,7 +170,16 @@ def validate_upgrade_overview(pr_body: str, touched_areas: dict[str, list[str]])
         errors.append("`### Protected Areas` is missing from `## Upgrade Overview`.")
     else:
         checked_areas = parse_checked_areas(protected_area_section)
-        missing_checked = sorted(set(touched_areas) - checked_areas)
+        normalized_touched_labels = {
+            _normalize_heading(area_label): area_label for area_label in touched_areas
+        }
+        missing_checked = sorted(
+            (
+                normalized_touched_labels[normalized_label]
+                for normalized_label in set(normalized_touched_labels) - checked_areas
+            ),
+            key=str.lower,
+        )
         if missing_checked:
             errors.append(
                 "The checked protected areas do not cover the touched categories: "

--- a/tests/integration/test_phase11_model_packs_api.py
+++ b/tests/integration/test_phase11_model_packs_api.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import urlencode
+from uuid import UUID, uuid4
+
+import anyio
+import psycopg
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+
+        request_received = True
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    request_headers = [(b"content-type", b"application/json")]
+    for key, value in (headers or {}).items():
+        request_headers.append((key.lower().encode(), value.encode()))
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": request_headers,
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def auth_header(session_token: str) -> dict[str, str]:
+    return {"authorization": f"Bearer {session_token}"}
+
+
+def _configure_settings(migrated_database_urls, monkeypatch) -> None:
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            database_url=migrated_database_urls["app"],
+            magic_link_ttl_seconds=600,
+            auth_session_ttl_seconds=3600,
+            device_link_ttl_seconds=600,
+            model_timeout_seconds=30,
+        ),
+    )
+
+
+def _bootstrap_workspace_session(email: str) -> tuple[str, str, str]:
+    start_status, start_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/start",
+        payload={"email": email},
+    )
+    assert start_status == 200
+
+    verify_status, verify_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/verify",
+        payload={
+            "challenge_token": start_payload["challenge"]["challenge_token"],
+            "device_label": "P11-S4 Device",
+            "device_key": f"device-{email}",
+        },
+    )
+    assert verify_status == 200
+    session_token = verify_payload["session_token"]
+    user_account_id = verify_payload["user_account"]["id"]
+
+    create_workspace_status, create_workspace_payload = invoke_request(
+        "POST",
+        "/v1/workspaces",
+        payload={"name": "P11 Model Pack Workspace"},
+        headers=auth_header(session_token),
+    )
+    assert create_workspace_status == 201
+    workspace_id = create_workspace_payload["workspace"]["id"]
+
+    bootstrap_status, bootstrap_payload = invoke_request(
+        "POST",
+        "/v1/workspaces/bootstrap",
+        payload={"workspace_id": workspace_id},
+        headers=auth_header(session_token),
+    )
+    assert bootstrap_status == 200
+    assert bootstrap_payload["workspace"]["bootstrap_status"] == "ready"
+    return session_token, workspace_id, user_account_id
+
+
+def _seed_thread_for_user(*, admin_db_url: str, user_id: str, email: str) -> str:
+    thread_id = str(uuid4())
+    with psycopg.connect(admin_db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO users (id, email, display_name)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (id) DO UPDATE
+                SET email = EXCLUDED.email,
+                    display_name = EXCLUDED.display_name
+                """,
+                (user_id, email, "Model Pack Runtime User"),
+            )
+            cur.execute(
+                """
+                INSERT INTO threads (id, user_id, title)
+                VALUES (%s, %s, %s)
+                """,
+                (thread_id, user_id, "Model Pack Runtime Thread"),
+            )
+        conn.commit()
+    return thread_id
+
+
+class FakeHTTPResponse:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+
+    def __enter__(self) -> "FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def _extract_context_payload(http_payload: dict[str, Any]) -> dict[str, Any]:
+    input_items = http_payload["input"]
+    context_item = next(
+        item
+        for item in input_items
+        if item["role"] == "user" and item["content"][0]["text"].startswith("[CONTEXT]\n")
+    )
+    context_text = context_item["content"][0]["text"].split("\n", maxsplit=1)[1]
+    return json.loads(context_text)
+
+
+def test_phase11_model_pack_catalog_bind_and_runtime_shaping(migrated_database_urls, monkeypatch) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, workspace_id, user_account_id = _bootstrap_workspace_session(
+        "model-pack-a@example.com"
+    )
+
+    create_provider_status, create_provider_payload = invoke_request(
+        "POST",
+        "/v1/providers",
+        payload={
+            "provider_key": "openai_compatible",
+            "display_name": "Pack Runtime Provider",
+            "base_url": "https://provider.example/v1",
+            "api_key": "provider-secret-key",
+            "default_model": "gpt-5-mini",
+        },
+        headers=auth_header(session_token),
+    )
+    assert create_provider_status == 201
+    provider_id = create_provider_payload["provider"]["id"]
+
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v1/model-packs",
+        headers=auth_header(session_token),
+    )
+    assert list_status == 200
+    listed_ids = {item["pack_id"] for item in list_payload["items"]}
+    assert {"llama", "qwen", "gemma", "gpt-oss"}.issubset(listed_ids)
+
+    detail_status, detail_payload = invoke_request(
+        "GET",
+        "/v1/model-packs/gpt-oss",
+        query_params={"version": "1.0.0"},
+        headers=auth_header(session_token),
+    )
+    assert detail_status == 200
+    assert detail_payload["model_pack"]["pack_id"] == "gpt-oss"
+    assert detail_payload["model_pack"]["pack_version"] == "1.0.0"
+
+    reserved_create_status, reserved_create_payload = invoke_request(
+        "POST",
+        "/v1/model-packs",
+        payload={
+            "pack_id": "llama",
+            "pack_version": "1.0.0",
+            "display_name": "Conflicting Reserved Pack",
+            "family": "custom",
+            "description": "Should be rejected.",
+            "contract": {
+                "contract_version": "model_pack_contract_v1",
+                "context": {},
+                "tools": {"mode": "none"},
+                "response": {},
+                "compatibility": {
+                    "provider_keys": ["openai_compatible"],
+                    "runtime_providers": ["openai_responses"],
+                },
+            },
+            "metadata": {},
+        },
+        headers=auth_header(session_token),
+    )
+    assert reserved_create_status == 409
+    assert "reserved for tier-1 catalog entries" in reserved_create_payload["detail"]
+
+    create_pack_status, create_pack_payload = invoke_request(
+        "POST",
+        "/v1/model-packs",
+        payload={
+            "pack_id": "custom-brief",
+            "pack_version": "1.0.0",
+            "display_name": "Custom Brief",
+            "family": "custom",
+            "description": "Custom operational brief style.",
+            "contract": {
+                "contract_version": "model_pack_contract_v1",
+                "context": {
+                    "max_sessions_cap": 3,
+                    "max_events_cap": 8,
+                    "max_memories_cap": 5,
+                    "max_entities_cap": 5,
+                    "max_entity_edges_cap": 10,
+                },
+                "tools": {"mode": "none"},
+                "response": {
+                    "system_instruction_append": "Keep responses concise and grounded.",
+                    "developer_instruction_append": "Prioritize explicit next actions.",
+                },
+                "compatibility": {
+                    "provider_keys": ["openai_compatible", "ollama", "llamacpp"],
+                    "runtime_providers": ["openai_responses"],
+                    "notes": "Custom workspace brief style.",
+                },
+            },
+            "metadata": {"owner": "ops"},
+        },
+        headers=auth_header(session_token),
+    )
+    assert create_pack_status == 201
+    assert create_pack_payload["model_pack"]["pack_id"] == "custom-brief"
+
+    bind_status, bind_payload = invoke_request(
+        "POST",
+        "/v1/model-packs/gpt-oss/bind",
+        payload={"pack_version": "1.0.0", "metadata": {"reason": "workspace-default"}},
+        headers=auth_header(session_token),
+    )
+    assert bind_status == 200
+    assert bind_payload["binding"]["model_pack"]["pack_id"] == "gpt-oss"
+    assert bind_payload["binding"]["binding_source"] == "manual"
+
+    binding_status, binding_payload = invoke_request(
+        "GET",
+        f"/v1/workspaces/{workspace_id}/model-pack-binding",
+        headers=auth_header(session_token),
+    )
+    assert binding_status == 200
+    assert binding_payload["binding"]["model_pack"]["pack_id"] == "gpt-oss"
+
+    thread_id = _seed_thread_for_user(
+        admin_db_url=migrated_database_urls["admin"],
+        user_id=user_account_id,
+        email="model-pack-a@example.com",
+    )
+
+    captured_model_requests: list[dict[str, Any]] = []
+
+    def fake_urlopen(request, timeout):
+        del timeout
+        payload = json.loads(request.data.decode("utf-8"))
+        captured_model_requests.append(payload)
+        return FakeHTTPResponse(
+            json.dumps(
+                {
+                    "id": f"resp_{len(captured_model_requests)}",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "content": [{"type": "output_text", "text": "Pack runtime response"}],
+                        }
+                    ],
+                    "usage": {
+                        "input_tokens": 12,
+                        "output_tokens": 4,
+                        "total_tokens": 16,
+                    },
+                }
+            ).encode("utf-8")
+        )
+
+    monkeypatch.setattr("alicebot_api.response_generation.urlopen", fake_urlopen)
+
+    runtime_status, runtime_payload = invoke_request(
+        "POST",
+        "/v1/runtime/invoke",
+        payload={
+            "provider_id": provider_id,
+            "thread_id": thread_id,
+            "message": "Summarize current status.",
+            "max_sessions": 10,
+            "max_events": 40,
+            "max_memories": 50,
+            "max_entities": 50,
+            "max_entity_edges": 100,
+        },
+        headers=auth_header(session_token),
+    )
+    assert runtime_status == 200
+    assert runtime_payload["metadata"]["model_pack"] == {
+        "pack_id": "gpt-oss",
+        "pack_version": "1.0.0",
+        "source": "workspace_binding",
+    }
+
+    first_request = captured_model_requests[0]
+    first_context = _extract_context_payload(first_request)
+    assert first_context["limits"]["max_memories"] == 6
+    assert first_context["limits"]["max_entities"] == 6
+    assert first_context["limits"]["max_entity_edges"] == 12
+    assert (
+        "Use precise language, preserve continuity facts"
+        in first_request["input"][0]["content"][0]["text"]
+    )
+    assert (
+        "When uncertain, state the uncertainty"
+        in first_request["input"][1]["content"][0]["text"]
+    )
+
+    runtime_override_status, runtime_override_payload = invoke_request(
+        "POST",
+        "/v1/runtime/invoke",
+        payload={
+            "provider_id": provider_id,
+            "thread_id": thread_id,
+            "message": "Summarize current status with request override.",
+            "pack_id": "qwen",
+            "pack_version": "1.0.0",
+            "max_sessions": 10,
+            "max_events": 40,
+            "max_memories": 50,
+            "max_entities": 50,
+            "max_entity_edges": 100,
+        },
+        headers=auth_header(session_token),
+    )
+    assert runtime_override_status == 200
+    assert runtime_override_payload["metadata"]["model_pack"] == {
+        "pack_id": "qwen",
+        "pack_version": "1.0.0",
+        "source": "request",
+    }
+
+    second_request = captured_model_requests[1]
+    second_context = _extract_context_payload(second_request)
+    assert second_context["limits"]["max_memories"] == 4
+    assert second_context["limits"]["max_entity_edges"] == 8
+    assert "Keep outputs directly actionable and compact." in second_request["input"][1]["content"][0]["text"]
+
+
+def test_phase11_workspace_model_pack_binding_is_workspace_isolated(migrated_database_urls, monkeypatch) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token_a, workspace_id_a, _ = _bootstrap_workspace_session("model-pack-iso-a@example.com")
+    session_token_b, _, _ = _bootstrap_workspace_session("model-pack-iso-b@example.com")
+
+    bind_status, _ = invoke_request(
+        "POST",
+        "/v1/model-packs/llama/bind",
+        payload={"pack_version": "1.0.0"},
+        headers=auth_header(session_token_a),
+    )
+    assert bind_status == 200
+
+    cross_workspace_status, cross_workspace_payload = invoke_request(
+        "GET",
+        f"/v1/workspaces/{workspace_id_a}/model-pack-binding",
+        headers=auth_header(session_token_b),
+    )
+    assert cross_workspace_status == 404
+    assert "was not found" in cross_workspace_payload["detail"]
+
+    valid_workspace_status, valid_workspace_payload = invoke_request(
+        "GET",
+        f"/v1/workspaces/{workspace_id_a}/model-pack-binding",
+        headers=auth_header(session_token_a),
+    )
+    assert valid_workspace_status == 200
+    assert valid_workspace_payload["binding"]["model_pack"]["pack_id"] == "llama"
+    assert UUID(valid_workspace_payload["binding"]["id"])

--- a/tests/unit/test_20260412_0054_phase11_model_packs_tier1.py
+++ b/tests/unit/test_20260412_0054_phase11_model_packs_tier1.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260412_0054_phase11_model_packs_tier1"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == list(module._UPGRADE_STATEMENTS) + list(module._UPGRADE_GRANT_STATEMENTS)
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_upgrade_adds_workspace_consistent_binding_constraint() -> None:
+    module = load_migration_module()
+    ddl = "\n".join(module._UPGRADE_STATEMENTS)
+    assert "FOREIGN KEY (model_pack_id, workspace_id)" in ddl
+    assert "REFERENCES model_packs(id, workspace_id)" in ddl
+
+
+def test_upgrade_adds_model_pack_workspace_composite_unique() -> None:
+    module = load_migration_module()
+    ddl = "\n".join(module._UPGRADE_STATEMENTS)
+    assert "UNIQUE (id, workspace_id)" in ddl

--- a/tests/unit/test_model_packs.py
+++ b/tests/unit/test_model_packs.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from alicebot_api.model_packs import (
+    MODEL_PACK_CONTRACT_VERSION_V1,
+    ModelPackNotFoundError,
+    ModelPackValidationError,
+    apply_runtime_limit_caps,
+    build_model_pack_runtime_shape,
+    ensure_tier1_model_packs_for_workspace,
+    is_reserved_tier1_pack_key,
+    normalize_model_pack_contract,
+    normalize_pack_id,
+    normalize_pack_version,
+    resolve_workspace_model_pack_selection,
+)
+
+
+_NOW = datetime.now(timezone.utc)
+
+
+def _contract(*, system_append: str = "", developer_append: str = "") -> dict[str, object]:
+    return {
+        "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
+        "context": {
+            "max_sessions_cap": 3,
+            "max_events_cap": 8,
+            "max_memories_cap": 5,
+            "max_entities_cap": 5,
+            "max_entity_edges_cap": 10,
+        },
+        "tools": {"mode": "none"},
+        "response": {
+            "system_instruction_append": system_append,
+            "developer_instruction_append": developer_append,
+        },
+        "compatibility": {
+            "provider_keys": ["openai_compatible", "ollama", "llamacpp"],
+            "runtime_providers": ["openai_responses"],
+            "notes": "unit test",
+        },
+    }
+
+
+def _pack_row(*, pack_id: str, pack_version: str = "1.0.0") -> dict[str, object]:
+    return {
+        "id": uuid4(),
+        "workspace_id": uuid4(),
+        "created_by_user_account_id": uuid4(),
+        "pack_id": pack_id,
+        "pack_version": pack_version,
+        "display_name": f"{pack_id} pack",
+        "family": "custom",
+        "description": "desc",
+        "status": "active",
+        "contract": normalize_model_pack_contract(_contract()),
+        "metadata": {},
+        "created_at": _NOW,
+        "updated_at": _NOW,
+    }
+
+
+class FakeModelPackStore:
+    def __init__(self) -> None:
+        self.packs_by_key: dict[tuple[str, str], dict[str, object]] = {}
+        self.packs_by_row_id: dict[object, dict[str, object]] = {}
+        self.binding: dict[str, object] | None = None
+
+    def get_model_pack_for_workspace_optional(
+        self,
+        *,
+        workspace_id,
+        pack_id: str,
+        pack_version: str | None = None,
+    ):
+        del workspace_id
+        if pack_version is None:
+            candidates = [
+                row
+                for (candidate_pack_id, _), row in self.packs_by_key.items()
+                if candidate_pack_id == pack_id
+            ]
+            if not candidates:
+                return None
+            candidates.sort(key=lambda row: (row["created_at"], row["id"]), reverse=True)
+            return candidates[0]
+        return self.packs_by_key.get((pack_id, pack_version))
+
+    def create_model_pack(
+        self,
+        *,
+        workspace_id,
+        created_by_user_account_id,
+        pack_id: str,
+        pack_version: str,
+        display_name: str,
+        family: str,
+        description: str,
+        status: str,
+        contract,
+        metadata,
+    ):
+        row = {
+            "id": uuid4(),
+            "workspace_id": workspace_id,
+            "created_by_user_account_id": created_by_user_account_id,
+            "pack_id": pack_id,
+            "pack_version": pack_version,
+            "display_name": display_name,
+            "family": family,
+            "description": description,
+            "status": status,
+            "contract": contract,
+            "metadata": metadata,
+            "created_at": _NOW,
+            "updated_at": _NOW,
+        }
+        self.packs_by_key[(pack_id, pack_version)] = row
+        self.packs_by_row_id[row["id"]] = row
+        return row
+
+    def create_model_pack_if_absent_optional(
+        self,
+        *,
+        workspace_id,
+        created_by_user_account_id,
+        pack_id: str,
+        pack_version: str,
+        display_name: str,
+        family: str,
+        description: str,
+        status: str,
+        contract,
+        metadata,
+    ):
+        key = (pack_id, pack_version)
+        if key in self.packs_by_key:
+            return None
+        return self.create_model_pack(
+            workspace_id=workspace_id,
+            created_by_user_account_id=created_by_user_account_id,
+            pack_id=pack_id,
+            pack_version=pack_version,
+            display_name=display_name,
+            family=family,
+            description=description,
+            status=status,
+            contract=contract,
+            metadata=metadata,
+        )
+
+    def get_latest_workspace_model_pack_binding_optional(self, *, workspace_id):
+        del workspace_id
+        return self.binding
+
+    def get_model_pack_for_workspace_by_row_id_optional(self, *, workspace_id, model_pack_id):
+        del workspace_id
+        return self.packs_by_row_id.get(model_pack_id)
+
+
+class SimulatedSeedRaceModelPackStore(FakeModelPackStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self._simulated_race_for_keys: set[tuple[str, str]] = set()
+
+    def create_model_pack_if_absent_optional(
+        self,
+        *,
+        workspace_id,
+        created_by_user_account_id,
+        pack_id: str,
+        pack_version: str,
+        display_name: str,
+        family: str,
+        description: str,
+        status: str,
+        contract,
+        metadata,
+    ):
+        key = (pack_id, pack_version)
+        if key == ("llama", "1.0.0") and key not in self._simulated_race_for_keys:
+            self._simulated_race_for_keys.add(key)
+            super().create_model_pack(
+                workspace_id=workspace_id,
+                created_by_user_account_id=created_by_user_account_id,
+                pack_id=pack_id,
+                pack_version=pack_version,
+                display_name=display_name,
+                family=family,
+                description=description,
+                status=status,
+                contract=contract,
+                metadata=metadata,
+            )
+            return None
+        return super().create_model_pack_if_absent_optional(
+            workspace_id=workspace_id,
+            created_by_user_account_id=created_by_user_account_id,
+            pack_id=pack_id,
+            pack_version=pack_version,
+            display_name=display_name,
+            family=family,
+            description=description,
+            status=status,
+            contract=contract,
+            metadata=metadata,
+        )
+
+
+def test_normalize_pack_id_and_version() -> None:
+    assert normalize_pack_id(" GPT-OSS ") == "gpt-oss"
+    assert normalize_pack_version("1.2.3") == "1.2.3"
+
+    with pytest.raises(ModelPackValidationError, match="pack_id"):
+        normalize_pack_id("Bad ID")
+    with pytest.raises(ModelPackValidationError, match="semver"):
+        normalize_pack_version("v1")
+
+
+def test_normalize_model_pack_contract_rejects_invalid_provider_key() -> None:
+    with pytest.raises(ModelPackValidationError, match="unsupported provider key"):
+        normalize_model_pack_contract(
+            {
+                "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
+                "context": {},
+                "tools": {"mode": "none"},
+                "response": {},
+                "compatibility": {
+                    "provider_keys": ["unknown"],
+                    "runtime_providers": ["openai_responses"],
+                },
+            }
+        )
+
+
+def test_build_runtime_shape_and_apply_caps() -> None:
+    shape = build_model_pack_runtime_shape(
+        normalize_model_pack_contract(
+            _contract(
+                system_append="System overlay",
+                developer_append="Developer overlay",
+            )
+        )
+    )
+
+    assert shape.system_instruction_append == "System overlay"
+    assert shape.developer_instruction_append == "Developer overlay"
+
+    assert apply_runtime_limit_caps(
+        max_sessions=20,
+        max_events=40,
+        max_memories=60,
+        max_entities=80,
+        max_entity_edges=100,
+        shape=shape,
+    ) == (3, 8, 5, 5, 10)
+
+
+def test_ensure_tier1_model_packs_for_workspace_seeds_once() -> None:
+    store = FakeModelPackStore()
+    workspace_id = uuid4()
+    user_account_id = uuid4()
+
+    first_seed = ensure_tier1_model_packs_for_workspace(
+        store=store,  # type: ignore[arg-type]
+        workspace_id=workspace_id,
+        created_by_user_account_id=user_account_id,
+    )
+    second_seed = ensure_tier1_model_packs_for_workspace(
+        store=store,  # type: ignore[arg-type]
+        workspace_id=workspace_id,
+        created_by_user_account_id=user_account_id,
+    )
+
+    assert len(first_seed) == 4
+    assert len(second_seed) == 4
+    assert len(store.packs_by_key) == 4
+    assert {row["pack_id"] for row in first_seed} == {"llama", "qwen", "gemma", "gpt-oss"}
+
+
+def test_ensure_tier1_model_packs_handles_seed_race_with_existing_row() -> None:
+    store = SimulatedSeedRaceModelPackStore()
+    seeded = ensure_tier1_model_packs_for_workspace(
+        store=store,  # type: ignore[arg-type]
+        workspace_id=uuid4(),
+        created_by_user_account_id=uuid4(),
+    )
+    assert len(seeded) == 4
+    assert {row["pack_id"] for row in seeded} == {"llama", "qwen", "gemma", "gpt-oss"}
+
+
+def test_is_reserved_tier1_pack_key() -> None:
+    assert is_reserved_tier1_pack_key(pack_id="llama", pack_version="1.0.0")
+    assert not is_reserved_tier1_pack_key(pack_id="llama", pack_version="1.0.1")
+    assert not is_reserved_tier1_pack_key(pack_id="custom-brief", pack_version="1.0.0")
+
+
+def test_pack_selection_prefers_request_over_workspace_binding() -> None:
+    store = FakeModelPackStore()
+    workspace_id = uuid4()
+    request_pack = _pack_row(pack_id="qwen")
+    bound_pack = _pack_row(pack_id="llama")
+    store.packs_by_key[("qwen", "1.0.0")] = request_pack
+    store.packs_by_key[("llama", "1.0.0")] = bound_pack
+    store.packs_by_row_id[request_pack["id"]] = request_pack
+    store.packs_by_row_id[bound_pack["id"]] = bound_pack
+    store.binding = {
+        "model_pack_id": bound_pack["id"],
+    }
+
+    selected = resolve_workspace_model_pack_selection(
+        store=store,  # type: ignore[arg-type]
+        workspace_id=workspace_id,
+        requested_pack_id="qwen",
+        requested_pack_version="1.0.0",
+    )
+
+    assert selected.source == "request"
+    assert selected.pack is request_pack
+
+
+def test_pack_selection_uses_workspace_binding_when_request_not_supplied() -> None:
+    store = FakeModelPackStore()
+    workspace_id = uuid4()
+    bound_pack = _pack_row(pack_id="llama")
+    store.packs_by_key[("llama", "1.0.0")] = bound_pack
+    store.packs_by_row_id[bound_pack["id"]] = bound_pack
+    store.binding = {
+        "model_pack_id": bound_pack["id"],
+    }
+
+    selected = resolve_workspace_model_pack_selection(
+        store=store,  # type: ignore[arg-type]
+        workspace_id=workspace_id,
+        requested_pack_id=None,
+        requested_pack_version=None,
+    )
+
+    assert selected.source == "workspace_binding"
+    assert selected.pack is bound_pack
+
+
+def test_pack_selection_raises_when_request_pack_is_missing() -> None:
+    store = FakeModelPackStore()
+
+    with pytest.raises(ModelPackNotFoundError, match="was not found"):
+        resolve_workspace_model_pack_selection(
+            store=store,  # type: ignore[arg-type]
+            workspace_id=uuid4(),
+            requested_pack_id="gemma",
+            requested_pack_version="1.0.0",
+        )

--- a/tests/unit/test_protected_path_guardrails.py
+++ b/tests/unit/test_protected_path_guardrails.py
@@ -121,3 +121,42 @@ Revert the change set and redeploy. No irreversible data rewrite occurs in this 
     )
 
     assert errors == []
+
+
+def test_validate_upgrade_overview_accepts_checked_continuity_apis_label() -> None:
+    touched = {
+        "continuity APIs": ["apps/api/src/alicebot_api/main.py"],
+    }
+
+    errors = guardrails.validate_upgrade_overview(
+        """
+## Upgrade Overview
+
+### Protected Areas
+
+- [x] continuity APIs
+
+### Compatibility Impact
+
+Additive-only API changes with backward-compatible request and response fields.
+
+### Migration / Rollout
+
+No extra migration sequencing beyond standard deployment.
+
+### Operator Action
+
+No manual operator steps are required.
+
+### Validation
+
+Executed guardrail parser tests and validated checked-area coverage for continuity APIs.
+
+### Rollback
+
+Revert the change and redeploy to restore the previous behavior.
+""",
+        touched,
+    )
+
+    assert not any("continuity APIs" in error for error in errors)


### PR DESCRIPTION
## Summary
This PR delivers Phase 11 Sprint 4 by adding the first declarative model-pack layer on top of the shipped provider/runtime abstraction.

## What changed
- adds tier-1 model pack persistence, catalog APIs, and workspace binding flows
- adds pack contracts and tier-1 seeded packs for `llama`, `qwen`, `gemma`, and `gpt-oss`
- keeps pack-driven shaping on the existing `POST /v1/runtime/invoke` seam rather than creating a parallel runtime path
- adds docs for tier-1 model pack behavior and compatibility posture
- updates build/review evidence and control-doc truth markers to match the committed `P11-S4` payload

## Upgrade Overview
### Protected Areas
- [x] continuity APIs
- [x] memory schema
- [x] trust rules

### Compatibility Impact
`P11-S4` is additive on top of the shipped provider/runtime abstraction. Existing `P11-S1` through `P11-S3` provider behavior and `v0/responses` behavior stay on the same runtime seam; the new surface is the model-pack catalog, binding APIs, and pack-aware shaping metadata on invoke responses.

### Migration / Rollout
Apply the `20260412_0054_phase11_model_packs_tier1` migration before using pack catalog or binding flows. Roll out by seeding and validating tier-1 packs in one workspace first, then bind a pack and confirm invoke shaping behavior before wider adoption.

### Operator Action
Operators need to run the standard API migration flow and then use the pack catalog/binding endpoints for workspace setup. No manual backfill is required for existing providers; pack adoption is opt-in through workspace binding or explicit request override.

### Validation
Validation for this branch head is: `python3 scripts/check_control_doc_truth.py` PASS, `./.venv/bin/python -m pytest tests/unit tests/integration -q` PASS (`1133 passed in 188.69s`), and `pnpm --dir apps/web test` PASS (`62 passed` files, `199 passed` tests, duration `4.66s`). Sprint-specific model-pack API, migration, and contract coverage is included in the new `P11-S4` test files.

### Rollback
Rollback is a standard application rollback plus reverting the `P11-S4` commit and migration if the model-pack layer must be withdrawn. If rollout issues appear after seeding or binding, operators can stop using pack bindings and continue using the shipped provider/runtime paths without changing existing provider registrations.

## Verification
- `python3 scripts/check_control_doc_truth.py`
  - PASS
- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
  - PASS (`1133 passed in 188.69s`)
- `pnpm --dir apps/web test`
  - PASS (`62 passed` files, `199 passed` tests)
  - duration `4.66s`

## Merge Scope Notes
- `ARCHITECTURE.md` and `PRODUCT_BRIEF.md` remain locally dirty and are explicitly excluded from this sprint merge scope.
