### PR TITLE
B2: ship Hermes auto-capture pipeline

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,9 +32,11 @@ This keeps Alice continuity semantics centralized while adding Hermes-native aut
 Implemented in B1:
 - `alice_prefetch_context`
 
-Planned for B2+ (not shipped in B1):
+Implemented in B2:
 - `alice_capture_candidates`
 - `alice_commit_captures`
+
+Planned for B3+:
 - `alice_session_flush`
 - `alice_review_queue`
 - `alice_review_apply`
@@ -46,17 +48,17 @@ Planned for B2+ (not shipped in B1):
 3. Alice returns compact continuity payload (summary, relevant memories, open loops, recent decisions/changes, optional resume brief, trust posture).
 4. Provider injects payload into Hermes context before model response.
 
-### Flow 2: Post-response Candidate Extraction (planned B2+)
+### Flow 2: Post-response Candidate Extraction (implemented in B2)
 1. Hermes emits assistant response.
 2. Provider sends user/assistant turn pair to `alice_capture_candidates`.
 3. Alice returns typed candidates with confidence, trust class, proposed action, evidence snippet, and target object type.
 
-### Flow 3: Post-response Commit (planned B2+)
+### Flow 3: Post-response Commit (implemented in B2)
 1. In `assist`/`auto`, provider submits candidates to `alice_commit_captures`.
 2. Policy gates auto-save vs review queue using type allowlist + confidence threshold.
 3. Writes are idempotent across repeated sync attempts.
 
-### Flow 4: Session-End Flush (planned B2+)
+### Flow 4: Session-End Flush (planned B3+)
 1. On session end, provider calls `alice_session_flush`.
 2. Alice performs dedupe merge, contradiction checks, open-loop normalization, summary refresh, and review queue updates.
 

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,73 +1,83 @@
 # BUILD_REPORT
 
 ## sprint objective
-Implement Bridge Sprint 1 (`B1`) Hermes provider contract foundation by extending the shipped provider with bridge-phase config normalization, deterministic lifecycle hooks (`prefetch`, `queue_prefetch`, `sync_turn`, `on_session_end`), provider status/readiness validation, and the new automation-oriented MCP prefetch surface `alice_prefetch_context`.
+Implement Bridge Sprint 2 (`B2`) auto-capture pipeline on top of the shipped Hermes provider and B1 contract foundation: candidate extraction, commit policy, mode support (`manual`, `assist`, `auto`), review-queue persistence for non-auto-saved items, and deterministic idempotent/no-op behavior.
 
 ## completed work
-- Extended (not replaced) the shipped Hermes Alice provider with bridge contract behavior:
-  - normalized canonical bridge config keys for lifecycle operation
-  - preserved legacy config-key compatibility
-  - added provider status/readiness reporting without live network dependency
-  - added deterministic session-end flush behavior
-  - added duplicate-write suppression for repeated `sync_turn` and `on_memory_write` callback execution
-  - fixed capture-queue worker start race and bounded dedupe behavior to avoid suppressing valid later repeats
-- Added MCP tool `alice_prefetch_context` with deterministic prefetch text assembled from existing continuity resumption semantics.
-- Updated smoke script to emit provider bridge status/lifecycle readiness evidence.
-- Updated install and integration docs for bridge contract keys, lifecycle mapping, compatibility keys, and MCP tool surface.
-- Added/updated unit and integration coverage for:
-  - provider config compatibility and invalid-config status
-  - deterministic lifecycle dedupe/flush behavior
-  - MCP tool surface stability including `alice_prefetch_context`
-- Aligned control-doc truth checks and active control docs to the current bridge-phase baseline.
-- Clarified architecture docs so B2+ capture/review surfaces are marked as planned (not shipped in B1).
-
-Legacy compatibility keys preserved:
-- `prefetch_limit`
-- `max_recent_changes`
-- `max_open_loops`
-- `include_non_promotable_facts`
-- `auto_capture`
-- `mirror_memory_writes`
+- Added B2 capture pipeline core in Alice continuity:
+  - implemented `alice_capture_candidates` extraction from user/assistant turn pairs
+  - implemented `alice_commit_captures` commit policy over extracted candidates
+  - implemented candidate classes: `decision`, `commitment`, `waiting_for`, `blocker`, `preference`, `correction`, `note`, `no_op`
+  - candidate payloads now include confidence, trust class, evidence snippet, and proposed action
+- Implemented commit policy operating modes:
+  - `manual`: routes non-`no_op` candidates to review persistence
+  - `assist`: auto-saves only explicit high-confidence allowlist candidates
+  - `auto`: auto-saves allowlist candidates at the auto-mode confidence gate
+- Implemented policy allowlist and review routing evidence:
+  - auto-save allowlist categories: `correction`, `preference`, `decision`, `commitment`, `waiting_for`, `blocker`
+  - review-routed categories by type policy: `note`
+  - additionally, low-confidence or policy-disallowed candidates route to review under mode gates
+- Added idempotent commit behavior using commit fingerprint + candidate fingerprint lookup to prevent duplicate writes on repeated sync attempts.
+- Added no-op protection so no-op turns (`no_op`) produce no memory writes.
+- Wired new HTTP surfaces:
+  - `POST /v0/continuity/captures/candidates`
+  - `POST /v0/continuity/captures/commit`
+- Wired new MCP surfaces:
+  - `alice_capture_candidates`
+  - `alice_commit_captures`
+  - preserved existing `alice_capture` and other shipped tools for fallback/manual workflows
+- Wired Hermes provider B2 flow in `sync_turn`:
+  - `assist`/`auto` modes now run candidate extraction then commit
+  - `manual` mode suppresses automatic `sync_turn` capture
+  - fallback to legacy `/v0/continuity/captures` path when B2 endpoints are unavailable
+  - preserved dedupe queue and session-end flush behavior
+- Updated sprint-scoped integration docs and smoke script for B2 mode/pipeline truth.
+- Updated control-doc truth checker markers from B1-active to B2-active so required verification reflects active sprint state.
 
 ## incomplete work
-- No code deliverable remains incomplete in B1 scope.
+- None in B2 packet scope.
 
 ## files changed
 - `ARCHITECTURE.md`
 - `BUILD_REPORT.md`
 - `PRODUCT_BRIEF.md`
 - `README.md`
+- `REVIEW_REPORT.md`
 - `ROADMAP.md`
-- `RULES.md`
-- `docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py`
+- `apps/api/src/alicebot_api/continuity_capture.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/main.py`
 - `apps/api/src/alicebot_api/mcp_tools.py`
+- `apps/api/src/alicebot_api/store.py`
+- `docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py`
 - `docs/integrations/hermes-memory-provider.md`
 - `docs/integrations/mcp.md`
-- `scripts/check_control_doc_truth.py`
-- `scripts/install_hermes_alice_memory_provider.py`
 - `scripts/run_hermes_memory_provider_smoke.py`
-- `tests/unit/test_hermes_memory_provider.py`
+- `scripts/check_control_doc_truth.py`
+- `tests/unit/test_continuity_capture.py`
+- `tests/integration/test_continuity_capture_api.py`
 - `tests/unit/test_mcp.py`
-- `tests/integration/test_mcp_server.py`
+- `tests/unit/test_hermes_memory_provider.py`
 
 ## tests run
 1. `python3 scripts/check_control_doc_truth.py`
    - Result: PASS
-   - Output: `Control-doc truth check: PASS`
+   - Output summary: verified README, ROADMAP, sprint packet, RULES, current state, archive planning marker
 2. `./.venv/bin/python -m pytest tests/unit tests/integration -q`
    - Result: PASS
-   - Output: `1174 passed in 186.28s (0:03:06)`
+   - Output: `1188 passed in 191.85s (0:03:11)`
 3. `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py`
    - Result: PASS
    - Output summary:
      - single external provider enforcement validated
-     - provider registered with expected tool set
-     - `structural.bridge_status.ready=true`
-     - `structural.bridge_status.errors=[]`
-     - lifecycle hooks status present for `prefetch`, `queue_prefetch`, `sync_turn`, `on_session_end`
+     - provider registered with expected tool schemas
+     - `bridge_contract_version` reported as `bridge_b2`
+     - bridge status `ready=true`, `errors=[]`
+     - config includes `bridge_mode=assist`
+     - lifecycle hooks report `prefetch`, `queue_prefetch`, `sync_turn`, `on_session_end`, and `bridge_mode`
 
 ## blockers/issues
 - None.
 
 ## recommended next step
-Proceed with reviewer re-check against B1 acceptance criteria using this updated evidence set.
+Run B2 review against acceptance criteria with focus on policy calibration (confidence thresholds) and confirm desired `auto`-mode aggressiveness before promoting B3 review actions.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -70,7 +70,7 @@ Review-required:
 - low-confidence extractions
 
 ## Active Sprint Status
-Bridge Sprint 1 (`B1`) is now the active execution sprint. It is limited to provider-contract foundation work on top of the shipped Hermes provider surface.
+Bridge Sprint 2 (`B2`) is now the active execution sprint. It is limited to the auto-capture pipeline on top of the shipped Hermes provider surface and the `B1` contract foundation.
 
 ## Known Gaps To Resolve Before Build
 - Candidate scoring rubric and confidence calibration method are not specified.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Phase 11 is complete and shipped:
 - `P11-S6` Model Packs Tier 2 + Launch Clarity Assets is shipped
 - `P11-R1` Provider Runtime Hardening is shipped
 - A bridge phase is now active: Hermes Auto-Capture
-- `B1` Hermes Provider Contract Foundation is the active sprint
+- `B1` Hermes Provider Contract Foundation is shipped
+- `B2` Auto-Capture Pipeline is the active sprint
 - Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md](docs/archive/planning/2026-04-08-context-compaction/README.md)
 
 ## Why Alice exists

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,40 +4,50 @@
 PASS
 
 ## criteria met
-- The shipped Hermes provider was extended, not replaced (`docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py`).
-- Bridge config normalization and readiness/status reporting are present, including legacy compatibility reporting.
-- Lifecycle hooks `prefetch`, `queue_prefetch`, `sync_turn`, and `on_session_end` are implemented with deterministic behavior, and duplicate callback suppression is covered.
-- New MCP tool `alice_prefetch_context` is implemented, wired, and documented (`apps/api/src/alicebot_api/mcp_tools.py`, `docs/integrations/mcp.md`).
-- Existing Hermes tools (`alice_recall`, `alice_resumption_brief`, `alice_open_loops`) remain intact.
-- B1 required verification commands all pass:
-  - `python3 scripts/check_control_doc_truth.py` -> PASS
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> `1174 passed in 186.28s (0:03:06)`
-  - `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py` -> PASS
-- No local identifiers were found in changed code/docs after fixes.
+- `alice_capture_candidates` is implemented and wired through API and MCP.
+- `alice_commit_captures` is implemented and wired through API and MCP.
+- Commit operating modes are implemented and exercised: `manual`, `assist`, `auto`.
+- Candidate classes required by B2 are present: `decision`, `commitment`, `waiting_for`, `blocker`, `preference`, `correction`, `note`, `no_op`.
+- Candidate outputs include confidence, trust class, evidence snippet, and proposed action.
+- Auto-save allowlist categories are explicit and implemented: `correction`, `preference`, `decision`, `commitment`, `waiting_for`, `blocker`.
+- Review-routed category by type policy is explicit and implemented: `note`.
+- Low-confidence/policy-gated candidates route to review persistence rather than auto-save.
+- No-op turns produce no memory writes.
+- Repeated sync attempts are idempotent via `(sync_fingerprint, candidate_id)` duplicate guard.
+- Hermes provider uses the B2 pipeline in `assist`/`auto`, preserves `manual` behavior, and keeps legacy fallback.
+- B2 docs/code do not claim `alice_review_queue` or `alice_review_apply` as shipped.
+- Previously flagged gaps are fixed:
+  - explicit `auto` mode tests added
+  - strict boolean validation for candidate `explicit` added
+  - `ARCHITECTURE.md` bridge status updated to reflect B2 implementation
+- Local identifier hygiene check on changed files passed (no local machine paths/usernames leaked in changed code/docs/reports).
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking quality issues found after fixes.
-- Minor residual note: callback dedupe now uses a short bounded window; if callback replay behavior changes materially in Hermes, this window may need retuning.
+- No blocking quality issues found in B2 scope after fixes.
 
 ## regression risks
-- Low.
-- Primary risk area remains concurrent lifecycle callback timing; current unit coverage and full suite pass reduce risk materially.
+- Moderate-low risk in policy calibration (confidence thresholds), but implementation behavior is deterministic and covered by unit/integration tests.
+- Idempotency/no-op regressions are specifically covered.
 
 ## docs issues
-- Previously identified doc/report inconsistencies were corrected:
-  - architecture now marks B2+ surfaces as planned
-  - build report file list and command results are aligned with current state
-- Local identifier hygiene: PASS.
+- None blocking.
+- Bridge status documentation is now aligned with B2 implementation state.
 
 ## should anything be added to RULES.md?
-- Optional improvement: add a permanent rule that sprint reports must match `git diff --name-only` for the sprint-owned file list.
+- No required change.
 
 ## should anything update ARCHITECTURE.md?
-- No further update required for B1 acceptance after current “Implemented in B1” vs “Planned for B2+” separation.
+- Completed in this fix pass: B2 surfaces and runtime flow status markers were updated from planned to implemented where applicable.
 
 ## recommended next action
-1. Approve B1 for merge review.
-2. Carry the new capture-queue/dedupe tests forward as required regression coverage for future bridge sprints.
+1. Approve B2 for merge.
+2. Start B3 review-action scope (`alice_review_queue`, `alice_review_apply`) using B2 persisted review items as baseline fixtures.
+
+## evidence summary
+- Required verification commands (re-run):
+  - `python3 scripts/check_control_doc_truth.py` -> PASS
+  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> `1188 passed in 191.85s (0:03:11)`
+  - `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py` -> PASS

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@
 Phase 11 remains baseline truth and is not future scope.
 
 ## Active Planning Status
-- Bridge Sprint 1 (`B1`) is the active execution sprint.
+- Bridge Sprint 2 (`B2`) is the active execution sprint.
 - The remaining bridge-phase milestones are planned but not yet promoted.
 
 ## Bridge Phase: Hermes Auto-Capture (Planned)

--- a/apps/api/src/alicebot_api/continuity_capture.py
+++ b/apps/api/src/alicebot_api/continuity_capture.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import dataclass
 from uuid import UUID
@@ -10,16 +11,28 @@ from alicebot_api.continuity_objects import (
     list_continuity_objects_for_capture_events,
 )
 from alicebot_api.contracts import (
+    CONTINUITY_CAPTURE_ASSIST_AUTOSAVE_TYPES,
+    CONTINUITY_CAPTURE_CANDIDATE_TYPES,
+    CONTINUITY_CAPTURE_COMMIT_MODES,
     CONTINUITY_CAPTURE_EXPLICIT_SIGNALS,
     CONTINUITY_CAPTURE_LIST_ORDER,
+    CONTINUITY_CAPTURE_REVIEW_REQUIRED_TYPES,
     DEFAULT_CONTINUITY_CAPTURE_LIMIT,
     MAX_CONTINUITY_CAPTURE_LIMIT,
+    ContinuityCaptureCandidateRecord,
+    ContinuityCaptureCandidatesInput,
+    ContinuityCaptureCandidatesResponse,
+    ContinuityCaptureCommitInput,
+    ContinuityCaptureCommitRecord,
+    ContinuityCaptureCommitResponse,
+    ContinuityCaptureCommitSummary,
     ContinuityCaptureCreateInput,
     ContinuityCaptureCreateResponse,
     ContinuityCaptureDetailResponse,
     ContinuityCaptureEventRecord,
     ContinuityCaptureInboxItem,
     ContinuityCaptureInboxResponse,
+    MemoryTrustClass,
 )
 from alicebot_api.store import ContinuityCaptureEventRow, ContinuityStore, JsonObject
 
@@ -37,6 +50,19 @@ class DerivedObjectDecision:
     object_type: str
     normalized_text: str
     confidence: float
+    admission_reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractedCandidate:
+    candidate_type: str
+    object_type: str | None
+    normalized_text: str
+    confidence: float
+    trust_class: MemoryTrustClass
+    evidence_snippet: str
+    explicit: bool
+    source_role: str
     admission_reason: str
 
 
@@ -63,6 +89,74 @@ _HIGH_CONFIDENCE_PREFIXES: tuple[tuple[str, str, str], ...] = (
     ("fact:", "MemoryFact", "high_confidence_prefix_fact"),
     ("note:", "Note", "high_confidence_prefix_note"),
 )
+
+_CANDIDATE_PREFIX_RULES: tuple[tuple[str, str, str | None, str], ...] = (
+    ("decision:", "decision", "Decision", "explicit_prefix_decision"),
+    ("commitment:", "commitment", "Commitment", "explicit_prefix_commitment"),
+    ("waiting for:", "waiting_for", "WaitingFor", "explicit_prefix_waiting_for"),
+    ("waiting on:", "waiting_for", "WaitingFor", "explicit_prefix_waiting_for"),
+    ("blocker:", "blocker", "Blocker", "explicit_prefix_blocker"),
+    ("preference:", "preference", "MemoryFact", "explicit_prefix_preference"),
+    ("correction:", "correction", "Note", "explicit_prefix_correction"),
+    ("correct:", "correction", "Note", "explicit_prefix_correction"),
+    ("note:", "note", "Note", "explicit_prefix_note"),
+)
+
+_CANDIDATE_REGEX_RULES: tuple[tuple[re.Pattern[str], str, str | None, str, float], ...] = (
+    (
+        re.compile(r"\b(i prefer|i like|i don't like|remember that i prefer)\b", re.IGNORECASE),
+        "preference",
+        "MemoryFact",
+        "explicit_phrase_preference",
+        0.9,
+    ),
+    (
+        re.compile(r"\b(decision|we decided|i decided|decided that)\b", re.IGNORECASE),
+        "decision",
+        "Decision",
+        "explicit_phrase_decision",
+        0.9,
+    ),
+    (
+        re.compile(r"\b(i will|we will|i'll|we'll|i need to|remind me to)\b", re.IGNORECASE),
+        "commitment",
+        "Commitment",
+        "explicit_phrase_commitment",
+        0.9,
+    ),
+    (
+        re.compile(r"\b(waiting for|waiting on|awaiting)\b", re.IGNORECASE),
+        "waiting_for",
+        "WaitingFor",
+        "explicit_phrase_waiting_for",
+        0.86,
+    ),
+    (
+        re.compile(r"\b(blocked|blocker|cannot proceed|can't proceed)\b", re.IGNORECASE),
+        "blocker",
+        "Blocker",
+        "explicit_phrase_blocker",
+        0.86,
+    ),
+    (
+        re.compile(r"\b(correction|actually|instead|update)\b", re.IGNORECASE),
+        "correction",
+        "Note",
+        "explicit_phrase_correction",
+        0.9,
+    ),
+)
+
+_ACK_ONLY_TURNS: set[str] = {
+    "ok",
+    "okay",
+    "thanks",
+    "thank you",
+    "sounds good",
+    "great",
+    "got it",
+    "understood",
+}
 
 
 def _normalize_content(raw_content: str) -> str:
@@ -179,6 +273,460 @@ def _validate_capture_limit(limit: int) -> None:
         raise ContinuityCaptureValidationError(
             f"limit must be between 1 and {MAX_CONTINUITY_CAPTURE_LIMIT}"
         )
+
+
+def _candidate_id(*, candidate_type: str, normalized_text: str, source_role: str) -> str:
+    encoded = f"{candidate_type}|{normalized_text}|{source_role}".encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _derive_trust_class(*, explicit: bool, confidence: float) -> MemoryTrustClass:
+    if explicit and confidence >= 0.9:
+        return "deterministic"
+    if confidence >= 0.85:
+        return "llm_corroborated"
+    return "llm_single_source"
+
+
+def _build_candidate_record(candidate: ExtractedCandidate) -> ContinuityCaptureCandidateRecord:
+    candidate_id = _candidate_id(
+        candidate_type=candidate.candidate_type,
+        normalized_text=candidate.normalized_text,
+        source_role=candidate.source_role,
+    )
+    if candidate.candidate_type == "no_op":
+        proposed_action = "no_op"
+    elif (
+        candidate.explicit
+        and candidate.candidate_type in CONTINUITY_CAPTURE_ASSIST_AUTOSAVE_TYPES
+        and candidate.confidence >= 0.9
+    ):
+        proposed_action = "auto_save_candidate"
+    else:
+        proposed_action = "queue_for_review"
+
+    return {
+        "candidate_id": candidate_id,
+        "candidate_type": candidate.candidate_type,
+        "object_type": candidate.object_type,
+        "normalized_text": candidate.normalized_text,
+        "confidence": candidate.confidence,
+        "trust_class": candidate.trust_class,
+        "evidence_snippet": candidate.evidence_snippet,
+        "explicit": candidate.explicit,
+        "source_role": candidate.source_role,
+        "admission_reason": candidate.admission_reason,
+        "proposed_action": proposed_action,
+    }
+
+
+def _extract_from_role(*, text: str, source_role: str) -> ExtractedCandidate | None:
+    normalized = _normalize_content(text)
+    if normalized == "":
+        return None
+
+    lowered = normalized.casefold()
+    for prefix, candidate_type, object_type, reason in _CANDIDATE_PREFIX_RULES:
+        if not lowered.startswith(prefix):
+            continue
+        stripped = _normalize_content(normalized[len(prefix) :])
+        if stripped == "":
+            return None
+        confidence = 0.98
+        return ExtractedCandidate(
+            candidate_type=candidate_type,
+            object_type=object_type,
+            normalized_text=stripped,
+            confidence=confidence,
+            trust_class=_derive_trust_class(explicit=True, confidence=confidence),
+            evidence_snippet=_truncate(stripped, max_length=220),
+            explicit=True,
+            source_role=source_role,
+            admission_reason=reason,
+        )
+
+    for pattern, candidate_type, object_type, reason, confidence in _CANDIDATE_REGEX_RULES:
+        match = pattern.search(normalized)
+        if match is None:
+            continue
+        return ExtractedCandidate(
+            candidate_type=candidate_type,
+            object_type=object_type,
+            normalized_text=normalized,
+            confidence=confidence,
+            trust_class=_derive_trust_class(explicit=True, confidence=confidence),
+            evidence_snippet=_truncate(match.group(0), max_length=220),
+            explicit=True,
+            source_role=source_role,
+            admission_reason=reason,
+        )
+
+    return None
+
+
+def _is_ack_only_turn(*, user_text: str, assistant_text: str) -> bool:
+    normalized_user = _normalize_content(user_text).casefold()
+    normalized_assistant = _normalize_content(assistant_text).casefold()
+    if normalized_user == "" and normalized_assistant == "":
+        return True
+    if normalized_user in _ACK_ONLY_TURNS and normalized_assistant in _ACK_ONLY_TURNS:
+        return True
+    if normalized_user == "" and normalized_assistant in _ACK_ONLY_TURNS:
+        return True
+    if normalized_assistant == "" and normalized_user in _ACK_ONLY_TURNS:
+        return True
+    return False
+
+
+def _no_op_candidate(*, user_text: str, assistant_text: str) -> ContinuityCaptureCandidateRecord:
+    evidence = _normalize_content(" ".join(part for part in [user_text, assistant_text] if part))
+    candidate = ExtractedCandidate(
+        candidate_type="no_op",
+        object_type=None,
+        normalized_text="",
+        confidence=1.0,
+        trust_class="deterministic",
+        evidence_snippet=_truncate(evidence, max_length=220),
+        explicit=False,
+        source_role="combined",
+        admission_reason="turn_no_actionable_capture",
+    )
+    return _build_candidate_record(candidate)
+
+
+def _object_type_for_candidate(candidate_type: str, object_type: str | None) -> str:
+    if object_type is not None:
+        return object_type
+
+    fallback_map = {
+        "decision": "Decision",
+        "commitment": "Commitment",
+        "waiting_for": "WaitingFor",
+        "blocker": "Blocker",
+        "preference": "MemoryFact",
+        "correction": "Note",
+        "note": "Note",
+    }
+    return fallback_map.get(candidate_type, "Note")
+
+
+def _explicit_signal_for_candidate(candidate_type: str) -> str | None:
+    signal_map = {
+        "decision": "decision",
+        "commitment": "commitment",
+        "waiting_for": "waiting_for",
+        "blocker": "blocker",
+        "preference": "remember_this",
+        "correction": "note",
+        "note": "note",
+    }
+    return signal_map.get(candidate_type)
+
+
+def _body_for_candidate(*, candidate: ContinuityCaptureCandidateRecord, object_type: str) -> JsonObject:
+    normalized_text = candidate["normalized_text"]
+    candidate_type = candidate["candidate_type"]
+
+    if object_type == "Decision":
+        key = "decision_text"
+    elif object_type == "Commitment":
+        key = "commitment_text"
+    elif object_type == "WaitingFor":
+        key = "waiting_for_text"
+    elif object_type == "Blocker":
+        key = "blocking_reason"
+    elif object_type == "NextAction":
+        key = "action_text"
+    elif object_type == "MemoryFact":
+        key = "fact_text"
+    else:
+        key = "body"
+
+    payload: JsonObject = {
+        key: normalized_text,
+        "candidate_type": candidate_type,
+        "explicit": candidate["explicit"],
+        "evidence_snippet": candidate["evidence_snippet"],
+    }
+    if candidate_type == "correction":
+        payload["correction_text"] = normalized_text
+    if candidate_type == "preference":
+        payload["preference_text"] = normalized_text
+    return payload
+
+
+def _normalize_commit_mode(mode: str) -> str:
+    normalized = mode.strip().lower()
+    if normalized not in CONTINUITY_CAPTURE_COMMIT_MODES:
+        allowed = ", ".join(CONTINUITY_CAPTURE_COMMIT_MODES)
+        raise ContinuityCaptureValidationError(f"mode must be one of: {allowed}")
+    return normalized
+
+
+def _normalize_candidate(payload: JsonObject) -> ContinuityCaptureCandidateRecord:
+    candidate_type = str(payload.get("candidate_type", "")).strip().lower()
+    if candidate_type not in CONTINUITY_CAPTURE_CANDIDATE_TYPES:
+        allowed = ", ".join(CONTINUITY_CAPTURE_CANDIDATE_TYPES)
+        raise ContinuityCaptureValidationError(f"candidate_type must be one of: {allowed}")
+
+    raw_object_type = payload.get("object_type")
+    if raw_object_type is None:
+        object_type: str | None = None
+    elif isinstance(raw_object_type, str) and raw_object_type.strip() != "":
+        object_type = raw_object_type.strip()
+    else:
+        raise ContinuityCaptureValidationError("object_type must be a string when provided")
+
+    normalized_text = _normalize_content(str(payload.get("normalized_text", "")))
+    if candidate_type != "no_op" and normalized_text == "":
+        raise ContinuityCaptureValidationError("normalized_text must not be empty for non-no-op candidates")
+
+    raw_confidence = payload.get("confidence", 0.0)
+    if isinstance(raw_confidence, bool):
+        raise ContinuityCaptureValidationError("confidence must be a number")
+    try:
+        confidence = float(raw_confidence)
+    except (TypeError, ValueError) as exc:
+        raise ContinuityCaptureValidationError("confidence must be a number") from exc
+    if confidence < 0.0 or confidence > 1.0:
+        raise ContinuityCaptureValidationError("confidence must be between 0.0 and 1.0")
+
+    raw_explicit = payload.get("explicit", False)
+    if not isinstance(raw_explicit, bool):
+        raise ContinuityCaptureValidationError("explicit must be a boolean")
+    explicit = raw_explicit
+    source_role = _normalize_content(str(payload.get("source_role", "combined"))) or "combined"
+    admission_reason = _normalize_content(str(payload.get("admission_reason", "derived_candidate")))
+    evidence_snippet = _normalize_content(str(payload.get("evidence_snippet", normalized_text)))
+
+    candidate = ExtractedCandidate(
+        candidate_type=candidate_type,
+        object_type=object_type,
+        normalized_text=normalized_text,
+        confidence=confidence,
+        trust_class=_derive_trust_class(explicit=explicit, confidence=confidence),
+        evidence_snippet=evidence_snippet,
+        explicit=explicit,
+        source_role=source_role,
+        admission_reason=admission_reason,
+    )
+    return _build_candidate_record(candidate)
+
+
+def _resolve_commit_decision(
+    *,
+    candidate: ContinuityCaptureCandidateRecord,
+    mode: str,
+) -> tuple[str, str, str]:
+    candidate_type = candidate["candidate_type"]
+    confidence = candidate["confidence"]
+    explicit = candidate["explicit"]
+
+    if candidate_type == "no_op":
+        return "no_op", "no_actionable_candidate", "none"
+
+    if mode == "manual":
+        return "queued_for_review", "manual_mode_requires_review", "review_queue"
+
+    if candidate_type in CONTINUITY_CAPTURE_REVIEW_REQUIRED_TYPES:
+        return "queued_for_review", "type_requires_review", "review_queue"
+
+    if mode == "assist":
+        if (
+            candidate_type in CONTINUITY_CAPTURE_ASSIST_AUTOSAVE_TYPES
+            and explicit
+            and confidence >= 0.9
+        ):
+            return "auto_saved", "assist_mode_allowlist_explicit_high_confidence", "continuity_objects"
+        return "queued_for_review", "assist_mode_review_gate", "review_queue"
+
+    if mode == "auto":
+        if candidate_type in CONTINUITY_CAPTURE_ASSIST_AUTOSAVE_TYPES and confidence >= 0.85:
+            return "auto_saved", "auto_mode_allowlist_high_confidence", "continuity_objects"
+        return "queued_for_review", "auto_mode_review_gate", "review_queue"
+
+    return "queued_for_review", "unsupported_mode_review_fallback", "review_queue"
+
+
+def capture_continuity_candidates(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: ContinuityCaptureCandidatesInput,
+) -> ContinuityCaptureCandidatesResponse:
+    del store, user_id
+
+    user_text = _normalize_content(request.user_content)
+    assistant_text = _normalize_content(request.assistant_content)
+
+    candidates: list[ContinuityCaptureCandidateRecord] = []
+    seen_keys: set[tuple[str, str]] = set()
+
+    for source_role, text in (("user", user_text), ("assistant", assistant_text)):
+        extracted = _extract_from_role(text=text, source_role=source_role)
+        if extracted is None:
+            continue
+        key = (extracted.candidate_type, extracted.normalized_text)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        candidates.append(_build_candidate_record(extracted))
+
+    if not candidates:
+        candidates = [_no_op_candidate(user_text=user_text, assistant_text=assistant_text)]
+    elif _is_ack_only_turn(user_text=user_text, assistant_text=assistant_text):
+        candidates = [_no_op_candidate(user_text=user_text, assistant_text=assistant_text)]
+
+    summary = {
+        "candidate_count": len(candidates),
+        "explicit_count": sum(1 for candidate in candidates if candidate["explicit"]),
+        "high_confidence_count": sum(1 for candidate in candidates if candidate["confidence"] >= 0.9),
+        "no_op_count": sum(1 for candidate in candidates if candidate["candidate_type"] == "no_op"),
+    }
+
+    return {
+        "candidates": candidates,
+        "summary": summary,
+    }
+
+
+def commit_continuity_captures(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: ContinuityCaptureCommitInput,
+) -> ContinuityCaptureCommitResponse:
+    mode = _normalize_commit_mode(request.mode)
+
+    normalized_sync_fingerprint = _normalize_content(request.sync_fingerprint or "")
+    commits: list[ContinuityCaptureCommitRecord] = []
+    auto_saved_types: set[str] = set()
+    review_queued_types: set[str] = set()
+
+    auto_saved_count = 0
+    review_queued_count = 0
+    noop_count = 0
+    duplicate_noop_count = 0
+
+    normalized_candidates = [_normalize_candidate(candidate) for candidate in request.candidates]
+
+    for candidate in normalized_candidates:
+        sync_fingerprint = normalized_sync_fingerprint or f"candidate:{candidate['candidate_id']}"
+
+        if candidate["candidate_type"] != "no_op":
+            existing_row = store.get_continuity_object_by_commit_fingerprint_optional(
+                sync_fingerprint=sync_fingerprint,
+                candidate_id=candidate["candidate_id"],
+            )
+            if existing_row is not None:
+                existing_object = get_continuity_object_for_capture_event(
+                    store,
+                    user_id=user_id,
+                    capture_event_id=existing_row["capture_event_id"],
+                )
+                commits.append(
+                    {
+                        "candidate_id": candidate["candidate_id"],
+                        "candidate_type": candidate["candidate_type"],
+                        "decision": "duplicate_noop",
+                        "reason": "idempotent_sync_duplicate",
+                        "persistence_target": "none",
+                        "capture_event": None,
+                        "continuity_object": existing_object,
+                    }
+                )
+                duplicate_noop_count += 1
+                continue
+
+        decision, reason, persistence_target = _resolve_commit_decision(candidate=candidate, mode=mode)
+
+        if decision == "no_op":
+            commits.append(
+                {
+                    "candidate_id": candidate["candidate_id"],
+                    "candidate_type": candidate["candidate_type"],
+                    "decision": "no_op",
+                    "reason": reason,
+                    "persistence_target": "none",
+                    "capture_event": None,
+                    "continuity_object": None,
+                }
+            )
+            noop_count += 1
+            continue
+
+        object_type = _object_type_for_candidate(candidate["candidate_type"], candidate["object_type"])
+        explicit_signal = _explicit_signal_for_candidate(candidate["candidate_type"])
+        admission_posture = "DERIVED" if decision == "auto_saved" else "TRIAGE"
+
+        capture_event_row = store.create_continuity_capture_event(
+            raw_content=candidate["normalized_text"],
+            explicit_signal=explicit_signal,
+            admission_posture=admission_posture,
+            admission_reason=_truncate(candidate["admission_reason"], max_length=200),
+        )
+        serialized_capture = _serialize_capture_event(capture_event_row)
+
+        provenance: JsonObject = {
+            "capture_event_id": str(capture_event_row["id"]),
+            "source_kind": "continuity_capture_candidate",
+            "candidate_id": candidate["candidate_id"],
+            "candidate_type": candidate["candidate_type"],
+            "sync_fingerprint": sync_fingerprint,
+            "commit_mode": mode,
+            "commit_decision": decision,
+            "admission_reason": candidate["admission_reason"],
+            "explicit": candidate["explicit"],
+            "trust_class": candidate["trust_class"],
+            "evidence_snippet": candidate["evidence_snippet"],
+        }
+
+        continuity_object = create_continuity_object_record(
+            store,
+            user_id=user_id,
+            capture_event_id=capture_event_row["id"],
+            object_type=object_type,
+            status="active" if decision == "auto_saved" else "stale",
+            title=_title_for_object_type(object_type, candidate["normalized_text"]),
+            body=_body_for_candidate(candidate=candidate, object_type=object_type),
+            provenance=provenance,
+            confidence=candidate["confidence"],
+        )
+
+        if decision == "auto_saved":
+            auto_saved_count += 1
+            auto_saved_types.add(candidate["candidate_type"])
+        else:
+            review_queued_count += 1
+            review_queued_types.add(candidate["candidate_type"])
+
+        commits.append(
+            {
+                "candidate_id": candidate["candidate_id"],
+                "candidate_type": candidate["candidate_type"],
+                "decision": decision,
+                "reason": reason,
+                "persistence_target": persistence_target,
+                "capture_event": serialized_capture,
+                "continuity_object": continuity_object,
+            }
+        )
+
+    summary: ContinuityCaptureCommitSummary = {
+        "mode": mode,  # type: ignore[typeddict-item]
+        "candidate_count": len(normalized_candidates),
+        "auto_saved_count": auto_saved_count,
+        "review_queued_count": review_queued_count,
+        "noop_count": noop_count,
+        "duplicate_noop_count": duplicate_noop_count,
+        "auto_saved_types": sorted(auto_saved_types),
+        "review_queued_types": sorted(review_queued_types),
+    }
+
+    return {
+        "commits": commits,
+        "summary": summary,
+    }
 
 
 def capture_continuity_input(
@@ -331,7 +879,9 @@ def get_continuity_capture_detail(
 __all__ = [
     "ContinuityCaptureNotFoundError",
     "ContinuityCaptureValidationError",
+    "capture_continuity_candidates",
     "capture_continuity_input",
+    "commit_continuity_captures",
     "get_continuity_capture_detail",
     "list_continuity_capture_inbox",
 ]

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -239,6 +239,24 @@ ContinuityCaptureExplicitSignal = Literal[
     "note",
 ]
 ContinuityCaptureAdmissionPosture = Literal["DERIVED", "TRIAGE"]
+ContinuityCaptureCandidateType = Literal[
+    "decision",
+    "commitment",
+    "waiting_for",
+    "blocker",
+    "preference",
+    "correction",
+    "note",
+    "no_op",
+]
+ContinuityCaptureCommitMode = Literal["manual", "assist", "auto"]
+ContinuityCaptureCommitDecision = Literal[
+    "auto_saved",
+    "queued_for_review",
+    "no_op",
+    "duplicate_noop",
+]
+ContinuityCaptureProposedAction = Literal["auto_save_candidate", "queue_for_review", "no_op"]
 ContinuityRecallScopeKind = Literal["thread", "task", "project", "person"]
 ContinuityCorrectionAction = Literal["confirm", "edit", "delete", "supersede", "mark_stale"]
 ContinuityReviewStatus = Literal["active", "stale", "superseded", "deleted"]
@@ -763,6 +781,26 @@ CONTINUITY_CAPTURE_EXPLICIT_SIGNALS = [
     "next_action",
     "note",
 ]
+CONTINUITY_CAPTURE_CANDIDATE_TYPES = [
+    "decision",
+    "commitment",
+    "waiting_for",
+    "blocker",
+    "preference",
+    "correction",
+    "note",
+    "no_op",
+]
+CONTINUITY_CAPTURE_COMMIT_MODES = ["manual", "assist", "auto"]
+CONTINUITY_CAPTURE_ASSIST_AUTOSAVE_TYPES = [
+    "correction",
+    "preference",
+    "decision",
+    "commitment",
+    "waiting_for",
+    "blocker",
+]
+CONTINUITY_CAPTURE_REVIEW_REQUIRED_TYPES = ["note"]
 CONTINUITY_CORRECTION_ACTIONS = [
     "confirm",
     "edit",
@@ -1790,6 +1828,38 @@ class ContinuityCaptureCreateInput:
 
 
 @dataclass(frozen=True, slots=True)
+class ContinuityCaptureCandidatesInput:
+    user_content: str
+    assistant_content: str
+    session_id: str | None = None
+    source_kind: str = "sync_turn"
+
+    def as_payload(self) -> JsonObject:
+        return {
+            "user_content": self.user_content,
+            "assistant_content": self.assistant_content,
+            "session_id": self.session_id,
+            "source_kind": self.source_kind,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuityCaptureCommitInput:
+    mode: ContinuityCaptureCommitMode = "assist"
+    candidates: list[JsonObject] = field(default_factory=list)
+    sync_fingerprint: str | None = None
+    source_kind: str = "sync_turn"
+
+    def as_payload(self) -> JsonObject:
+        return {
+            "mode": self.mode,
+            "candidates": self.candidates,
+            "sync_fingerprint": self.sync_fingerprint,
+            "source_kind": self.source_kind,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class ContinuityReviewQueueQueryInput:
     status: ContinuityReviewStatusFilter = "correction_ready"
     limit: int = DEFAULT_CONTINUITY_REVIEW_LIMIT
@@ -2674,6 +2744,58 @@ class ContinuityCaptureEventRecord(TypedDict):
     admission_posture: ContinuityCaptureAdmissionPosture
     admission_reason: str
     created_at: str
+
+
+class ContinuityCaptureCandidateRecord(TypedDict):
+    candidate_id: str
+    candidate_type: ContinuityCaptureCandidateType
+    object_type: ContinuityObjectType | None
+    normalized_text: str
+    confidence: float
+    trust_class: MemoryTrustClass
+    evidence_snippet: str
+    explicit: bool
+    source_role: str
+    admission_reason: str
+    proposed_action: ContinuityCaptureProposedAction
+
+
+class ContinuityCaptureCandidatesSummary(TypedDict):
+    candidate_count: int
+    explicit_count: int
+    high_confidence_count: int
+    no_op_count: int
+
+
+class ContinuityCaptureCandidatesResponse(TypedDict):
+    candidates: list[ContinuityCaptureCandidateRecord]
+    summary: ContinuityCaptureCandidatesSummary
+
+
+class ContinuityCaptureCommitRecord(TypedDict):
+    candidate_id: str
+    candidate_type: ContinuityCaptureCandidateType
+    decision: ContinuityCaptureCommitDecision
+    reason: str
+    persistence_target: str
+    capture_event: ContinuityCaptureEventRecord | None
+    continuity_object: ContinuityObjectRecord | None
+
+
+class ContinuityCaptureCommitSummary(TypedDict):
+    mode: ContinuityCaptureCommitMode
+    candidate_count: int
+    auto_saved_count: int
+    review_queued_count: int
+    noop_count: int
+    duplicate_noop_count: int
+    auto_saved_types: list[str]
+    review_queued_types: list[str]
+
+
+class ContinuityCaptureCommitResponse(TypedDict):
+    commits: list[ContinuityCaptureCommitRecord]
+    summary: ContinuityCaptureCommitSummary
 
 
 class ContinuityLifecycleStateRecord(TypedDict):

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -93,6 +93,8 @@ from alicebot_api.contracts import (
     MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
     ContextCompilerLimits,
     ContinuityArtifactDetailResponse,
+    ContinuityCaptureCandidatesInput,
+    ContinuityCaptureCommitInput,
     ContinuityCaptureCreateInput,
     ContinuityExplainResponse,
     ContinuityLifecycleDetailResponse,
@@ -372,7 +374,9 @@ from alicebot_api.explicit_signal_capture import (
 from alicebot_api.continuity_capture import (
     ContinuityCaptureNotFoundError,
     ContinuityCaptureValidationError,
+    capture_continuity_candidates,
     capture_continuity_input,
+    commit_continuity_captures,
     get_continuity_capture_detail,
     list_continuity_capture_inbox,
 )
@@ -1043,6 +1047,22 @@ class ContinuityCaptureRequest(BaseModel):
     user_id: UUID
     raw_content: str = Field(min_length=1, max_length=4000)
     explicit_signal: str | None = Field(default=None, min_length=1, max_length=100)
+
+
+class ContinuityCaptureCandidatesRequest(BaseModel):
+    user_id: UUID
+    user_content: str = Field(default="", max_length=4000)
+    assistant_content: str = Field(default="", max_length=4000)
+    session_id: str | None = Field(default=None, min_length=1, max_length=200)
+    source_kind: str = Field(default="sync_turn", min_length=1, max_length=80)
+
+
+class ContinuityCaptureCommitRequest(BaseModel):
+    user_id: UUID
+    mode: str = Field(default="assist", min_length=1, max_length=20)
+    candidates: list[dict[str, object]] = Field(default_factory=list)
+    sync_fingerprint: str | None = Field(default=None, min_length=1, max_length=200)
+    source_kind: str = Field(default="sync_turn", min_length=1, max_length=80)
 
 
 class ContinuityCorrectionRequest(BaseModel):
@@ -4702,6 +4722,56 @@ def create_continuity_capture(request: ContinuityCaptureRequest) -> JSONResponse
 
     return JSONResponse(
         status_code=201,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.post("/v0/continuity/captures/candidates")
+def create_continuity_capture_candidates(request: ContinuityCaptureCandidatesRequest) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            payload = capture_continuity_candidates(
+                ContinuityStore(conn),
+                user_id=request.user_id,
+                request=ContinuityCaptureCandidatesInput(
+                    user_content=request.user_content,
+                    assistant_content=request.assistant_content,
+                    session_id=request.session_id,
+                    source_kind=request.source_kind,
+                ),
+            )
+    except ContinuityCaptureValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.post("/v0/continuity/captures/commit")
+def commit_continuity_capture_candidates(request: ContinuityCaptureCommitRequest) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            payload = commit_continuity_captures(
+                ContinuityStore(conn),
+                user_id=request.user_id,
+                request=ContinuityCaptureCommitInput(
+                    mode=request.mode,  # type: ignore[arg-type]
+                    candidates=request.candidates,
+                    sync_fingerprint=request.sync_fingerprint,
+                    source_kind=request.source_kind,
+                ),
+            )
+    except (ContinuityCaptureValidationError, ContinuityObjectValidationError) as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
         content=jsonable_encoder(payload),
     )
 

--- a/apps/api/src/alicebot_api/mcp_tools.py
+++ b/apps/api/src/alicebot_api/mcp_tools.py
@@ -8,7 +8,9 @@ from uuid import UUID
 
 from alicebot_api.continuity_capture import (
     ContinuityCaptureValidationError,
+    capture_continuity_candidates,
     capture_continuity_input,
+    commit_continuity_captures,
 )
 from alicebot_api.continuity_evidence import (
     ContinuityEvidenceNotFoundError,
@@ -35,6 +37,7 @@ from alicebot_api.continuity_review import (
     list_continuity_review_queue,
 )
 from alicebot_api.contracts import (
+    CONTINUITY_CAPTURE_COMMIT_MODES,
     CONTINUITY_CAPTURE_EXPLICIT_SIGNALS,
     CONTINUITY_CORRECTION_ACTIONS,
     CONTINUITY_REVIEW_QUEUE_ORDER,
@@ -51,6 +54,8 @@ from alicebot_api.contracts import (
     MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
     MAX_CONTINUITY_REVIEW_LIMIT,
     MAX_TEMPORAL_TIMELINE_LIMIT,
+    ContinuityCaptureCandidatesInput,
+    ContinuityCaptureCommitInput,
     ContinuityCaptureCreateInput,
     ContinuityCorrectionInput,
     ContinuityOpenLoopDashboardQueryInput,
@@ -337,6 +342,53 @@ def _handle_alice_capture(context: MCPRuntimeContext, arguments: Mapping[str, ob
             request=ContinuityCaptureCreateInput(
                 raw_content=_parse_required_text(arguments, "raw_content"),
                 explicit_signal=explicit_signal,
+            ),
+        )
+
+
+def _handle_alice_capture_candidates(
+    context: MCPRuntimeContext,
+    arguments: Mapping[str, object],
+) -> JsonObject:
+    with _store_context(context) as store:
+        return capture_continuity_candidates(
+            store,
+            user_id=context.user_id,
+            request=ContinuityCaptureCandidatesInput(
+                user_content=_parse_optional_text(arguments, "user_content") or "",
+                assistant_content=_parse_optional_text(arguments, "assistant_content") or "",
+                session_id=_parse_optional_text(arguments, "session_id"),
+                source_kind=_parse_optional_text(arguments, "source_kind") or "sync_turn",
+            ),
+        )
+
+
+def _handle_alice_commit_captures(
+    context: MCPRuntimeContext,
+    arguments: Mapping[str, object],
+) -> JsonObject:
+    raw_mode = _parse_optional_text(arguments, "mode") or "assist"
+    mode = raw_mode.lower()
+    if mode not in CONTINUITY_CAPTURE_COMMIT_MODES:
+        allowed = ", ".join(CONTINUITY_CAPTURE_COMMIT_MODES)
+        raise MCPToolError(f"mode must be one of: {allowed}")
+
+    raw_candidates = arguments.get("candidates", [])
+    if not isinstance(raw_candidates, list):
+        raise MCPToolError("candidates must be a JSON array")
+    for item in raw_candidates:
+        if not isinstance(item, dict):
+            raise MCPToolError("each candidate must be a JSON object")
+
+    with _store_context(context) as store:
+        return commit_continuity_captures(
+            store,
+            user_id=context.user_id,
+            request=ContinuityCaptureCommitInput(
+                mode=mode,  # type: ignore[arg-type]
+                candidates=list(raw_candidates),
+                sync_fingerprint=_parse_optional_text(arguments, "sync_fingerprint"),
+                source_kind=_parse_optional_text(arguments, "source_kind") or "sync_turn",
             ),
         )
 
@@ -787,6 +839,37 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
         },
     },
     {
+        "name": "alice_capture_candidates",
+        "description": "Extract continuity candidates from one user/assistant turn without writing memory.",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "user_content": {"type": "string"},
+                "assistant_content": {"type": "string"},
+                "session_id": {"type": "string"},
+                "source_kind": {"type": "string"},
+            },
+        },
+    },
+    {
+        "name": "alice_commit_captures",
+        "description": "Commit extracted continuity candidates using manual/assist/auto bridge policy.",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "mode": {"type": "string", "enum": list(CONTINUITY_CAPTURE_COMMIT_MODES)},
+                "sync_fingerprint": {"type": "string"},
+                "source_kind": {"type": "string"},
+                "candidates": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                },
+            },
+        },
+    },
+    {
         "name": "alice_recall",
         "description": "Recall continuity objects with deterministic ranking and provenance fields.",
         "inputSchema": {
@@ -1044,6 +1127,8 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
 
 _TOOL_HANDLERS = {
     "alice_capture": _handle_alice_capture,
+    "alice_capture_candidates": _handle_alice_capture_candidates,
+    "alice_commit_captures": _handle_alice_commit_captures,
     "alice_recall": _handle_alice_recall,
     "alice_state_at": _handle_alice_state_at,
     "alice_resume": _handle_alice_resume,

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -4829,6 +4829,32 @@ GET_CONTINUITY_OBJECT_SQL = """
                 WHERE id = %s
                 """
 
+GET_CONTINUITY_OBJECT_BY_COMMIT_FINGERPRINT_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  capture_event_id,
+                  object_type,
+                  status,
+                  is_preserved,
+                  is_searchable,
+                  is_promotable,
+                  title,
+                  body,
+                  provenance,
+                  confidence,
+                  last_confirmed_at,
+                  supersedes_object_id,
+                  superseded_by_object_id,
+                  created_at,
+                  updated_at
+                FROM continuity_objects
+                WHERE provenance ->> 'sync_fingerprint' = %s
+                  AND provenance ->> 'candidate_id' = %s
+                ORDER BY created_at DESC, id DESC
+                LIMIT 1
+                """
+
 LIST_CONTINUITY_OBJECTS_FOR_CAPTURE_EVENTS_SQL = """
                 SELECT
                   id,
@@ -5995,6 +6021,17 @@ class ContinuityStore:
         return self._fetch_optional_one(
             GET_CONTINUITY_OBJECT_SQL,
             (continuity_object_id,),
+        )
+
+    def get_continuity_object_by_commit_fingerprint_optional(
+        self,
+        *,
+        sync_fingerprint: str,
+        candidate_id: str,
+    ) -> ContinuityObjectRow | None:
+        return self._fetch_optional_one(
+            GET_CONTINUITY_OBJECT_BY_COMMIT_FINGERPRINT_SQL,
+            (sync_fingerprint, candidate_id),
         )
 
     def list_continuity_review_queue(

--- a/docs/integrations/hermes-memory-provider.md
+++ b/docs/integrations/hermes-memory-provider.md
@@ -16,6 +16,8 @@ Hermes behavior with this provider:
 - prefetch: turn-start context assembled from Alice resumption brief
 - bridge-phase lifecycle contract for `prefetch`, `queue_prefetch`, `sync_turn`, and `on_session_end`
 - deterministic capture dedupe for repeated callback execution
+- B2 auto-capture pipeline for `sync_turn`: `alice_capture_candidates` then `alice_commit_captures`
+- capture mode policy support: `manual`, `assist` (default), `auto`
 - local status readiness reporting without live network calls
 
 ## Continuity Model Mapping
@@ -26,8 +28,8 @@ The provider maps Alice continuity responses into Hermes provider hooks:
 |---|---|---|
 | `prefetch(query)` | `GET /v0/continuity/resumption-brief` | renders last decision, next action, open loops, and recent changes into ephemeral context |
 | `queue_prefetch(query)` | `GET /v0/continuity/resumption-brief` | asynchronously prebuilds pre-turn context cache for next `prefetch` |
-| `sync_turn(user, assistant)` | `POST /v0/continuity/captures` | optional post-turn capture hook with duplicate-write suppression |
-| `on_session_end()` | `POST /v0/continuity/captures` | deterministic flush of pending capture work before provider shutdown |
+| `sync_turn(user, assistant)` | `POST /v0/continuity/captures/candidates` + `POST /v0/continuity/captures/commit` | post-turn extraction/commit pipeline with mode policy and duplicate-write suppression |
+| `on_session_end()` | same as queued `sync_turn` pipeline work | deterministic flush of pending capture/commit work before provider shutdown |
 | `alice_recall` tool | `GET /v0/continuity/recall` | returns ranked continuity objects with provenance and scope filters |
 | `alice_resumption_brief` tool | `GET /v0/continuity/resumption-brief` | returns structured resume sections for deterministic follow-through |
 | `alice_open_loops` tool | `GET /v0/continuity/open-loops` | returns waiting/blocker/stale/next-action open-loop groups |
@@ -145,6 +147,7 @@ Practical default:
 - `prefetch_include_non_promotable_facts` (bool)
 - `sync_turn_capture_enabled` (bool, default `false`)
 - `memory_write_capture_enabled` (bool, default `false`)
+- `bridge_mode` (string enum: `manual`, `assist`, `auto`; default `assist`)
 - `session_end_flush_timeout_seconds` (float, default `5.0`)
 
 Legacy compatibility keys still accepted for shipped configs:
@@ -155,3 +158,4 @@ Legacy compatibility keys still accepted for shipped configs:
 - `include_non_promotable_facts`
 - `auto_capture`
 - `mirror_memory_writes`
+- `capture_mode`

--- a/docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py
+++ b/docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py
@@ -39,7 +39,9 @@ _DEFAULT_MAX_OPEN_LOOPS = 5
 _DEFAULT_CAPTURE_CHAR_LIMIT = 3800
 _DEFAULT_SESSION_END_FLUSH_TIMEOUT_SECONDS = 5.0
 _CAPTURE_DEDUPE_WINDOW_SECONDS = 5.0
-_BRIDGE_CONTRACT_VERSION = "bridge_b1"
+_DEFAULT_BRIDGE_MODE = "assist"
+_BRIDGE_CAPTURE_MODES = ("manual", "assist", "auto")
+_BRIDGE_CONTRACT_VERSION = "bridge_b2"
 
 _RECALL_LIMIT_MIN = 1
 _RECALL_LIMIT_MAX = 50
@@ -58,6 +60,7 @@ _BRIDGE_CONFIG_ALIASES: Dict[str, tuple[str, ...]] = {
     "prefetch_include_non_promotable_facts": ("include_non_promotable_facts",),
     "sync_turn_capture_enabled": ("auto_capture",),
     "memory_write_capture_enabled": ("mirror_memory_writes",),
+    "bridge_mode": ("capture_mode",),
 }
 _SAFE_TOOL_ERROR_MESSAGES = (
     "internal provider error",
@@ -171,6 +174,14 @@ def _parse_float(value: Any, *, default: float, min_value: float, max_value: flo
     except (TypeError, ValueError):
         return default
     return max(min_value, min(max_value, parsed))
+
+
+def _parse_bridge_mode(value: Any, *, default: str) -> str:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _BRIDGE_CAPTURE_MODES:
+            return normalized
+    return default
 
 
 def _normalize_base_url(value: str) -> str:
@@ -296,6 +307,13 @@ def _default_config() -> Dict[str, Any]:
                 os.environ.get("ALICE_MEMORY_MIRROR_WRITES"),
             ),
             default=False,
+        ),
+        "bridge_mode": _parse_bridge_mode(
+            _first_non_empty(
+                os.environ.get("ALICE_MEMORY_BRIDGE_MODE"),
+                os.environ.get("ALICE_MEMORY_CAPTURE_MODE"),
+            ),
+            default=_DEFAULT_BRIDGE_MODE,
         ),
         "session_end_flush_timeout_seconds": _parse_float(
             os.environ.get("ALICE_MEMORY_SESSION_END_FLUSH_TIMEOUT_SECONDS"),
@@ -459,6 +477,12 @@ class AliceMemoryProvider(MemoryProvider):
                 "default": "false",
             },
             {
+                "key": "bridge_mode",
+                "description": "Bridge capture operating mode: manual, assist, or auto",
+                "choices": list(_BRIDGE_CAPTURE_MODES),
+                "default": _DEFAULT_BRIDGE_MODE,
+            },
+            {
                 "key": "session_end_flush_timeout_seconds",
                 "description": "Session-end capture flush timeout in seconds",
                 "default": str(_DEFAULT_SESSION_END_FLUSH_TIMEOUT_SECONDS),
@@ -526,6 +550,8 @@ class AliceMemoryProvider(MemoryProvider):
             return
         if self._agent_context != "primary":
             return
+        if self._config.get("bridge_mode", _DEFAULT_BRIDGE_MODE) == "manual":
+            return
 
         raw_content = self._build_turn_capture_payload(user_content, assistant_content)
         if not raw_content:
@@ -584,6 +610,7 @@ class AliceMemoryProvider(MemoryProvider):
                 "queue_prefetch": True,
                 "sync_turn": bool(config.get("sync_turn_capture_enabled", False)),
                 "on_session_end": True,
+                "bridge_mode": str(config.get("bridge_mode", _DEFAULT_BRIDGE_MODE)),
             },
             "config": config,
             "config_path": loaded["config_path"],
@@ -788,7 +815,69 @@ class AliceMemoryProvider(MemoryProvider):
                 self._capture_pending_fingerprints.discard(fingerprint)
                 self._capture_recent_fingerprints[fingerprint] = time.monotonic()
 
+    def _is_sync_turn_payload(self, raw_content: str) -> bool:
+        stripped = raw_content.strip()
+        return stripped.startswith("User:") or stripped.startswith("Assistant:")
+
+    def _split_turn_capture_payload(self, raw_content: str) -> tuple[str, str]:
+        user_text = ""
+        assistant_text = ""
+        for line in raw_content.splitlines():
+            if line.startswith("User: "):
+                user_text = line[len("User: ") :].strip()
+                continue
+            if line.startswith("Assistant: "):
+                assistant_text = line[len("Assistant: ") :].strip()
+        return user_text, assistant_text
+
+    def _post_sync_turn_capture(self, raw_content: str) -> None:
+        user_text, assistant_text = self._split_turn_capture_payload(raw_content)
+        mode = _parse_bridge_mode(
+            self._config.get("bridge_mode", _DEFAULT_BRIDGE_MODE),
+            default=_DEFAULT_BRIDGE_MODE,
+        )
+        sync_fingerprint = self._capture_fingerprint(kind="sync_turn", raw_content=raw_content)
+
+        candidates_payload = self._request_json(
+            "POST",
+            "/v0/continuity/captures/candidates",
+            payload={
+                "user_content": user_text[:_DEFAULT_CAPTURE_CHAR_LIMIT],
+                "assistant_content": assistant_text[:_DEFAULT_CAPTURE_CHAR_LIMIT],
+                "source_kind": "sync_turn",
+            },
+        )
+        candidates = candidates_payload.get("candidates")
+        if not isinstance(candidates, list):
+            raise RuntimeError("Alice API returned an invalid response payload")
+
+        self._request_json(
+            "POST",
+            "/v0/continuity/captures/commit",
+            payload={
+                "mode": mode,
+                "sync_fingerprint": sync_fingerprint,
+                "source_kind": "sync_turn",
+                "candidates": candidates,
+            },
+        )
+
     def _post_capture(self, raw_content: str) -> None:
+        if self._is_sync_turn_payload(raw_content):
+            mode = _parse_bridge_mode(
+                self._config.get("bridge_mode", _DEFAULT_BRIDGE_MODE),
+                default=_DEFAULT_BRIDGE_MODE,
+            )
+            if mode in {"assist", "auto"}:
+                try:
+                    self._post_sync_turn_capture(raw_content)
+                    return
+                except RuntimeError as exc:
+                    message = str(exc)
+                    if "HTTP status 404" not in message and "HTTP status 400" not in message:
+                        raise
+                    logger.debug("Alice bridge capture endpoints unavailable, falling back to legacy capture path")
+
         payload = {
             "raw_content": raw_content[:_DEFAULT_CAPTURE_CHAR_LIMIT],
         }
@@ -949,6 +1038,14 @@ def _load_config_dict_from_values(values: Dict[str, Any]) -> tuple[Dict[str, Any
     config["memory_write_capture_enabled"] = _parse_bool(
         memory_write_capture_value,
         default=False,
+    )
+
+    bridge_mode_value, bridge_mode_source = _resolve_config_value(values, "bridge_mode")
+    if bridge_mode_source != "bridge_mode":
+        legacy_config_keys.append(bridge_mode_source)
+    config["bridge_mode"] = _parse_bridge_mode(
+        bridge_mode_value,
+        default=_DEFAULT_BRIDGE_MODE,
     )
 
     config["session_end_flush_timeout_seconds"] = _parse_float(

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -23,6 +23,8 @@ MCP uses the same local runtime scope as CLI:
 ## Shipped Tool Surface
 
 - `alice_capture`
+- `alice_capture_candidates`
+- `alice_commit_captures`
 - `alice_recall`
 - `alice_state_at`
 - `alice_resume`
@@ -38,6 +40,7 @@ MCP uses the same local runtime scope as CLI:
 
 `alice_explain` now accepts either `continuity_object_id` for evidence-chain inspection or `entity_id` plus optional `at` for temporal explain output.
 `alice_prefetch_context` provides an automation-oriented pre-turn context assembly surface using the same continuity resumption semantics shipped for `alice_resume`.
+`alice_capture_candidates` and `alice_commit_captures` provide the B2 bridge auto-capture pipeline over user/assistant turns with `manual`/`assist`/`auto` commit policy support.
 
 ## Example: Claude Desktop MCP Config
 

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -20,7 +20,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "Phase 10 is complete and shipped.",
             "Phase 11 is complete and shipped:",
-            "`B1` Hermes Provider Contract Foundation is the active sprint",
+            "`B2` Auto-Capture Pipeline is the active sprint",
             "Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md]",
         ),
     ),
@@ -28,13 +28,13 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="ROADMAP.md",
         required_markers=(
             "Phase 11 remains baseline truth and is not future scope.",
-            "Bridge Sprint 1 (`B1`) is the active execution sprint.",
+            "Bridge Sprint 2 (`B2`) is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Bridge Sprint 1 (B1): Hermes Provider Contract Foundation",
+            "Bridge Sprint 2 (B2): Auto-Capture Pipeline",
             "Phase 10 is complete and shipped.",
             "Phase 11 is complete and shipped.",
         ),
@@ -52,7 +52,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
             "Phase 9 is shipped.",
             "Phase 10 is shipped.",
             "Phase 11 is shipped and remains baseline truth.",
-            "Bridge Sprint 1 (`B1`) is the active execution sprint.",
+            "Bridge Sprint 2 (`B2`) is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(

--- a/scripts/run_hermes_memory_provider_smoke.py
+++ b/scripts/run_hermes_memory_provider_smoke.py
@@ -104,6 +104,7 @@ def _run_structural_validation(provider_class: type) -> Dict[str, Any]:
                     "prefetch_include_non_promotable_facts": False,
                     "sync_turn_capture_enabled": False,
                     "memory_write_capture_enabled": False,
+                    "bridge_mode": "assist",
                     "session_end_flush_timeout_seconds": 5.0,
                 },
                 indent=2,
@@ -151,6 +152,7 @@ def _run_live_prefetch(
                     "prefetch_max_recent_changes": 3,
                     "prefetch_max_open_loops": 3,
                     "prefetch_include_non_promotable_facts": False,
+                    "bridge_mode": "assist",
                 },
                 indent=2,
             )

--- a/tests/integration/test_continuity_capture_api.py
+++ b/tests/integration/test_continuity_capture_api.py
@@ -236,3 +236,194 @@ def test_continuity_capture_rejects_invalid_signal_and_enforces_user_scope(
             "order": ["created_at_desc", "id_desc"],
         },
     }
+
+
+def test_continuity_capture_candidate_and_commit_pipeline_supports_assist_mode_autosave(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="pipeline-assist@example.com")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    candidates_status, candidates_payload = invoke_request(
+        "POST",
+        "/v0/continuity/captures/candidates",
+        payload={
+            "user_id": str(user_id),
+            "user_content": "Decision: keep provider-plus-MCP architecture",
+            "assistant_content": "Correction: default bridge mode is assist",
+        },
+    )
+    assert candidates_status == 200
+    assert candidates_payload["summary"]["candidate_count"] == 2
+    assert {item["candidate_type"] for item in candidates_payload["candidates"]} == {"decision", "correction"}
+
+    commit_status, commit_payload = invoke_request(
+        "POST",
+        "/v0/continuity/captures/commit",
+        payload={
+            "user_id": str(user_id),
+            "mode": "assist",
+            "sync_fingerprint": "sync-assist-pipeline-001",
+            "candidates": candidates_payload["candidates"],
+        },
+    )
+    assert commit_status == 200
+    assert commit_payload["summary"] == {
+        "mode": "assist",
+        "candidate_count": 2,
+        "auto_saved_count": 2,
+        "review_queued_count": 0,
+        "noop_count": 0,
+        "duplicate_noop_count": 0,
+        "auto_saved_types": ["correction", "decision"],
+        "review_queued_types": [],
+    }
+    assert all(item["decision"] == "auto_saved" for item in commit_payload["commits"])
+
+
+def test_continuity_capture_pipeline_routes_disallowed_or_low_confidence_candidates_to_review_queue(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="pipeline-review@example.com")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    candidates_status, candidates_payload = invoke_request(
+        "POST",
+        "/v0/continuity/captures/candidates",
+        payload={
+            "user_id": str(user_id),
+            "user_content": "Note: broad recap for later refinement",
+            "assistant_content": "",
+        },
+    )
+    assert candidates_status == 200
+    assert candidates_payload["candidates"][0]["candidate_type"] == "note"
+
+    commit_status, commit_payload = invoke_request(
+        "POST",
+        "/v0/continuity/captures/commit",
+        payload={
+            "user_id": str(user_id),
+            "mode": "assist",
+            "sync_fingerprint": "sync-review-pipeline-001",
+            "candidates": candidates_payload["candidates"],
+        },
+    )
+    assert commit_status == 200
+    assert commit_payload["summary"]["auto_saved_count"] == 0
+    assert commit_payload["summary"]["review_queued_count"] == 1
+    assert commit_payload["summary"]["review_queued_types"] == ["note"]
+    assert commit_payload["commits"][0]["decision"] == "queued_for_review"
+    assert commit_payload["commits"][0]["continuity_object"]["status"] == "stale"
+
+    review_status, review_payload = invoke_request(
+        "GET",
+        "/v0/continuity/review-queue",
+        query_params={"user_id": str(user_id), "status": "stale", "limit": "20"},
+    )
+    assert review_status == 200
+    assert review_payload["summary"]["returned_count"] == 1
+    assert review_payload["items"][0]["status"] == "stale"
+
+
+def test_continuity_capture_pipeline_noop_and_repeated_sync_are_write_safe(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="pipeline-noop@example.com")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    noop_candidates_status, noop_candidates_payload = invoke_request(
+        "POST",
+        "/v0/continuity/captures/candidates",
+        payload={
+            "user_id": str(user_id),
+            "user_content": "thanks",
+            "assistant_content": "ok",
+        },
+    )
+    assert noop_candidates_status == 200
+    assert noop_candidates_payload["summary"]["no_op_count"] == 1
+
+    noop_commit_status, noop_commit_payload = invoke_request(
+        "POST",
+        "/v0/continuity/captures/commit",
+        payload={
+            "user_id": str(user_id),
+            "mode": "assist",
+            "sync_fingerprint": "sync-noop-001",
+            "candidates": noop_candidates_payload["candidates"],
+        },
+    )
+    assert noop_commit_status == 200
+    assert noop_commit_payload["summary"]["noop_count"] == 1
+    assert noop_commit_payload["summary"]["auto_saved_count"] == 0
+    assert noop_commit_payload["summary"]["review_queued_count"] == 0
+
+    list_status_before, list_payload_before = invoke_request(
+        "GET",
+        "/v0/continuity/captures",
+        query_params={"user_id": str(user_id), "limit": "20"},
+    )
+    assert list_status_before == 200
+    assert list_payload_before["summary"]["total_count"] == 0
+
+    candidates_status, candidates_payload = invoke_request(
+        "POST",
+        "/v0/continuity/captures/candidates",
+        payload={
+            "user_id": str(user_id),
+            "user_content": "Decision: ship deterministic commit policy",
+            "assistant_content": "",
+        },
+    )
+    assert candidates_status == 200
+
+    first_commit_status, first_commit_payload = invoke_request(
+        "POST",
+        "/v0/continuity/captures/commit",
+        payload={
+            "user_id": str(user_id),
+            "mode": "assist",
+            "sync_fingerprint": "sync-repeat-001",
+            "candidates": candidates_payload["candidates"],
+        },
+    )
+    assert first_commit_status == 200
+    assert first_commit_payload["summary"]["auto_saved_count"] == 1
+
+    second_commit_status, second_commit_payload = invoke_request(
+        "POST",
+        "/v0/continuity/captures/commit",
+        payload={
+            "user_id": str(user_id),
+            "mode": "assist",
+            "sync_fingerprint": "sync-repeat-001",
+            "candidates": candidates_payload["candidates"],
+        },
+    )
+    assert second_commit_status == 200
+    assert second_commit_payload["summary"]["auto_saved_count"] == 0
+    assert second_commit_payload["summary"]["duplicate_noop_count"] == 1
+
+    list_status_after, list_payload_after = invoke_request(
+        "GET",
+        "/v0/continuity/captures",
+        query_params={"user_id": str(user_id), "limit": "20"},
+    )
+    assert list_status_after == 200
+    assert list_payload_after["summary"]["total_count"] == 1

--- a/tests/unit/test_continuity_capture.py
+++ b/tests/unit/test_continuity_capture.py
@@ -8,11 +8,17 @@ import pytest
 from alicebot_api.continuity_capture import (
     ContinuityCaptureNotFoundError,
     ContinuityCaptureValidationError,
+    capture_continuity_candidates,
     capture_continuity_input,
+    commit_continuity_captures,
     get_continuity_capture_detail,
     list_continuity_capture_inbox,
 )
-from alicebot_api.contracts import ContinuityCaptureCreateInput
+from alicebot_api.contracts import (
+    ContinuityCaptureCandidatesInput,
+    ContinuityCaptureCommitInput,
+    ContinuityCaptureCreateInput,
+)
 
 
 class ContinuityCaptureStoreStub:
@@ -22,6 +28,7 @@ class ContinuityCaptureStoreStub:
         self.capture_events: dict[UUID, dict[str, object]] = {}
         self.capture_event_order: list[UUID] = []
         self.objects_by_capture_event: dict[UUID, dict[str, object]] = {}
+        self.objects_by_commit_fingerprint: dict[tuple[str, str], dict[str, object]] = {}
 
     def create_continuity_capture_event(
         self,
@@ -88,10 +95,22 @@ class ContinuityCaptureStoreStub:
             "updated_at": self.base_time,
         }
         self.objects_by_capture_event[capture_event_id] = row
+        sync_fingerprint = str(provenance.get("sync_fingerprint", ""))
+        candidate_id = str(provenance.get("candidate_id", ""))
+        if sync_fingerprint and candidate_id:
+            self.objects_by_commit_fingerprint[(sync_fingerprint, candidate_id)] = row
         return row
 
     def get_continuity_object_by_capture_event_optional(self, capture_event_id: UUID):
         return self.objects_by_capture_event.get(capture_event_id)
+
+    def get_continuity_object_by_commit_fingerprint_optional(
+        self,
+        *,
+        sync_fingerprint: str,
+        candidate_id: str,
+    ):
+        return self.objects_by_commit_fingerprint.get((sync_fingerprint, candidate_id))
 
     def list_continuity_objects_for_capture_events(self, capture_event_ids: list[UUID]):
         return [
@@ -226,3 +245,234 @@ def test_continuity_capture_validation_and_not_found_contracts() -> None:
             user_id=store.user_id,
             capture_event_id=uuid4(),
         )
+
+
+def test_capture_candidates_extracts_explicit_decision_and_correction_from_turn_pair() -> None:
+    store = ContinuityCaptureStoreStub()
+
+    payload = capture_continuity_candidates(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCandidatesInput(
+            user_content="Decision: ship B2 this week",
+            assistant_content="Correction: use assist mode as default",
+        ),
+    )
+
+    assert payload["summary"]["candidate_count"] == 2
+    assert payload["summary"]["explicit_count"] == 2
+    assert {item["candidate_type"] for item in payload["candidates"]} == {"decision", "correction"}
+    assert all(item["proposed_action"] == "auto_save_candidate" for item in payload["candidates"])
+
+
+def test_capture_candidates_returns_no_op_for_ack_only_turns() -> None:
+    store = ContinuityCaptureStoreStub()
+
+    payload = capture_continuity_candidates(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCandidatesInput(
+            user_content="thanks",
+            assistant_content="ok",
+        ),
+    )
+
+    assert payload["summary"]["candidate_count"] == 1
+    assert payload["summary"]["no_op_count"] == 1
+    assert payload["candidates"][0]["candidate_type"] == "no_op"
+
+
+def test_commit_captures_assist_mode_auto_saves_explicit_decisions_and_routes_notes_to_review() -> None:
+    store = ContinuityCaptureStoreStub()
+    candidates = capture_continuity_candidates(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCandidatesInput(
+            user_content="Decision: keep release freeze",
+            assistant_content="Note: broad summary for later",
+        ),
+    )["candidates"]
+
+    payload = commit_continuity_captures(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCommitInput(
+            mode="assist",
+            sync_fingerprint="sync:assist-001",
+            candidates=candidates,  # type: ignore[arg-type]
+        ),
+    )
+
+    commits = payload["commits"]
+    assert len(commits) == 2
+    decision_commit = next(item for item in commits if item["candidate_type"] == "decision")
+    note_commit = next(item for item in commits if item["candidate_type"] == "note")
+
+    assert decision_commit["decision"] == "auto_saved"
+    assert decision_commit["continuity_object"] is not None
+    assert decision_commit["continuity_object"]["status"] == "active"
+    assert note_commit["decision"] == "queued_for_review"
+    assert note_commit["continuity_object"] is not None
+    assert note_commit["continuity_object"]["status"] == "stale"
+
+    assert payload["summary"] == {
+        "mode": "assist",
+        "candidate_count": 2,
+        "auto_saved_count": 1,
+        "review_queued_count": 1,
+        "noop_count": 0,
+        "duplicate_noop_count": 0,
+        "auto_saved_types": ["decision"],
+        "review_queued_types": ["note"],
+    }
+
+
+def test_commit_captures_manual_mode_routes_explicit_items_to_review() -> None:
+    store = ContinuityCaptureStoreStub()
+    candidates = capture_continuity_candidates(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCandidatesInput(
+            user_content="Decision: defer launch by one week",
+            assistant_content="",
+        ),
+    )["candidates"]
+
+    payload = commit_continuity_captures(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCommitInput(
+            mode="manual",
+            sync_fingerprint="sync:manual-001",
+            candidates=candidates,  # type: ignore[arg-type]
+        ),
+    )
+
+    assert payload["commits"][0]["decision"] == "queued_for_review"
+    assert payload["commits"][0]["continuity_object"]["status"] == "stale"
+    assert payload["summary"]["auto_saved_count"] == 0
+    assert payload["summary"]["review_queued_count"] == 1
+
+
+def test_commit_captures_auto_mode_autosaves_allowlist_candidates_above_threshold() -> None:
+    store = ContinuityCaptureStoreStub()
+    payload = commit_continuity_captures(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCommitInput(
+            mode="auto",
+            sync_fingerprint="sync:auto-001",
+            candidates=[
+                {
+                    "candidate_type": "waiting_for",
+                    "object_type": "WaitingFor",
+                    "normalized_text": "waiting on release approval",
+                    "confidence": 0.86,
+                    "explicit": False,
+                    "source_role": "assistant",
+                    "admission_reason": "derived_waiting_for",
+                    "evidence_snippet": "waiting on release approval",
+                }
+            ],
+        ),
+    )
+
+    assert payload["commits"][0]["decision"] == "auto_saved"
+    assert payload["commits"][0]["continuity_object"] is not None
+    assert payload["commits"][0]["continuity_object"]["status"] == "active"
+    assert payload["summary"]["auto_saved_count"] == 1
+    assert payload["summary"]["review_queued_count"] == 0
+    assert payload["summary"]["auto_saved_types"] == ["waiting_for"]
+
+
+def test_commit_captures_auto_mode_routes_below_threshold_candidates_to_review() -> None:
+    store = ContinuityCaptureStoreStub()
+    payload = commit_continuity_captures(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCommitInput(
+            mode="auto",
+            sync_fingerprint="sync:auto-002",
+            candidates=[
+                {
+                    "candidate_type": "decision",
+                    "object_type": "Decision",
+                    "normalized_text": "ship the bridge now",
+                    "confidence": 0.84,
+                    "explicit": True,
+                    "source_role": "user",
+                    "admission_reason": "explicit_prefix_decision",
+                    "evidence_snippet": "ship the bridge now",
+                }
+            ],
+        ),
+    )
+
+    assert payload["commits"][0]["decision"] == "queued_for_review"
+    assert payload["commits"][0]["continuity_object"] is not None
+    assert payload["commits"][0]["continuity_object"]["status"] == "stale"
+    assert payload["summary"]["auto_saved_count"] == 0
+    assert payload["summary"]["review_queued_count"] == 1
+    assert payload["summary"]["review_queued_types"] == ["decision"]
+
+
+def test_commit_captures_rejects_non_boolean_explicit_values() -> None:
+    store = ContinuityCaptureStoreStub()
+
+    with pytest.raises(ContinuityCaptureValidationError, match="explicit must be a boolean"):
+        commit_continuity_captures(
+            store,  # type: ignore[arg-type]
+            user_id=store.user_id,
+            request=ContinuityCaptureCommitInput(
+                mode="assist",
+                sync_fingerprint="sync:explicit-validation-001",
+                candidates=[
+                    {
+                        "candidate_type": "decision",
+                        "object_type": "Decision",
+                        "normalized_text": "ship after review",
+                        "confidence": 0.95,
+                        "explicit": "true",
+                        "source_role": "user",
+                        "admission_reason": "explicit_prefix_decision",
+                        "evidence_snippet": "ship after review",
+                    }
+                ],
+            ),
+        )
+
+
+def test_commit_captures_is_idempotent_for_repeated_sync_attempts() -> None:
+    store = ContinuityCaptureStoreStub()
+    candidates = capture_continuity_candidates(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCandidatesInput(
+            user_content="Decision: freeze scope for bridge sprint",
+            assistant_content="",
+        ),
+    )["candidates"]
+
+    first = commit_continuity_captures(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCommitInput(
+            mode="assist",
+            sync_fingerprint="sync:repeat-001",
+            candidates=candidates,  # type: ignore[arg-type]
+        ),
+    )
+    second = commit_continuity_captures(
+        store,  # type: ignore[arg-type]
+        user_id=store.user_id,
+        request=ContinuityCaptureCommitInput(
+            mode="assist",
+            sync_fingerprint="sync:repeat-001",
+            candidates=candidates,  # type: ignore[arg-type]
+        ),
+    )
+
+    assert first["summary"]["auto_saved_count"] == 1
+    assert second["summary"]["auto_saved_count"] == 0
+    assert second["summary"]["duplicate_noop_count"] == 1
+    assert second["commits"][0]["decision"] == "duplicate_noop"

--- a/tests/unit/test_hermes_memory_provider.py
+++ b/tests/unit/test_hermes_memory_provider.py
@@ -172,6 +172,7 @@ def test_bridge_status_reports_legacy_config_compatibility(
                 "include_non_promotable_facts": True,
                 "auto_capture": True,
                 "mirror_memory_writes": True,
+                "capture_mode": "auto",
             },
             indent=2,
         )
@@ -190,8 +191,10 @@ def test_bridge_status_reports_legacy_config_compatibility(
     assert status["config"]["prefetch_include_non_promotable_facts"] is True
     assert status["config"]["sync_turn_capture_enabled"] is True
     assert status["config"]["memory_write_capture_enabled"] is True
+    assert status["config"]["bridge_mode"] == "auto"
     assert status["legacy_config_keys"] == [
         "auto_capture",
+        "capture_mode",
         "include_non_promotable_facts",
         "max_open_loops",
         "max_recent_changes",
@@ -297,3 +300,96 @@ def test_sync_turn_allows_same_content_after_session_flush(monkeypatch: pytest.M
         "User: Need decision\nAssistant: Decision confirmed",
         "User: Need decision\nAssistant: Decision confirmed",
     ]
+
+
+def test_sync_turn_skips_capture_in_manual_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_provider_module(monkeypatch)
+    provider = module.AliceMemoryProvider()
+    provider._config = {
+        "sync_turn_capture_enabled": True,
+        "bridge_mode": "manual",
+        "session_end_flush_timeout_seconds": 5.0,
+    }
+
+    captured: list[str] = []
+
+    def _fake_post_capture(raw_content: str) -> None:
+        captured.append(raw_content)
+
+    monkeypatch.setattr(provider, "_post_capture", _fake_post_capture)
+
+    provider.sync_turn("Decision: keep scope tight", "Confirmed")
+    provider.on_session_end(session_id="session-manual")
+
+    assert captured == []
+
+
+def test_post_capture_uses_b2_candidate_commit_pipeline_for_sync_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_provider_module(monkeypatch)
+    provider = module.AliceMemoryProvider()
+    provider._config = {
+        "bridge_mode": "assist",
+    }
+
+    requests: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def _fake_request_json(method: str, path: str, *, params=None, payload=None):  # type: ignore[no-untyped-def]
+        del params
+        requests.append((method, path, payload))
+        if path == "/v0/continuity/captures/candidates":
+            return {
+                "candidates": [
+                    {
+                        "candidate_id": "cand-1",
+                        "candidate_type": "decision",
+                        "object_type": "Decision",
+                        "normalized_text": "Keep scope tight",
+                        "confidence": 0.98,
+                        "trust_class": "deterministic",
+                        "evidence_snippet": "Decision",
+                        "explicit": True,
+                        "source_role": "user",
+                        "admission_reason": "explicit_prefix_decision",
+                        "proposed_action": "auto_save_candidate",
+                    }
+                ]
+            }
+        return {"ok": True}
+
+    monkeypatch.setattr(provider, "_request_json", _fake_request_json)
+
+    provider._post_capture("User: Decision: Keep scope tight\nAssistant: Confirmed")
+
+    assert requests[0][0:2] == ("POST", "/v0/continuity/captures/candidates")
+    assert requests[1][0:2] == ("POST", "/v0/continuity/captures/commit")
+    assert requests[1][2] is not None
+    assert requests[1][2]["mode"] == "assist"
+    assert requests[1][2]["source_kind"] == "sync_turn"
+    assert isinstance(requests[1][2]["sync_fingerprint"], str)
+    assert requests[1][2]["sync_fingerprint"].startswith("sync_turn:")
+
+
+def test_post_capture_falls_back_to_legacy_endpoint_when_b2_endpoints_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_provider_module(monkeypatch)
+    provider = module.AliceMemoryProvider()
+    provider._config = {
+        "bridge_mode": "assist",
+    }
+
+    requests: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def _fake_request_json(method: str, path: str, *, params=None, payload=None):  # type: ignore[no-untyped-def]
+        del params
+        requests.append((method, path, payload))
+        if path == "/v0/continuity/captures/candidates":
+            raise RuntimeError("Alice API request failed with HTTP status 404")
+        return {"ok": True}
+
+    monkeypatch.setattr(provider, "_request_json", _fake_request_json)
+
+    provider._post_capture("User: Decision: Keep scope tight\nAssistant: Confirmed")
+
+    assert requests[0][1] == "/v0/continuity/captures/candidates"
+    assert requests[1][1] == "/v0/continuity/captures"

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -14,6 +14,8 @@ def test_mcp_tool_surface_is_adr_aligned_and_deterministic() -> None:
     names = [tool["name"] for tool in tools]
     assert names == [
         "alice_capture",
+        "alice_capture_candidates",
+        "alice_commit_captures",
         "alice_recall",
         "alice_state_at",
         "alice_resume",


### PR DESCRIPTION
## Summary
- add the B2 auto-capture pipeline on top of the shipped Hermes provider and B1 contract foundation with alice_capture_candidates and alice_commit_captures
- implement operating modes manual, assist, and auto, plus deterministic idempotent and no-op behavior for repeated sync attempts
- persist non-auto-saved candidates for later review while preserving legacy fallback and existing Hermes provider architecture

## Scope Notes
- auto-save allowlist categories: correction, preference, decision, commitment, waiting_for, blocker
- type-routed review category: note
- low-confidence or policy-disallowed candidates route to review rather than auto-save
- does not claim alice_review_queue or alice_review_apply as shipped in B2

## Verification
- python3 scripts/check_control_doc_truth.py
- ./.venv/bin/python -m pytest tests/unit tests/integration -q
- ./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py

## Upgrade Overview
### Protected Areas
- [x] continuity APIs
- [x] memory schema
- [x] trust rules
- [x] evidence pipeline

### Compatibility Impact
This extends the existing Hermes bridge flow with capture extraction and commit policy while preserving the shipped provider, MCP fallback, and continuity semantics. Existing Hermes tools remain intact, and the new B2 capture surfaces layer on top of the existing continuity capture seam rather than replacing it.

### Migration / Rollout
Deploy the Alice API and Hermes provider changes together so the B2 HTTP and MCP capture surfaces, commit policy logic, and provider sync behavior stay aligned. No review-action expansion is included in this sprint, so downstream consumers should keep using persisted review items as passive outputs only.

### Operator Action
Validate the B2 operating modes manual, assist, and auto with the Hermes smoke flow. Confirm the auto-save allowlist categories correction, preference, decision, commitment, waiting_for, and blocker, and confirm note plus low-confidence candidates route to review persistence rather than memory writes.

### Validation
Branch-local verification passed:
- python3 scripts/check_control_doc_truth.py -> PASS
- ./.venv/bin/python -m pytest tests/unit tests/integration -q -> 1188 passed in 191.85s (0:03:11)
- ./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py -> PASS

### Rollback
Revert the squash merge commit to restore the pre-B2 provider and continuity behavior, then re-run the Hermes smoke and full test suite before redeploying.