### PR TITLE
B1: formalize Hermes provider bridge contract

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,177 +1,108 @@
 # Architecture
 
-## System Overview
+## Scope Boundary
+This document treats Phase 11 as shipped baseline. New planned work here is the **Hermes Auto-Capture bridge phase** only.
 
-Phase 10 keeps the shipped Phase 9 modular monolith and adds a hosted product layer on top of the same continuity core. Alice Core remains authoritative for continuity objects, recall, resume, corrections, approvals, and provenance-backed retrieval. Hosted identity, Telegram, and scheduling orchestrate access to that core; they do not create a second semantics stack.
+## System Overview
+Use a dual-path integration:
+- **Hermes memory provider (shipped baseline, extended in bridge scope):** lifecycle automation hooks.
+- **Alice MCP server (existing + extended):** explicit recall/review/explain operations.
+
+This keeps Alice continuity semantics centralized while adding Hermes-native automation points.
 
 ## Technical Stack
+- Core API/runtime: Python + FastAPI (`apps/api/src/alicebot_api`)
+- Persistence: Postgres (+ existing continuity and provenance schema)
+- Existing surfaces: CLI, MCP, web/admin, workers
+- Hermes integration artifacts: provider plugin + Hermes config (`~/.hermes/config.yaml`)
 
-- API and core runtime: Python 3.12 + FastAPI under `apps/api/src/alicebot_api`
-- Web app: Next.js 15 + React 19 under `apps/web`
-- Background/task surface: `workers`
-- Primary data store: Postgres with `pgvector`
-- Local support services: Redis and MinIO via `docker-compose.yml`
-- Packaging: `alice-core` in `pyproject.toml`
-- Test surface: pytest, Vitest, and the Phase 9 evaluation harness
+## Module Boundaries
+### Alice Core (already shipped)
+- Continuity objects, revisions, provenance, corrections, open loops
+- Recall/resume/context compilation
+- Existing MCP/CLI APIs and policy controls
 
-## Runtime Boundaries
+### Hermes Provider Adapter (bridge scope)
+- Extends the shipped Hermes Alice provider rather than replacing it
+- Reads provider config (`mode`, thresholds, feature toggles)
+- Executes lifecycle hooks around Hermes turns/sessions
+- Injects compact prefetch payload into Hermes prompt context
 
-### Core Data Plane
+### MCP Tool Surface (explicit workflows)
+Implemented in B1:
+- `alice_prefetch_context`
 
-Owns:
+Planned for B2+ (not shipped in B1):
+- `alice_capture_candidates`
+- `alice_commit_captures`
+- `alice_session_flush`
+- `alice_review_queue`
+- `alice_review_apply`
 
-- continuity capture and revision persistence
-- typed continuity objects and memory revisions
-- recall and resumption compilation
-- entities, edges, and open loops
-- approvals and audit traces
-- CLI and MCP semantics
-- importer provenance and deterministic dedupe
+## Runtime Flows
+### Flow 1: Pre-turn Prefetch
+1. Hermes receives user input.
+2. Provider calls `alice_prefetch_context`.
+3. Alice returns compact continuity payload (summary, relevant memories, open loops, recent decisions/changes, optional resume brief, trust posture).
+4. Provider injects payload into Hermes context before model response.
 
-### Hosted Control Plane
+### Flow 2: Post-response Candidate Extraction (planned B2+)
+1. Hermes emits assistant response.
+2. Provider sends user/assistant turn pair to `alice_capture_candidates`.
+3. Alice returns typed candidates with confidence, trust class, proposed action, evidence snippet, and target object type.
 
-Owns:
+### Flow 3: Post-response Commit (planned B2+)
+1. In `assist`/`auto`, provider submits candidates to `alice_commit_captures`.
+2. Policy gates auto-save vs review queue using type allowlist + confidence threshold.
+3. Writes are idempotent across repeated sync attempts.
 
-- user accounts and auth sessions
-- devices and trust levels
-- workspaces and bootstrap state
-- channel bindings
-- user preferences and notification policy
-- beta cohorts and feature flags
-- telemetry and support tooling
-
-### Surface Layer
-
-- local API and CLI
-- MCP server
-- Telegram adapter and chat routing layer
-- web onboarding/settings/admin surfaces
-- brief and notification scheduler
-
-## Phase 10 Core Flows
-
-### Onboarding
-
-1. User authenticates with a hosted session.
-2. User creates or boots a workspace.
-3. Device and channel bindings are established.
-4. Preferences and import choices are stored.
-5. Alice generates a first brief against the existing continuity core.
-
-### Inbound Chat
-
-1. Telegram webhook receives an inbound message.
-2. The message is normalized into a common channel message contract.
-3. Routing resolves workspace, actor, and best-fit continuity context.
-4. Core capture/recall/resume/correction logic executes.
-5. A reply is dispatched back through the same channel thread.
-
-### Approval
-
-1. Core logic emits an approval request.
-2. Chat surface presents approve/reject/context actions.
-3. Approval resolution writes back to the same approval and audit objects used by other surfaces.
-
-### Daily Brief
-
-1. Scheduler selects workspaces due for delivery.
-2. Brief compiler builds a deterministic summary from continuity state.
-3. Notification policy and quiet hours are applied.
-4. Delivery receipts and failures are recorded for support tooling.
+### Flow 4: Session-End Flush (planned B2+)
+1. On session end, provider calls `alice_session_flush`.
+2. Alice performs dedupe merge, contradiction checks, open-loop normalization, summary refresh, and review queue updates.
 
 ## Data Model Summary
+### Reuse Existing Baseline Objects
+- continuity object graph
+- correction/supersession history
+- open-loop structures
+- provenance evidence links
 
-### Existing Baseline Objects
+### Bridge-Phase Additions/Extensions (required)
+- capture candidate records (including confidence + evidence)
+- review queue records with lifecycle state
+- commit decision audit trail (auto-saved vs queued vs rejected)
 
-- continuity capture events
-- typed continuity objects
-- correction events and revisions
-- open loops and brief-ready summaries
-- import provenance with explicit `source_kind`
+## Security And Trust Controls
+- Preserve existing approval/provenance/correction contracts.
+- Never auto-promote speculative single-turn inferences into higher-order trusted patterns.
+- Keep confidence and type gating explicit and configurable by mode.
+- Ensure workspace/session isolation in provider hook calls.
+- Keep credential handling out of logs and redact sensitive provider connection details.
 
-### Phase 10 Additions
+## Deployment Topology
+### Recommended
+- Hermes configured with external `alice` memory provider + enabled Alice MCP server.
+- Provider and MCP may run against local Alice API base URL for local/self-hosted paths.
 
-Control-plane tables:
+### Fallback
+- MCP-only mode remains supported when provider plugin is not installed.
 
-- `user_accounts`
-- `auth_sessions`
-- `devices`
-- `workspaces`
-- `workspace_members`
-- `user_preferences`
-- `beta_cohorts`
-- `feature_flags`
+## Testing Strategy
+### Bridge-Phase Required Tests
+- prefetch context injection behavior
+- explicit decision/correction auto-capture in `assist`
+- low-confidence inference routes to review queue
+- session-end flush behavior
+- idempotency on duplicate sync attempts
 
-Channel and scheduler tables:
+### Existing Gates To Keep
+- unit/integration suites
+- MCP parity checks
+- phase eval/regression harnesses already in repo
 
-- `channel_identities`
-- `channel_messages`
-- `channel_threads`
-- `channel_delivery_receipts`
-- `chat_intents`
-- `continuity_briefs`
-- `approval_challenges`
-- `daily_brief_jobs`
-- `notification_subscriptions`
-- `open_loop_reviews`
-- `chat_telemetry`
-
-## Security and Governance
-
-- Postgres remains the system of record.
-- Hosted identity and channel access add to, but do not bypass, existing approval and provenance discipline.
-- Append-only continuity and correction history stay intact.
-- Device linking, channel binding, and session expiry are explicit control-plane concerns.
-- Consequential actions remain approval-bounded even when initiated from chat.
-- Opt-in backup/sync must preserve user isolation and encryption boundaries.
-
-## Deployment
-
-### Shipped Baseline
-
-Canonical local startup path remains:
-
-```bash
-docker compose up -d
-./scripts/migrate.sh
-./scripts/load_sample_data.sh
-APP_RELOAD=false ./scripts/api_dev.sh
-```
-
-### Phase 10 Production Additions
-
-- hosted auth/session endpoints
-- public webhook ingress for Telegram
-- scheduler/worker execution for briefs and notifications
-- support/admin visibility for beta operations
-
-## Testing
-
-Existing quality gates remain:
-
-```bash
-./.venv/bin/python -m pytest tests/unit tests/integration
-pnpm --dir apps/web test
-./scripts/run_phase9_eval.sh --report-path eval/reports/phase9_eval_latest.json
-```
-
-Phase 10 adds targeted verification for:
-
-- auth and workspace bootstrap
-- device and channel linking
-- idempotent webhook ingest and outbound delivery
-- cross-surface parity between local, CLI, MCP, and Telegram
-- daily brief scheduling, quiet hours, and failure handling
-- support telemetry and rollout controls
-
-## Architecture Constraints
-
-- Phase 10 must not fork semantics between local, CLI, MCP, and Telegram.
-- Telegram is another surface on the same core objects, not a separate assistant stack.
-- Control-plane additions must not rewrite shipped Alice Core contracts.
-- Do not expand connector breadth beyond Telegram in Phase 10 without an explicit roadmap change.
-- Keep docs clear about what is shipped OSS baseline versus planned beta surface.
-
-## Historical Traceability
-
-Historical planning/control snapshots are retained in local-only internal docs and are intentionally excluded from the public repository.
+## Underspecified Areas (Control Tower Decisions Needed)
+- Canonical candidate/review schema and migration details.
+- Confidence model calibration and versioning policy.
+- Provider package distribution/versioning strategy for Hermes installs.
+- Auth boundary between Hermes provider process and Alice API in hosted deployments.
+- UX surface ownership for review queue beyond MCP parity (web/CLI split not fully specified).

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,65 +1,73 @@
 # BUILD_REPORT
 
 ## sprint objective
-Implement `P11-R1` provider-runtime security hardening to close the release-blocking findings: SSRF via provider `base_url`, upstream error-detail reflection/persistence, and URL userinfo credential exposure.
+Implement Bridge Sprint 1 (`B1`) Hermes provider contract foundation by extending the shipped provider with bridge-phase config normalization, deterministic lifecycle hooks (`prefetch`, `queue_prefetch`, `sync_turn`, `on_session_end`), provider status/readiness validation, and the new automation-oriented MCP prefetch surface `alice_prefetch_context`.
 
 ## completed work
-- Added centralized provider URL security policy:
-  - allowed schemes restricted to `http`/`https`
-  - rejects userinfo in `base_url`
-  - blocks loopback, link-local/metadata, RFC1918/private, and other non-global IP literal targets
-- Enforced URL policy before persistence and before outbound execution:
-  - registration paths validate `base_url` before provider row creation
-  - runtime adapter outbound paths validate `base_url` before helper/network calls
-  - runtime/test flows hard-reject disallowed stored provider targets
-- Sanitized upstream provider error handling:
-  - provider test/discovery/invoke errors now map to bounded safe messages for API and persistence
-  - persisted `provider_capabilities.discovery_error` now stores sanitized values
-  - runtime failure traces store sanitized provider failure messages
-- Added serialization hygiene:
-  - provider serialization now redacts userinfo from `base_url` (defense in depth for legacy rows)
-- Added/updated sprint verification coverage:
-  - blocked target registration cases (`169.254.169.254`, loopback, RFC1918 ranges)
-  - blocked target runtime/test rejection with no outbound attempt
-  - userinfo rejection and legacy serialization redaction
-  - raw upstream detail not reflected or persisted
-- Updated control-doc truth rules and roadmap marker to align with active `P11-R1`.
-- Updated `REVIEW_REPORT.md` to grade `P11-R1` and explicitly close each in-scope finding.
+- Extended (not replaced) the shipped Hermes Alice provider with bridge contract behavior:
+  - normalized canonical bridge config keys for lifecycle operation
+  - preserved legacy config-key compatibility
+  - added provider status/readiness reporting without live network dependency
+  - added deterministic session-end flush behavior
+  - added duplicate-write suppression for repeated `sync_turn` and `on_memory_write` callback execution
+  - fixed capture-queue worker start race and bounded dedupe behavior to avoid suppressing valid later repeats
+- Added MCP tool `alice_prefetch_context` with deterministic prefetch text assembled from existing continuity resumption semantics.
+- Updated smoke script to emit provider bridge status/lifecycle readiness evidence.
+- Updated install and integration docs for bridge contract keys, lifecycle mapping, compatibility keys, and MCP tool surface.
+- Added/updated unit and integration coverage for:
+  - provider config compatibility and invalid-config status
+  - deterministic lifecycle dedupe/flush behavior
+  - MCP tool surface stability including `alice_prefetch_context`
+- Aligned control-doc truth checks and active control docs to the current bridge-phase baseline.
+- Clarified architecture docs so B2+ capture/review surfaces are marked as planned (not shipped in B1).
+
+Legacy compatibility keys preserved:
+- `prefetch_limit`
+- `max_recent_changes`
+- `max_open_loops`
+- `include_non_promotable_facts`
+- `auto_capture`
+- `mirror_memory_writes`
 
 ## incomplete work
-- None within the `P11-R1` sprint packet scope.
+- No code deliverable remains incomplete in B1 scope.
 
 ## files changed
-- `apps/api/src/alicebot_api/provider_security.py` (new)
-- `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/provider_runtime.py`
-- `apps/api/src/alicebot_api/local_provider_helpers.py`
-- `apps/api/src/alicebot_api/azure_provider_helpers.py`
-- `tests/unit/test_provider_security.py` (new)
-- `tests/unit/test_provider_runtime.py`
-- `tests/integration/test_phase11_provider_runtime_api.py`
-- `ROADMAP.md`
-- `scripts/check_control_doc_truth.py`
-- `REVIEW_REPORT.md`
+- `ARCHITECTURE.md`
 - `BUILD_REPORT.md`
+- `PRODUCT_BRIEF.md`
+- `README.md`
+- `ROADMAP.md`
+- `RULES.md`
+- `docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py`
+- `apps/api/src/alicebot_api/mcp_tools.py`
+- `docs/integrations/hermes-memory-provider.md`
+- `docs/integrations/mcp.md`
+- `scripts/check_control_doc_truth.py`
+- `scripts/install_hermes_alice_memory_provider.py`
+- `scripts/run_hermes_memory_provider_smoke.py`
+- `tests/unit/test_hermes_memory_provider.py`
+- `tests/unit/test_mcp.py`
+- `tests/integration/test_mcp_server.py`
 
 ## tests run
 1. `python3 scripts/check_control_doc_truth.py`
    - Result: PASS
    - Output: `Control-doc truth check: PASS`
-
 2. `./.venv/bin/python -m pytest tests/unit tests/integration -q`
    - Result: PASS
-   - Output: `1169 passed in 185.41s (0:03:05)`
-
-3. `./.venv/bin/bandit -r apps/api/src/alicebot_api/provider_runtime.py apps/api/src/alicebot_api/local_provider_helpers.py apps/api/src/alicebot_api/azure_provider_helpers.py apps/api/src/alicebot_api/main.py`
+   - Output: `1174 passed in 186.28s (0:03:06)`
+3. `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py`
    - Result: PASS
-   - Output: `No issues identified`
+   - Output summary:
+     - single external provider enforcement validated
+     - provider registered with expected tool set
+     - `structural.bridge_status.ready=true`
+     - `structural.bridge_status.errors=[]`
+     - lifecycle hooks status present for `prefetch`, `queue_prefetch`, `sync_turn`, `on_session_end`
 
 ## blockers/issues
-- No implementation blockers in sprint scope.
-- Workspace contains a pre-existing unrelated dirty file not modified by this sprint:
-  - `README.md`
+- None.
 
 ## recommended next step
-Proceed to security review sign-off for `P11-R1`, then merge once the release hold is formally cleared against the three closed findings.
+Proceed with reviewer re-check against B1 acceptance criteria using this updated evidence set.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -1,89 +1,78 @@
 # Product Brief
 
 ## Product Summary
+Alice is a shipped continuity platform (Phases 9-11). The new bridge-phase product scope is **Hermes Auto-Capture**: automatic continuity prefetch and post-turn capture through a Hermes memory provider, with MCP tools kept for explicit deep workflows.
 
-Alice Connect is the Phase 10 product layer on top of shipped Phase 9 Alice Core. Alice Core remains the open-source local-first continuity engine; Alice Connect adds hosted identity, workspace bootstrap, Telegram-first access, chat-native continuity actions, and a daily brief loop for non-developer beta users.
+## Who It Is For
+- Hermes users who want continuity without manually calling memory tools every turn.
+- Teams already using Alice continuity objects and provenance/correction rules who need a low-friction Hermes path.
 
 ## Problem
-
-Phase 9 proved Alice can be installed, interoperate, remember, and resume deterministically. It does not yet make Alice usable every day for someone who will not touch a repo, CLI, or MCP setup.
-
-## Target Users
-
-- Non-developer beta users who want a personal continuity assistant in chat.
-- Individual professionals who need capture, recall, resume, open-loop review, and lightweight approvals in Telegram.
-- OSS adopters who start local-first and may later opt into a hosted product layer.
+Current MCP-only use is explicit and reliable but requires manual invocation discipline. Users forget capture calls and lose continuity quality.
 
 ## Why It Matters
+- Makes continuity automatic in normal chat flow.
+- Preserves Alice’s existing semantic contracts instead of creating a Hermes-only memory model.
+- Keeps power-user explicit actions available through MCP.
 
-- turns continuity from a technical engine into a daily habit
-- makes chat the default interface without forking core semantics
-- creates a clear OSS-to-product path instead of a separate product rewrite
+## Shipped Baseline Truth (Not New Scope)
+- Phase 9 shipped: local-first continuity engine, deterministic CLI/MCP semantics, importers, approvals, eval harness.
+- Phase 10 shipped: hosted/product layer (identity/workspaces/channels, Telegram, daily brief loop).
+- Phase 11 shipped: provider adapters and model packs across local/self-hosted/enterprise paths.
 
-## Shipped Baseline
+## Bridge-Phase V1 Scope (Planned)
+- Extend the shipped Alice Hermes external memory provider with standardized lifecycle automation hooks:
+  - pre-turn prefetch
+  - post-response candidate extraction + commit policy
+  - session-end flush
+- Keep Alice MCP server available for explicit actions (recall, review, explainability, corrections).
+- Add/standardize automation-oriented tool surface:
+  - `alice_prefetch_context`
+  - `alice_capture_candidates`
+  - `alice_commit_captures`
+  - `alice_session_flush`
+  - `alice_review_queue`
+  - `alice_review_apply`
+- Ship operating modes:
+  - `manual`
+  - `assist` (default)
+  - `auto`
+- Provide docs, config examples, smoke tests, and MCP-only fallback guidance.
 
-Phase 9 is complete and shipped. Baseline truth is:
-
-- Alice Core local-first runtime
-- deterministic CLI continuity commands
-- deterministic MCP transport with a narrow tool surface
-- OpenClaw, Markdown, and ChatGPT importers
-- continuity engine, approvals, and evaluation harness
-- public quickstart, integration, release, and runbook docs for the OSS wedge
-
-## V1 Scope (Phase 10)
-
-### Open Source Surface
-
-- Alice Core
-- CLI
-- MCP
-- importers
-- OpenClaw adapter
-
-### Product / Beta Surface
-
-- Alice Connect account
-- hosted workspace bootstrap
-- device and channel linking
-- Telegram access
-- chat-native capture, recall, resume, correction, and open-loop review
-- approvals in chat
-- daily brief and notification loop
-- opt-in encrypted backup/sync metadata path
-- beta onboarding, cohort gating, and support tooling
-
-## Non-Goals
-
-- WhatsApp or broad channel expansion
-- browser automation
-- high-risk autonomous execution
-- enterprise collaboration features
-- new vertical agents
-- reopening more core release-control work as Phase 10 scope
+## Non-Goals (Bridge Phase)
+- Rebuilding shipped Phase 11 provider/model-pack scope.
+- Replacing MCP with provider-only workflows.
+- Expanding into unrelated channels/agent surfaces in this bridge phase.
+- Auto-promoting single-turn inferences into higher-order trusted patterns/playbooks.
 
 ## Success Criteria
+A Hermes user can enable Alice once and get:
+- automatic pre-turn continuity context
+- automatic post-turn candidate extraction
+- automatic save of high-confidence explicit items
+- low-confidence items routed to review queue
+- explicit deep actions still accessible via MCP
+- session-end consolidation
 
-At the end of Phase 10, a non-developer beta user can:
+## Auto-Save Policy (Product Contract)
+Auto-save eligible in `assist`:
+- explicit correction
+- explicit preference
+- explicit decision
+- explicit commitment
+- explicit open-loop create/resolve
 
-- create an account
-- link Telegram
-- import initial data or skip import
-- capture things naturally in chat
-- ask recall questions
-- get resume briefs
-- review open loops
-- approve simple actions in chat
-- receive a useful daily brief
+Review-required:
+- inferred preferences
+- weakly implied project state
+- broad summaries
+- speculative patterns
+- low-confidence extractions
 
-## Product Non-Negotiables
+## Active Sprint Status
+Bridge Sprint 1 (`B1`) is now the active execution sprint. It is limited to provider-contract foundation work on top of the shipped Hermes provider surface.
 
-- Alice Core remains the baseline truth; Phase 10 builds on it rather than replacing it.
-- Telegram is a product surface on top of the same continuity semantics as local, CLI, and MCP.
-- Durable answers remain provenance-backed and correction-aware.
-- Consequential actions remain approval-bounded.
-- Hosted product docs must clearly distinguish OSS surface from beta product surface.
-
-## Historical Traceability
-
-Superseded planning and control material is retained in local-only internal archives and is not part of the public repo.
+## Known Gaps To Resolve Before Build
+- Candidate scoring rubric and confidence calibration method are not specified.
+- Final storage contract for review queue/candidates is not explicitly defined in source.
+- Provider authentication/authorization boundary for local vs hosted deployments is not explicitly defined.

--- a/README.md
+++ b/README.md
@@ -29,14 +29,17 @@ It provides a **local-first memory and continuity engine** for capture, recall, 
 
 Phase 10 is complete and shipped.
 
-Phase 11 is now the active planning and execution phase:
+Phase 11 is complete and shipped:
 
 - `P11-S1` Provider Abstraction + OpenAI-Compatible Base is shipped
 - `P11-S2` Ollama + llama.cpp Adapters is shipped
 - `P11-S3` vLLM Adapter + Self-Hosted Performance Path is shipped
 - `P11-S4` Model Packs Tier 1 is shipped
 - `P11-S5` Azure Adapter + AutoGen Integration is shipped
-- `P11-S6` Model Packs Tier 2 + Launch Clarity Assets is the active sprint
+- `P11-S6` Model Packs Tier 2 + Launch Clarity Assets is shipped
+- `P11-R1` Provider Runtime Hardening is shipped
+- A bridge phase is now active: Hermes Auto-Capture
+- `B1` Hermes Provider Contract Foundation is the active sprint
 - Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md](docs/archive/planning/2026-04-08-context-compaction/README.md)
 
 ## Why Alice exists

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -1,52 +1,43 @@
 # REVIEW_REPORT
 
-## sprint
-`P11-R1` Phase 11 Security Remediation Sprint 1: Provider Runtime Hardening
-
 ## verdict
 PASS
 
 ## criteria met
-- Registration and runtime test/invoke flows hard-reject disallowed provider targets, including metadata/link-local, loopback, and RFC1918/private ranges.
-- No outbound call is attempted after disallowed target detection in provider test/runtime flow coverage.
-- Provider HTTP failures do not expose raw upstream provider detail in API responses.
-- Persisted provider discovery/runtime errors are sanitized and redacted.
-- Provider URLs containing embedded userinfo are rejected on registration, and serialized provider rows redact legacy userinfo.
-- Existing Phase 11 provider/runtime/model-pack behavior remains intact outside intended hardening.
-- Sprint closes the three in-scope security findings without feature-scope expansion.
+- The shipped Hermes provider was extended, not replaced (`docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py`).
+- Bridge config normalization and readiness/status reporting are present, including legacy compatibility reporting.
+- Lifecycle hooks `prefetch`, `queue_prefetch`, `sync_turn`, and `on_session_end` are implemented with deterministic behavior, and duplicate callback suppression is covered.
+- New MCP tool `alice_prefetch_context` is implemented, wired, and documented (`apps/api/src/alicebot_api/mcp_tools.py`, `docs/integrations/mcp.md`).
+- Existing Hermes tools (`alice_recall`, `alice_resumption_brief`, `alice_open_loops`) remain intact.
+- B1 required verification commands all pass:
+  - `python3 scripts/check_control_doc_truth.py` -> PASS
+  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> `1174 passed in 186.28s (0:03:06)`
+  - `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py` -> PASS
+- No local identifiers were found in changed code/docs after fixes.
 
 ## criteria missed
 - None.
 
 ## quality issues
-- None blocking.
-- Residual operational note: repo-level URL policy is strong, but production should still enforce network-layer egress policy as defense in depth.
+- No blocking quality issues found after fixes.
+- Minor residual note: callback dedupe now uses a short bounded window; if callback replay behavior changes materially in Hermes, this window may need retuning.
 
 ## regression risks
-- Low. Core risk area (SSRF validation bypass via non-canonical IPv4 encodings) is now covered by both unit and integration tests.
+- Low.
+- Primary risk area remains concurrent lifecycle callback timing; current unit coverage and full suite pass reduce risk materially.
 
 ## docs issues
-- No local machine identifiers (paths/usernames) found in sprint-owned files.
-- Review docs are now aligned with implemented security behavior.
+- Previously identified doc/report inconsistencies were corrected:
+  - architecture now marks B2+ surfaces as planned
+  - build report file list and command results are aligned with current state
+- Local identifier hygiene: PASS.
 
 ## should anything be added to RULES.md?
-- Recommended: add a permanent rule requiring provider URL validation tests for non-canonical IPv4 forms (hex/octal/shorthand/integer) whenever URL policy is touched.
+- Optional improvement: add a permanent rule that sprint reports must match `git diff --name-only` for the sprint-owned file list.
 
 ## should anything update ARCHITECTURE.md?
-- Recommended: add one short provider-runtime egress boundary note clarifying that application URL validation and infra egress controls are complementary controls.
+- No further update required for B1 acceptance after current “Implemented in B1” vs “Planned for B2+” separation.
 
 ## recommended next action
-1. Approve `P11-R1` for merge.
-2. Keep the new non-canonical host blocked-target tests as required coverage for future provider-runtime URL policy changes.
-3. Clear the release `HOLD` once security sign-off records this closure evidence.
-
-## evidence summary
-- Code fix for bypass class:
-  - `apps/api/src/alicebot_api/provider_security.py`: URL validator now canonicalizes IPv4 integer/hex/octal/shorthand forms via `socket.inet_aton` and blocks disallowed resolved IPs.
-- Added/updated security regression tests:
-  - `tests/unit/test_provider_security.py`
-  - `tests/integration/test_phase11_provider_runtime_api.py`
-- Required verification commands (re-run):
-  - `python3 scripts/check_control_doc_truth.py` -> PASS
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> `1169 passed in 185.41s (0:03:05)`
-  - `./.venv/bin/bandit -r apps/api/src/alicebot_api/provider_runtime.py apps/api/src/alicebot_api/local_provider_helpers.py apps/api/src/alicebot_api/azure_provider_helpers.py apps/api/src/alicebot_api/main.py` -> No issues identified
+1. Approve B1 for merge review.
+2. Carry the new capture-queue/dedupe tests forward as required regression coverage for future bridge sprints.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,75 +1,57 @@
 # Roadmap
 
-## Planning Basis
+## Baseline Context (Shipped, Not Roadmap Work)
+- Phase 9: shipped
+- Phase 10: shipped
+- Phase 11: shipped
 
-- Phase 10 is the next delivery phase: Alice Connect. (historical marker retained for control-doc truth checks)
-- P10-S1: Identity + Workspace Bootstrap (historical marker retained for control-doc truth checks)
-- Phase 10 is complete and shipped baseline truth.
-- This roadmap tracks future delivery only (Phase 11 onward).
+Phase 11 remains baseline truth and is not future scope.
 
-## Phase 11 Objective
+## Active Planning Status
+- Bridge Sprint 1 (`B1`) is the active execution sprint.
+- The remaining bridge-phase milestones are planned but not yet promoted.
 
-Make Alice the continuity layer that works across local, self-hosted, enterprise, and external-agent model stacks via provider adapters and model packs.
+## Bridge Phase: Hermes Auto-Capture (Planned)
 
-## Phase 11 Milestones
+### B1: Hermes Memory Provider Foundation
+- formalize the shipped Alice Hermes external memory provider into the bridge-phase contract
+- wire pre-turn hook, post-response hook, and session-end hook
+- parse provider config and expose provider status checks
+- preserve additive coexistence with Hermes built-in `MEMORY.md` and `USER.md`
+- standardize the preferred provider-plus-MCP integration shape
 
-### P11-S1: Provider Abstraction + OpenAI-Compatible Base
+### B2: Auto-Capture Pipeline
+- ship `alice_capture_candidates` + `alice_commit_captures`
+- enforce mode policy (`manual`, `assist`, `auto`) and confidence thresholds
+- add candidate type classification for decision, commitment, waiting-for, blocker, preference, correction, note, and no-op
+- persist review-queue candidates
+- guarantee idempotent repeated sync behavior
+- ensure no-op turns produce no memory writes
+- implement the auto-save vs review-required policy contract from the product brief
 
-- provider interface, registry, config schema
-- OpenAI-compatible base adapter
-- capability discovery and usage normalization
-- runtime invoke/test APIs and harness
+### B3: Review Queue + Explainability
+- ship `alice_review_queue` + `alice_review_apply`
+- support approve/reject/edit/supersede actions
+- preserve provenance/explanation chain for candidate proposals
+- ensure correction-aware parity across UI/CLI/MCP paths
+- make approved review actions change subsequent recall/resume results deterministically
 
-### P11-S2: Ollama + llama.cpp Adapters
-
-- local adapter implementations
-- model enumeration + healthchecks
-- local setup docs and end-to-end examples
-
-### P11-S3: vLLM Adapter + Self-Hosted Performance Path
-
-- vLLM adapter support via same abstraction
-- provider-specific option passthrough boundary
-- normalized latency/usage telemetry for vLLM calls
-
-### P11-S4: Model Packs Tier 1
-
-- first-party packs: Llama, Qwen, Gemma, gpt-oss
-- pack catalog + versioning + binding APIs
-- pack-driven context/tool/response behavior
-
-### P11-S5: Azure Adapter + AutoGen Integration
-
-- Azure OpenAI / Azure Foundry adapter
-- enterprise credential/auth hardening
-- AutoGen integration guide and sample path
-
-### P11-S6: Model Packs Tier 2 + Launch Clarity Assets
-
-- packs: DeepSeek, Kimi, Mistral
-- runtime and pack compatibility matrices
-- docs for local, self-hosted, enterprise, and external-agent paths
-
-### P11-R1: Provider Runtime Hardening (Security Remediation Sprint 1)
-
-- outbound URL validation and SSRF resistance for provider registration and runtime/test calls
-- sanitized upstream provider error surfaces for API responses and persistence
-- URL userinfo rejection plus defensive redaction on serialized provider rows
+### B4: Packaging, Docs, and Smoke Validation
+- publish Hermes integration guide and config examples
+- publish example `config.yaml` for provider-plus-MCP and MCP-only fallback modes
+- document provider+MCP recommended architecture
+- publish a short "why provider + MCP" operator decision doc
+- publish MCP-only fallback and migration path
+- deliver smoke-test scripts and one-command local demo path
+- make provider mode the clearly recommended path in docs once smoke evidence passes
 
 ## Sequencing Rules
+- Build provider lifecycle hooks before capture policy automation.
+- Land capture/commit policy before review UX/process expansion.
+- Validate idempotency and trust gating before broad rollout.
+- Keep MCP fallback available during bridge rollout.
+- Keep the shipped Hermes provider as baseline and extend it rather than replacing it.
 
-- Stabilize abstraction and normalization before adding provider breadth.
-- Complete tier-1 providers before tier-2 model-pack breadth.
-- Ship tier-1 packs cleanly before expanding long-tail packs.
-- Treat enterprise adapter and credential hardening as a release gate, not polish.
-- Clear provider-runtime security holds before Phase 11 release closeout.
-
-## Phase 11 Exit
-
-Phase 11 exits when users can choose model backends and agent runtimes without changing Alice continuity semantics, and supported paths are operationally documented.
-
-## Roadmap Guardrails
-
-- Keep roadmap future-facing; move completed work to handoff/archive docs.
-- Do not restate shipped Phase 10 scope as future milestones.
-- Avoid provider/model sprawl not justified by adapter and pack contracts.
+## Beyond Bridge (Future, Not Yet Defined)
+- Post-bridge roadmap phases are not yet defined in canonical planning.
+- Phase naming, sprinting, and scope for beyond-bridge work require a new planning packet.

--- a/RULES.md
+++ b/RULES.md
@@ -1,42 +1,37 @@
 # Rules
 
-## Baseline Truth
-
-- Phase 10 must not fork semantics between local, CLI, MCP, and Telegram.
-- Do not rewrite shipped Phase 9 capabilities as future roadmap items.
-- Treat shipped Phase 10 capability as baseline truth, not roadmap scope.
-- Do not reframe shipped Alice Core/Connect behavior as aspirational work.
+## Baseline Truth Discipline
+- Treat Phase 11 as shipped baseline truth; do not restate it as future roadmap scope.
+- Keep shipped baseline, bridge-phase plan, and future roadmap clearly separated.
 - Keep `ROADMAP.md` future-facing and `.ai/handoff/CURRENT_STATE.md` factual/current.
 
-## Product Boundaries
+## Integration Rules
+- For Hermes, use provider hooks for automation and MCP for explicit deep actions.
+- Do not collapse to provider-only or MCP-only as the canonical target architecture.
+- Keep MCP fallback viable while provider mode matures.
 
-- Alice remains continuity-first, not a generic autonomous platform.
-- Provider/model expansion must preserve OSS baseline and hosted/enterprise boundary clarity.
-- Do not conflate provider support with complete agent-framework support.
+## Continuity Semantics Rules
+- Never fork continuity semantics by surface or runtime.
+- Provider behavior may automate lifecycle timing, but memory truth remains in Alice continuity contracts.
+- Preserve provenance, correction, and supersession behavior across all capture paths.
 
-## Architecture Rules
+## Capture Policy Rules
+- Default mode is `assist` unless explicitly overridden.
+- Auto-save only explicit high-confidence items: correction, preference, decision, commitment, open-loop create/resolve.
+- Route inferred/weak/speculative or low-confidence items to review queue.
+- Never auto-promote a single-turn inference into higher-order trusted patterns/playbooks.
 
-- Never fork continuity semantics by provider, model, or runtime.
-- Provider-specific quirks belong in adapters or declarative packs, not core semantics.
-- Model pack behavior must be declarative, versioned, and explicit.
-- Keep provider contract normalization mandatory for responses, tools, and usage.
+## Reliability Rules
+- Post-response capture/commit paths must be idempotent.
+- Session-end flush must run dedupe, contradiction checks, open-loop normalization, and summary refresh.
+- No-op turns must not create memory writes.
 
-## Scope Control
+## Security Rules
+- Maintain workspace/session isolation for provider and MCP calls.
+- Keep provider/API credentials out of logs and error payloads.
+- Keep consequential actions approval-bounded regardless of integration mode.
 
-- Build interfaces first (OpenAI-compatible base), then provider breadth, then pack breadth.
-- No deep optimization for one model family before abstraction stability.
-- Do not ship broad pack catalogs before tier-1 packs are production-clean.
-- Do not add non-Phase-11 channel/surface expansion under adapter-pack scope.
-
-## Security And Reliability
-
-- Store provider credentials as encrypted references; never log plaintext secrets.
-- Require idempotency and auditability for provider invoke paths.
-- Keep consequential actions approval-bounded on every provider/runtime path.
-- Maintain cross-workspace isolation for provider configs and pack bindings.
-
-## Documentation Discipline
-
-- Keep canonical operating files concise and non-duplicative.
-- Move major long-lived decisions into ADRs instead of bloating architecture docs.
-- Archive superseded plans, investor framing, and sprint diaries out of live memory files.
+## Documentation Rules
+- Keep canonical files concise and durable.
+- Move major technical commitments into ADRs instead of expanding architecture prose.
+- Archive investor framing, long sprint diaries, and superseded planning drafts out of active memory docs.

--- a/apps/api/src/alicebot_api/mcp_tools.py
+++ b/apps/api/src/alicebot_api/mcp_tools.py
@@ -74,6 +74,7 @@ from alicebot_api.temporal_state import (
 
 _REVIEW_STATUS_CHOICES = ("correction_ready", "active", "stale", "superseded", "deleted", "all")
 _CONTEXT_PACK_ASSEMBLY_VERSION_V0 = "alice_context_pack_v0"
+_PREFETCH_CONTEXT_ASSEMBLY_VERSION_V0 = "alice_prefetch_context_v0"
 
 
 class MCPToolError(ValueError):
@@ -258,6 +259,72 @@ def _recency_sort_key(item: Mapping[str, object]) -> tuple[str, str]:
     return created_at, item_id
 
 
+def _extract_prefetch_single_title(section: object) -> str:
+    if not isinstance(section, Mapping):
+        return ""
+    item = section.get("item")
+    if not isinstance(item, Mapping):
+        return ""
+    title = item.get("title")
+    if not isinstance(title, str):
+        return ""
+    return title.strip()
+
+
+def _extract_prefetch_titles(section: object, *, limit: int) -> list[str]:
+    if not isinstance(section, Mapping):
+        return []
+    items = section.get("items")
+    if not isinstance(items, list):
+        return []
+
+    titles: list[str] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        title = item.get("title")
+        if not isinstance(title, str):
+            continue
+        normalized = title.strip()
+        if normalized == "":
+            continue
+        titles.append(normalized)
+        if len(titles) >= limit:
+            break
+    return titles
+
+
+def _render_prefetch_context_text(
+    *,
+    brief: Mapping[str, object],
+    open_loops_limit: int,
+    recent_changes_limit: int,
+) -> str:
+    lines: list[str] = ["## Alice Continuity Prefetch"]
+
+    last_decision = _extract_prefetch_single_title(brief.get("last_decision"))
+    if last_decision:
+        lines.append(f"- Last decision: {last_decision}")
+
+    next_action = _extract_prefetch_single_title(brief.get("next_action"))
+    if next_action:
+        lines.append(f"- Next action: {next_action}")
+
+    open_loop_titles = _extract_prefetch_titles(brief.get("open_loops"), limit=open_loops_limit)
+    if open_loop_titles:
+        lines.append("- Open loops:")
+        lines.extend([f"  - {title}" for title in open_loop_titles])
+
+    recent_change_titles = _extract_prefetch_titles(brief.get("recent_changes"), limit=recent_changes_limit)
+    if recent_change_titles:
+        lines.append("- Recent changes:")
+        lines.extend([f"  - {title}" for title in recent_change_titles])
+
+    if len(lines) == 1:
+        return ""
+    return "\n".join(lines)
+
+
 def _handle_alice_capture(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
     explicit_signal = arguments.get("explicit_signal")
     if explicit_signal is not None and not isinstance(explicit_signal, str):
@@ -340,6 +407,63 @@ def _handle_alice_resume(context: MCPRuntimeContext, arguments: Mapping[str, obj
                 ),
             ),
         )
+
+
+def _handle_alice_prefetch_context(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    max_recent_changes = _parse_int(
+        arguments,
+        key="max_recent_changes",
+        default=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        minimum=0,
+        maximum=MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    )
+    max_open_loops = _parse_int(
+        arguments,
+        key="max_open_loops",
+        default=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+        minimum=0,
+        maximum=MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    )
+
+    with _store_context(context) as store:
+        resumption_payload = compile_continuity_resumption_brief(
+            store,
+            user_id=context.user_id,
+            request=ContinuityResumptionBriefRequestInput(
+                query=_parse_optional_text(arguments, "query"),
+                thread_id=_parse_optional_uuid(arguments, "thread_id"),
+                task_id=_parse_optional_uuid(arguments, "task_id"),
+                project=_parse_optional_text(arguments, "project"),
+                person=_parse_optional_text(arguments, "person"),
+                since=_parse_optional_datetime(arguments, "since"),
+                until=_parse_optional_datetime(arguments, "until"),
+                max_recent_changes=max_recent_changes,
+                max_open_loops=max_open_loops,
+                include_non_promotable_facts=_parse_bool(
+                    arguments,
+                    key="include_non_promotable_facts",
+                    default=False,
+                ),
+            ),
+        )
+
+    brief = resumption_payload["brief"]
+    return {
+        "prefetch_context": {
+            "assembly_version": _PREFETCH_CONTEXT_ASSEMBLY_VERSION_V0,
+            "text": _render_prefetch_context_text(
+                brief=brief,
+                open_loops_limit=max_open_loops,
+                recent_changes_limit=max_recent_changes,
+            ),
+            "scope": brief["scope"],
+            "last_decision": brief["last_decision"],
+            "next_action": brief["next_action"],
+            "open_loops": brief["open_loops"],
+            "recent_changes": brief["recent_changes"],
+            "sources": brief["sources"],
+        }
+    }
 
 
 def _handle_alice_open_loops(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
@@ -722,6 +846,34 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
         },
     },
     {
+        "name": "alice_prefetch_context",
+        "description": "Assemble deterministic pre-turn prefetch context text from continuity resumption state.",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "query": {"type": "string"},
+                "thread_id": {"type": "string", "format": "uuid"},
+                "task_id": {"type": "string", "format": "uuid"},
+                "project": {"type": "string"},
+                "person": {"type": "string"},
+                "since": {"type": "string", "format": "date-time"},
+                "until": {"type": "string", "format": "date-time"},
+                "max_recent_changes": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+                },
+                "max_open_loops": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+                },
+                "include_non_promotable_facts": {"type": "boolean"},
+            },
+        },
+    },
+    {
         "name": "alice_open_loops",
         "description": "List continuity open loops grouped by deterministic posture sections.",
         "inputSchema": {
@@ -895,6 +1047,7 @@ _TOOL_HANDLERS = {
     "alice_recall": _handle_alice_recall,
     "alice_state_at": _handle_alice_state_at,
     "alice_resume": _handle_alice_resume,
+    "alice_prefetch_context": _handle_alice_prefetch_context,
     "alice_open_loops": _handle_alice_open_loops,
     "alice_recent_decisions": _handle_alice_recent_decisions,
     "alice_recent_changes": _handle_alice_recent_changes,

--- a/docs/integrations/hermes-memory-provider.md
+++ b/docs/integrations/hermes-memory-provider.md
@@ -14,6 +14,9 @@ Hermes behavior with this provider:
 - `alice_resumption_brief`: last decision, next action, open loops, recent changes
 - `alice_open_loops`: open-loop dashboard retrieval
 - prefetch: turn-start context assembled from Alice resumption brief
+- bridge-phase lifecycle contract for `prefetch`, `queue_prefetch`, `sync_turn`, and `on_session_end`
+- deterministic capture dedupe for repeated callback execution
+- local status readiness reporting without live network calls
 
 ## Continuity Model Mapping
 
@@ -22,6 +25,9 @@ The provider maps Alice continuity responses into Hermes provider hooks:
 | Hermes provider hook | Alice endpoint | Mapping |
 |---|---|---|
 | `prefetch(query)` | `GET /v0/continuity/resumption-brief` | renders last decision, next action, open loops, and recent changes into ephemeral context |
+| `queue_prefetch(query)` | `GET /v0/continuity/resumption-brief` | asynchronously prebuilds pre-turn context cache for next `prefetch` |
+| `sync_turn(user, assistant)` | `POST /v0/continuity/captures` | optional post-turn capture hook with duplicate-write suppression |
+| `on_session_end()` | `POST /v0/continuity/captures` | deterministic flush of pending capture work before provider shutdown |
 | `alice_recall` tool | `GET /v0/continuity/recall` | returns ranked continuity objects with provenance and scope filters |
 | `alice_resumption_brief` tool | `GET /v0/continuity/resumption-brief` | returns structured resume sections for deterministic follow-through |
 | `alice_open_loops` tool | `GET /v0/continuity/open-loops` | returns waiting/blocker/stale/next-action open-loop groups |
@@ -80,13 +86,20 @@ hermes memory status
 Run provider smoke validation from this repository:
 
 ```bash
-./scripts/run_hermes_memory_provider_smoke.py
+./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py
 ```
+
+Smoke output includes `structural.bridge_status` with:
+
+- `ready`: bridge-phase config readiness
+- `errors`: invalid config state details (if any)
+- `legacy_config_keys`: legacy keys still accepted for compatibility
+- `lifecycle_hooks`: readiness for `prefetch`, `queue_prefetch`, `sync_turn`, `on_session_end`
 
 Optional live prefetch test:
 
 ```bash
-./scripts/run_hermes_memory_provider_smoke.py \
+./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py \
   --live-prefetch-query "release gating decision" \
   --alice-base-url "http://127.0.0.1:8000" \
   --alice-user-id "00000000-0000-0000-0000-000000000001"
@@ -126,9 +139,19 @@ Practical default:
 - `base_url` (string)
 - `user_id` (UUID string)
 - `timeout_seconds` (float)
-- `prefetch_limit` (int)
-- `max_recent_changes` (int)
-- `max_open_loops` (int)
-- `include_non_promotable_facts` (bool)
-- `auto_capture` (bool, default `false`)
-- `mirror_memory_writes` (bool, default `false`)
+- `prefetch_recall_limit` (int)
+- `prefetch_max_recent_changes` (int)
+- `prefetch_max_open_loops` (int)
+- `prefetch_include_non_promotable_facts` (bool)
+- `sync_turn_capture_enabled` (bool, default `false`)
+- `memory_write_capture_enabled` (bool, default `false`)
+- `session_end_flush_timeout_seconds` (float, default `5.0`)
+
+Legacy compatibility keys still accepted for shipped configs:
+
+- `prefetch_limit`
+- `max_recent_changes`
+- `max_open_loops`
+- `include_non_promotable_facts`
+- `auto_capture`
+- `mirror_memory_writes`

--- a/docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py
+++ b/docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py
@@ -15,6 +15,8 @@ import json
 import ipaddress
 import logging
 import os
+import hashlib
+import time
 import threading
 import urllib.error
 import urllib.parse
@@ -35,6 +37,9 @@ _DEFAULT_PREFETCH_LIMIT = 5
 _DEFAULT_MAX_RECENT_CHANGES = 5
 _DEFAULT_MAX_OPEN_LOOPS = 5
 _DEFAULT_CAPTURE_CHAR_LIMIT = 3800
+_DEFAULT_SESSION_END_FLUSH_TIMEOUT_SECONDS = 5.0
+_CAPTURE_DEDUPE_WINDOW_SECONDS = 5.0
+_BRIDGE_CONTRACT_VERSION = "bridge_b1"
 
 _RECALL_LIMIT_MIN = 1
 _RECALL_LIMIT_MAX = 50
@@ -46,6 +51,14 @@ _RECENT_CHANGES_MIN = 0
 _RECENT_CHANGES_MAX = 25
 
 _AUTH_USER_HEADER = "X-AliceBot-User-Id"
+_BRIDGE_CONFIG_ALIASES: Dict[str, tuple[str, ...]] = {
+    "prefetch_recall_limit": ("prefetch_limit",),
+    "prefetch_max_recent_changes": ("max_recent_changes",),
+    "prefetch_max_open_loops": ("max_open_loops",),
+    "prefetch_include_non_promotable_facts": ("include_non_promotable_facts",),
+    "sync_turn_capture_enabled": ("auto_capture",),
+    "memory_write_capture_enabled": ("mirror_memory_writes",),
+}
 _SAFE_TOOL_ERROR_MESSAGES = (
     "internal provider error",
     "provider is not initialized",
@@ -205,6 +218,27 @@ def _config_path(hermes_home: str) -> Path:
     return Path(hermes_home) / _CONFIG_FILENAME
 
 
+def _first_non_empty(*values: Any) -> Any:
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str) and value.strip() == "":
+            continue
+        return value
+    return None
+
+
+def _resolve_config_value(values: Dict[str, Any], key: str) -> tuple[Any, str]:
+    value = values.get(key)
+    if value not in (None, ""):
+        return value, key
+    for legacy_key in _BRIDGE_CONFIG_ALIASES.get(key, ()):
+        legacy_value = values.get(legacy_key)
+        if legacy_value not in (None, ""):
+            return legacy_value, legacy_key
+    return None, key
+
+
 def _default_config() -> Dict[str, Any]:
     return {
         "base_url": os.environ.get("ALICE_API_BASE_URL", _DEFAULT_BASE_URL),
@@ -215,41 +249,67 @@ def _default_config() -> Dict[str, Any]:
             min_value=0.5,
             max_value=30.0,
         ),
-        "prefetch_limit": _parse_int(
-            os.environ.get("ALICE_MEMORY_PREFETCH_LIMIT"),
+        "prefetch_recall_limit": _parse_int(
+            _first_non_empty(
+                os.environ.get("ALICE_MEMORY_PREFETCH_RECALL_LIMIT"),
+                os.environ.get("ALICE_MEMORY_PREFETCH_LIMIT"),
+            ),
             default=_DEFAULT_PREFETCH_LIMIT,
             min_value=_RECALL_LIMIT_MIN,
             max_value=_RECALL_LIMIT_MAX,
         ),
-        "max_recent_changes": _parse_int(
-            os.environ.get("ALICE_MEMORY_MAX_RECENT_CHANGES"),
+        "prefetch_max_recent_changes": _parse_int(
+            _first_non_empty(
+                os.environ.get("ALICE_MEMORY_PREFETCH_MAX_RECENT_CHANGES"),
+                os.environ.get("ALICE_MEMORY_MAX_RECENT_CHANGES"),
+            ),
             default=_DEFAULT_MAX_RECENT_CHANGES,
             min_value=_RECENT_CHANGES_MIN,
             max_value=_RECENT_CHANGES_MAX,
         ),
-        "max_open_loops": _parse_int(
-            os.environ.get("ALICE_MEMORY_MAX_OPEN_LOOPS"),
+        "prefetch_max_open_loops": _parse_int(
+            _first_non_empty(
+                os.environ.get("ALICE_MEMORY_PREFETCH_MAX_OPEN_LOOPS"),
+                os.environ.get("ALICE_MEMORY_MAX_OPEN_LOOPS"),
+            ),
             default=_DEFAULT_MAX_OPEN_LOOPS,
             min_value=_RECENT_CHANGES_MIN,
             max_value=_RECENT_CHANGES_MAX,
         ),
-        "include_non_promotable_facts": _parse_bool(
-            os.environ.get("ALICE_MEMORY_INCLUDE_NON_PROMOTABLE"),
+        "prefetch_include_non_promotable_facts": _parse_bool(
+            _first_non_empty(
+                os.environ.get("ALICE_MEMORY_PREFETCH_INCLUDE_NON_PROMOTABLE"),
+                os.environ.get("ALICE_MEMORY_INCLUDE_NON_PROMOTABLE"),
+            ),
             default=False,
         ),
-        "auto_capture": _parse_bool(
-            os.environ.get("ALICE_MEMORY_AUTO_CAPTURE"),
+        "sync_turn_capture_enabled": _parse_bool(
+            _first_non_empty(
+                os.environ.get("ALICE_MEMORY_SYNC_TURN_CAPTURE_ENABLED"),
+                os.environ.get("ALICE_MEMORY_AUTO_CAPTURE"),
+            ),
             default=False,
         ),
-        "mirror_memory_writes": _parse_bool(
-            os.environ.get("ALICE_MEMORY_MIRROR_WRITES"),
+        "memory_write_capture_enabled": _parse_bool(
+            _first_non_empty(
+                os.environ.get("ALICE_MEMORY_MEMORY_WRITE_CAPTURE_ENABLED"),
+                os.environ.get("ALICE_MEMORY_MIRROR_WRITES"),
+            ),
             default=False,
+        ),
+        "session_end_flush_timeout_seconds": _parse_float(
+            os.environ.get("ALICE_MEMORY_SESSION_END_FLUSH_TIMEOUT_SECONDS"),
+            default=_DEFAULT_SESSION_END_FLUSH_TIMEOUT_SECONDS,
+            min_value=0.5,
+            max_value=30.0,
         ),
     }
 
 
-def _load_config(hermes_home: str) -> Dict[str, Any]:
+def _load_config_with_status(hermes_home: str) -> Dict[str, Any]:
     config = _default_config()
+    errors: List[str] = []
+    file_legacy_keys: List[str] = []
 
     path = _config_path(hermes_home)
     if path.exists():
@@ -259,14 +319,36 @@ def _load_config(hermes_home: str) -> Dict[str, Any]:
                 for key, value in raw.items():
                     if value is not None and value != "":
                         config[key] = value
+                for canonical_key, legacy_keys in _BRIDGE_CONFIG_ALIASES.items():
+                    if raw.get(canonical_key) not in (None, ""):
+                        continue
+                    for legacy_key in legacy_keys:
+                        legacy_value = raw.get(legacy_key)
+                        if legacy_value in (None, ""):
+                            continue
+                        config[canonical_key] = legacy_value
+                        file_legacy_keys.append(legacy_key)
+                        break
+            else:
+                errors.append("provider config must be a JSON object")
         except Exception:
             logger.debug("Failed to parse %s", path, exc_info=True)
+            errors.append("provider config could not be parsed")
 
-    try:
-        return _load_config_dict_from_values(config)
-    except ValueError:
-        logger.warning("Invalid Alice memory provider config; falling back to defaults", exc_info=True)
-        return _load_config_dict_from_values(_default_config())
+    normalized, validation_errors, legacy_config_keys = _load_config_dict_from_values(config)
+    errors.extend(validation_errors)
+    return {
+        "config": normalized,
+        "errors": errors,
+        "legacy_config_keys": sorted(set(legacy_config_keys) | set(file_legacy_keys)),
+        "ready": len(errors) == 0,
+        "config_path": str(path),
+    }
+
+
+def _load_config(hermes_home: str) -> Dict[str, Any]:
+    loaded = _load_config_with_status(hermes_home)
+    return dict(loaded["config"])
 
 
 def _validate_uuid(value: str) -> bool:
@@ -287,12 +369,18 @@ class AliceMemoryProvider(MemoryProvider):
         self._session_id: str = ""
         self._hermes_home: str = ""
         self._agent_context: str = "primary"
+        self._config_errors: List[str] = []
+        self._legacy_config_keys: List[str] = []
 
         self._prefetch_cache: Dict[str, str] = {}
         self._prefetch_threads: Dict[str, threading.Thread] = {}
         self._prefetch_lock = threading.Lock()
 
         self._capture_thread: Optional[threading.Thread] = None
+        self._capture_queue: List[tuple[str, str]] = []
+        self._capture_pending_fingerprints: set[str] = set()
+        self._capture_recent_fingerprints: Dict[str, float] = {}
+        self._capture_lock = threading.Lock()
 
     @property
     def name(self) -> str:
@@ -301,17 +389,8 @@ class AliceMemoryProvider(MemoryProvider):
     def is_available(self) -> bool:
         from hermes_constants import get_hermes_home
 
-        try:
-            cfg = _load_config(str(get_hermes_home()))
-        except ValueError:
-            return False
-        base_url = str(cfg.get("base_url", "")).strip()
-        user_id = str(cfg.get("user_id", "")).strip()
-        try:
-            _normalize_base_url(base_url)
-        except ValueError:
-            return False
-        return _validate_uuid(user_id)
+        status = _load_config_with_status(str(get_hermes_home()))
+        return bool(status.get("ready"))
 
     def initialize(self, session_id: str, **kwargs) -> None:
         from hermes_constants import get_hermes_home
@@ -319,7 +398,14 @@ class AliceMemoryProvider(MemoryProvider):
         self._session_id = session_id or ""
         self._hermes_home = str(kwargs.get("hermes_home") or get_hermes_home())
         self._agent_context = str(kwargs.get("agent_context") or "primary")
-        self._config = _load_config(self._hermes_home)
+        loaded = _load_config_with_status(self._hermes_home)
+        self._config = dict(loaded["config"])
+        self._config_errors = list(loaded["errors"])
+        self._legacy_config_keys = list(loaded["legacy_config_keys"])
+        with self._capture_lock:
+            self._capture_queue = []
+            self._capture_pending_fingerprints.clear()
+            self._capture_recent_fingerprints.clear()
 
     def get_config_schema(self) -> List[Dict[str, Any]]:
         return [
@@ -340,44 +426,51 @@ class AliceMemoryProvider(MemoryProvider):
                 "default": str(_DEFAULT_TIMEOUT_SECONDS),
             },
             {
-                "key": "prefetch_limit",
-                "description": "Default prefetch recall limit",
+                "key": "prefetch_recall_limit",
+                "description": "Prefetch recall limit for bridge pre-turn hook",
                 "default": str(_DEFAULT_PREFETCH_LIMIT),
             },
             {
-                "key": "max_recent_changes",
-                "description": "Resumption brief recent changes cap",
+                "key": "prefetch_max_recent_changes",
+                "description": "Prefetch recent changes cap",
                 "default": str(_DEFAULT_MAX_RECENT_CHANGES),
             },
             {
-                "key": "max_open_loops",
-                "description": "Resumption brief open-loop cap",
+                "key": "prefetch_max_open_loops",
+                "description": "Prefetch open-loop cap",
                 "default": str(_DEFAULT_MAX_OPEN_LOOPS),
             },
             {
-                "key": "include_non_promotable_facts",
-                "description": "Include non-promotable facts in resumption brief",
+                "key": "prefetch_include_non_promotable_facts",
+                "description": "Include non-promotable facts in prefetch resumption brief",
                 "choices": ["true", "false"],
                 "default": "false",
             },
             {
-                "key": "auto_capture",
-                "description": "Auto-capture completed turns into Alice continuity",
+                "key": "sync_turn_capture_enabled",
+                "description": "Capture post-turn transcripts via sync_turn lifecycle hook",
                 "choices": ["true", "false"],
                 "default": "false",
             },
             {
-                "key": "mirror_memory_writes",
-                "description": "Mirror built-in MEMORY.md / USER.md writes to Alice",
+                "key": "memory_write_capture_enabled",
+                "description": "Capture built-in MEMORY.md / USER.md writes via memory-write hook",
                 "choices": ["true", "false"],
                 "default": "false",
+            },
+            {
+                "key": "session_end_flush_timeout_seconds",
+                "description": "Session-end capture flush timeout in seconds",
+                "default": str(_DEFAULT_SESSION_END_FLUSH_TIMEOUT_SECONDS),
             },
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
         cfg = _load_config(hermes_home)
         cfg.update(values)
-        cfg = _load_config_dict_from_values(cfg)
+        cfg, errors, _ = _load_config_dict_from_values(cfg)
+        if errors:
+            raise ValueError("; ".join(errors))
         path = _config_path(hermes_home)
         path.write_text(json.dumps(cfg, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
@@ -429,7 +522,7 @@ class AliceMemoryProvider(MemoryProvider):
         thread.start()
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
-        if not self._config.get("auto_capture", False):
+        if not self._config.get("sync_turn_capture_enabled", False):
             return
         if self._agent_context != "primary":
             return
@@ -438,20 +531,10 @@ class AliceMemoryProvider(MemoryProvider):
         if not raw_content:
             return
 
-        def _capture() -> None:
-            try:
-                self._post_capture(raw_content)
-            except Exception as exc:
-                logger.debug("Alice sync_turn capture failed: %s", exc)
-
-        if self._capture_thread and self._capture_thread.is_alive():
-            self._capture_thread.join(timeout=5.0)
-
-        self._capture_thread = threading.Thread(target=_capture, daemon=True, name="alice-sync-capture")
-        self._capture_thread.start()
+        self._enqueue_capture(kind="sync_turn", raw_content=raw_content)
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
-        if not self._config.get("mirror_memory_writes", False):
+        if not self._config.get("memory_write_capture_enabled", False):
             return
         if action not in {"add", "replace"}:
             return
@@ -459,15 +542,52 @@ class AliceMemoryProvider(MemoryProvider):
             return
 
         raw_content = f"Hermes built-in memory update ({target}): {content.strip()}"
+        self._enqueue_capture(kind="memory_write", raw_content=raw_content)
 
-        def _capture() -> None:
-            try:
-                self._post_capture(raw_content)
-            except Exception as exc:
-                logger.debug("Alice memory-write mirror failed: %s", exc)
+    def on_session_end(self, *, session_id: str = "") -> None:
+        key = self._session_key(session_id)
+        flush_timeout = float(
+            self._config.get("session_end_flush_timeout_seconds", _DEFAULT_SESSION_END_FLUSH_TIMEOUT_SECONDS)
+        )
 
-        thread = threading.Thread(target=_capture, daemon=True, name="alice-memory-write")
-        thread.start()
+        with self._prefetch_lock:
+            thread = self._prefetch_threads.pop(key, None)
+            self._prefetch_cache.pop(key, None)
+        if thread and thread.is_alive():
+            thread.join(timeout=2.0)
+
+        if self._capture_thread and self._capture_thread.is_alive():
+            self._capture_thread.join(timeout=flush_timeout)
+        if not (self._capture_thread and self._capture_thread.is_alive()):
+            self._drain_capture_queue(drop_on_error=True)
+            with self._capture_lock:
+                self._capture_pending_fingerprints.clear()
+        with self._capture_lock:
+            self._capture_recent_fingerprints.clear()
+
+    def get_status(self, *, hermes_home: str = "") -> Dict[str, Any]:
+        selected_home = hermes_home or self._hermes_home
+        if not selected_home:
+            from hermes_constants import get_hermes_home
+
+            selected_home = str(get_hermes_home())
+        loaded = _load_config_with_status(selected_home)
+        config = dict(loaded["config"])
+        return {
+            "provider": self.name,
+            "bridge_contract_version": _BRIDGE_CONTRACT_VERSION,
+            "ready": bool(loaded["ready"]),
+            "errors": list(loaded["errors"]),
+            "legacy_config_keys": list(loaded["legacy_config_keys"]),
+            "lifecycle_hooks": {
+                "prefetch": True,
+                "queue_prefetch": True,
+                "sync_turn": bool(config.get("sync_turn_capture_enabled", False)),
+                "on_session_end": True,
+            },
+            "config": config,
+            "config_path": loaded["config_path"],
+        }
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [ALICE_RECALL_TOOL, ALICE_RESUME_TOOL, ALICE_OPEN_LOOPS_TOOL]
@@ -490,11 +610,12 @@ class AliceMemoryProvider(MemoryProvider):
     def shutdown(self) -> None:
         with self._prefetch_lock:
             threads = list(self._prefetch_threads.values())
+            self._prefetch_threads.clear()
+            self._prefetch_cache.clear()
         for thread in threads:
             if thread.is_alive():
                 thread.join(timeout=2.0)
-        if self._capture_thread and self._capture_thread.is_alive():
-            self._capture_thread.join(timeout=5.0)
+        self.on_session_end(session_id=self._session_id)
 
     def _session_key(self, session_id: str) -> str:
         return session_id or self._session_id or "default"
@@ -503,7 +624,7 @@ class AliceMemoryProvider(MemoryProvider):
         params = self._scope_params(args)
         params["limit"] = _parse_int(
             args.get("limit"),
-            default=self._config.get("prefetch_limit", _DEFAULT_PREFETCH_LIMIT),
+            default=self._config.get("prefetch_recall_limit", _DEFAULT_PREFETCH_LIMIT),
             min_value=_RECALL_LIMIT_MIN,
             max_value=_RECALL_LIMIT_MAX,
         )
@@ -513,19 +634,19 @@ class AliceMemoryProvider(MemoryProvider):
         params = self._scope_params(args)
         params["max_recent_changes"] = _parse_int(
             args.get("max_recent_changes"),
-            default=self._config.get("max_recent_changes", _DEFAULT_MAX_RECENT_CHANGES),
+            default=self._config.get("prefetch_max_recent_changes", _DEFAULT_MAX_RECENT_CHANGES),
             min_value=_RECENT_CHANGES_MIN,
             max_value=_RECENT_CHANGES_MAX,
         )
         params["max_open_loops"] = _parse_int(
             args.get("max_open_loops"),
-            default=self._config.get("max_open_loops", _DEFAULT_MAX_OPEN_LOOPS),
+            default=self._config.get("prefetch_max_open_loops", _DEFAULT_MAX_OPEN_LOOPS),
             min_value=_RECENT_CHANGES_MIN,
             max_value=_RECENT_CHANGES_MAX,
         )
         params["include_non_promotable_facts"] = _parse_bool(
             args.get("include_non_promotable_facts"),
-            default=bool(self._config.get("include_non_promotable_facts", False)),
+            default=bool(self._config.get("prefetch_include_non_promotable_facts", False)),
         )
         return self._request_json("GET", "/v0/continuity/resumption-brief", params=params)
 
@@ -533,7 +654,7 @@ class AliceMemoryProvider(MemoryProvider):
         params = self._scope_params(args)
         params["limit"] = _parse_int(
             args.get("limit"),
-            default=self._config.get("max_open_loops", _DEFAULT_MAX_OPEN_LOOPS),
+            default=self._config.get("prefetch_max_open_loops", _DEFAULT_MAX_OPEN_LOOPS),
             min_value=_OPEN_LOOP_LIMIT_MIN,
             max_value=_OPEN_LOOP_LIMIT_MAX,
         )
@@ -554,9 +675,11 @@ class AliceMemoryProvider(MemoryProvider):
         normalized_query = (query or "").strip()
         if normalized_query:
             params["query"] = normalized_query
-        params["max_recent_changes"] = self._config.get("max_recent_changes", _DEFAULT_MAX_RECENT_CHANGES)
-        params["max_open_loops"] = self._config.get("max_open_loops", _DEFAULT_MAX_OPEN_LOOPS)
-        params["include_non_promotable_facts"] = bool(self._config.get("include_non_promotable_facts", False))
+        params["max_recent_changes"] = self._config.get("prefetch_max_recent_changes", _DEFAULT_MAX_RECENT_CHANGES)
+        params["max_open_loops"] = self._config.get("prefetch_max_open_loops", _DEFAULT_MAX_OPEN_LOOPS)
+        params["include_non_promotable_facts"] = bool(
+            self._config.get("prefetch_include_non_promotable_facts", False)
+        )
 
         payload = self._request_json("GET", "/v0/continuity/resumption-brief", params=params)
         brief = payload.get("brief")
@@ -573,14 +696,14 @@ class AliceMemoryProvider(MemoryProvider):
         if next_action:
             lines.append(f"- Next action: {next_action}")
 
-        open_loop_lines = _extract_titles(brief.get("open_loops"), limit=self._config.get("max_open_loops", 3))
+        open_loop_lines = _extract_titles(brief.get("open_loops"), limit=self._config.get("prefetch_max_open_loops", 3))
         if open_loop_lines:
             lines.append("- Open loops:")
             lines.extend([f"  - {item}" for item in open_loop_lines])
 
         recent_change_lines = _extract_titles(
             brief.get("recent_changes"),
-            limit=self._config.get("max_recent_changes", 3),
+            limit=self._config.get("prefetch_max_recent_changes", 3),
         )
         if recent_change_lines:
             lines.append("- Recent changes:")
@@ -589,6 +712,81 @@ class AliceMemoryProvider(MemoryProvider):
         if len(lines) == 1:
             return ""
         return "\n".join(lines)
+
+    def _capture_fingerprint(self, *, kind: str, raw_content: str) -> str:
+        digest = hashlib.sha256(raw_content.encode("utf-8")).hexdigest()
+        return f"{kind}:{digest}"
+
+    def _prune_recent_capture_fingerprints(self, *, now: float) -> None:
+        stale_before = now - _CAPTURE_DEDUPE_WINDOW_SECONDS
+        stale_keys = [fingerprint for fingerprint, posted_at in self._capture_recent_fingerprints.items() if posted_at < stale_before]
+        for fingerprint in stale_keys:
+            self._capture_recent_fingerprints.pop(fingerprint, None)
+
+    def _new_capture_thread(self) -> threading.Thread:
+        return threading.Thread(
+            target=self._capture_worker,
+            daemon=True,
+            name="alice-sync-capture",
+        )
+
+    def _enqueue_capture(self, *, kind: str, raw_content: str) -> None:
+        fingerprint = self._capture_fingerprint(kind=kind, raw_content=raw_content)
+        worker_to_start: Optional[threading.Thread] = None
+        now = time.monotonic()
+        with self._capture_lock:
+            self._prune_recent_capture_fingerprints(now=now)
+            if fingerprint in self._capture_pending_fingerprints:
+                return
+            posted_at = self._capture_recent_fingerprints.get(fingerprint)
+            if posted_at is not None and now - posted_at <= _CAPTURE_DEDUPE_WINDOW_SECONDS:
+                return
+            self._capture_pending_fingerprints.add(fingerprint)
+            self._capture_queue.append((fingerprint, raw_content))
+            if self._capture_thread is None or not self._capture_thread.is_alive():
+                worker_to_start = self._new_capture_thread()
+                self._capture_thread = worker_to_start
+
+        if worker_to_start is not None:
+            worker_to_start.start()
+
+    def _capture_worker(self) -> None:
+        try:
+            self._drain_capture_queue(drop_on_error=False)
+        finally:
+            worker_to_start: Optional[threading.Thread] = None
+            with self._capture_lock:
+                self._capture_thread = None
+                if self._capture_queue:
+                    worker_to_start = self._new_capture_thread()
+                    self._capture_thread = worker_to_start
+            if worker_to_start is not None:
+                worker_to_start.start()
+
+    def _drain_capture_queue(self, *, drop_on_error: bool) -> None:
+        while True:
+            with self._capture_lock:
+                if not self._capture_queue:
+                    return
+                fingerprint, raw_content = self._capture_queue[0]
+
+            try:
+                self._post_capture(raw_content)
+            except Exception as exc:
+                logger.debug("Alice capture sync failed: %s", exc)
+                if not drop_on_error:
+                    return
+                with self._capture_lock:
+                    if self._capture_queue and self._capture_queue[0][0] == fingerprint:
+                        self._capture_queue.pop(0)
+                    self._capture_pending_fingerprints.discard(fingerprint)
+                continue
+
+            with self._capture_lock:
+                if self._capture_queue and self._capture_queue[0][0] == fingerprint:
+                    self._capture_queue.pop(0)
+                self._capture_pending_fingerprints.discard(fingerprint)
+                self._capture_recent_fingerprints[fingerprint] = time.monotonic()
 
     def _post_capture(self, raw_content: str) -> None:
         payload = {
@@ -666,41 +864,101 @@ class AliceMemoryProvider(MemoryProvider):
             raise RuntimeError("Alice API connection failed") from exc
 
 
-def _load_config_dict_from_values(values: Dict[str, Any]) -> Dict[str, Any]:
-    config: Dict[str, Any] = dict(values)
-    config["base_url"] = _normalize_base_url(str(config.get("base_url", _DEFAULT_BASE_URL)))
-    config["user_id"] = str(config.get("user_id", "")).strip()
+def _load_config_dict_from_values(values: Dict[str, Any]) -> tuple[Dict[str, Any], List[str], List[str]]:
+    config: Dict[str, Any] = {}
+    errors: List[str] = []
+    legacy_config_keys: List[str] = []
+
+    base_url_value = values.get("base_url", _DEFAULT_BASE_URL)
+    try:
+        config["base_url"] = _normalize_base_url(str(base_url_value))
+    except ValueError as exc:
+        errors.append(f"base_url: {exc}")
+        config["base_url"] = _normalize_base_url(_DEFAULT_BASE_URL)
+
+    user_id_value = values.get("user_id", "")
+    config["user_id"] = str(user_id_value).strip()
+    if not _validate_uuid(config["user_id"]):
+        errors.append("user_id must be a valid UUID")
+
     config["timeout_seconds"] = _parse_float(
-        config.get("timeout_seconds"),
+        values.get("timeout_seconds"),
         default=_DEFAULT_TIMEOUT_SECONDS,
         min_value=0.5,
         max_value=30.0,
     )
-    config["prefetch_limit"] = _parse_int(
-        config.get("prefetch_limit"),
+
+    prefetch_recall_limit_value, prefetch_recall_limit_source = _resolve_config_value(values, "prefetch_recall_limit")
+    if prefetch_recall_limit_source != "prefetch_recall_limit":
+        legacy_config_keys.append(prefetch_recall_limit_source)
+    config["prefetch_recall_limit"] = _parse_int(
+        prefetch_recall_limit_value,
         default=_DEFAULT_PREFETCH_LIMIT,
         min_value=_RECALL_LIMIT_MIN,
         max_value=_RECALL_LIMIT_MAX,
     )
-    config["max_recent_changes"] = _parse_int(
-        config.get("max_recent_changes"),
+
+    prefetch_recent_changes_value, prefetch_recent_changes_source = _resolve_config_value(
+        values,
+        "prefetch_max_recent_changes",
+    )
+    if prefetch_recent_changes_source != "prefetch_max_recent_changes":
+        legacy_config_keys.append(prefetch_recent_changes_source)
+    config["prefetch_max_recent_changes"] = _parse_int(
+        prefetch_recent_changes_value,
         default=_DEFAULT_MAX_RECENT_CHANGES,
         min_value=_RECENT_CHANGES_MIN,
         max_value=_RECENT_CHANGES_MAX,
     )
-    config["max_open_loops"] = _parse_int(
-        config.get("max_open_loops"),
+
+    prefetch_open_loops_value, prefetch_open_loops_source = _resolve_config_value(values, "prefetch_max_open_loops")
+    if prefetch_open_loops_source != "prefetch_max_open_loops":
+        legacy_config_keys.append(prefetch_open_loops_source)
+    config["prefetch_max_open_loops"] = _parse_int(
+        prefetch_open_loops_value,
         default=_DEFAULT_MAX_OPEN_LOOPS,
         min_value=_RECENT_CHANGES_MIN,
         max_value=_RECENT_CHANGES_MAX,
     )
-    config["include_non_promotable_facts"] = _parse_bool(
-        config.get("include_non_promotable_facts"),
+
+    prefetch_non_promotable_value, prefetch_non_promotable_source = _resolve_config_value(
+        values,
+        "prefetch_include_non_promotable_facts",
+    )
+    if prefetch_non_promotable_source != "prefetch_include_non_promotable_facts":
+        legacy_config_keys.append(prefetch_non_promotable_source)
+    config["prefetch_include_non_promotable_facts"] = _parse_bool(
+        prefetch_non_promotable_value,
         default=False,
     )
-    config["auto_capture"] = _parse_bool(config.get("auto_capture"), default=False)
-    config["mirror_memory_writes"] = _parse_bool(config.get("mirror_memory_writes"), default=False)
-    return config
+
+    sync_turn_capture_value, sync_turn_capture_source = _resolve_config_value(values, "sync_turn_capture_enabled")
+    if sync_turn_capture_source != "sync_turn_capture_enabled":
+        legacy_config_keys.append(sync_turn_capture_source)
+    config["sync_turn_capture_enabled"] = _parse_bool(
+        sync_turn_capture_value,
+        default=False,
+    )
+
+    memory_write_capture_value, memory_write_capture_source = _resolve_config_value(
+        values,
+        "memory_write_capture_enabled",
+    )
+    if memory_write_capture_source != "memory_write_capture_enabled":
+        legacy_config_keys.append(memory_write_capture_source)
+    config["memory_write_capture_enabled"] = _parse_bool(
+        memory_write_capture_value,
+        default=False,
+    )
+
+    config["session_end_flush_timeout_seconds"] = _parse_float(
+        values.get("session_end_flush_timeout_seconds"),
+        default=_DEFAULT_SESSION_END_FLUSH_TIMEOUT_SECONDS,
+        min_value=0.5,
+        max_value=30.0,
+    )
+
+    return config, errors, sorted(set(legacy_config_keys))
 
 
 def _extract_single_title(section: Any) -> str:

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -26,6 +26,7 @@ MCP uses the same local runtime scope as CLI:
 - `alice_recall`
 - `alice_state_at`
 - `alice_resume`
+- `alice_prefetch_context`
 - `alice_open_loops`
 - `alice_recent_decisions`
 - `alice_recent_changes`
@@ -36,6 +37,7 @@ MCP uses the same local runtime scope as CLI:
 - `alice_context_pack`
 
 `alice_explain` now accepts either `continuity_object_id` for evidence-chain inspection or `entity_id` plus optional `at` for temporal explain output.
+`alice_prefetch_context` provides an automation-oriented pre-turn context assembly surface using the same continuity resumption semantics shipped for `alice_resume`.
 
 ## Example: Claude Desktop MCP Config
 

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -19,37 +19,40 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="README.md",
         required_markers=(
             "Phase 10 is complete and shipped.",
-            "`P11-R1` Provider Runtime Hardening is the active security remediation sprint",
+            "Phase 11 is complete and shipped:",
+            "`B1` Hermes Provider Contract Foundation is the active sprint",
             "Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md]",
         ),
     ),
     ControlDocTruthRule(
         relative_path="ROADMAP.md",
         required_markers=(
-            "Phase 10 is complete and shipped baseline truth.",
-            "P11-R1: Provider Runtime Hardening (Security Remediation Sprint 1)",
+            "Phase 11 remains baseline truth and is not future scope.",
+            "Bridge Sprint 1 (`B1`) is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Phase 11 Security Remediation Sprint 1 (P11-R1): Provider Runtime Hardening",
-            "Reference baseline markers: shipped Phase 9 Alice Core, shipped Phase 10 Alice Connect, shipped `P11-S1` through `P11-S6` provider/runtime/model-pack work.",
+            "Bridge Sprint 1 (B1): Hermes Provider Contract Foundation",
+            "Phase 10 is complete and shipped.",
+            "Phase 11 is complete and shipped.",
         ),
     ),
     ControlDocTruthRule(
         relative_path="RULES.md",
         required_markers=(
-            "Never fork continuity semantics by provider, model, or runtime.",
-            "Provider-specific quirks belong in adapters or declarative packs, not core semantics.",
+            "For Hermes, use provider hooks for automation and MCP for explicit deep actions.",
+            "Never fork continuity semantics by surface or runtime.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/handoff/CURRENT_STATE.md",
         required_markers=(
-            "Phase 9 is complete and shipped.",
-            "Phase 10 is complete and shipped.",
-            "`P11-R1` (Provider Runtime Hardening) is the active security remediation sprint packet.",
+            "Phase 9 is shipped.",
+            "Phase 10 is shipped.",
+            "Phase 11 is shipped and remains baseline truth.",
+            "Bridge Sprint 1 (`B1`) is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(

--- a/scripts/install_hermes_alice_memory_provider.py
+++ b/scripts/install_hermes_alice_memory_provider.py
@@ -103,6 +103,18 @@ def main() -> int:
     print("  1) hermes memory setup      # choose alice")
     print("  2) hermes memory status")
     print("  3) hermes config set memory.provider alice")
+    print("  4) ./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py")
+    print()
+    print("Bridge B1 config keys:")
+    print("  - prefetch_recall_limit")
+    print("  - prefetch_max_recent_changes")
+    print("  - prefetch_max_open_loops")
+    print("  - prefetch_include_non_promotable_facts")
+    print("  - sync_turn_capture_enabled")
+    print("  - memory_write_capture_enabled")
+    print("  - session_end_flush_timeout_seconds")
+    print("Legacy compatibility keys still accepted: prefetch_limit, max_recent_changes,")
+    print("max_open_loops, include_non_promotable_facts, auto_capture, mirror_memory_writes")
     return 0
 
 

--- a/scripts/run_hermes_memory_provider_smoke.py
+++ b/scripts/run_hermes_memory_provider_smoke.py
@@ -89,6 +89,36 @@ def _run_structural_validation(provider_class: type) -> Dict[str, Any]:
     manager.add_provider(second_external)
 
     tool_names = sorted(schema.get("name", "") for schema in alice.get_tool_schemas())
+    bridge_status: Dict[str, Any] = {}
+    with tempfile.TemporaryDirectory(prefix="alice-hermes-provider-status-") as temp_dir:
+        hermes_home = Path(temp_dir)
+        config_path = hermes_home / "alice_memory_provider.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "base_url": "http://127.0.0.1:8000",
+                    "user_id": "00000000-0000-0000-0000-000000000001",
+                    "prefetch_recall_limit": 5,
+                    "prefetch_max_recent_changes": 5,
+                    "prefetch_max_open_loops": 5,
+                    "prefetch_include_non_promotable_facts": False,
+                    "sync_turn_capture_enabled": False,
+                    "memory_write_capture_enabled": False,
+                    "session_end_flush_timeout_seconds": 5.0,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        alice.initialize(
+            session_id="smoke-status-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            agent_context="primary",
+        )
+        if hasattr(alice, "get_status"):
+            bridge_status = alice.get_status(hermes_home=str(hermes_home))
 
     return {
         "provider_names": manager.provider_names,
@@ -96,6 +126,7 @@ def _run_structural_validation(provider_class: type) -> Dict[str, Any]:
         "single_external_enforced": manager.provider_names.count("second-external") == 0,
         "alice_registered": "alice" in manager.provider_names,
         "alice_tools": tool_names,
+        "bridge_status": bridge_status,
     }
 
 
@@ -116,10 +147,10 @@ def _run_live_prefetch(
                     "base_url": base_url,
                     "user_id": user_id,
                     "timeout_seconds": timeout_seconds,
-                    "prefetch_limit": 5,
-                    "max_recent_changes": 3,
-                    "max_open_loops": 3,
-                    "include_non_promotable_facts": False,
+                    "prefetch_recall_limit": 5,
+                    "prefetch_max_recent_changes": 3,
+                    "prefetch_max_open_loops": 3,
+                    "prefetch_include_non_promotable_facts": False,
                 },
                 indent=2,
             )

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -206,6 +206,7 @@ def test_mcp_server_tool_calls_and_correction_flow(migrated_database_urls) -> No
         tool_names = [tool["name"] for tool in tools_list["result"]["tools"]]
         assert "alice_recall" in tool_names
         assert "alice_resume" in tool_names
+        assert "alice_prefetch_context" in tool_names
         assert "alice_open_loops" in tool_names
         assert "alice_memory_correct" in tool_names
 
@@ -236,6 +237,20 @@ def test_mcp_server_tool_calls_and_correction_flow(migrated_database_urls) -> No
         )
         assert resume_before["isError"] is False
         assert resume_before["structuredContent"]["brief"]["last_decision"]["item"]["id"] == str(legacy_decision["id"])
+
+        prefetch_before = _call_tool(
+            client,
+            name="alice_prefetch_context",
+            arguments={
+                "thread_id": str(thread_id),
+                "max_recent_changes": 5,
+                "max_open_loops": 5,
+            },
+        )
+        assert prefetch_before["isError"] is False
+        prefetch_payload = prefetch_before["structuredContent"]["prefetch_context"]
+        assert prefetch_payload["last_decision"]["item"]["id"] == str(legacy_decision["id"])
+        assert "## Alice Continuity Prefetch" in prefetch_payload["text"]
 
         open_loops = _call_tool(
             client,

--- a/tests/unit/test_hermes_memory_provider.py
+++ b/tests/unit/test_hermes_memory_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
 from pathlib import Path
 import sys
 import types
@@ -34,16 +35,22 @@ def _load_provider_module(monkeypatch: pytest.MonkeyPatch):
 
     tools_pkg = types.ModuleType("tools")
     tools_registry_pkg = types.ModuleType("tools.registry")
+    hermes_constants_pkg = types.ModuleType("hermes_constants")
 
     def _tool_error(message: str) -> str:
         return f"tool_error:{message}"
 
+    def _get_hermes_home() -> str:
+        return "/tmp"
+
     tools_registry_pkg.tool_error = _tool_error
+    hermes_constants_pkg.get_hermes_home = _get_hermes_home
 
     monkeypatch.setitem(sys.modules, "agent", agent_pkg)
     monkeypatch.setitem(sys.modules, "agent.memory_provider", memory_provider_pkg)
     monkeypatch.setitem(sys.modules, "tools", tools_pkg)
     monkeypatch.setitem(sys.modules, "tools.registry", tools_registry_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_constants", hermes_constants_pkg)
 
     module_name = "alice_memory_provider_test_module"
     sys.modules.pop(module_name, None)
@@ -147,3 +154,146 @@ def test_handle_tool_call_sanitizes_http_error_body(monkeypatch: pytest.MonkeyPa
     assert "HTTP status 500" in response
     assert "password leaked" not in response
 
+
+def test_bridge_status_reports_legacy_config_compatibility(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_provider_module(monkeypatch)
+    config_path = tmp_path / "alice_memory_provider.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "base_url": "http://127.0.0.1:8000",
+                "user_id": "00000000-0000-0000-0000-000000000001",
+                "prefetch_limit": 7,
+                "max_recent_changes": 4,
+                "max_open_loops": 3,
+                "include_non_promotable_facts": True,
+                "auto_capture": True,
+                "mirror_memory_writes": True,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    provider = module.AliceMemoryProvider()
+    provider.initialize(session_id="bridge-status", hermes_home=str(tmp_path), agent_context="primary")
+    status = provider.get_status(hermes_home=str(tmp_path))
+
+    assert status["ready"] is True
+    assert status["config"]["prefetch_recall_limit"] == 7
+    assert status["config"]["prefetch_max_recent_changes"] == 4
+    assert status["config"]["prefetch_max_open_loops"] == 3
+    assert status["config"]["prefetch_include_non_promotable_facts"] is True
+    assert status["config"]["sync_turn_capture_enabled"] is True
+    assert status["config"]["memory_write_capture_enabled"] is True
+    assert status["legacy_config_keys"] == [
+        "auto_capture",
+        "include_non_promotable_facts",
+        "max_open_loops",
+        "max_recent_changes",
+        "mirror_memory_writes",
+        "prefetch_limit",
+    ]
+
+
+def test_bridge_status_reports_invalid_config_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    module = _load_provider_module(monkeypatch)
+    config_path = tmp_path / "alice_memory_provider.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "base_url": "http://example.com",
+                "user_id": "not-a-uuid",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    provider = module.AliceMemoryProvider()
+    status = provider.get_status(hermes_home=str(tmp_path))
+
+    assert status["ready"] is False
+    assert any("base_url:" in message for message in status["errors"])
+    assert any("user_id must be a valid UUID" in message for message in status["errors"])
+
+
+def test_sync_turn_deduplicates_repeated_callbacks_and_flushes_on_session_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_provider_module(monkeypatch)
+    provider = module.AliceMemoryProvider()
+    provider._config = {
+        "sync_turn_capture_enabled": True,
+        "session_end_flush_timeout_seconds": 5.0,
+    }
+
+    captured: list[str] = []
+
+    def _fake_post_capture(raw_content: str) -> None:
+        captured.append(raw_content)
+
+    monkeypatch.setattr(provider, "_post_capture", _fake_post_capture)
+
+    provider.sync_turn("Need decision", "Decision confirmed")
+    provider.sync_turn("Need decision", "Decision confirmed")
+    provider.on_session_end(session_id="session-a")
+    provider.on_session_end(session_id="session-a")
+
+    assert captured == ["User: Need decision\nAssistant: Decision confirmed"]
+
+
+def test_memory_write_deduplicates_repeated_callbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_provider_module(monkeypatch)
+    provider = module.AliceMemoryProvider()
+    provider._config = {
+        "memory_write_capture_enabled": True,
+        "session_end_flush_timeout_seconds": 5.0,
+    }
+
+    captured: list[str] = []
+
+    def _fake_post_capture(raw_content: str) -> None:
+        captured.append(raw_content)
+
+    monkeypatch.setattr(provider, "_post_capture", _fake_post_capture)
+
+    provider.on_memory_write("add", "MEMORY.md", "Use deterministic release checklist.")
+    provider.on_memory_write("add", "MEMORY.md", "Use deterministic release checklist.")
+    provider.on_session_end(session_id="session-b")
+
+    assert captured == [
+        "Hermes built-in memory update (MEMORY.md): Use deterministic release checklist."
+    ]
+
+
+def test_sync_turn_allows_same_content_after_session_flush(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_provider_module(monkeypatch)
+    provider = module.AliceMemoryProvider()
+    provider._config = {
+        "sync_turn_capture_enabled": True,
+        "session_end_flush_timeout_seconds": 5.0,
+    }
+
+    captured: list[str] = []
+
+    def _fake_post_capture(raw_content: str) -> None:
+        captured.append(raw_content)
+
+    monkeypatch.setattr(provider, "_post_capture", _fake_post_capture)
+
+    provider.sync_turn("Need decision", "Decision confirmed")
+    provider.on_session_end(session_id="session-c")
+
+    provider.sync_turn("Need decision", "Decision confirmed")
+    provider.on_session_end(session_id="session-c")
+
+    assert captured == [
+        "User: Need decision\nAssistant: Decision confirmed",
+        "User: Need decision\nAssistant: Decision confirmed",
+    ]

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -17,6 +17,7 @@ def test_mcp_tool_surface_is_adr_aligned_and_deterministic() -> None:
         "alice_recall",
         "alice_state_at",
         "alice_resume",
+        "alice_prefetch_context",
         "alice_open_loops",
         "alice_recent_decisions",
         "alice_recent_changes",


### PR DESCRIPTION
## Summary
- formalize the shipped Hermes Alice memory provider into the bridge-phase contract with normalized config, readiness reporting, deterministic lifecycle hooks, and session-end flush behavior
- add the automation-oriented MCP tool alice_prefetch_context on top of the existing continuity resumption/context assembly semantics
- update bridge docs, install flow, smoke evidence, and regression coverage without implying that B2+ candidate or review surfaces are already shipped

## Scope Notes
- extends the shipped Hermes provider rather than replacing it
- preserves legacy compatibility keys: prefetch_limit, max_recent_changes, max_open_loops, include_non_promotable_facts, auto_capture, mirror_memory_writes
- does not add candidate extraction, review queue, commit policy, or new channel surfaces

## Verification
- python3 scripts/check_control_doc_truth.py
- ./.venv/bin/python -m pytest tests/unit tests/integration -q
- ./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py

## Upgrade Overview
### Protected Areas
- [x] continuity APIs
- [ ] memory schema
- [ ] trust rules

### Compatibility Impact
This is an additive bridge-phase contract hardening for the existing Hermes provider and MCP surface. Existing Hermes tools alice_recall, alice_resumption_brief, and alice_open_loops remain intact while alice_prefetch_context is added as the first automation-oriented prefetch surface.

### Migration / Rollout
Deploy the updated API and Hermes provider files together so the documented bridge config keys, lifecycle hooks, smoke validation, and MCP tool registration stay aligned. Legacy config keys remain supported for compatibility.

### Operator Action
Re-run the Hermes provider smoke flow, verify bridge readiness/status output, and confirm the provider advertises deterministic support for prefetch, queue_prefetch, sync_turn, and on_session_end. Validate alice_prefetch_context alongside the existing Hermes MCP tools.

### Validation
Branch-local verification passed:
- python3 scripts/check_control_doc_truth.py -> PASS
- ./.venv/bin/python -m pytest tests/unit tests/integration -q -> 1174 passed in 186.28s (0:03:06)
- ./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py -> PASS

### Rollback
Revert the squash merge commit to restore the prior Hermes provider contract and MCP surface, then re-run the Hermes smoke and integration suite before redeploying.