### PR TITLE
P11-S5: Azure adapter and AutoGen path

### DIFF
--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,91 +1,73 @@
 # BUILD_REPORT
 
 ## sprint objective
-Implement Phase 11 Sprint 4 (`P11-S4`) Model Packs Tier 1 by adding a declarative model-pack layer with tier-1 packs (`llama`, `qwen`, `gemma`, `gpt-oss`), pack catalog/versioning APIs, workspace binding APIs, and pack-driven runtime shaping on the existing `POST /v1/runtime/invoke` seam.
+Implement P11-S5: Azure Adapter + AutoGen Integration through the existing provider abstraction by adding Azure provider registration/test/invoke support, enterprise credential/auth hardening, Azure capability posture fields, and AutoGen integration documentation/sample path.
 
 ## completed work
-- Added new persistence tables via migration:
-  - `model_packs`
-  - `workspace_model_pack_bindings`
-  - workspace-consistent binding foreign-key integrity (`model_pack_id`, `workspace_id`)
-- Added model-pack domain helper module:
-  - `apps/api/src/alicebot_api/model_packs.py`
-  - contract validation (`model_pack_contract_v1`)
-  - tier-1 pack seeding for workspace scope with concurrency-safe upsert behavior
-  - pack version and family normalization
-  - canonical tier-1 pack key reservation checks
-  - workspace binding vs request override precedence resolution
-  - declarative runtime shaping helpers (context cap shaping + instruction overlays)
-- Extended store layer in `apps/api/src/alicebot_api/store.py`:
-  - typed rows for model packs and bindings
-  - model-pack CRUD/list/get queries
-  - binding create/get-latest queries (workspace-scoped)
-- Extended API contracts in `apps/api/src/alicebot_api/contracts.py`:
-  - model-pack families/status/binding-source literals
-  - model-pack response typed dicts and list order constant
-- Added new v1 model-pack endpoints in `apps/api/src/alicebot_api/main.py`:
-  - `GET /v1/model-packs`
-  - `GET /v1/model-packs/{pack_id}`
-  - `POST /v1/model-packs`
-  - `POST /v1/model-packs/{pack_id}/bind`
-  - `GET /v1/workspaces/{workspace_id}/model-pack-binding`
-- Updated `POST /v1/runtime/invoke` in `apps/api/src/alicebot_api/main.py`:
-  - pack selection precedence: request override > workspace binding > none
-  - pack-driven context cap shaping and instruction overlays
-  - model-pack metadata returned for invoke auditing
-  - no parallel runtime path created; existing provider invoke seam preserved
-- Updated response generation seam in `apps/api/src/alicebot_api/response_generation.py`:
-  - added optional system/developer instruction overrides for runtime shaping
-  - default `v0/responses` behavior remains unchanged
-- Added sprint docs under `docs/`:
-  - `docs/integrations/phase11-model-packs-tier1.md`
-  - `docs/integrations/phase11-model-pack-compatibility.md`
-- Updated control-doc truth markers for active sprint alignment:
-  - `scripts/check_control_doc_truth.py`
-- Updated active sprint truth markers:
-  - `README.md`
-- Added sprint tests:
-  - unit: `tests/unit/test_model_packs.py`
-  - migration unit: `tests/unit/test_20260412_0054_phase11_model_packs_tier1.py`
-  - integration: `tests/integration/test_phase11_model_packs_api.py`
+- Added Azure provider adapter support in the runtime adapter registry (`provider_key: azure`) with normalized capability discovery and invoke behavior using the existing `openai_responses` runtime contract.
+- Added Azure-specific helper module for:
+  - auth header handling (`azure_api_key`, `azure_ad_token`)
+  - `api-version` query handling
+  - model enumeration payload parsing
+  - OpenAI-compatible responses invoke payload/response normalization
+- Added additive provider data fields and migration support:
+  - `model_providers.azure_api_version`
+  - `model_providers.azure_auth_secret_ref`
+  - expanded `model_providers.auth_mode` constraint to include Azure auth modes
+- Added Azure secret-reference credential handling in runtime secret resolution:
+  - Azure modes now resolve credentials from `azure_auth_secret_ref`
+  - plaintext Azure credentials are not persisted in provider rows
+- Added Azure registration endpoint:
+  - `POST /v1/providers/azure/register`
+  - strict auth payload validation (mode-specific field requirements)
+- Preserved existing provider/runtime seams and behavior for shipped P11-S1 through P11-S4 paths.
+- Added Azure capability snapshot posture fields:
+  - `azure_api_version`
+  - `azure_auth_mode`
+- Added docs and sample integration path:
+  - Azure + AutoGen integration guide in `docs/integrations/phase11-azure-autogen.md`
+  - runtime bridge sample in `scripts/run_phase11_autogen_runtime_bridge.py`
+- Updated control-doc truth checker markers to P11-S5 active-sprint truth so required truth checks pass.
 
 ## incomplete work
-- None identified against `P11-S4` packet acceptance criteria and required API/data scope.
+- None within the sprint packet scope.
 
 ## files changed
-- `apps/api/alembic/versions/20260412_0054_phase11_model_packs_tier1.py`
-- `apps/api/src/alicebot_api/model_packs.py`
+- `apps/api/src/alicebot_api/azure_provider_helpers.py` (new)
+- `apps/api/src/alicebot_api/provider_runtime.py`
+- `apps/api/src/alicebot_api/main.py`
 - `apps/api/src/alicebot_api/store.py`
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/response_generation.py`
-- `docs/integrations/phase11-model-packs-tier1.md`
-- `docs/integrations/phase11-model-pack-compatibility.md`
-- `tests/unit/test_model_packs.py`
-- `tests/unit/test_20260412_0054_phase11_model_packs_tier1.py`
-- `tests/integration/test_phase11_model_packs_api.py`
+- `apps/api/alembic/versions/20260412_0055_phase11_azure_provider_config_fields.py` (new)
+- `tests/unit/test_provider_runtime.py`
+- `tests/integration/test_phase11_provider_runtime_api.py`
+- `tests/unit/test_20260412_0055_phase11_azure_provider_config_fields.py` (new)
+- `docs/integrations/phase11-azure-autogen.md` (new)
+- `scripts/run_phase11_autogen_runtime_bridge.py` (new)
 - `scripts/check_control_doc_truth.py`
 - `README.md`
 - `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
 
 ## tests run
-- `python3 scripts/check_control_doc_truth.py`
-  - Result: `PASS`
-- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-  - Result: `PASS` (`1133 passed in 188.69s (0:03:08)`)
-- `pnpm --dir apps/web test`
-  - Result: `PASS` (`62` files, `199` tests, duration `4.66s`)
-- Sprint-targeted verification subsets:
-  - `./.venv/bin/python -m pytest tests/unit/test_model_packs.py tests/unit/test_20260412_0054_phase11_model_packs_tier1.py tests/integration/test_phase11_model_packs_api.py -q`
-  - Result: `PASS` (`15 passed in 1.47s`)
-  - `python3 -m pytest tests/unit/test_control_doc_truth.py tests/unit/test_response_generation.py tests/integration/test_phase11_provider_runtime_api.py -q`
-  - Result: `PASS` (`15 passed in 2.25s`)
+1. `python3 scripts/check_control_doc_truth.py`
+- Result: PASS
+
+2. `./.venv/bin/python -m pytest tests/unit tests/integration -q`
+- Result: PASS (`1142 passed in 196.54s (0:03:16)`)
+
+3. `pnpm --dir apps/web test`
+- Result: PASS (`62 passed`, `199 passed`, duration `4.62s`)
+
+4. Focused sprint tests during implementation:
+- `./.venv/bin/python -m pytest tests/unit/test_provider_runtime.py tests/unit/test_provider_secrets.py tests/unit/test_20260412_0055_phase11_azure_provider_config_fields.py tests/integration/test_phase11_provider_runtime_api.py -q`
+- Result: PASS (`20 passed`)
 
 ## blockers/issues
-- No active blockers.
-- Pre-existing dirty files were present before sprint implementation and were not modified as part of this sprint scope: `ARCHITECTURE.md`, `PRODUCT_BRIEF.md`.
+- No functional blockers for sprint scope implementation.
+- Pre-existing dirty files not modified as sprint work and excluded from sprint merge scope:
+  - `ARCHITECTURE.md`
+  - `PRODUCT_BRIEF.md`
 
 ## recommended next step
-1. Open/refresh a sprint PR for `P11-S4` and keep only the sprint-owned files above in merge scope.
-2. Run reviewer pass focused on `P11-S4` acceptance criteria and workspace-isolation/runtime-shaping behavior.
+Proceed to Control Tower merge approval for `P11-S5`, then run staging validation against a live Azure endpoint for both `azure_api_key` and `azure_ad_token` registration/invoke flows before production rollout.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Phase 11 is now the active planning and execution phase:
 - `P11-S1` Provider Abstraction + OpenAI-Compatible Base is shipped
 - `P11-S2` Ollama + llama.cpp Adapters is shipped
 - `P11-S3` vLLM Adapter + Self-Hosted Performance Path is shipped
-- `P11-S4` Model Packs Tier 1 is the active sprint
-- later Phase 11 work adds Azure, tier-2 packs, and agent integration guides
+- `P11-S4` Model Packs Tier 1 is shipped
+- `P11-S5` Azure Adapter + AutoGen Integration is the active sprint
+- later Phase 11 work adds tier-2 packs and launch-clarity assets
 - Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md](docs/archive/planning/2026-04-08-context-compaction/README.md)
 
 ## Why Alice exists
@@ -126,7 +127,7 @@ The current open-source surface includes:
 - shared explainability across recall, resume, open-loop review, and explain surfaces
 - scheduled archive maintenance, ops status reporting, and failure alerting
 - Hermes external memory provider for always-on continuity prefetch and Alice memory tools inside Hermes
-- provider runtime abstraction with workspace-scoped provider registration, capability snapshots, an OpenAI-compatible base adapter, and local Ollama/llama.cpp adapters
+- provider runtime abstraction with workspace-scoped provider registration, capability snapshots, OpenAI-compatible base adapter, local Ollama/llama.cpp adapters, and Azure adapter support
 - importers for OpenClaw, Markdown, and ChatGPT exports
 - OpenClaw adapter and demo path
 - evaluation harness and integration docs
@@ -208,6 +209,7 @@ See:
 - [docs/integrations/hermes-memory-provider.md](docs/integrations/hermes-memory-provider.md)
 - [docs/integrations/hermes-skill-pack.md](docs/integrations/hermes-skill-pack.md)
 - [docs/integrations/phase11-local-provider-adapters.md](docs/integrations/phase11-local-provider-adapters.md)
+- [docs/integrations/phase11-azure-autogen.md](docs/integrations/phase11-azure-autogen.md)
 
 Hermes runtime smoke test:
 

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,53 +4,45 @@
 PASS
 
 ## criteria met
-- All `P11-S4` in-scope APIs are implemented and exercised:
-  - `GET /v1/model-packs`
-  - `GET /v1/model-packs/{pack_id}`
-  - `POST /v1/model-packs`
-  - `POST /v1/model-packs/{pack_id}/bind`
-  - `GET /v1/workspaces/{workspace_id}/model-pack-binding`
-  - pack-aware shaping on `POST /v1/runtime/invoke`
-- In-scope data additions are implemented:
-  - `model_packs`
-  - `workspace_model_pack_bindings`
-- Tier-1 packs (`llama`, `qwen`, `gemma`, `gpt-oss`) are seeded with declarative contracts and versioning.
-- Runtime selection precedence is implemented as required: request override > workspace binding > none.
-- Pack-driven shaping remains on the existing invoke seam (no parallel runtime path).
-- Previously identified hardening gaps are fixed:
-  - Tier-1 seeding is now concurrency-safe via `ON CONFLICT DO NOTHING` insert path.
-  - Canonical tier-1 pack keys are reserved in create flow.
-  - Migration now enforces workspace-consistent binding integrity for `(model_pack_id, workspace_id)`.
-- Required verification commands pass on current branch state:
-  - `python3 scripts/check_control_doc_truth.py` -> PASS
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> PASS (`1133 passed in 188.69s`)
-  - `pnpm --dir apps/web test` -> PASS (`62 files`, `199 tests`, duration `4.66s`)
-- No local identifiers (local computer paths, usernames, etc.) were found in sprint-owned changed code/docs reviewed.
+- `POST /v1/providers/azure/register` is implemented and validated with strict auth-mode payload checks.
+- Azure provider registration/test/invoke flows are covered through shipped APIs:
+  - `POST /v1/providers/azure/register`
+  - `POST /v1/providers/test`
+  - `POST /v1/runtime/invoke`
+  - `GET /v1/providers`
+  - `GET /v1/providers/{provider_id}`
+- Credential/auth hardening is implemented for Azure:
+  - Azure credentials are persisted via secret references (`azure_auth_secret_ref`)
+  - Integration tests verify no plaintext Azure credential leakage in `model_providers`
+- Azure invoke path uses the existing normalized provider abstraction/adapter registry (no continuity-semantic fork).
+- Azure capability posture additions are present (`azure_api_version`, `azure_auth_mode`).
+- AutoGen integration guide and sample path are present:
+  - `docs/integrations/phase11-azure-autogen.md`
+  - `scripts/run_phase11_autogen_runtime_bridge.py`
+- Required verification commands pass (re-run after fix):
+  - `python3 scripts/check_control_doc_truth.py` ✅
+  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` ✅ (`1142 passed in 196.54s`)
+  - `pnpm --dir apps/web test` ✅ (`62 files / 199 tests passed`, duration `4.62s`)
+- Local identifier check: no local machine paths/usernames found in sprint-owned changed files.
 
 ## criteria missed
-- None identified for `P11-S4` acceptance criteria.
+- None.
 
 ## quality issues
-- No blocking quality issues remain in sprint-owned scope after the fix pass.
+- None blocking or non-blocking found in sprint-owned implementation after scope cleanup.
 
 ## regression risks
-- Low.
-- Main residual risk is normal operational dependency on provider availability/reachability, which is already surfaced through existing provider/runtime error handling.
+- Low residual risk: Azure behavior is validated in mocked integration tests; live-endpoint staging validation is still recommended for environment-specific routing/auth nuances.
 
 ## docs issues
-- `BUILD_REPORT.md` now aligns with observed sprint-owned changed files (including `README.md` truth-marker update).
-- Out-of-scope dirty files remain in the local working tree and should stay excluded from sprint merge scope:
-  - `ARCHITECTURE.md`
-  - `PRODUCT_BRIEF.md`
-- No local machine identifiers detected in sprint-owned docs/code reviewed.
+- Sprint docs are present and scoped correctly for P11-S5.
 
 ## should anything be added to RULES.md?
-- Optional improvement only: encode the new practice explicitly (seed/bootstrap paths must be concurrency-safe and idempotent).
+- Optional improvement: add a standing rule that sprint PRs must exclude unrelated dirty local files before review.
 
 ## should anything update ARCHITECTURE.md?
-- Optional improvement only: add an explicit line that workspace-pack binding integrity is enforced on `(model_pack_id, workspace_id)`.
+- No required architecture update for P11-S5 acceptance.
 
 ## recommended next action
-1. Prepare/refresh the sprint PR with only sprint-owned files in merge scope.
-2. Keep `ARCHITECTURE.md` and `PRODUCT_BRIEF.md` out of the sprint merge.
-3. Proceed to merge approval for `P11-S4`.
+1. Proceed with sprint merge review/approval for `P11-S5`.
+2. Run staging smoke validation against live Azure for both `azure_api_key` and `azure_ad_token` before production rollout.

--- a/apps/api/alembic/versions/20260412_0055_phase11_azure_provider_config_fields.py
+++ b/apps/api/alembic/versions/20260412_0055_phase11_azure_provider_config_fields.py
@@ -1,0 +1,93 @@
+"""Add Azure provider configuration and secret-ref fields."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260412_0055"
+down_revision = "20260412_0054"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_STATEMENTS = (
+    "ALTER TABLE model_providers ADD COLUMN azure_api_version text NOT NULL DEFAULT ''",
+    "ALTER TABLE model_providers ADD COLUMN azure_auth_secret_ref text NOT NULL DEFAULT ''",
+    "ALTER TABLE model_providers DROP CONSTRAINT IF EXISTS model_providers_auth_mode_check",
+    (
+        "ALTER TABLE model_providers "
+        "ADD CONSTRAINT model_providers_auth_mode_check "
+        "CHECK (auth_mode IN ('bearer', 'none', 'azure_api_key', 'azure_ad_token'))"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "ADD CONSTRAINT model_providers_azure_api_version_length_check "
+        "CHECK (char_length(azure_api_version) <= 40)"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "ADD CONSTRAINT model_providers_azure_auth_secret_ref_length_check "
+        "CHECK (char_length(azure_auth_secret_ref) <= 400)"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "ADD CONSTRAINT model_providers_azure_api_version_required_for_azure_auth_check "
+        "CHECK ("
+        "(auth_mode IN ('azure_api_key', 'azure_ad_token') AND char_length(azure_api_version) >= 1) "
+        "OR (auth_mode IN ('bearer', 'none'))"
+        ")"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "ADD CONSTRAINT model_providers_azure_secret_ref_required_for_azure_auth_check "
+        "CHECK ("
+        "(auth_mode IN ('azure_api_key', 'azure_ad_token') AND char_length(azure_auth_secret_ref) >= 1) "
+        "OR (auth_mode IN ('bearer', 'none'))"
+        ")"
+    ),
+)
+
+_DOWNGRADE_STATEMENTS = (
+    (
+        "ALTER TABLE model_providers "
+        "DROP CONSTRAINT IF EXISTS model_providers_azure_secret_ref_required_for_azure_auth_check"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "DROP CONSTRAINT IF EXISTS model_providers_azure_api_version_required_for_azure_auth_check"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "DROP CONSTRAINT IF EXISTS model_providers_azure_auth_secret_ref_length_check"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "DROP CONSTRAINT IF EXISTS model_providers_azure_api_version_length_check"
+    ),
+    "ALTER TABLE model_providers DROP CONSTRAINT IF EXISTS model_providers_auth_mode_check",
+    (
+        "UPDATE model_providers "
+        "SET auth_mode = 'bearer' "
+        "WHERE auth_mode IN ('azure_api_key', 'azure_ad_token')"
+    ),
+    (
+        "ALTER TABLE model_providers "
+        "ADD CONSTRAINT model_providers_auth_mode_check "
+        "CHECK (auth_mode IN ('bearer', 'none'))"
+    ),
+    "ALTER TABLE model_providers DROP COLUMN IF EXISTS azure_auth_secret_ref",
+    "ALTER TABLE model_providers DROP COLUMN IF EXISTS azure_api_version",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/azure_provider_helpers.py
+++ b/apps/api/src/alicebot_api/azure_provider_helpers.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+from alicebot_api.contracts import ModelInvocationRequest, ModelInvocationResponse, ModelUsagePayload
+from alicebot_api.response_generation import ModelInvocationError
+
+AZURE_AUTH_MODE_API_KEY = "azure_api_key"
+AZURE_AUTH_MODE_AD_TOKEN = "azure_ad_token"
+DEFAULT_AZURE_API_VERSION = "2024-10-21"
+
+
+def build_azure_auth_headers(*, auth_mode: str, credential: str) -> dict[str, str]:
+    mode = auth_mode.strip().lower()
+    token = credential.strip()
+    if token == "":
+        raise ModelInvocationError("azure credential is required")
+    if mode == AZURE_AUTH_MODE_API_KEY:
+        return {"api-key": token}
+    if mode == AZURE_AUTH_MODE_AD_TOKEN:
+        return {"Authorization": f"Bearer {token}"}
+    raise ModelInvocationError(f"unsupported provider auth_mode: {auth_mode}")
+
+
+def request_azure_json(
+    *,
+    method: str,
+    base_url: str,
+    path: str,
+    api_version: str,
+    timeout_seconds: int,
+    headers: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    endpoint = _append_api_version(
+        url=base_url.rstrip("/") + normalized_path,
+        api_version=api_version,
+    )
+    request_headers = {"Accept": "application/json"}
+    if headers:
+        request_headers.update(headers)
+    body = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+    request = Request(endpoint, data=body, headers=request_headers, method=method)
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            raw_payload = response.read()
+    except HTTPError as exc:
+        detail = _extract_http_error_detail(exc)
+        if detail is not None:
+            raise ModelInvocationError(detail) from exc
+        raise ModelInvocationError(f"model provider returned HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise ModelInvocationError(f"model provider request failed: {exc.reason}") from exc
+
+    try:
+        parsed_payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        raise ModelInvocationError("model provider returned invalid JSON") from exc
+
+    if not isinstance(parsed_payload, dict):
+        raise ModelInvocationError("model provider returned invalid JSON")
+    return parsed_payload
+
+
+def parse_azure_models(payload: dict[str, Any]) -> list[str]:
+    data_payload = payload.get("data")
+    if not isinstance(data_payload, list):
+        raise ModelInvocationError("azure model enumeration payload is invalid")
+    model_names: set[str] = set()
+    for model_payload in data_payload:
+        if not isinstance(model_payload, dict):
+            continue
+        raw_name = model_payload.get("id")
+        if isinstance(raw_name, str) and raw_name.strip():
+            model_names.add(raw_name.strip())
+    return sorted(model_names)
+
+
+def invoke_azure_openai_responses(
+    *,
+    request: ModelInvocationRequest,
+    base_url: str,
+    auth_mode: str,
+    credential: str,
+    api_version: str,
+    invoke_path: str,
+    timeout_seconds: int,
+) -> ModelInvocationResponse:
+    if request.provider != "openai_responses":
+        raise ModelInvocationError(f"unsupported model provider: {request.provider}")
+    headers = build_azure_auth_headers(auth_mode=auth_mode, credential=credential)
+    payload = request_azure_json(
+        method="POST",
+        base_url=base_url,
+        path=invoke_path,
+        api_version=api_version,
+        timeout_seconds=timeout_seconds,
+        headers=headers,
+        payload=_build_openai_responses_payload(request),
+    )
+    output_text = _extract_output_text(payload)
+    finish_reason = "completed" if payload.get("status") == "completed" else "incomplete"
+    response_id = payload.get("id")
+    return ModelInvocationResponse(
+        provider=request.provider,
+        model=request.model,
+        response_id=response_id if isinstance(response_id, str) else None,
+        finish_reason=finish_reason,
+        output_text=output_text,
+        usage=_parse_usage(payload),
+    )
+
+
+def _append_api_version(*, url: str, api_version: str) -> str:
+    version = api_version.strip()
+    if version == "":
+        raise ModelInvocationError("azure api_version is required")
+    parts = urlsplit(url)
+    query_items = parse_qsl(parts.query, keep_blank_values=True)
+    query_without_api_version = [(key, value) for key, value in query_items if key != "api-version"]
+    query_without_api_version.append(("api-version", version))
+    return urlunsplit(
+        (
+            parts.scheme,
+            parts.netloc,
+            parts.path,
+            urlencode(query_without_api_version),
+            parts.fragment,
+        )
+    )
+
+
+def _openai_input_message(role: str, content: str) -> dict[str, object]:
+    return {
+        "role": role,
+        "content": [{"type": "input_text", "text": content}],
+    }
+
+
+def _build_openai_responses_payload(request: ModelInvocationRequest) -> dict[str, object]:
+    sections = {section.name: section.content for section in request.prompt.sections}
+    return {
+        "model": request.model,
+        "store": request.store,
+        "tool_choice": request.tool_choice,
+        "tools": [],
+        "input": [
+            _openai_input_message("system", sections["system"]),
+            _openai_input_message("developer", sections["developer"]),
+            _openai_input_message("user", f"[CONTEXT]\n{sections['context']}"),
+            _openai_input_message("user", f"[CONVERSATION]\n{sections['conversation']}"),
+        ],
+        "text": {"format": {"type": "text"}},
+    }
+
+
+def _extract_output_text(payload: dict[str, Any]) -> str:
+    output_items = payload.get("output")
+    if not isinstance(output_items, list):
+        raise ModelInvocationError("model response did not include assistant output text")
+    for output_item in output_items:
+        if not isinstance(output_item, dict) or output_item.get("type") != "message":
+            continue
+        content_items = output_item.get("content")
+        if not isinstance(content_items, list):
+            continue
+        for content_item in content_items:
+            if not isinstance(content_item, dict) or content_item.get("type") != "output_text":
+                continue
+            text = content_item.get("text")
+            if isinstance(text, str) and text:
+                return text
+    raise ModelInvocationError("model response did not include assistant output text")
+
+
+def _parse_usage(payload: dict[str, Any]) -> ModelUsagePayload:
+    usage_payload = payload.get("usage")
+    if not isinstance(usage_payload, dict):
+        return {"input_tokens": None, "output_tokens": None, "total_tokens": None}
+
+    usage: ModelUsagePayload = {
+        "input_tokens": (
+            usage_payload.get("input_tokens")
+            if isinstance(usage_payload.get("input_tokens"), int)
+            else None
+        ),
+        "output_tokens": (
+            usage_payload.get("output_tokens")
+            if isinstance(usage_payload.get("output_tokens"), int)
+            else None
+        ),
+        "total_tokens": (
+            usage_payload.get("total_tokens")
+            if isinstance(usage_payload.get("total_tokens"), int)
+            else None
+        ),
+    }
+
+    for details_key in ("input_tokens_details", "prompt_tokens_details"):
+        details = usage_payload.get(details_key)
+        if not isinstance(details, dict):
+            continue
+        cached_tokens = details.get("cached_tokens")
+        if isinstance(cached_tokens, int):
+            usage["cached_input_tokens"] = cached_tokens
+            break
+
+    return usage
+
+
+def _extract_http_error_detail(exc: HTTPError) -> str | None:
+    raw_body = exc.read().decode("utf-8", errors="replace")
+    try:
+        parsed_error = json.loads(raw_body)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(parsed_error, dict):
+        return None
+
+    error = parsed_error.get("error")
+    if isinstance(error, dict):
+        detail = error.get("message")
+        if isinstance(detail, str) and detail.strip():
+            return detail
+    detail = parsed_error.get("detail")
+    if isinstance(detail, str) and detail.strip():
+        return detail
+    return None

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -189,7 +189,7 @@ ToolAllowlistDecision = Literal["allowed", "denied", "approval_required"]
 ToolRoutingDecision = Literal["ready", "denied", "approval_required"]
 PromptSectionName = Literal["system", "developer", "context", "conversation"]
 ModelProvider = Literal["openai_responses"]
-ProviderAdapterKey = Literal["openai_compatible", "ollama", "llamacpp"]
+ProviderAdapterKey = Literal["openai_compatible", "ollama", "llamacpp", "azure"]
 ModelProviderStatus = Literal["active"]
 ProviderCapabilityDiscoveryStatus = Literal["ready", "failed"]
 ModelPackFamily = Literal["llama", "qwen", "gemma", "gpt-oss", "custom"]
@@ -1558,6 +1558,7 @@ class ModelProviderRecord(TypedDict):
     model_list_path: str
     healthcheck_path: str
     invoke_path: str
+    azure_api_version: str
     metadata: JsonObject
     created_at: str
     updated_at: str

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -601,7 +601,13 @@ from alicebot_api.proxy_execution import (
     ProxyExecutionIdempotencyError,
     execute_approved_proxy_request,
 )
+from alicebot_api.azure_provider_helpers import (
+    AZURE_AUTH_MODE_AD_TOKEN,
+    AZURE_AUTH_MODE_API_KEY,
+    DEFAULT_AZURE_API_VERSION,
+)
 from alicebot_api.provider_runtime import (
+    AZURE_ADAPTER_KEY,
     LLAMACPP_ADAPTER_KEY,
     OLLAMA_ADAPTER_KEY,
     OPENAI_COMPATIBLE_ADAPTER_KEY,
@@ -1459,6 +1465,7 @@ def _serialize_model_provider(provider: ModelProviderRow) -> dict[str, object]:
         "model_list_path": provider["model_list_path"],
         "healthcheck_path": provider["healthcheck_path"],
         "invoke_path": provider["invoke_path"],
+        "azure_api_version": provider["azure_api_version"],
         "metadata": provider["metadata"],
         "created_at": provider["created_at"].isoformat(),
         "updated_at": provider["updated_at"].isoformat(),
@@ -1562,6 +1569,7 @@ def _fallback_provider_capability_snapshot(
     model_list_path: str,
     healthcheck_path: str,
     invoke_path: str,
+    extra_snapshot_fields: dict[str, object] | None = None,
 ) -> dict[str, object]:
     snapshot = normalized_capability_snapshot(
         adapter_key=adapter_key,
@@ -1582,6 +1590,8 @@ def _fallback_provider_capability_snapshot(
             "models": [],
         }
     )
+    if extra_snapshot_fields:
+        snapshot.update(extra_snapshot_fields)
     return snapshot
 
 
@@ -1658,6 +1668,8 @@ def _register_workspace_provider(
         model_list_path=normalized_model_list_path,
         healthcheck_path=normalized_healthcheck_path,
         invoke_path=normalized_invoke_path,
+        azure_api_version="",
+        azure_auth_secret_ref="",
     )
 
     runtime_provider = resolve_runtime_provider_config_secrets(
@@ -1680,6 +1692,127 @@ def _register_workspace_provider(
             model_list_path=normalized_model_list_path,
             healthcheck_path=normalized_healthcheck_path,
             invoke_path=normalized_invoke_path,
+        )
+        discovery_status = "failed"
+        discovery_error = str(exc)
+
+    capability = store.upsert_provider_capability(
+        workspace_id=workspace_id,
+        provider_id=provider["id"],
+        discovered_by_user_account_id=created_by_user_account_id,
+        adapter_key=adapter.adapter_key,
+        discovery_status=discovery_status,
+        capability_snapshot=capability_snapshot,
+        discovery_error=discovery_error,
+    )
+    return provider, capability
+
+
+def _normalize_azure_api_version(value: str) -> str:
+    api_version = value.strip()
+    if api_version == "":
+        raise ValueError("api_version is required")
+    return api_version
+
+
+def _register_workspace_azure_provider(
+    *,
+    settings: Settings,
+    store: ContinuityStore,
+    workspace_id: UUID,
+    created_by_user_account_id: UUID,
+    display_name: str,
+    base_url: str,
+    credential: str,
+    auth_mode: str,
+    default_model: str,
+    model_list_path: str,
+    healthcheck_path: str,
+    invoke_path: str,
+    api_version: str,
+    metadata: dict[str, object],
+) -> tuple[ModelProviderRow, ProviderCapabilityRow]:
+    normalized_display_name = display_name.strip()
+    normalized_base_url = base_url.strip()
+    normalized_credential = credential.strip()
+    normalized_default_model = default_model.strip()
+    normalized_auth_mode = auth_mode.strip().lower()
+    normalized_api_version = _normalize_azure_api_version(api_version)
+    normalized_model_list_path = _normalize_provider_path(
+        field_name="model_list_path",
+        value=model_list_path,
+    )
+    normalized_healthcheck_path = _normalize_provider_path(
+        field_name="healthcheck_path",
+        value=healthcheck_path,
+    )
+    normalized_invoke_path = _normalize_provider_path(
+        field_name="invoke_path",
+        value=invoke_path,
+    )
+
+    if normalized_display_name == "":
+        raise ValueError("display_name is required")
+    if normalized_base_url == "":
+        raise ValueError("base_url is required")
+    if normalized_default_model == "":
+        raise ValueError("default_model is required")
+    if normalized_auth_mode not in {AZURE_AUTH_MODE_API_KEY, AZURE_AUTH_MODE_AD_TOKEN}:
+        raise ValueError(f"unsupported auth_mode: {auth_mode}")
+    if normalized_credential == "":
+        raise ValueError("azure credential is required")
+
+    secret_ref = build_provider_secret_ref(workspace_id=workspace_id)
+    write_provider_api_key(
+        settings=settings,
+        secret_ref=secret_ref,
+        api_key=normalized_credential,
+    )
+    encoded_secret_ref = encode_provider_secret_ref(secret_ref=secret_ref)
+
+    provider = store.create_model_provider(
+        workspace_id=workspace_id,
+        created_by_user_account_id=created_by_user_account_id,
+        provider_key=AZURE_ADAPTER_KEY,
+        model_provider=OPENAI_RESPONSES_PROVIDER,
+        display_name=normalized_display_name,
+        base_url=normalized_base_url,
+        api_key="auth_mode_azure_secret_ref",
+        default_model=normalized_default_model,
+        status="active",
+        metadata=metadata,
+        auth_mode=normalized_auth_mode,
+        model_list_path=normalized_model_list_path,
+        healthcheck_path=normalized_healthcheck_path,
+        invoke_path=normalized_invoke_path,
+        azure_api_version=normalized_api_version,
+        azure_auth_secret_ref=encoded_secret_ref,
+    )
+
+    runtime_provider = resolve_runtime_provider_config_secrets(
+        config=RuntimeProviderConfig.from_row(provider),
+        settings=settings,
+    )
+    adapter = provider_adapter_registry.resolve(runtime_provider.provider_key)
+    discovery_status: str = "ready"
+    discovery_error: str | None = None
+
+    try:
+        capability_snapshot = adapter.discover_capabilities(
+            config=runtime_provider,
+            settings=settings,
+        )
+    except ModelInvocationError as exc:
+        capability_snapshot = _fallback_provider_capability_snapshot(
+            adapter_key=adapter.adapter_key,
+            runtime_provider=adapter.runtime_provider,
+            model_list_path=normalized_model_list_path,
+            healthcheck_path=normalized_healthcheck_path,
+            invoke_path=normalized_invoke_path,
+            extra_snapshot_fields={
+                "azure_api_version": normalized_api_version,
+                "azure_auth_mode": normalized_auth_mode,
+            },
         )
         discovery_status = "failed"
         discovery_error = str(exc)
@@ -2146,6 +2279,40 @@ class RegisterLlamaCppProviderRequest(BaseModel):
     healthcheck_path: str = Field(default="/health", min_length=1, max_length=200)
     invoke_path: str = Field(default="/v1/chat/completions", min_length=1, max_length=200)
     metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class RegisterAzureProviderRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str = Field(min_length=1, max_length=120)
+    base_url: str = Field(min_length=1, max_length=500)
+    auth_mode: Literal["azure_api_key", "azure_ad_token"] = AZURE_AUTH_MODE_API_KEY
+    api_key: str | None = Field(default=None, max_length=8000)
+    ad_token: str | None = Field(default=None, max_length=16000)
+    api_version: str = Field(default=DEFAULT_AZURE_API_VERSION, min_length=1, max_length=40)
+    default_model: str = Field(min_length=1, max_length=200)
+    model_list_path: str = Field(default="/openai/models", min_length=1, max_length=200)
+    healthcheck_path: str = Field(default="/openai/models", min_length=1, max_length=200)
+    invoke_path: str = Field(default="/openai/responses", min_length=1, max_length=200)
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_auth_payload(self) -> "RegisterAzureProviderRequest":
+        api_key = None if self.api_key is None else self.api_key.strip()
+        ad_token = None if self.ad_token is None else self.ad_token.strip()
+
+        if self.auth_mode == AZURE_AUTH_MODE_API_KEY:
+            if api_key in (None, ""):
+                raise ValueError("api_key is required when auth_mode is azure_api_key")
+            if ad_token not in (None, ""):
+                raise ValueError("ad_token must be empty when auth_mode is azure_api_key")
+            return self
+
+        if ad_token in (None, ""):
+            raise ValueError("ad_token is required when auth_mode is azure_ad_token")
+        if api_key not in (None, ""):
+            raise ValueError("api_key must be empty when auth_mode is azure_ad_token")
+        return self
 
 
 class TestProviderRequest(BaseModel):
@@ -6426,6 +6593,74 @@ def register_v1_llamacpp_provider(
     )
 
 
+@app.post("/v1/providers/azure/register")
+def register_v1_azure_provider(
+    request: Request,
+    body: RegisterAzureProviderRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    if body.auth_mode == AZURE_AUTH_MODE_API_KEY:
+        credential = body.api_key
+    else:
+        credential = body.ad_token
+    assert credential is not None
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                workspace = get_current_workspace(
+                    conn,
+                    user_account_id=resolution["user_account"]["id"],
+                    preferred_workspace_id=resolution["session"]["workspace_id"],
+                )
+                if workspace is None:
+                    return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+
+                store = ContinuityStore(conn)
+                provider, capability = _register_workspace_azure_provider(
+                    settings=settings,
+                    store=store,
+                    workspace_id=workspace["id"],
+                    created_by_user_account_id=resolution["user_account"]["id"],
+                    display_name=body.display_name,
+                    base_url=body.base_url,
+                    credential=credential,
+                    auth_mode=body.auth_mode,
+                    default_model=body.default_model,
+                    model_list_path=body.model_list_path,
+                    healthcheck_path=body.healthcheck_path,
+                    invoke_path=body.invoke_path,
+                    api_version=body.api_version,
+                    metadata=body.metadata,
+                )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except psycopg.errors.UniqueViolation:
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "provider display_name must be unique within the workspace"},
+        )
+    except ProviderAdapterNotFoundError as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
+    except ProviderSecretManagerError as exc:
+        return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=201,
+        content=jsonable_encoder(
+            {
+                "provider": _serialize_model_provider(provider),
+                "capabilities": _serialize_provider_capability(capability),
+            }
+        ),
+    )
+
+
 @app.get("/v1/providers")
 def list_v1_providers(request: Request) -> JSONResponse:
     settings = get_settings()
@@ -6550,6 +6785,13 @@ def test_v1_provider(request: Request, body: TestProviderRequest) -> JSONRespons
                         settings=settings,
                     )
                 except ModelInvocationError as exc:
+                    extra_snapshot_fields = None
+                    if runtime_provider.provider_key == AZURE_ADAPTER_KEY:
+                        extra_snapshot_fields = {
+                            "azure_api_version": runtime_provider.azure_api_version.strip()
+                            or DEFAULT_AZURE_API_VERSION,
+                            "azure_auth_mode": runtime_provider.auth_mode,
+                        }
                     capability = store.upsert_provider_capability(
                         workspace_id=workspace["id"],
                         provider_id=runtime_provider.provider_id,
@@ -6562,6 +6804,7 @@ def test_v1_provider(request: Request, body: TestProviderRequest) -> JSONRespons
                             model_list_path=runtime_provider.model_list_path,
                             healthcheck_path=runtime_provider.healthcheck_path,
                             invoke_path=runtime_provider.invoke_path,
+                            extra_snapshot_fields=extra_snapshot_fields,
                         ),
                         discovery_error=str(exc),
                     )

--- a/apps/api/src/alicebot_api/provider_runtime.py
+++ b/apps/api/src/alicebot_api/provider_runtime.py
@@ -5,6 +5,15 @@ import json
 from typing import NotRequired, Protocol, TypedDict
 from uuid import UUID
 
+from alicebot_api.azure_provider_helpers import (
+    AZURE_AUTH_MODE_AD_TOKEN,
+    AZURE_AUTH_MODE_API_KEY,
+    DEFAULT_AZURE_API_VERSION,
+    build_azure_auth_headers,
+    invoke_azure_openai_responses,
+    parse_azure_models,
+    request_azure_json,
+)
 from alicebot_api.config import Settings
 from alicebot_api.contracts import (
     ModelInvocationRequest,
@@ -26,12 +35,13 @@ from alicebot_api.response_generation import (
     OpenAICompatibleTransportConfig,
     invoke_openai_compatible_model,
 )
-from alicebot_api.provider_secrets import resolve_provider_api_key
+from alicebot_api.provider_secrets import ProviderSecretManagerError, resolve_provider_api_key
 from alicebot_api.store import JsonObject
 
 OPENAI_COMPATIBLE_ADAPTER_KEY = "openai_compatible"
 OLLAMA_ADAPTER_KEY = "ollama"
 LLAMACPP_ADAPTER_KEY = "llamacpp"
+AZURE_ADAPTER_KEY = "azure"
 OPENAI_RESPONSES_PROVIDER = "openai_responses"
 PROVIDER_CAPABILITY_VERSION_V1 = "provider_capability_v1"
 
@@ -61,6 +71,8 @@ class ProviderCapabilitySnapshot(TypedDict):
     invoke_endpoint: NotRequired[str]
     model_count: NotRequired[int]
     models: NotRequired[list[str]]
+    azure_api_version: NotRequired[str]
+    azure_auth_mode: NotRequired[str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,6 +91,8 @@ class RuntimeProviderConfig:
     model_list_path: str
     healthcheck_path: str
     invoke_path: str
+    azure_api_version: str
+    azure_auth_secret_ref: str
     metadata: JsonObject
 
     @classmethod
@@ -98,6 +112,8 @@ class RuntimeProviderConfig:
             model_list_path=str(row.get("model_list_path", "")),
             healthcheck_path=str(row.get("healthcheck_path", "")),
             invoke_path=str(row.get("invoke_path", "")),
+            azure_api_version=str(row.get("azure_api_version", "")),
+            azure_auth_secret_ref=str(row.get("azure_auth_secret_ref", "")),
             metadata=row["metadata"],  # type: ignore[assignment]
         )
 
@@ -207,6 +223,83 @@ class OpenAICompatibleAdapter:
                 timeout_seconds=settings.model_timeout_seconds,
             ),
             request=request,
+        )
+
+
+class AzureAdapter:
+    adapter_key = AZURE_ADAPTER_KEY
+    runtime_provider = OPENAI_RESPONSES_PROVIDER
+    default_healthcheck_path = "/openai/models"
+    default_model_list_path = "/openai/models"
+    default_invoke_path = "/openai/responses"
+
+    def discover_capabilities(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderCapabilitySnapshot:
+        api_version = config.azure_api_version.strip() or DEFAULT_AZURE_API_VERSION
+        headers = build_azure_auth_headers(auth_mode=config.auth_mode, credential=config.api_key)
+        healthcheck_path = config.healthcheck_path or self.default_healthcheck_path
+        model_list_path = config.model_list_path or self.default_model_list_path
+        request_azure_json(
+            method="GET",
+            base_url=config.base_url,
+            path=healthcheck_path,
+            api_version=api_version,
+            timeout_seconds=settings.healthcheck_timeout_seconds,
+            headers=headers,
+        )
+        model_payload = request_azure_json(
+            method="GET",
+            base_url=config.base_url,
+            path=model_list_path,
+            api_version=api_version,
+            timeout_seconds=settings.healthcheck_timeout_seconds,
+            headers=headers,
+        )
+        models = parse_azure_models(model_payload)
+        snapshot = normalized_capability_snapshot(
+            adapter_key=self.adapter_key,
+            runtime_provider=self.runtime_provider,
+            supports_tool_calls=False,
+            supports_streaming=False,
+            supports_store=False,
+            supports_vision_input=False,
+            supports_audio_input=False,
+        )
+        snapshot.update(
+            {
+                "health_status": "ok",
+                "health_endpoint": healthcheck_path,
+                "models_endpoint": model_list_path,
+                "invoke_endpoint": config.invoke_path or self.default_invoke_path,
+                "model_count": len(models),
+                "models": models,
+                "azure_api_version": api_version,
+                "azure_auth_mode": config.auth_mode,
+            }
+        )
+        return snapshot
+
+    def invoke(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+        request: ModelInvocationRequest,
+    ) -> ModelInvocationResponse:
+        if request.provider != self.runtime_provider:
+            raise ModelInvocationError(f"unsupported model provider: {request.provider}")
+        return invoke_azure_openai_responses(
+            request=request,
+            base_url=config.base_url,
+            auth_mode=config.auth_mode,
+            credential=config.api_key,
+            api_version=config.azure_api_version.strip() or DEFAULT_AZURE_API_VERSION,
+            invoke_path=config.invoke_path or self.default_invoke_path,
+            timeout_seconds=settings.model_timeout_seconds,
         )
 
 
@@ -367,6 +460,7 @@ class LlamaCppAdapter:
 def make_provider_adapter_registry() -> ProviderAdapterRegistry:
     registry = ProviderAdapterRegistry()
     registry.register(OpenAICompatibleAdapter())
+    registry.register(AzureAdapter())
     registry.register(OllamaAdapter())
     registry.register(LlamaCppAdapter())
     return registry
@@ -377,6 +471,17 @@ def resolve_runtime_provider_config_secrets(
     config: RuntimeProviderConfig,
     settings: Settings,
 ) -> RuntimeProviderConfig:
+    if config.provider_key == AZURE_ADAPTER_KEY and config.auth_mode in {
+        AZURE_AUTH_MODE_API_KEY,
+        AZURE_AUTH_MODE_AD_TOKEN,
+    }:
+        azure_secret_ref = config.azure_auth_secret_ref.strip()
+        if azure_secret_ref == "":
+            raise ProviderSecretManagerError("azure_auth_secret_ref is required for azure auth modes")
+        return replace(
+            config,
+            api_key=resolve_provider_api_key(settings=settings, api_key_field=azure_secret_ref),
+        )
     return replace(
         config,
         api_key=resolve_provider_api_key(settings=settings, api_key_field=config.api_key),

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -354,6 +354,8 @@ class ModelProviderRow(TypedDict):
     model_list_path: str
     healthcheck_path: str
     invoke_path: str
+    azure_api_version: str
+    azure_auth_secret_ref: str
     metadata: JsonObject
     created_at: datetime
     updated_at: datetime
@@ -2113,11 +2115,15 @@ INSERT_MODEL_PROVIDER_SQL = """
                   model_list_path,
                   healthcheck_path,
                   invoke_path,
+                  azure_api_version,
+                  azure_auth_secret_ref,
                   metadata,
                   created_at,
                   updated_at
                 )
                 VALUES (
+                  %s,
+                  %s,
                   %s,
                   %s,
                   %s,
@@ -2150,6 +2156,8 @@ INSERT_MODEL_PROVIDER_SQL = """
                   model_list_path,
                   healthcheck_path,
                   invoke_path,
+                  azure_api_version,
+                  azure_auth_secret_ref,
                   metadata,
                   created_at,
                   updated_at
@@ -2171,6 +2179,8 @@ GET_MODEL_PROVIDER_FOR_WORKSPACE_SQL = """
                   model_list_path,
                   healthcheck_path,
                   invoke_path,
+                  azure_api_version,
+                  azure_auth_secret_ref,
                   metadata,
                   created_at,
                   updated_at
@@ -2195,6 +2205,8 @@ LIST_MODEL_PROVIDERS_FOR_WORKSPACE_SQL = """
                   model_list_path,
                   healthcheck_path,
                   invoke_path,
+                  azure_api_version,
+                  azure_auth_secret_ref,
                   metadata,
                   created_at,
                   updated_at
@@ -6268,6 +6280,8 @@ class ContinuityStore:
         model_list_path: str = "",
         healthcheck_path: str = "",
         invoke_path: str = "",
+        azure_api_version: str = "",
+        azure_auth_secret_ref: str = "",
     ) -> ModelProviderRow:
         return self._fetch_one(
             "create_model_provider",
@@ -6286,6 +6300,8 @@ class ContinuityStore:
                 model_list_path,
                 healthcheck_path,
                 invoke_path,
+                azure_api_version,
+                azure_auth_secret_ref,
                 Jsonb(metadata),
             ),
         )

--- a/docs/integrations/phase11-azure-autogen.md
+++ b/docs/integrations/phase11-azure-autogen.md
@@ -1,0 +1,114 @@
+# Phase 11 Azure + AutoGen Integration (P11-S5)
+
+This guide covers the sprint-owned enterprise provider and framework path:
+
+- `POST /v1/providers/azure/register`
+- `POST /v1/providers/test`
+- `POST /v1/runtime/invoke`
+- `GET /v1/providers`
+- `GET /v1/providers/{provider_id}`
+
+Scope note: this page documents Azure provider registration/runtime plus an AutoGen-oriented runtime bridge path.
+
+## Prerequisites
+
+1. Start Alice API and data services.
+2. Authenticate and obtain a hosted session bearer token.
+3. Have a thread ID available for runtime invoke.
+4. Have an Azure OpenAI or Azure Foundry endpoint that supports OpenAI-compatible `/openai/models` and `/openai/responses` paths.
+
+## Register Azure With API Key Auth
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers/azure/register" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "Azure Primary",
+    "base_url": "https://YOUR_RESOURCE.openai.azure.com",
+    "auth_mode": "azure_api_key",
+    "api_key": "'"$AZURE_API_KEY"'",
+    "api_version": "2024-10-21",
+    "default_model": "gpt-4.1-mini"
+  }'
+```
+
+## Register Azure With Entra Token Auth
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers/azure/register" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "Azure Entra",
+    "base_url": "https://YOUR_RESOURCE.services.ai.azure.com",
+    "auth_mode": "azure_ad_token",
+    "ad_token": "'"$AZURE_AD_TOKEN"'",
+    "api_version": "2024-10-21",
+    "default_model": "gpt-4.1"
+  }'
+```
+
+Credential posture:
+
+- Azure credentials are persisted as provider secret references.
+- Provider responses never return plaintext Azure credentials.
+
+## Test Provider Connectivity
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers/test" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_id": "'"$PROVIDER_ID"'",
+    "prompt": "Reply in one sentence confirming Azure runtime connectivity."
+  }'
+```
+
+Azure capability snapshots include additional posture fields:
+
+- `azure_api_version`
+- `azure_auth_mode`
+
+## Invoke Through Normalized Runtime Seam
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/runtime/invoke" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_id": "'"$PROVIDER_ID"'",
+    "thread_id": "'"$THREAD_ID"'",
+    "message": "Summarize current enterprise runtime status in one sentence."
+  }'
+```
+
+Optional model-pack seam (if you want explicit pack selection):
+
+```json
+{
+  "pack_id": "llama",
+  "pack_version": "1.0.0"
+}
+```
+
+## AutoGen Sample Path
+
+Use the sprint bridge script to call Alice runtime through an AutoGen-style model client shape:
+
+```bash
+./scripts/run_phase11_autogen_runtime_bridge.py \
+  --session-token "$SESSION_TOKEN" \
+  --provider-id "$PROVIDER_ID" \
+  --thread-id "$THREAD_ID" \
+  --user-message "Provide a concise status update." \
+  --show-raw
+```
+
+The script exposes `AutoGenAliceRuntimeClient.create(messages=[...])`, which lets AutoGen orchestration remain outside Alice while continuity, provider auth, model-pack shaping, and runtime invocation stay inside shipped Alice seams.
+
+## Guardrails
+
+- This sprint adds Azure + AutoGen path only.
+- Tier-2 packs and broader framework integrations remain later Phase 11 scope.

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -19,7 +19,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="README.md",
         required_markers=(
             "Phase 10 is complete and shipped.",
-            "`P11-S4` Model Packs Tier 1 is the active sprint",
+            "`P11-S5` Azure Adapter + AutoGen Integration is the active sprint",
             "Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md]",
         ),
     ),
@@ -27,14 +27,14 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="ROADMAP.md",
         required_markers=(
             "Phase 10 is complete and shipped baseline truth.",
-            "P11-S4: Model Packs Tier 1",
+            "P11-S5: Azure Adapter + AutoGen Integration",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Phase 11 Sprint 4 (P11-S4): Model Packs Tier 1",
-            "Phase 10, `P11-S1`, `P11-S2`, and `P11-S3` shipped scope remain baseline truth and are not reopened as sprint work",
+            "Phase 11 Sprint 5 (P11-S5): Azure Adapter + AutoGen Integration",
+            "Phase 10, `P11-S1`, `P11-S2`, `P11-S3`, and `P11-S4` shipped scope remain baseline truth and are not reopened as sprint work",
         ),
     ),
     ControlDocTruthRule(
@@ -49,7 +49,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "Phase 9 is complete and shipped.",
             "Phase 10 is complete and shipped.",
-            "`P11-S4` (Model Packs Tier 1) is the active execution sprint packet.",
+            "`P11-S5` (Azure Adapter + AutoGen Integration) is the active execution sprint packet.",
         ),
     ),
     ControlDocTruthRule(

--- a/scripts/run_phase11_autogen_runtime_bridge.py
+++ b/scripts/run_phase11_autogen_runtime_bridge.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""AutoGen-style bridge to Alice P11-S5 runtime invoke endpoints.
+
+This script demonstrates a minimal model-client shape that external frameworks
+can call while Alice remains the continuity and provider runtime surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def _request_json(
+    *,
+    method: str,
+    url: str,
+    bearer_token: str,
+    payload: dict[str, Any] | None = None,
+    timeout_seconds: int = 30,
+) -> dict[str, Any]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = Request(
+        url=url,
+        method=method,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {bearer_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            raw_payload = response.read()
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed with HTTP {exc.code}: {error_body}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"{method} {url} failed: {exc.reason}") from exc
+
+    try:
+        parsed = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{method} {url} returned invalid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"{method} {url} returned invalid payload shape")
+    return parsed
+
+
+def _latest_user_message(messages: list[dict[str, str]]) -> str:
+    for message in reversed(messages):
+        role = message.get("role", "").strip().lower()
+        content = message.get("content", "").strip()
+        if role == "user" and content != "":
+            return content
+    raise ValueError("messages must include at least one non-empty user message")
+
+
+@dataclass(frozen=True, slots=True)
+class AutoGenAliceRuntimeClient:
+    api_base_url: str
+    session_token: str
+    provider_id: str
+    thread_id: str
+    model: str | None = None
+    pack_id: str | None = None
+    pack_version: str | None = None
+    timeout_seconds: int = 30
+
+    def create(self, *, messages: list[dict[str, str]]) -> dict[str, Any]:
+        user_message = _latest_user_message(messages)
+        payload: dict[str, Any] = {
+            "provider_id": self.provider_id,
+            "thread_id": self.thread_id,
+            "message": user_message,
+        }
+        if self.model is not None and self.model.strip() != "":
+            payload["model"] = self.model.strip()
+        if self.pack_id is not None and self.pack_id.strip() != "":
+            payload["pack_id"] = self.pack_id.strip()
+        if self.pack_version is not None and self.pack_version.strip() != "":
+            payload["pack_version"] = self.pack_version.strip()
+
+        runtime_response = _request_json(
+            method="POST",
+            url=f"{self.api_base_url.rstrip('/')}/v1/runtime/invoke",
+            bearer_token=self.session_token,
+            payload=payload,
+            timeout_seconds=self.timeout_seconds,
+        )
+        assistant = runtime_response.get("assistant")
+        if not isinstance(assistant, dict):
+            raise RuntimeError("runtime invoke response missing assistant payload")
+        text = assistant.get("text")
+        if not isinstance(text, str) or text.strip() == "":
+            raise RuntimeError("runtime invoke response missing assistant text")
+        return {
+            "content": text,
+            "assistant": assistant,
+            "trace": runtime_response.get("trace"),
+            "metadata": runtime_response.get("metadata"),
+        }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="run_phase11_autogen_runtime_bridge.py",
+        description=(
+            "Send an AutoGen-style message list through Alice /v1/runtime/invoke "
+            "with provider/model-pack seams preserved."
+        ),
+    )
+    parser.add_argument(
+        "--api-base-url",
+        default="http://127.0.0.1:8000",
+        help="Alice API base URL (default: http://127.0.0.1:8000).",
+    )
+    parser.add_argument("--session-token", required=True, help="Hosted session bearer token.")
+    parser.add_argument("--provider-id", required=True, help="Registered provider ID (Azure for P11-S5).")
+    parser.add_argument("--thread-id", required=True, help="Thread ID used for runtime invoke continuity.")
+    parser.add_argument("--user-message", required=True, help="Latest user message content.")
+    parser.add_argument("--model", default=None, help="Optional runtime model override.")
+    parser.add_argument("--pack-id", default=None, help="Optional model-pack ID.")
+    parser.add_argument("--pack-version", default=None, help="Optional model-pack version.")
+    parser.add_argument("--timeout-seconds", type=int, default=30, help="Request timeout in seconds.")
+    parser.add_argument(
+        "--show-raw",
+        action="store_true",
+        help="Print full runtime payload instead of content-only shape.",
+    )
+    args = parser.parse_args()
+
+    client = AutoGenAliceRuntimeClient(
+        api_base_url=args.api_base_url,
+        session_token=args.session_token,
+        provider_id=args.provider_id,
+        thread_id=args.thread_id,
+        model=args.model,
+        pack_id=args.pack_id,
+        pack_version=args.pack_version,
+        timeout_seconds=args.timeout_seconds,
+    )
+    result = client.create(messages=[{"role": "user", "content": args.user_message}])
+    if args.show_raw:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(json.dumps({"content": result["content"]}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_phase11_provider_runtime_api.py
+++ b/tests/integration/test_phase11_provider_runtime_api.py
@@ -512,3 +512,246 @@ def test_phase11_local_provider_rejects_api_key_when_auth_mode_none(
     )
     assert status == 400
     assert payload["detail"] == "api_key must be empty when auth_mode is none"
+
+
+def test_phase11_azure_provider_registration_test_and_no_plaintext_storage(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, workspace_id, _ = _bootstrap_workspace_session("provider-azure-reg@example.com")
+    captured_requests: list[dict[str, object]] = []
+
+    def fake_urlopen(request, timeout):
+        captured_requests.append(
+            {
+                "url": request.full_url,
+                "timeout": timeout,
+                "headers": dict(request.header_items()),
+                "body": None if request.data is None else json.loads(request.data.decode("utf-8")),
+            }
+        )
+        url = request.full_url
+        if url.startswith("https://azure.example/openai/models"):
+            return FakeHTTPResponse(json.dumps({"data": [{"id": "gpt-4.1-mini"}]}).encode("utf-8"))
+        if url.startswith("https://azure.example/openai/responses"):
+            return FakeHTTPResponse(
+                json.dumps(
+                    {
+                        "id": "resp_azure_test_1",
+                        "status": "completed",
+                        "output": [
+                            {
+                                "type": "message",
+                                "content": [{"type": "output_text", "text": "Azure runtime response"}],
+                            }
+                        ],
+                        "usage": {
+                            "input_tokens": 10,
+                            "output_tokens": 4,
+                            "total_tokens": 14,
+                        },
+                    }
+                ).encode("utf-8")
+            )
+        raise AssertionError(f"unexpected azure URL: {url}")
+
+    monkeypatch.setattr("alicebot_api.azure_provider_helpers.urlopen", fake_urlopen)
+
+    register_status, register_payload = invoke_request(
+        "POST",
+        "/v1/providers/azure/register",
+        payload={
+            "display_name": "Azure Primary",
+            "base_url": "https://azure.example",
+            "auth_mode": "azure_api_key",
+            "api_key": "azure-secret-key",
+            "api_version": "2024-10-21",
+            "default_model": "gpt-4.1-mini",
+            "metadata": {"kind": "enterprise"},
+        },
+        headers=auth_header(session_token),
+    )
+    assert register_status == 201
+    provider_id = register_payload["provider"]["id"]
+    assert register_payload["provider"]["provider_key"] == "azure"
+    assert register_payload["provider"]["auth_mode"] == "azure_api_key"
+    assert register_payload["provider"]["azure_api_version"] == "2024-10-21"
+    assert register_payload["capabilities"]["discovery_status"] == "ready"
+    assert register_payload["capabilities"]["snapshot"]["azure_api_version"] == "2024-10-21"
+    assert register_payload["capabilities"]["snapshot"]["azure_auth_mode"] == "azure_api_key"
+    assert register_payload["capabilities"]["snapshot"]["models"] == ["gpt-4.1-mini"]
+
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v1/providers",
+        headers=auth_header(session_token),
+    )
+    assert list_status == 200
+    assert list_payload["summary"]["total_count"] == 1
+    assert list_payload["items"][0]["id"] == provider_id
+
+    detail_status, detail_payload = invoke_request(
+        "GET",
+        f"/v1/providers/{provider_id}",
+        headers=auth_header(session_token),
+    )
+    assert detail_status == 200
+    assert detail_payload["provider"]["provider_key"] == "azure"
+    assert detail_payload["capabilities"]["provider_id"] == provider_id
+
+    test_status, test_payload = invoke_request(
+        "POST",
+        "/v1/providers/test",
+        payload={
+            "provider_id": provider_id,
+            "prompt": "Reply with a concise Azure connectivity check.",
+        },
+        headers=auth_header(session_token),
+    )
+    assert test_status == 200
+    assert test_payload["result"]["text"] == "Azure runtime response"
+    assert test_payload["result"]["usage"]["total_tokens"] == 14
+
+    with psycopg.connect(migrated_database_urls["admin"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT api_key, azure_auth_secret_ref, auth_mode, azure_api_version
+                FROM model_providers
+                WHERE id = %s
+                  AND workspace_id = %s
+                """,
+                (provider_id, workspace_id),
+            )
+            row = cur.fetchone()
+    assert row is not None
+    stored_api_key, stored_secret_ref, stored_auth_mode, stored_api_version = row
+    assert stored_auth_mode == "azure_api_key"
+    assert stored_api_version == "2024-10-21"
+    assert stored_api_key != "azure-secret-key"
+    assert stored_secret_ref != "azure-secret-key"
+    assert stored_secret_ref.startswith("provider_secret_ref:")
+
+    captured_urls = [record["url"] for record in captured_requests]
+    assert "https://azure.example/openai/models?api-version=2024-10-21" in captured_urls
+    assert "https://azure.example/openai/responses?api-version=2024-10-21" in captured_urls
+    invoke_record = next(record for record in captured_requests if "/openai/responses?" in record["url"])
+    invoke_headers = {key.lower(): value for key, value in invoke_record["headers"].items()}
+    assert invoke_headers["api-key"] == "azure-secret-key"
+    assert "authorization" not in invoke_headers
+
+
+def test_phase11_azure_runtime_invoke_workspace_isolation_and_ad_token_auth(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token_a, _, user_account_id_a = _bootstrap_workspace_session("provider-azure-a@example.com")
+    session_token_b, _, _ = _bootstrap_workspace_session("provider-azure-b@example.com")
+    captured_requests: list[dict[str, object]] = []
+
+    def fake_urlopen(request, timeout):
+        captured_requests.append(
+            {
+                "url": request.full_url,
+                "timeout": timeout,
+                "headers": dict(request.header_items()),
+                "body": None if request.data is None else json.loads(request.data.decode("utf-8")),
+            }
+        )
+        url = request.full_url
+        if url.startswith("https://foundry.example/openai/models"):
+            return FakeHTTPResponse(json.dumps({"data": [{"id": "gpt-4.1"}]}).encode("utf-8"))
+        if url.startswith("https://foundry.example/openai/responses"):
+            return FakeHTTPResponse(
+                json.dumps(
+                    {
+                        "id": "resp_azure_runtime_1",
+                        "status": "completed",
+                        "output": [
+                            {
+                                "type": "message",
+                                "content": [{"type": "output_text", "text": "Azure runtime invoke works"}],
+                            }
+                        ],
+                        "usage": {
+                            "input_tokens": 12,
+                            "output_tokens": 5,
+                            "total_tokens": 17,
+                        },
+                    }
+                ).encode("utf-8")
+            )
+        raise AssertionError(f"unexpected azure URL: {url}")
+
+    monkeypatch.setattr("alicebot_api.azure_provider_helpers.urlopen", fake_urlopen)
+
+    register_status, register_payload = invoke_request(
+        "POST",
+        "/v1/providers/azure/register",
+        payload={
+            "display_name": "Azure Entra",
+            "base_url": "https://foundry.example",
+            "auth_mode": "azure_ad_token",
+            "ad_token": "entra-token-secret",
+            "api_version": "2024-10-21",
+            "default_model": "gpt-4.1",
+        },
+        headers=auth_header(session_token_a),
+    )
+    assert register_status == 201
+    provider_id = register_payload["provider"]["id"]
+    assert register_payload["provider"]["auth_mode"] == "azure_ad_token"
+
+    other_workspace_status, other_workspace_payload = invoke_request(
+        "GET",
+        f"/v1/providers/{provider_id}",
+        headers=auth_header(session_token_b),
+    )
+    assert other_workspace_status == 404
+    assert "was not found" in other_workspace_payload["detail"]
+
+    invalid_register_status, invalid_register_payload = invoke_request(
+        "POST",
+        "/v1/providers/azure/register",
+        payload={
+            "display_name": "Azure Invalid",
+            "base_url": "https://foundry.example",
+            "auth_mode": "azure_ad_token",
+            "ad_token": "valid-token-that-should-have-been-alone",
+            "api_key": "must-not-be-sent",
+            "default_model": "gpt-4.1",
+        },
+        headers=auth_header(session_token_a),
+    )
+    assert invalid_register_status == 422
+    assert "api_key must be empty when auth_mode is azure_ad_token" in json.dumps(
+        invalid_register_payload["detail"]
+    )
+
+    thread_id = _seed_thread_for_user(
+        admin_db_url=migrated_database_urls["admin"],
+        user_id=user_account_id_a,
+        email="provider-azure-a@example.com",
+    )
+    runtime_status, runtime_payload = invoke_request(
+        "POST",
+        "/v1/runtime/invoke",
+        payload={
+            "provider_id": provider_id,
+            "thread_id": thread_id,
+            "message": "Give a concise enterprise runtime check.",
+        },
+        headers=auth_header(session_token_a),
+    )
+    assert runtime_status == 200
+    assert runtime_payload["assistant"]["provider_id"] == provider_id
+    assert runtime_payload["assistant"]["provider_key"] == "azure"
+    assert runtime_payload["assistant"]["text"] == "Azure runtime invoke works"
+    assert runtime_payload["assistant"]["usage"]["total_tokens"] == 17
+
+    invoke_record = next(record for record in captured_requests if "/openai/responses?" in record["url"])
+    headers = {key.lower(): value for key, value in invoke_record["headers"].items()}
+    assert headers["authorization"] == "Bearer entra-token-secret"
+    assert "api-key" not in headers

--- a/tests/unit/test_20260412_0055_phase11_azure_provider_config_fields.py
+++ b/tests/unit/test_20260412_0055_phase11_azure_provider_config_fields.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260412_0055_phase11_azure_provider_config_fields"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == list(module._UPGRADE_STATEMENTS)
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)

--- a/tests/unit/test_provider_runtime.py
+++ b/tests/unit/test_provider_runtime.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from apps.api.src.alicebot_api.config import Settings
 from alicebot_api.provider_runtime import (
+    AZURE_ADAPTER_KEY,
     LLAMACPP_ADAPTER_KEY,
     OLLAMA_ADAPTER_KEY,
     OPENAI_COMPATIBLE_ADAPTER_KEY,
@@ -13,6 +14,13 @@ from alicebot_api.provider_runtime import (
     RuntimeProviderConfig,
     build_provider_test_model_request,
     make_provider_adapter_registry,
+    resolve_runtime_provider_config_secrets,
+)
+from alicebot_api.provider_secrets import (
+    ProviderSecretManagerError,
+    build_provider_secret_ref,
+    encode_provider_secret_ref,
+    write_provider_api_key,
 )
 
 
@@ -39,6 +47,8 @@ def make_runtime_provider_config(
     model_list_path: str = "/models",
     healthcheck_path: str = "/models",
     invoke_path: str = "/responses",
+    azure_api_version: str = "",
+    azure_auth_secret_ref: str = "",
 ) -> RuntimeProviderConfig:
     return RuntimeProviderConfig(
         provider_id=uuid4(),
@@ -55,6 +65,8 @@ def make_runtime_provider_config(
         model_list_path=model_list_path,
         healthcheck_path=healthcheck_path,
         invoke_path=invoke_path,
+        azure_api_version=azure_api_version,
+        azure_auth_secret_ref=azure_auth_secret_ref,
         metadata={},
     )
 
@@ -63,14 +75,17 @@ def test_provider_registry_resolves_registered_adapter() -> None:
     registry = make_provider_adapter_registry()
 
     adapter = registry.resolve(OPENAI_COMPATIBLE_ADAPTER_KEY)
+    azure_adapter = registry.resolve(AZURE_ADAPTER_KEY)
     ollama_adapter = registry.resolve(OLLAMA_ADAPTER_KEY)
     llamacpp_adapter = registry.resolve(LLAMACPP_ADAPTER_KEY)
 
     assert adapter.adapter_key == OPENAI_COMPATIBLE_ADAPTER_KEY
     assert adapter.runtime_provider == OPENAI_RESPONSES_PROVIDER
+    assert azure_adapter.adapter_key == AZURE_ADAPTER_KEY
     assert ollama_adapter.adapter_key == OLLAMA_ADAPTER_KEY
     assert llamacpp_adapter.adapter_key == LLAMACPP_ADAPTER_KEY
     assert registry.keys() == [
+        AZURE_ADAPTER_KEY,
         LLAMACPP_ADAPTER_KEY,
         OLLAMA_ADAPTER_KEY,
         OPENAI_COMPATIBLE_ADAPTER_KEY,
@@ -311,3 +326,158 @@ def test_llamacpp_adapter_discovers_capabilities_and_invokes(monkeypatch) -> Non
     assert captured[0]["url"] == "http://127.0.0.1:8080/health"
     assert captured[1]["url"] == "http://127.0.0.1:8080/v1/models"
     assert captured[2]["url"] == "http://127.0.0.1:8080/v1/chat/completions"
+
+
+def test_azure_adapter_discovers_capabilities_and_invokes_with_api_key(monkeypatch) -> None:
+    captured: list[dict[str, object]] = []
+    registry = make_provider_adapter_registry()
+    adapter = registry.resolve(AZURE_ADAPTER_KEY)
+    runtime_provider = make_runtime_provider_config(
+        provider_key=AZURE_ADAPTER_KEY,
+        base_url="https://azure.example",
+        api_key="azure-api-key",
+        auth_mode="azure_api_key",
+        model_list_path="/openai/models",
+        healthcheck_path="/openai/models",
+        invoke_path="/openai/responses",
+        azure_api_version="2024-10-21",
+    )
+
+    def fake_urlopen(request, timeout):
+        body = None if request.data is None else json.loads(request.data.decode("utf-8"))
+        captured.append(
+            {
+                "url": request.full_url,
+                "timeout": timeout,
+                "headers": dict(request.header_items()),
+                "body": body,
+            }
+        )
+        if request.full_url.startswith("https://azure.example/openai/models"):
+            return FakeHTTPResponse(json.dumps({"data": [{"id": "gpt-4.1-mini"}]}).encode("utf-8"))
+        return FakeHTTPResponse(
+            json.dumps(
+                {
+                    "id": "resp_azure_test_1",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "content": [{"type": "output_text", "text": "Azure provider online"}],
+                        }
+                    ],
+                    "usage": {
+                        "input_tokens": 11,
+                        "output_tokens": 4,
+                        "total_tokens": 15,
+                    },
+                }
+            ).encode("utf-8")
+        )
+
+    monkeypatch.setattr("alicebot_api.azure_provider_helpers.urlopen", fake_urlopen)
+
+    capabilities = adapter.discover_capabilities(
+        config=runtime_provider,
+        settings=Settings(healthcheck_timeout_seconds=5),
+    )
+    response = adapter.invoke(
+        config=runtime_provider,
+        settings=Settings(model_timeout_seconds=12),
+        request=build_provider_test_model_request(
+            runtime_provider=OPENAI_RESPONSES_PROVIDER,
+            model="gpt-4.1-mini",
+            prompt_text="Azure runtime check",
+        ),
+    )
+
+    assert capabilities["adapter_key"] == AZURE_ADAPTER_KEY
+    assert capabilities["health_status"] == "ok"
+    assert capabilities["model_count"] == 1
+    assert capabilities["models"] == ["gpt-4.1-mini"]
+    assert capabilities["azure_api_version"] == "2024-10-21"
+    assert capabilities["azure_auth_mode"] == "azure_api_key"
+    assert response.output_text == "Azure provider online"
+    assert response.usage["total_tokens"] == 15
+    assert captured[0]["url"] == "https://azure.example/openai/models?api-version=2024-10-21"
+    assert captured[1]["url"] == "https://azure.example/openai/models?api-version=2024-10-21"
+    assert captured[2]["url"] == "https://azure.example/openai/responses?api-version=2024-10-21"
+    azure_headers = {key.lower(): value for key, value in captured[2]["headers"].items()}
+    assert azure_headers["api-key"] == "azure-api-key"
+    assert "authorization" not in azure_headers
+
+
+def test_azure_adapter_uses_bearer_token_auth_mode(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    registry = make_provider_adapter_registry()
+    adapter = registry.resolve(AZURE_ADAPTER_KEY)
+    runtime_provider = make_runtime_provider_config(
+        provider_key=AZURE_ADAPTER_KEY,
+        base_url="https://foundry.example",
+        api_key="entra-token-value",
+        auth_mode="azure_ad_token",
+        model_list_path="/openai/models",
+        healthcheck_path="/openai/models",
+        invoke_path="/openai/responses",
+        azure_api_version="2024-10-21",
+    )
+
+    def fake_urlopen(request, timeout):
+        del timeout
+        captured["headers"] = dict(request.header_items())
+        return FakeHTTPResponse(json.dumps({"data": [{"id": "gpt-4.1"}]}).encode("utf-8"))
+
+    monkeypatch.setattr("alicebot_api.azure_provider_helpers.urlopen", fake_urlopen)
+
+    adapter.discover_capabilities(
+        config=runtime_provider,
+        settings=Settings(healthcheck_timeout_seconds=5),
+    )
+
+    headers = {key.lower(): value for key, value in captured["headers"].items()}
+    assert headers["authorization"] == "Bearer entra-token-value"
+    assert "api-key" not in headers
+
+
+def test_resolve_runtime_provider_config_secrets_for_azure_secret_ref(tmp_path) -> None:
+    settings = Settings(provider_secret_manager_url=f"file://{tmp_path}")
+    secret_ref = build_provider_secret_ref(workspace_id=uuid4())
+    write_provider_api_key(
+        settings=settings,
+        secret_ref=secret_ref,
+        api_key="resolved-azure-secret",
+    )
+    config = make_runtime_provider_config(
+        provider_key=AZURE_ADAPTER_KEY,
+        auth_mode="azure_api_key",
+        api_key="auth_mode_azure_secret_ref",
+        azure_auth_secret_ref=encode_provider_secret_ref(secret_ref=secret_ref),
+        azure_api_version="2024-10-21",
+    )
+
+    resolved = resolve_runtime_provider_config_secrets(
+        config=config,
+        settings=settings,
+    )
+
+    assert resolved.api_key == "resolved-azure-secret"
+
+
+def test_resolve_runtime_provider_config_secrets_rejects_missing_azure_secret_ref() -> None:
+    config = make_runtime_provider_config(
+        provider_key=AZURE_ADAPTER_KEY,
+        auth_mode="azure_api_key",
+        api_key="auth_mode_azure_secret_ref",
+        azure_auth_secret_ref="",
+        azure_api_version="2024-10-21",
+    )
+
+    try:
+        resolve_runtime_provider_config_secrets(
+            config=config,
+            settings=Settings(),
+        )
+    except ProviderSecretManagerError as exc:
+        assert "azure_auth_secret_ref is required" in str(exc)
+    else:  # pragma: no cover - defensive guard
+        raise AssertionError("expected ProviderSecretManagerError")


### PR DESCRIPTION
## Summary
This PR delivers Phase 11 Sprint 5 by adding the Azure enterprise provider path and the first framework integration slice on top of the shipped provider/runtime and model-pack seams.

## What changed
- adds Azure provider registration, test, and invoke support through the existing provider abstraction
- hardens enterprise credential and auth handling for Azure auth modes with secret references
- preserves the existing normalized runtime seam while adding Azure capability posture fields
- adds AutoGen integration guidance and a sample runtime bridge path built on the shipped runtime/model-pack seams
- updates build/review evidence and control-doc truth markers to match the committed `P11-S5` payload

## Upgrade Overview
### Protected Areas
- [x] continuity APIs
- [x] memory schema
- [x] trust rules

### Compatibility Impact
`P11-S5` is additive on top of the shipped `P11-S1` through `P11-S4` seams. Existing provider/runtime/model-pack behavior and `v0/responses` behavior remain on the same normalized runtime path; the new surface is Azure registration plus Azure-backed invoke support through the existing APIs and the new integration guidance for AutoGen.

### Migration / Rollout
Apply the `20260412_0055_phase11_azure_provider_config_fields` migration before registering Azure providers. Roll out by validating one Azure provider with each supported auth mode (`azure_api_key`, `azure_ad_token`) in a staging workspace before broader enterprise adoption.

### Operator Action
Operators need to run the standard API migration flow, register Azure providers with the correct auth mode fields, and store Azure credentials via secret references rather than plaintext provider-row values. The AutoGen bridge sample is documentation and example code only; it does not require separate runtime state migration.

### Validation
Validation for this branch head is: `python3 scripts/check_control_doc_truth.py` PASS, `./.venv/bin/python -m pytest tests/unit tests/integration -q` PASS (`1142 passed in 196.54s`), and `pnpm --dir apps/web test` PASS (`62 passed` files, `199 passed` tests, duration `4.62s`). Sprint-owned Azure integration, migration, and provider-runtime coverage is included in the updated provider test files.

### Rollback
Rollback is a standard application rollback plus reverting the `P11-S5` commit and migration if the Azure path must be withdrawn. If rollout issues appear after registration, operators can stop using Azure provider registrations and continue using the shipped OpenAI-compatible, local, self-hosted, and model-pack paths without changing existing continuity semantics.

## Verification
- `python3 scripts/check_control_doc_truth.py`
  - PASS
- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
  - PASS (`1142 passed in 196.54s`)
- `pnpm --dir apps/web test`
  - PASS (`62 passed` files, `199 passed` tests)
  - duration `4.62s`
