### PR TITLE
P11-S6: ship tier-2 packs and launch clarity assets

### DIFF
--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,73 +1,65 @@
 # BUILD_REPORT
 
 ## sprint objective
-Implement P11-S5: Azure Adapter + AutoGen Integration through the existing provider abstraction by adding Azure provider registration/test/invoke support, enterprise credential/auth hardening, Azure capability posture fields, and AutoGen integration documentation/sample path.
+Implement `P11-S6` by adding tier-2 model packs (DeepSeek, Kimi, Mistral) on the shipped model-pack abstraction, plus compatibility/setup clarity assets for local, self-hosted, enterprise, and external-agent paths, without reopening `P11-S1` through `P11-S5` architecture.
 
 ## completed work
-- Added Azure provider adapter support in the runtime adapter registry (`provider_key: azure`) with normalized capability discovery and invoke behavior using the existing `openai_responses` runtime contract.
-- Added Azure-specific helper module for:
-  - auth header handling (`azure_api_key`, `azure_ad_token`)
-  - `api-version` query handling
-  - model enumeration payload parsing
-  - OpenAI-compatible responses invoke payload/response normalization
-- Added additive provider data fields and migration support:
-  - `model_providers.azure_api_version`
-  - `model_providers.azure_auth_secret_ref`
-  - expanded `model_providers.auth_mode` constraint to include Azure auth modes
-- Added Azure secret-reference credential handling in runtime secret resolution:
-  - Azure modes now resolve credentials from `azure_auth_secret_ref`
-  - plaintext Azure credentials are not persisted in provider rows
-- Added Azure registration endpoint:
-  - `POST /v1/providers/azure/register`
-  - strict auth payload validation (mode-specific field requirements)
-- Preserved existing provider/runtime seams and behavior for shipped P11-S1 through P11-S4 paths.
-- Added Azure capability snapshot posture fields:
-  - `azure_api_version`
-  - `azure_auth_mode`
-- Added docs and sample integration path:
-  - Azure + AutoGen integration guide in `docs/integrations/phase11-azure-autogen.md`
-  - runtime bridge sample in `scripts/run_phase11_autogen_runtime_bridge.py`
-- Updated control-doc truth checker markers to P11-S5 active-sprint truth so required truth checks pass.
+- Added tier-2 built-in pack specs in `model_packs.py`:
+  - `deepseek@1.0.0`
+  - `kimi@1.0.0`
+  - `mistral@1.0.0`
+- Preserved shipped pack API behavior and selection semantics:
+  - seeded catalog still resolves through existing `/v1/model-packs` flow
+  - workspace binding and request override precedence are unchanged
+  - no new runtime/provider paths were introduced
+- Extended family contract/type support for tier-2 families:
+  - `deepseek`, `kimi`, `mistral`
+- Added additive migration `20260412_0056_phase11_model_packs_tier2_families.py` to widen `model_packs_family_check` without schema redesign.
+- Updated catalog reservation conflict text to cover built-in catalog entries (tier-1 + tier-2).
+- Added/updated sprint docs:
+  - `docs/integrations/phase11-model-pack-compatibility.md` with provider/pack compatibility matrices
+  - `docs/integrations/phase11-setup-paths.md` with operator setup paths for local, self-hosted, enterprise, and external-agent use
+  - `docs/integrations/phase11-azure-autogen.md` guardrails/references refreshed for P11-S6
+- Updated sprint-owned tests for tier-2 catalog presence, runtime override behavior, and migration coverage.
+- Updated control-doc truth checker markers to active `P11-S6` packet/state markers.
+- Updated `REVIEW_REPORT.md` for `P11-S6`.
 
 ## incomplete work
 - None within the sprint packet scope.
 
 ## files changed
-- `apps/api/src/alicebot_api/azure_provider_helpers.py` (new)
-- `apps/api/src/alicebot_api/provider_runtime.py`
-- `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/store.py`
+- `apps/api/src/alicebot_api/model_packs.py`
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/alembic/versions/20260412_0055_phase11_azure_provider_config_fields.py` (new)
-- `tests/unit/test_provider_runtime.py`
-- `tests/integration/test_phase11_provider_runtime_api.py`
-- `tests/unit/test_20260412_0055_phase11_azure_provider_config_fields.py` (new)
-- `docs/integrations/phase11-azure-autogen.md` (new)
-- `scripts/run_phase11_autogen_runtime_bridge.py` (new)
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/alembic/versions/20260412_0056_phase11_model_packs_tier2_families.py` (new)
+- `tests/unit/test_model_packs.py`
+- `tests/integration/test_phase11_model_packs_api.py`
+- `tests/unit/test_20260412_0056_phase11_model_packs_tier2_families.py` (new)
+- `docs/integrations/phase11-model-pack-compatibility.md`
+- `docs/integrations/phase11-setup-paths.md` (new)
+- `docs/integrations/phase11-azure-autogen.md`
 - `scripts/check_control_doc_truth.py`
-- `README.md`
-- `BUILD_REPORT.md`
 - `REVIEW_REPORT.md`
+- `BUILD_REPORT.md`
 
 ## tests run
 1. `python3 scripts/check_control_doc_truth.py`
 - Result: PASS
 
 2. `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-- Result: PASS (`1142 passed in 196.54s (0:03:16)`)
+- Result: PASS (`1145 passed in 185.18s (0:03:05)`)
 
 3. `pnpm --dir apps/web test`
-- Result: PASS (`62 passed`, `199 passed`, duration `4.62s`)
+- Result: PASS (`62 files`, `199 tests passed`, duration `5.49s`)
 
 4. Focused sprint tests during implementation:
-- `./.venv/bin/python -m pytest tests/unit/test_provider_runtime.py tests/unit/test_provider_secrets.py tests/unit/test_20260412_0055_phase11_azure_provider_config_fields.py tests/integration/test_phase11_provider_runtime_api.py -q`
-- Result: PASS (`20 passed`)
+- `./.venv/bin/python -m pytest tests/unit/test_model_packs.py tests/integration/test_phase11_model_packs_api.py tests/unit/test_20260412_0056_phase11_model_packs_tier2_families.py -q`
+- Result: PASS (`14 passed in 1.62s`)
 
 ## blockers/issues
 - No functional blockers for sprint scope implementation.
-- Pre-existing dirty files not modified as sprint work and excluded from sprint merge scope:
-  - `ARCHITECTURE.md`
-  - `PRODUCT_BRIEF.md`
+- Pre-existing dirty file not modified as sprint work and excluded from sprint merge scope:
+  - `README.md`
 
 ## recommended next step
-Proceed to Control Tower merge approval for `P11-S5`, then run staging validation against a live Azure endpoint for both `azure_api_key` and `azure_ad_token` registration/invoke flows before production rollout.
+Proceed to merge review for `P11-S6`, then run staging smoke checks for one local provider, one self-hosted OpenAI-compatible provider, and one Azure provider with tier-2 and custom pack coverage.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,45 +4,49 @@
 PASS
 
 ## criteria met
-- `POST /v1/providers/azure/register` is implemented and validated with strict auth-mode payload checks.
-- Azure provider registration/test/invoke flows are covered through shipped APIs:
-  - `POST /v1/providers/azure/register`
-  - `POST /v1/providers/test`
-  - `POST /v1/runtime/invoke`
-  - `GET /v1/providers`
-  - `GET /v1/providers/{provider_id}`
-- Credential/auth hardening is implemented for Azure:
-  - Azure credentials are persisted via secret references (`azure_auth_secret_ref`)
-  - Integration tests verify no plaintext Azure credential leakage in `model_providers`
-- Azure invoke path uses the existing normalized provider abstraction/adapter registry (no continuity-semantic fork).
-- Azure capability posture additions are present (`azure_api_version`, `azure_auth_mode`).
-- AutoGen integration guide and sample path are present:
-  - `docs/integrations/phase11-azure-autogen.md`
-  - `scripts/run_phase11_autogen_runtime_bridge.py`
-- Required verification commands pass (re-run after fix):
-  - `python3 scripts/check_control_doc_truth.py` ✅
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` ✅ (`1142 passed in 196.54s`)
-  - `pnpm --dir apps/web test` ✅ (`62 files / 199 tests passed`, duration `4.62s`)
-- Local identifier check: no local machine paths/usernames found in sprint-owned changed files.
+- Tier-2 packs are implemented on the existing model-pack seam: `deepseek@1.0.0`, `kimi@1.0.0`, `mistral@1.0.0` (`apps/api/src/alicebot_api/model_packs.py`).
+- Family contract support is added additively in code + DB constraint migration (no provider/runtime redesign):
+  - `apps/api/src/alicebot_api/contracts.py`
+  - `apps/api/alembic/versions/20260412_0056_phase11_model_packs_tier2_families.py`
+- Pack listing/detail/binding/invoke flows remain on shipped APIs and semantics:
+  - workspace default binding still applies when no request override is provided
+  - request-level pack override still takes precedence
+  - reserved built-in catalog IDs/versions are blocked from custom create
+- Compatibility and launch-clarity docs are present and within sprint scope:
+  - `docs/integrations/phase11-model-pack-compatibility.md`
+  - `docs/integrations/phase11-setup-paths.md`
+  - `docs/integrations/phase11-azure-autogen.md` (guardrail/reference update)
+- Sprint tests cover tier-2 catalog presence, runtime shaping override path, and migration statements:
+  - `tests/unit/test_model_packs.py`
+  - `tests/integration/test_phase11_model_packs_api.py`
+  - `tests/unit/test_20260412_0056_phase11_model_packs_tier2_families.py`
+- Required verification commands were executed and passed:
+  - `python3 scripts/check_control_doc_truth.py` -> PASS
+  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> `1145 passed in 185.18s`
+  - `pnpm --dir apps/web test` -> `62 files passed, 199 tests passed in 5.49s`
+- Local identifier sweep on sprint-owned changes found no leaked local computer paths/usernames.
 
 ## criteria missed
 - None.
 
 ## quality issues
-- None blocking or non-blocking found in sprint-owned implementation after scope cleanup.
+- None blocking for `P11-S6`.
+- Overreach check: no new provider adapters, no new framework integrations beyond shipped AutoGen path, and no product-surface expansion detected.
 
 ## regression risks
-- Low residual risk: Azure behavior is validated in mocked integration tests; live-endpoint staging validation is still recommended for environment-specific routing/auth nuances.
+- Low: compatibility posture is declarative/documented, but real provider/model availability is deployment-dependent and should still be smoke-tested per environment.
 
 ## docs issues
-- Sprint docs are present and scoped correctly for P11-S5.
+- No scope violations found in sprint docs.
+- Process note: `README.md` is currently dirty in the workspace; ensure only intended sprint files are included in merge scope.
 
 ## should anything be added to RULES.md?
-- Optional improvement: add a standing rule that sprint PRs must exclude unrelated dirty local files before review.
+- No.
 
 ## should anything update ARCHITECTURE.md?
-- No required architecture update for P11-S5 acceptance.
+- No.
 
 ## recommended next action
-1. Proceed with sprint merge review/approval for `P11-S5`.
-2. Run staging smoke validation against live Azure for both `azure_api_key` and `azure_ad_token` before production rollout.
+1. Approve `P11-S6` for merge.
+2. Before merge, confirm the final PR file list excludes unrelated dirty files.
+3. Run staging smoke checks across one local provider path, one self-hosted openai-compatible path, and one Azure path using tier-2 pack bind/override flows.

--- a/apps/api/alembic/versions/20260412_0056_phase11_model_packs_tier2_families.py
+++ b/apps/api/alembic/versions/20260412_0056_phase11_model_packs_tier2_families.py
@@ -1,0 +1,40 @@
+"""Expand model-pack family constraint for Phase 11 tier-2 packs."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260412_0056"
+down_revision = "20260412_0055"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_STATEMENTS = (
+    "ALTER TABLE model_packs DROP CONSTRAINT IF EXISTS model_packs_family_check",
+    (
+        "ALTER TABLE model_packs ADD CONSTRAINT model_packs_family_check "
+        "CHECK (family IN ('llama', 'qwen', 'gemma', 'gpt-oss', 'deepseek', 'kimi', 'mistral', 'custom'))"
+    ),
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "ALTER TABLE model_packs DROP CONSTRAINT IF EXISTS model_packs_family_check",
+    (
+        "ALTER TABLE model_packs ADD CONSTRAINT model_packs_family_check "
+        "CHECK (family IN ('llama', 'qwen', 'gemma', 'gpt-oss', 'custom'))"
+    ),
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -192,7 +192,16 @@ ModelProvider = Literal["openai_responses"]
 ProviderAdapterKey = Literal["openai_compatible", "ollama", "llamacpp", "azure"]
 ModelProviderStatus = Literal["active"]
 ProviderCapabilityDiscoveryStatus = Literal["ready", "failed"]
-ModelPackFamily = Literal["llama", "qwen", "gemma", "gpt-oss", "custom"]
+ModelPackFamily = Literal[
+    "llama",
+    "qwen",
+    "gemma",
+    "gpt-oss",
+    "deepseek",
+    "kimi",
+    "mistral",
+    "custom",
+]
 ModelPackStatus = Literal["active"]
 ModelPackBindingSource = Literal["manual", "runtime_override"]
 ModelFinishReason = Literal["completed", "incomplete"]

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -7022,7 +7022,7 @@ def create_v1_model_pack(request: Request, body: CreateModelPackRequest) -> JSON
                         content={
                             "detail": (
                                 f"model pack {normalized_pack_id}@{normalized_pack_version} "
-                                "is reserved for tier-1 catalog entries"
+                                "is reserved for built-in catalog entries"
                             )
                         },
                     )

--- a/apps/api/src/alicebot_api/model_packs.py
+++ b/apps/api/src/alicebot_api/model_packs.py
@@ -12,7 +12,16 @@ MODEL_PACK_CONTRACT_VERSION_V1 = "model_pack_contract_v1"
 MODEL_PACK_STATUS_ACTIVE = "active"
 MODEL_PACK_BINDING_SOURCE_MANUAL = "manual"
 MODEL_PACK_BINDING_SOURCE_RUNTIME_OVERRIDE = "runtime_override"
-MODEL_PACK_FAMILIES: tuple[str, ...] = ("llama", "qwen", "gemma", "gpt-oss", "custom")
+MODEL_PACK_FAMILIES: tuple[str, ...] = (
+    "llama",
+    "qwen",
+    "gemma",
+    "gpt-oss",
+    "deepseek",
+    "kimi",
+    "mistral",
+    "custom",
+)
 MAX_CONTEXT_SESSIONS = 50
 MAX_CONTEXT_EVENTS = 200
 MAX_CONTEXT_MEMORIES = 200
@@ -44,6 +53,8 @@ class Tier1PackSpec:
     family: str
     description: str
     contract: JsonObject
+    seed: str
+    seed_version: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -329,6 +340,8 @@ def _tier1_pack_specs() -> tuple[Tier1PackSpec, ...]:
                     },
                 }
             ),
+            seed="tier1",
+            seed_version="p11-s4",
         ),
         Tier1PackSpec(
             pack_id="qwen",
@@ -362,6 +375,8 @@ def _tier1_pack_specs() -> tuple[Tier1PackSpec, ...]:
                     },
                 }
             ),
+            seed="tier1",
+            seed_version="p11-s4",
         ),
         Tier1PackSpec(
             pack_id="gemma",
@@ -395,6 +410,8 @@ def _tier1_pack_specs() -> tuple[Tier1PackSpec, ...]:
                     },
                 }
             ),
+            seed="tier1",
+            seed_version="p11-s4",
         ),
         Tier1PackSpec(
             pack_id="gpt-oss",
@@ -428,8 +445,124 @@ def _tier1_pack_specs() -> tuple[Tier1PackSpec, ...]:
                     },
                 }
             ),
+            seed="tier1",
+            seed_version="p11-s4",
         ),
     )
+
+
+def _tier2_pack_specs() -> tuple[Tier1PackSpec, ...]:
+    return (
+        Tier1PackSpec(
+            pack_id="deepseek",
+            pack_version="1.0.0",
+            display_name="DeepSeek Tier 2",
+            family="deepseek",
+            description="Tier-2 declarative runtime shaping for DeepSeek-family instruct models.",
+            contract=normalize_model_pack_contract(
+                {
+                    "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
+                    "context": {
+                        "max_sessions_cap": 3,
+                        "max_events_cap": 8,
+                        "max_memories_cap": 6,
+                        "max_entities_cap": 6,
+                        "max_entity_edges_cap": 12,
+                    },
+                    "tools": {"mode": "none"},
+                    "response": {
+                        "system_instruction_append": (
+                            "Prefer precise, concise outputs and anchor claims to explicit context."
+                        ),
+                        "developer_instruction_append": (
+                            "Keep recommendations concrete and avoid speculative branching."
+                        ),
+                    },
+                    "compatibility": {
+                        "provider_keys": ["openai_compatible", "ollama", "llamacpp"],
+                        "runtime_providers": ["openai_responses"],
+                        "notes": "Tier-2 baseline for DeepSeek-family backends.",
+                    },
+                }
+            ),
+            seed="tier2",
+            seed_version="p11-s6",
+        ),
+        Tier1PackSpec(
+            pack_id="kimi",
+            pack_version="1.0.0",
+            display_name="Kimi Tier 2",
+            family="kimi",
+            description="Tier-2 declarative runtime shaping for Kimi-family instruct models.",
+            contract=normalize_model_pack_contract(
+                {
+                    "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
+                    "context": {
+                        "max_sessions_cap": 3,
+                        "max_events_cap": 8,
+                        "max_memories_cap": 5,
+                        "max_entities_cap": 6,
+                        "max_entity_edges_cap": 10,
+                    },
+                    "tools": {"mode": "none"},
+                    "response": {
+                        "system_instruction_append": (
+                            "Use direct language and preserve important continuity facts."
+                        ),
+                        "developer_instruction_append": (
+                            "Favor short, execution-ready output with explicit next actions."
+                        ),
+                    },
+                    "compatibility": {
+                        "provider_keys": ["openai_compatible", "ollama", "llamacpp"],
+                        "runtime_providers": ["openai_responses"],
+                        "notes": "Tier-2 baseline for Kimi-family backends.",
+                    },
+                }
+            ),
+            seed="tier2",
+            seed_version="p11-s6",
+        ),
+        Tier1PackSpec(
+            pack_id="mistral",
+            pack_version="1.0.0",
+            display_name="Mistral Tier 2",
+            family="mistral",
+            description="Tier-2 declarative runtime shaping for Mistral-family instruct models.",
+            contract=normalize_model_pack_contract(
+                {
+                    "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
+                    "context": {
+                        "max_sessions_cap": 3,
+                        "max_events_cap": 8,
+                        "max_memories_cap": 5,
+                        "max_entities_cap": 5,
+                        "max_entity_edges_cap": 10,
+                    },
+                    "tools": {"mode": "none"},
+                    "response": {
+                        "system_instruction_append": (
+                            "Keep responses structured and grounded in available evidence."
+                        ),
+                        "developer_instruction_append": (
+                            "Prefer concise summaries and call out uncertainty when applicable."
+                        ),
+                    },
+                    "compatibility": {
+                        "provider_keys": ["openai_compatible", "ollama", "llamacpp"],
+                        "runtime_providers": ["openai_responses"],
+                        "notes": "Tier-2 baseline for Mistral-family backends.",
+                    },
+                }
+            ),
+            seed="tier2",
+            seed_version="p11-s6",
+        ),
+    )
+
+
+def _catalog_pack_specs() -> tuple[Tier1PackSpec, ...]:
+    return _tier1_pack_specs() + _tier2_pack_specs()
 
 
 def is_reserved_tier1_pack_key(*, pack_id: str, pack_version: str) -> bool:
@@ -437,7 +570,7 @@ def is_reserved_tier1_pack_key(*, pack_id: str, pack_version: str) -> bool:
     normalized_pack_version = normalize_pack_version(pack_version)
     return any(
         spec.pack_id == normalized_pack_id and spec.pack_version == normalized_pack_version
-        for spec in _tier1_pack_specs()
+        for spec in _catalog_pack_specs()
     )
 
 
@@ -448,7 +581,7 @@ def ensure_tier1_model_packs_for_workspace(
     created_by_user_account_id: UUID,
 ) -> list[ModelPackRow]:
     packs: list[ModelPackRow] = []
-    for spec in _tier1_pack_specs():
+    for spec in _catalog_pack_specs():
         created = store.create_model_pack_if_absent_optional(
             workspace_id=workspace_id,
             created_by_user_account_id=created_by_user_account_id,
@@ -459,7 +592,7 @@ def ensure_tier1_model_packs_for_workspace(
             description=spec.description,
             status=MODEL_PACK_STATUS_ACTIVE,
             contract=spec.contract,
-            metadata={"seed": "tier1", "seed_version": "p11-s4"},
+            metadata={"seed": spec.seed, "seed_version": spec.seed_version},
         )
         if created is not None:
             packs.append(created)
@@ -472,7 +605,7 @@ def ensure_tier1_model_packs_for_workspace(
         )
         if existing is None:
             raise RuntimeError(
-                f"tier-1 model pack {spec.pack_id}@{spec.pack_version} was expected but missing"
+                f"catalog model pack {spec.pack_id}@{spec.pack_version} was expected but missing"
             )
         packs.append(existing)
     return packs

--- a/docs/integrations/phase11-azure-autogen.md
+++ b/docs/integrations/phase11-azure-autogen.md
@@ -111,4 +111,7 @@ The script exposes `AutoGenAliceRuntimeClient.create(messages=[...])`, which let
 ## Guardrails
 
 - This sprint adds Azure + AutoGen path only.
-- Tier-2 packs and broader framework integrations remain later Phase 11 scope.
+- Broader framework integrations beyond AutoGen remain out of scope.
+- For phase-close compatibility/setup posture, see:
+  - `docs/integrations/phase11-model-pack-compatibility.md`
+  - `docs/integrations/phase11-setup-paths.md`

--- a/docs/integrations/phase11-model-pack-compatibility.md
+++ b/docs/integrations/phase11-model-pack-compatibility.md
@@ -1,16 +1,36 @@
-# Phase 11 Model Pack Compatibility (P11-S4)
+# Phase 11 Provider + Model Pack Compatibility (P11-S6)
 
-This table is the sprint-owned compatibility reference for tier-1 model packs.
+This reference defines the shipped provider/pack compatibility posture for Phase 11 closeout.
 
-| Pack ID | Version | Family | Runtime Provider | Provider Keys | Tool Mode |
+## Built-In Catalog Packs
+
+All built-in catalog packs are seeded per workspace on first model-pack API access and use:
+
+- `contract_version = model_pack_contract_v1`
+- `runtime_providers = ["openai_responses"]`
+- `tools.mode = "none"`
+
+| Pack ID | Version | Tier | Family | Provider Keys | Runtime Provider |
 |---|---|---|---|---|---|
-| `llama` | `1.0.0` | `llama` | `openai_responses` | `openai_compatible`, `ollama`, `llamacpp` | `none` |
-| `qwen` | `1.0.0` | `qwen` | `openai_responses` | `openai_compatible`, `ollama`, `llamacpp` | `none` |
-| `gemma` | `1.0.0` | `gemma` | `openai_responses` | `openai_compatible`, `ollama`, `llamacpp` | `none` |
-| `gpt-oss` | `1.0.0` | `gpt-oss` | `openai_responses` | `openai_compatible`, `ollama`, `llamacpp` | `none` |
+| `llama` | `1.0.0` | `tier1` | `llama` | `openai_compatible`, `ollama`, `llamacpp` | `openai_responses` |
+| `qwen` | `1.0.0` | `tier1` | `qwen` | `openai_compatible`, `ollama`, `llamacpp` | `openai_responses` |
+| `gemma` | `1.0.0` | `tier1` | `gemma` | `openai_compatible`, `ollama`, `llamacpp` | `openai_responses` |
+| `gpt-oss` | `1.0.0` | `tier1` | `gpt-oss` | `openai_compatible`, `ollama`, `llamacpp` | `openai_responses` |
+| `deepseek` | `1.0.0` | `tier2` | `deepseek` | `openai_compatible`, `ollama`, `llamacpp` | `openai_responses` |
+| `kimi` | `1.0.0` | `tier2` | `kimi` | `openai_compatible`, `ollama`, `llamacpp` | `openai_responses` |
+| `mistral` | `1.0.0` | `tier2` | `mistral` | `openai_compatible`, `ollama`, `llamacpp` | `openai_responses` |
+
+## Shipped Provider Paths
+
+| Path | Adapter Key | Primary APIs | Pack Posture |
+|---|---|---|---|
+| Local (Ollama) | `ollama` | `POST /v1/providers/ollama/register`, `POST /v1/providers/test`, `POST /v1/runtime/invoke` | Built-in catalog packs supported per pack `provider_keys`. |
+| Local (llama.cpp) | `llamacpp` | `POST /v1/providers/llamacpp/register`, `POST /v1/providers/test`, `POST /v1/runtime/invoke` | Built-in catalog packs supported per pack `provider_keys`. |
+| Self-hosted OpenAI-compatible (including vLLM path) | `openai_compatible` | `POST /v1/providers`, `POST /v1/providers/test`, `POST /v1/runtime/invoke` | Built-in catalog packs supported per pack `provider_keys`. |
+| Enterprise Azure | `azure` | `POST /v1/providers/azure/register`, `POST /v1/providers/test`, `POST /v1/runtime/invoke` | Uses the same pack seam; built-in catalog contracts are not Azure-keyed. Use custom packs when Azure-specific compatibility metadata is required. |
+| External-agent orchestration (AutoGen bridge) | runtime passthrough to configured provider | `scripts/run_phase11_autogen_runtime_bridge.py` + `POST /v1/runtime/invoke` | Same pack selection rules and metadata as direct runtime invoke. |
 
 ## Scope Notes
 
-- This reference is limited to tier-1 packs shipped in `P11-S4`.
-- Azure and tier-2 packs are explicitly out of scope for this sprint.
-- Provider adapter behavior remains in adapters; model-pack behavior remains declarative in pack contracts.
+- Provider behavior stays in adapters; pack behavior stays declarative in pack contracts.
+- This document reflects shipped Phase 11 surfaces only; no new providers or frameworks are implied.

--- a/docs/integrations/phase11-setup-paths.md
+++ b/docs/integrations/phase11-setup-paths.md
@@ -1,0 +1,137 @@
+# Phase 11 Setup Paths (P11-S6)
+
+This guide provides operator-facing setup and verification paths for shipped Phase 11 surfaces across local, self-hosted, enterprise, and external-agent runtime use.
+
+## Shared Prerequisites
+
+1. Start API and data services.
+2. Authenticate and obtain `SESSION_TOKEN`.
+3. Have a workspace selected and a thread available for runtime invoke.
+4. Verify catalog seeding:
+
+```bash
+curl -sS -X GET "http://127.0.0.1:8000/v1/model-packs" \
+  -H "Authorization: Bearer $SESSION_TOKEN"
+```
+
+Expected built-in packs include:
+
+- `llama@1.0.0`
+- `qwen@1.0.0`
+- `gemma@1.0.0`
+- `gpt-oss@1.0.0`
+- `deepseek@1.0.0`
+- `kimi@1.0.0`
+- `mistral@1.0.0`
+
+## Local Path: Ollama / llama.cpp
+
+Register a local provider, test it, optionally bind a pack, then invoke runtime.
+
+### Register Ollama
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers/ollama/register" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "Local Ollama",
+    "base_url": "http://127.0.0.1:11434",
+    "default_model": "qwen2.5:7b-instruct"
+  }'
+```
+
+### Bind a Pack
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/model-packs/deepseek/bind" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"pack_version":"1.0.0","metadata":{"reason":"local-default"}}'
+```
+
+### Test and Invoke
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers/test" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"provider_id":"'"$PROVIDER_ID"'","prompt":"Confirm local runtime connectivity."}'
+```
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/runtime/invoke" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_id":"'"$PROVIDER_ID"'",
+    "thread_id":"'"$THREAD_ID"'",
+    "message":"Summarize local runtime status."
+  }'
+```
+
+## Self-Hosted Path: OpenAI-Compatible (vLLM-Compatible Surface)
+
+Register with `provider_key = openai_compatible`, then use the same test/invoke seams.
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_key":"openai_compatible",
+    "display_name":"Self-Hosted vLLM",
+    "base_url":"https://selfhosted.example/v1",
+    "api_key":"'"$PROVIDER_API_KEY"'",
+    "default_model":"mistral-small-instruct"
+  }'
+```
+
+For explicit invoke override:
+
+```json
+{
+  "pack_id": "mistral",
+  "pack_version": "1.0.0"
+}
+```
+
+## Enterprise Path: Azure
+
+Register Azure through the shipped Azure endpoint, then use the shared test/invoke seams.
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers/azure/register" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name":"Azure Enterprise",
+    "base_url":"https://YOUR_RESOURCE.openai.azure.com",
+    "auth_mode":"azure_api_key",
+    "api_key":"'"$AZURE_API_KEY"'",
+    "api_version":"2024-10-21",
+    "default_model":"gpt-4.1-mini"
+  }'
+```
+
+Azure uses the same pack seam (`pack_id`, `pack_version`) on `POST /v1/runtime/invoke`. If Azure-specific compatibility metadata is needed, create and bind a custom pack.
+
+## External-Agent Path: AutoGen Bridge
+
+Use the shipped bridge script to run AutoGen-style orchestration while keeping Alice runtime/provider/pack semantics intact.
+
+```bash
+./scripts/run_phase11_autogen_runtime_bridge.py \
+  --session-token "$SESSION_TOKEN" \
+  --provider-id "$PROVIDER_ID" \
+  --thread-id "$THREAD_ID" \
+  --user-message "Provide an execution-ready status update."
+```
+
+## Operator Verification Checklist
+
+1. `GET /v1/model-packs` lists tier-1 and tier-2 built-in packs.
+2. `POST /v1/model-packs/{pack_id}/bind` succeeds for selected pack/version.
+3. `POST /v1/providers/test` succeeds for each configured provider path.
+4. `POST /v1/runtime/invoke` metadata reports resolved `model_pack` and `source`.
+5. Compatibility posture matches `docs/integrations/phase11-model-pack-compatibility.md`.

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -19,7 +19,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="README.md",
         required_markers=(
             "Phase 10 is complete and shipped.",
-            "`P11-S5` Azure Adapter + AutoGen Integration is the active sprint",
+            "`P11-S6` Model Packs Tier 2 + Launch Clarity Assets is the active sprint",
             "Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md]",
         ),
     ),
@@ -27,14 +27,14 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="ROADMAP.md",
         required_markers=(
             "Phase 10 is complete and shipped baseline truth.",
-            "P11-S5: Azure Adapter + AutoGen Integration",
+            "P11-S6: Model Packs Tier 2 + Launch Clarity Assets",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Phase 11 Sprint 5 (P11-S5): Azure Adapter + AutoGen Integration",
-            "Phase 10, `P11-S1`, `P11-S2`, `P11-S3`, and `P11-S4` shipped scope remain baseline truth and are not reopened as sprint work",
+            "Phase 11 Sprint 6 (P11-S6): Model Packs Tier 2 + Launch Clarity Assets",
+            "Reference baseline markers: shipped Phase 9 Alice Core, shipped Phase 10 Alice Connect, shipped `P11-S1` Provider Abstraction + OpenAI-Compatible Base, shipped `P11-S2` Ollama + llama.cpp Adapters, shipped `P11-S3` vLLM Adapter + Self-Hosted Performance Path, shipped `P11-S4` Model Packs Tier 1, and shipped `P11-S5` Azure Adapter + AutoGen Integration.",
         ),
     ),
     ControlDocTruthRule(
@@ -49,7 +49,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "Phase 9 is complete and shipped.",
             "Phase 10 is complete and shipped.",
-            "`P11-S5` (Azure Adapter + AutoGen Integration) is the active execution sprint packet.",
+            "`P11-S6` (Model Packs Tier 2 + Launch Clarity Assets) is the active execution sprint packet.",
         ),
     ),
     ControlDocTruthRule(

--- a/tests/integration/test_phase11_model_packs_api.py
+++ b/tests/integration/test_phase11_model_packs_api.py
@@ -203,17 +203,26 @@ def test_phase11_model_pack_catalog_bind_and_runtime_shaping(migrated_database_u
     )
     assert list_status == 200
     listed_ids = {item["pack_id"] for item in list_payload["items"]}
-    assert {"llama", "qwen", "gemma", "gpt-oss"}.issubset(listed_ids)
+    assert {
+        "llama",
+        "qwen",
+        "gemma",
+        "gpt-oss",
+        "deepseek",
+        "kimi",
+        "mistral",
+    }.issubset(listed_ids)
 
     detail_status, detail_payload = invoke_request(
         "GET",
-        "/v1/model-packs/gpt-oss",
+        "/v1/model-packs/deepseek",
         query_params={"version": "1.0.0"},
         headers=auth_header(session_token),
     )
     assert detail_status == 200
-    assert detail_payload["model_pack"]["pack_id"] == "gpt-oss"
+    assert detail_payload["model_pack"]["pack_id"] == "deepseek"
     assert detail_payload["model_pack"]["pack_version"] == "1.0.0"
+    assert detail_payload["model_pack"]["metadata"]["seed"] == "tier2"
 
     reserved_create_status, reserved_create_payload = invoke_request(
         "POST",
@@ -239,7 +248,7 @@ def test_phase11_model_pack_catalog_bind_and_runtime_shaping(migrated_database_u
         headers=auth_header(session_token),
     )
     assert reserved_create_status == 409
-    assert "reserved for tier-1 catalog entries" in reserved_create_payload["detail"]
+    assert "reserved for built-in catalog entries" in reserved_create_payload["detail"]
 
     create_pack_status, create_pack_payload = invoke_request(
         "POST",
@@ -394,6 +403,40 @@ def test_phase11_model_pack_catalog_bind_and_runtime_shaping(migrated_database_u
     assert second_context["limits"]["max_memories"] == 4
     assert second_context["limits"]["max_entity_edges"] == 8
     assert "Keep outputs directly actionable and compact." in second_request["input"][1]["content"][0]["text"]
+
+    tier2_override_status, tier2_override_payload = invoke_request(
+        "POST",
+        "/v1/runtime/invoke",
+        payload={
+            "provider_id": provider_id,
+            "thread_id": thread_id,
+            "message": "Summarize current status with tier-2 override.",
+            "pack_id": "deepseek",
+            "pack_version": "1.0.0",
+            "max_sessions": 10,
+            "max_events": 40,
+            "max_memories": 50,
+            "max_entities": 50,
+            "max_entity_edges": 100,
+        },
+        headers=auth_header(session_token),
+    )
+    assert tier2_override_status == 200
+    assert tier2_override_payload["metadata"]["model_pack"] == {
+        "pack_id": "deepseek",
+        "pack_version": "1.0.0",
+        "source": "request",
+    }
+
+    third_request = captured_model_requests[2]
+    third_context = _extract_context_payload(third_request)
+    assert third_context["limits"]["max_memories"] == 6
+    assert third_context["limits"]["max_entities"] == 6
+    assert third_context["limits"]["max_entity_edges"] == 12
+    assert (
+        "Keep recommendations concrete and avoid speculative branching."
+        in third_request["input"][1]["content"][0]["text"]
+    )
 
 
 def test_phase11_workspace_model_pack_binding_is_workspace_isolated(migrated_database_urls, monkeypatch) -> None:

--- a/tests/unit/test_20260412_0056_phase11_model_packs_tier2_families.py
+++ b/tests/unit/test_20260412_0056_phase11_model_packs_tier2_families.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260412_0056_phase11_model_packs_tier2_families"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == list(module._UPGRADE_STATEMENTS)
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_upgrade_family_constraint_includes_tier2_families() -> None:
+    module = load_migration_module()
+    ddl = "\n".join(module._UPGRADE_STATEMENTS)
+
+    assert "'deepseek'" in ddl
+    assert "'kimi'" in ddl
+    assert "'mistral'" in ddl

--- a/tests/unit/test_model_packs.py
+++ b/tests/unit/test_model_packs.py
@@ -276,10 +276,26 @@ def test_ensure_tier1_model_packs_for_workspace_seeds_once() -> None:
         created_by_user_account_id=user_account_id,
     )
 
-    assert len(first_seed) == 4
-    assert len(second_seed) == 4
-    assert len(store.packs_by_key) == 4
-    assert {row["pack_id"] for row in first_seed} == {"llama", "qwen", "gemma", "gpt-oss"}
+    assert len(first_seed) == 7
+    assert len(second_seed) == 7
+    assert len(store.packs_by_key) == 7
+    assert {row["pack_id"] for row in first_seed} == {
+        "llama",
+        "qwen",
+        "gemma",
+        "gpt-oss",
+        "deepseek",
+        "kimi",
+        "mistral",
+    }
+    assert {
+        row["pack_id"]: row["metadata"]
+        for row in first_seed
+        if row["pack_id"] in {"llama", "deepseek"}
+    } == {
+        "llama": {"seed": "tier1", "seed_version": "p11-s4"},
+        "deepseek": {"seed": "tier2", "seed_version": "p11-s6"},
+    }
 
 
 def test_ensure_tier1_model_packs_handles_seed_race_with_existing_row() -> None:
@@ -289,12 +305,21 @@ def test_ensure_tier1_model_packs_handles_seed_race_with_existing_row() -> None:
         workspace_id=uuid4(),
         created_by_user_account_id=uuid4(),
     )
-    assert len(seeded) == 4
-    assert {row["pack_id"] for row in seeded} == {"llama", "qwen", "gemma", "gpt-oss"}
+    assert len(seeded) == 7
+    assert {row["pack_id"] for row in seeded} == {
+        "llama",
+        "qwen",
+        "gemma",
+        "gpt-oss",
+        "deepseek",
+        "kimi",
+        "mistral",
+    }
 
 
 def test_is_reserved_tier1_pack_key() -> None:
     assert is_reserved_tier1_pack_key(pack_id="llama", pack_version="1.0.0")
+    assert is_reserved_tier1_pack_key(pack_id="deepseek", pack_version="1.0.0")
     assert not is_reserved_tier1_pack_key(pack_id="llama", pack_version="1.0.1")
     assert not is_reserved_tier1_pack_key(pack_id="custom-brief", pack_version="1.0.0")
 


### PR DESCRIPTION
## Summary
- add DeepSeek, Kimi, and Mistral built-in model packs on the existing Phase 11 model-pack abstraction
- add additive family constraint support and migration coverage for the new tier-2 pack families
- publish compatibility matrices and setup-path docs to make the shipped provider/pack surface operationally clear

## Scope Notes
- keeps provider/runtime architecture on the shipped P11-S1 through P11-S5 seams
- does not add new providers, new framework integrations, or new product-surface work
- excludes the unrelated local README.md worktree change from merge scope

## Verification
- python3 scripts/check_control_doc_truth.py
- ./.venv/bin/python -m pytest tests/unit tests/integration -q
- pnpm --dir apps/web test

## Upgrade Overview
### Protected Areas
- [x] continuity APIs
- [x] memory schema
- [x] trust rules

### Compatibility Impact
This is an additive Phase 11 closeout change. It extends the shipped model-pack catalog and compatibility metadata without introducing new provider adapters or forking existing invoke/binding semantics.

### Migration / Rollout
Apply the additive migration 20260412_0056_phase11_model_packs_tier2_families.py, deploy the API, and publish the updated compatibility/setup docs with the sprint release.

### Operator Action
Review docs/integrations/phase11-model-pack-compatibility.md and docs/integrations/phase11-setup-paths.md, then smoke-test one local, one self-hosted OpenAI-compatible, and one Azure path with tier-2 pack bind/override flows.

### Validation
Branch-local verification passed:
- python3 scripts/check_control_doc_truth.py -> PASS
- ./.venv/bin/python -m pytest tests/unit tests/integration -q -> 1145 passed in 185.18s
- pnpm --dir apps/web test -> 62 files passed, 199 tests passed in 5.49s

### Rollback
Revert the squash merge commit if needed and roll back the additive pack-family migration before redeploying the prior catalog state.