### PR TITLE
B3: ship review queue and explainability

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,10 +36,12 @@ Implemented in B2:
 - `alice_capture_candidates`
 - `alice_commit_captures`
 
-Planned for B3+:
-- `alice_session_flush`
+Implemented in B3:
 - `alice_review_queue`
 - `alice_review_apply`
+
+Planned for B4+:
+- `alice_session_flush`
 
 ## Runtime Flows
 ### Flow 1: Pre-turn Prefetch
@@ -58,7 +60,7 @@ Planned for B3+:
 2. Policy gates auto-save vs review queue using type allowlist + confidence threshold.
 3. Writes are idempotent across repeated sync attempts.
 
-### Flow 4: Session-End Flush (planned B3+)
+### Flow 4: Session-End Flush (planned B4+)
 1. On session end, provider calls `alice_session_flush`.
 2. Alice performs dedupe merge, contradiction checks, open-loop normalization, summary refresh, and review queue updates.
 

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,83 +1,68 @@
 # BUILD_REPORT
 
 ## sprint objective
-Implement Bridge Sprint 2 (`B2`) auto-capture pipeline on top of the shipped Hermes provider and B1 contract foundation: candidate extraction, commit policy, mode support (`manual`, `assist`, `auto`), review-queue persistence for non-auto-saved items, and deterministic idempotent/no-op behavior.
+Implement Bridge Sprint 3 (`B3`) review queue + explainability scope:
+- ship `alice_review_queue`
+- ship `alice_review_apply`
+- support review actions (`approve`, `reject`, `edit-and-approve`, `supersede-existing`)
+- expose explanation/provenance rationale in review surfaces
+- verify deterministic recall/resume effects after approved review actions
 
 ## completed work
-- Added B2 capture pipeline core in Alice continuity:
-  - implemented `alice_capture_candidates` extraction from user/assistant turn pairs
-  - implemented `alice_commit_captures` commit policy over extracted candidates
-  - implemented candidate classes: `decision`, `commitment`, `waiting_for`, `blocker`, `preference`, `correction`, `note`, `no_op`
-  - candidate payloads now include confidence, trust class, evidence snippet, and proposed action
-- Implemented commit policy operating modes:
-  - `manual`: routes non-`no_op` candidates to review persistence
-  - `assist`: auto-saves only explicit high-confidence allowlist candidates
-  - `auto`: auto-saves allowlist candidates at the auto-mode confidence gate
-- Implemented policy allowlist and review routing evidence:
-  - auto-save allowlist categories: `correction`, `preference`, `decision`, `commitment`, `waiting_for`, `blocker`
-  - review-routed categories by type policy: `note`
-  - additionally, low-confidence or policy-disallowed candidates route to review under mode gates
-- Added idempotent commit behavior using commit fingerprint + candidate fingerprint lookup to prevent duplicate writes on repeated sync attempts.
-- Added no-op protection so no-op turns (`no_op`) produce no memory writes.
-- Wired new HTTP surfaces:
-  - `POST /v0/continuity/captures/candidates`
-  - `POST /v0/continuity/captures/commit`
-- Wired new MCP surfaces:
-  - `alice_capture_candidates`
-  - `alice_commit_captures`
-  - preserved existing `alice_capture` and other shipped tools for fallback/manual workflows
-- Wired Hermes provider B2 flow in `sync_turn`:
-  - `assist`/`auto` modes now run candidate extraction then commit
-  - `manual` mode suppresses automatic `sync_turn` capture
-  - fallback to legacy `/v0/continuity/captures` path when B2 endpoints are unavailable
-  - preserved dedupe queue and session-end flush behavior
-- Updated sprint-scoped integration docs and smoke script for B2 mode/pipeline truth.
-- Updated control-doc truth checker markers from B1-active to B2-active so required verification reflects active sprint state.
+- Added MCP tool surface `alice_review_queue` with deterministic queue/detail behavior.
+- Added MCP tool surface `alice_review_apply` with B3 action vocabulary mapped to continuity correction semantics:
+  - `approve` -> `confirm`
+  - `edit-and-approve` -> `edit`
+  - `reject` -> `delete`
+  - `supersede-existing` -> `supersede`
+- Kept `alice_memory_review` and `alice_memory_correct` as compatibility aliases.
+- Extended continuity review serialization to include shared explanation records on review objects.
+- Added deterministic `proposal_rationale` to continuity explanation output.
+- Ensured explanation chain remains shared across review, recall, and resume paths.
+- Updated B3-scoped integration docs for MCP and Hermes memory-provider guidance.
+- Updated architecture status markers so B3 review surfaces are marked implemented and only B4 follow-up remains planned.
+- Updated control-doc truth checker markers to B3 active-sprint truth.
+- Updated B3 review evidence report (`REVIEW_REPORT.md`).
+- Added/updated sprint-owned tests for:
+  - MCP tool surface and B3 names
+  - action alias mapping and deterministic correction semantics
+  - review queue explainability presence
+  - recall exclusion after reject and recall/resume updates after supersede
 
 ## incomplete work
-- None in B2 packet scope.
+- None in B3 sprint scope.
 
 ## files changed
 - `ARCHITECTURE.md`
-- `BUILD_REPORT.md`
 - `PRODUCT_BRIEF.md`
 - `README.md`
-- `REVIEW_REPORT.md`
 - `ROADMAP.md`
-- `apps/api/src/alicebot_api/continuity_capture.py`
+- `apps/api/src/alicebot_api/continuity_explainability.py`
+- `apps/api/src/alicebot_api/continuity_review.py`
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/main.py`
 - `apps/api/src/alicebot_api/mcp_tools.py`
-- `apps/api/src/alicebot_api/store.py`
-- `docs/integrations/hermes-memory-provider/plugins/memory/alice/__init__.py`
-- `docs/integrations/hermes-memory-provider.md`
 - `docs/integrations/mcp.md`
-- `scripts/run_hermes_memory_provider_smoke.py`
+- `docs/integrations/hermes-memory-provider.md`
 - `scripts/check_control_doc_truth.py`
-- `tests/unit/test_continuity_capture.py`
-- `tests/integration/test_continuity_capture_api.py`
+- `tests/unit/test_continuity_review.py`
 - `tests/unit/test_mcp.py`
-- `tests/unit/test_hermes_memory_provider.py`
+- `tests/integration/test_mcp_server.py`
+- `REVIEW_REPORT.md`
+- `BUILD_REPORT.md`
 
 ## tests run
-1. `python3 scripts/check_control_doc_truth.py`
-   - Result: PASS
-   - Output summary: verified README, ROADMAP, sprint packet, RULES, current state, archive planning marker
-2. `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-   - Result: PASS
-   - Output: `1188 passed in 191.85s (0:03:11)`
-3. `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py`
-   - Result: PASS
-   - Output summary:
-     - single external provider enforcement validated
-     - provider registered with expected tool schemas
-     - `bridge_contract_version` reported as `bridge_b2`
-     - bridge status `ready=true`, `errors=[]`
-     - config includes `bridge_mode=assist`
-     - lifecycle hooks report `prefetch`, `queue_prefetch`, `sync_turn`, `on_session_end`, and `bridge_mode`
+- `python3 scripts/check_control_doc_truth.py`
+  - Result: PASS
+- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
+  - Result: `1189 passed in 196.98s (0:03:16)` (latest re-run)
+- `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py`
+  - Result: PASS
+  - Evidence summary: single-external-provider enforcement message emitted; structural payload reports `single_external_enforced=true` and `bridge_status.ready=true`.
+  - Local filesystem-specific path fields from script output were intentionally omitted for identifier hygiene.
 
 ## blockers/issues
-- None.
+- No functional blockers.
+- No outstanding evidence or documentation blockers after alignment updates.
 
 ## recommended next step
-Run B2 review against acceptance criteria with focus on policy calibration (confidence thresholds) and confirm desired `auto`-mode aggressiveness before promoting B3 review actions.
+Proceed to Bridge Sprint 4 (`B4`) packaging/docs/smoke closeout using the now-shipped B3 review queue/apply surfaces as baseline.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -70,7 +70,7 @@ Review-required:
 - low-confidence extractions
 
 ## Active Sprint Status
-Bridge Sprint 2 (`B2`) is now the active execution sprint. It is limited to the auto-capture pipeline on top of the shipped Hermes provider surface and the `B1` contract foundation.
+Bridge Sprint 3 (`B3`) is now the active execution sprint. It is limited to review queue and explainability work on top of the shipped Hermes provider surface plus the `B1` and `B2` bridge foundations.
 
 ## Known Gaps To Resolve Before Build
 - Candidate scoring rubric and confidence calibration method are not specified.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Phase 11 is complete and shipped:
 - `P11-R1` Provider Runtime Hardening is shipped
 - A bridge phase is now active: Hermes Auto-Capture
 - `B1` Hermes Provider Contract Foundation is shipped
-- `B2` Auto-Capture Pipeline is the active sprint
+- `B2` Auto-Capture Pipeline is shipped
+- `B3` Review Queue + Explainability is the active sprint
 - Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md](docs/archive/planning/2026-04-08-context-compaction/README.md)
 
 ## Why Alice exists

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,50 +4,43 @@
 PASS
 
 ## criteria met
-- `alice_capture_candidates` is implemented and wired through API and MCP.
-- `alice_commit_captures` is implemented and wired through API and MCP.
-- Commit operating modes are implemented and exercised: `manual`, `assist`, `auto`.
-- Candidate classes required by B2 are present: `decision`, `commitment`, `waiting_for`, `blocker`, `preference`, `correction`, `note`, `no_op`.
-- Candidate outputs include confidence, trust class, evidence snippet, and proposed action.
-- Auto-save allowlist categories are explicit and implemented: `correction`, `preference`, `decision`, `commitment`, `waiting_for`, `blocker`.
-- Review-routed category by type policy is explicit and implemented: `note`.
-- Low-confidence/policy-gated candidates route to review persistence rather than auto-save.
-- No-op turns produce no memory writes.
-- Repeated sync attempts are idempotent via `(sync_fingerprint, candidate_id)` duplicate guard.
-- Hermes provider uses the B2 pipeline in `assist`/`auto`, preserves `manual` behavior, and keeps legacy fallback.
-- B2 docs/code do not claim `alice_review_queue` or `alice_review_apply` as shipped.
-- Previously flagged gaps are fixed:
-  - explicit `auto` mode tests added
-  - strict boolean validation for candidate `explicit` added
-  - `ARCHITECTURE.md` bridge status updated to reflect B2 implementation
-- Local identifier hygiene check on changed files passed (no local machine paths/usernames leaked in changed code/docs/reports).
+- `alice_review_queue` is implemented and exposed on MCP.
+- `alice_review_apply` is implemented and exposed on MCP.
+- Required B3 review actions are supported through shipped surface semantics:
+  - `approve` -> `confirm`
+  - `edit-and-approve` -> `edit`
+  - `reject` -> `delete`
+  - `supersede-existing` -> `supersede`
+- Review payloads now include explainability/provenance chain data (`source_facts`, `evidence_segments`, `trust`, `supersession_notes`, `proposal_rationale`).
+- Approved review actions deterministically affect later recall/resume behavior (validated in integration flow using supersede).
+- Rejected review items are not treated as accepted continuity state (validated by recall exclusion after reject).
+- No local identifiers (local usernames/absolute machine paths) were found in changed code/docs/reports.
 
 ## criteria missed
-- None.
+- None functionally against B3 acceptance criteria.
 
 ## quality issues
-- No blocking quality issues found in B2 scope after fixes.
+- No blocking quality issues found in B3 scope.
 
 ## regression risks
-- Moderate-low risk in policy calibration (confidence thresholds), but implementation behavior is deterministic and covered by unit/integration tests.
-- Idempotency/no-op regressions are specifically covered.
+- Low: MCP surface additions are additive, and targeted + full unit/integration suites pass.
+- Moderate-low: review queue objects now include full explanation payloads, increasing response size; monitor MCP client assumptions on payload size/shape.
 
 ## docs issues
-- None blocking.
-- Bridge status documentation is now aligned with B2 implementation state.
+- None blocking. Architecture and build evidence alignment issues are fixed.
 
 ## should anything be added to RULES.md?
 - No required change.
 
 ## should anything update ARCHITECTURE.md?
-- Completed in this fix pass: B2 surfaces and runtime flow status markers were updated from planned to implemented where applicable.
+- No additional architecture changes required for B3.
 
 ## recommended next action
-1. Approve B2 for merge.
-2. Start B3 review-action scope (`alice_review_queue`, `alice_review_apply`) using B2 persisted review items as baseline fixtures.
+1. Approve B3 for merge.
+2. Start B4 packaging/docs/demo closeout.
 
-## evidence summary
-- Required verification commands (re-run):
-  - `python3 scripts/check_control_doc_truth.py` -> PASS
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> `1188 passed in 191.85s (0:03:11)`
-  - `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py` -> PASS
+## verification evidence checked
+- `python3 scripts/check_control_doc_truth.py` -> PASS
+- `./.venv/bin/python -m pytest tests/unit/test_continuity_review.py tests/unit/test_mcp.py tests/integration/test_mcp_server.py -q` -> `13 passed`
+- `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> `1189 passed in 196.98s (0:03:16)`
+- `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py` -> PASS

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@
 Phase 11 remains baseline truth and is not future scope.
 
 ## Active Planning Status
-- Bridge Sprint 2 (`B2`) is the active execution sprint.
+- Bridge Sprint 3 (`B3`) is the active execution sprint.
 - The remaining bridge-phase milestones are planned but not yet promoted.
 
 ## Bridge Phase: Hermes Auto-Capture (Planned)

--- a/apps/api/src/alicebot_api/continuity_explainability.py
+++ b/apps/api/src/alicebot_api/continuity_explainability.py
@@ -353,6 +353,36 @@ def _trust_record(
     }
 
 
+def _proposal_rationale(
+    *,
+    status: str,
+    source_fact_count: int,
+    evidence_segment_count: int,
+    trust_class: MemoryTrustClass,
+    confirmation_status: MemoryConfirmationStatus,
+    provenance_posture: ContinuityRecallProvenancePosture,
+    correction_count: int,
+) -> str:
+    lifecycle_clause = f"Candidate entered review with lifecycle status '{status}'."
+    source_clause = (
+        f"It is backed by {source_fact_count} source fact(s) and {evidence_segment_count} evidence segment(s)."
+    )
+    trust_clause = (
+        "Trust posture resolves to "
+        f"'{trust_class}' with confirmation status '{confirmation_status}' and provenance posture "
+        f"'{provenance_posture}'."
+    )
+    correction_clause = f"Correction history includes {correction_count} event(s)."
+    return " ".join(
+        [
+            lifecycle_clause,
+            source_clause,
+            trust_clause,
+            correction_clause,
+        ]
+    )
+
+
 def _supersession_notes(
     *,
     status: str,
@@ -475,33 +505,45 @@ def build_continuity_item_explanation(
         evidence_rows=evidence_rows,
         title=title,
     )
+    source_facts = _source_facts(
+        title=title,
+        body=body,
+        provenance=provenance,
+        capture_event=capture_event,
+    )
+    trust = _trust_record(
+        confidence=confidence,
+        confirmation_status=resolved_confirmation_status,
+        provenance_posture=resolved_provenance_posture,
+        evidence_segment_count=len(evidence_segments),
+        correction_count=len(correction_events),
+        source_event_count=source_event_count,
+    )
+    supersession_notes = _supersession_notes(
+        status=status,
+        supersedes_object_id=supersedes_object_id,
+        superseded_by_object_id=superseded_by_object_id,
+        correction_events=correction_events,
+    )
     return {
-        "source_facts": _source_facts(
-            title=title,
-            body=body,
-            provenance=provenance,
-            capture_event=capture_event,
-        ),
-        "trust": _trust_record(
-            confidence=confidence,
-            confirmation_status=resolved_confirmation_status,
-            provenance_posture=resolved_provenance_posture,
-            evidence_segment_count=len(evidence_segments),
-            correction_count=len(correction_events),
-            source_event_count=source_event_count,
-        ),
+        "source_facts": source_facts,
+        "trust": trust,
         "evidence_segments": evidence_segments,
-        "supersession_notes": _supersession_notes(
-            status=status,
-            supersedes_object_id=supersedes_object_id,
-            superseded_by_object_id=superseded_by_object_id,
-            correction_events=correction_events,
-        ),
+        "supersession_notes": supersession_notes,
         "timestamps": _timestamps_record(
             created_at=created_at,
             updated_at=updated_at,
             capture_event=capture_event,
             last_confirmed_at=last_confirmed_at,
+        ),
+        "proposal_rationale": _proposal_rationale(
+            status=status,
+            source_fact_count=len(source_facts),
+            evidence_segment_count=len(evidence_segments),
+            trust_class=trust["trust_class"],
+            confirmation_status=resolved_confirmation_status,
+            provenance_posture=resolved_provenance_posture,
+            correction_count=len(correction_events),
         ),
     }
 

--- a/apps/api/src/alicebot_api/continuity_review.py
+++ b/apps/api/src/alicebot_api/continuity_review.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from uuid import UUID
 
+from alicebot_api.continuity_explainability import build_continuity_item_explanation
 from alicebot_api.continuity_objects import serialize_continuity_lifecycle_state_from_record
 from alicebot_api.contracts import (
     CONTINUITY_CORRECTION_ACTIONS,
@@ -45,6 +46,14 @@ _STATUS_FILTERS: dict[ContinuityReviewStatusFilter, list[str]] = {
     "deleted": ["deleted"],
     "all": ["active", "stale", "superseded", "deleted"],
 }
+_CORRECTION_ACTION_ALIASES: dict[str, str] = {
+    "approve": "confirm",
+    "edit-and-approve": "edit",
+    "edit_and_approve": "edit",
+    "reject": "delete",
+    "supersede-existing": "supersede",
+    "supersede_existing": "supersede",
+}
 
 
 def _utcnow() -> datetime:
@@ -75,7 +84,10 @@ def _validate_confidence(confidence: float) -> float:
     return confidence
 
 
-def _serialize_review_object(record: ContinuityObjectRow) -> ContinuityReviewObjectRecord:
+def _serialize_review_object(
+    store: ContinuityStore,
+    record: ContinuityObjectRow,
+) -> ContinuityReviewObjectRecord:
     return {
         "id": str(record["id"]),
         "capture_event_id": str(record["capture_event_id"]),
@@ -95,6 +107,21 @@ def _serialize_review_object(record: ContinuityObjectRow) -> ContinuityReviewObj
         ),
         "created_at": record["created_at"].isoformat(),
         "updated_at": record["updated_at"].isoformat(),
+        "explanation": build_continuity_item_explanation(
+            store,
+            continuity_object_id=record["id"],
+            capture_event_id=record["capture_event_id"],
+            title=record["title"],
+            body=record["body"],
+            provenance=record["provenance"],
+            status=record["status"],
+            confidence=float(record["confidence"]),
+            last_confirmed_at=record["last_confirmed_at"],
+            supersedes_object_id=record["supersedes_object_id"],
+            superseded_by_object_id=record["superseded_by_object_id"],
+            created_at=record["created_at"],
+            updated_at=record["updated_at"],
+        ),
     }
 
 
@@ -145,6 +172,13 @@ def _lookup_object_or_raise(
     return record
 
 
+def _canonicalize_action(action: str) -> str:
+    normalized = action.strip()
+    if normalized in _CORRECTION_ACTION_ALIASES:
+        return _CORRECTION_ACTION_ALIASES[normalized]
+    return normalized
+
+
 def _validate_queue_query(request: ContinuityReviewQueueQueryInput) -> list[str]:
     if request.limit < 1 or request.limit > MAX_CONTINUITY_REVIEW_LIMIT:
         raise ContinuityReviewValidationError(
@@ -171,7 +205,7 @@ def list_continuity_review_queue(
     total_count = store.count_continuity_review_queue(statuses=statuses)
 
     return {
-        "items": [_serialize_review_object(row) for row in rows],
+        "items": [_serialize_review_object(store, row) for row in rows],
         "summary": {
             "status": request.status,
             "limit": request.limit,
@@ -209,14 +243,18 @@ def get_continuity_review_detail(
     )
 
     supersession_chain: ContinuitySupersessionChain = {
-        "supersedes": None if supersedes_object is None else _serialize_review_object(supersedes_object),
+        "supersedes": (
+            None if supersedes_object is None else _serialize_review_object(store, supersedes_object)
+        ),
         "superseded_by": (
-            None if superseded_by_object is None else _serialize_review_object(superseded_by_object)
+            None
+            if superseded_by_object is None
+            else _serialize_review_object(store, superseded_by_object)
         ),
     }
 
     detail: ContinuityReviewDetail = {
-        "continuity_object": _serialize_review_object(continuity_object),
+        "continuity_object": _serialize_review_object(store, continuity_object),
         "correction_events": [_serialize_correction_event(event) for event in correction_events],
         "supersession_chain": supersession_chain,
     }
@@ -255,7 +293,7 @@ def apply_continuity_correction(
 ) -> ContinuityCorrectionApplyResponse:
     del user_id
 
-    action = request.action
+    action = _canonicalize_action(request.action)
     if action not in CONTINUITY_CORRECTION_ACTIONS:
         allowed = ", ".join(CONTINUITY_CORRECTION_ACTIONS)
         raise ContinuityReviewValidationError(f"action must be one of: {allowed}")
@@ -417,9 +455,9 @@ def apply_continuity_correction(
             raise ContinuityReviewNotFoundError(f"continuity object {continuity_object_id} was not found")
 
         return {
-            "continuity_object": _serialize_review_object(updated),
+            "continuity_object": _serialize_review_object(store, updated),
             "correction_event": _serialize_correction_event(correction_event),
-            "replacement_object": _serialize_review_object(replacement_object),
+            "replacement_object": _serialize_review_object(store, replacement_object),
         }
 
     else:
@@ -469,7 +507,7 @@ def apply_continuity_correction(
         raise ContinuityReviewNotFoundError(f"continuity object {continuity_object_id} was not found")
 
     return {
-        "continuity_object": _serialize_review_object(updated),
+        "continuity_object": _serialize_review_object(store, updated),
         "correction_event": _serialize_correction_event(correction_event),
         "replacement_object": None,
     }

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -2836,6 +2836,7 @@ class ContinuityReviewObjectRecord(TypedDict):
     superseded_by_object_id: str | None
     created_at: str
     updated_at: str
+    explanation: NotRequired["ContinuityExplanationRecord"]
 
 
 class ContinuityCorrectionEventRecord(TypedDict):
@@ -2992,6 +2993,7 @@ class ContinuityExplanationRecord(TypedDict):
     evidence_segments: list[ContinuityExplanationEvidenceSegmentRecord]
     supersession_notes: list[ContinuityExplanationSupersessionNoteRecord]
     timestamps: ContinuityExplanationTimestampsRecord
+    proposal_rationale: NotRequired[str]
 
 
 class ContinuityExplainRecord(TypedDict):

--- a/apps/api/src/alicebot_api/mcp_tools.py
+++ b/apps/api/src/alicebot_api/mcp_tools.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
+from typing import cast
 from uuid import UUID
 
 from alicebot_api.continuity_capture import (
@@ -77,7 +78,34 @@ from alicebot_api.temporal_state import (
 )
 
 
-_REVIEW_STATUS_CHOICES = ("correction_ready", "active", "stale", "superseded", "deleted", "all")
+_REVIEW_STATUS_CHOICES = (
+    "pending_review",
+    "correction_ready",
+    "active",
+    "stale",
+    "superseded",
+    "deleted",
+    "all",
+)
+_REVIEW_STATUS_ALIASES = {
+    "pending": "pending_review",
+}
+_REVIEW_APPLY_ACTION_CHOICES = (
+    "approve",
+    "edit-and-approve",
+    "reject",
+    "supersede-existing",
+)
+_REVIEW_APPLY_ACTION_ALIASES = {
+    "edit_and_approve": "edit-and-approve",
+    "supersede_existing": "supersede-existing",
+}
+_REVIEW_APPLY_TO_CORRECTION_ACTION = {
+    "approve": "confirm",
+    "edit-and-approve": "edit",
+    "reject": "delete",
+    "supersede-existing": "supersede",
+}
 _CONTEXT_PACK_ASSEMBLY_VERSION_V0 = "alice_context_pack_v0"
 _PREFETCH_CONTEXT_ASSEMBLY_VERSION_V0 = "alice_prefetch_context_v0"
 
@@ -232,6 +260,51 @@ def _parse_bool(arguments: Mapping[str, object], *, key: str, default: bool = Fa
         if normalized in {"false", "0", "no"}:
             return False
     raise MCPToolError(f"{key} must be a boolean")
+
+
+def _parse_review_status(
+    arguments: Mapping[str, object],
+    *,
+    default: str,
+) -> str:
+    raw_status = arguments.get("status", default)
+    if not isinstance(raw_status, str):
+        raise MCPToolError("status must be a string")
+    normalized = raw_status.strip()
+    if normalized in _REVIEW_STATUS_ALIASES:
+        normalized = _REVIEW_STATUS_ALIASES[normalized]
+    if normalized not in _REVIEW_STATUS_CHOICES:
+        allowed = ", ".join(_REVIEW_STATUS_CHOICES)
+        raise MCPToolError(f"status must be one of: {allowed}")
+    if normalized == "pending_review":
+        return "stale"
+    return normalized
+
+
+def _parse_review_item_id(arguments: Mapping[str, object], *, required: bool) -> UUID | None:
+    review_item_id = _parse_optional_uuid(arguments, "review_item_id")
+    continuity_object_id = _parse_optional_uuid(arguments, "continuity_object_id")
+    if review_item_id is not None and continuity_object_id is not None and review_item_id != continuity_object_id:
+        raise MCPToolError("review_item_id and continuity_object_id must match when both are provided")
+    resolved = review_item_id or continuity_object_id
+    if required and resolved is None:
+        raise MCPToolError("review_item_id or continuity_object_id is required and must be a UUID string")
+    return resolved
+
+
+def _resolve_review_apply_action(raw_action: str, *, allow_legacy: bool) -> str:
+    normalized = raw_action.strip()
+    if normalized in _REVIEW_APPLY_ACTION_ALIASES:
+        normalized = _REVIEW_APPLY_ACTION_ALIASES[normalized]
+    mapped = _REVIEW_APPLY_TO_CORRECTION_ACTION.get(normalized)
+    if mapped is not None:
+        return mapped
+    if allow_legacy and normalized in CONTINUITY_CORRECTION_ACTIONS:
+        return normalized
+    allowed = list(_REVIEW_APPLY_ACTION_CHOICES)
+    if allow_legacy:
+        allowed.extend(CONTINUITY_CORRECTION_ACTIONS)
+    raise MCPToolError(f"action must be one of: {', '.join(allowed)}")
 
 
 def _build_recall_query(arguments: Mapping[str, object], *, limit: int) -> ContinuityRecallQueryInput:
@@ -644,8 +717,13 @@ def _handle_alice_timeline(context: MCPRuntimeContext, arguments: Mapping[str, o
         )
 
 
-def _handle_alice_memory_review(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
-    continuity_object_id = _parse_optional_uuid(arguments, "continuity_object_id")
+def _review_queue_payload(
+    context: MCPRuntimeContext,
+    arguments: Mapping[str, object],
+    *,
+    default_status: str,
+) -> JsonObject:
+    continuity_object_id = _parse_review_item_id(arguments, required=False)
     if continuity_object_id is not None:
         with _store_context(context) as store:
             payload = get_continuity_review_detail(
@@ -658,12 +736,7 @@ def _handle_alice_memory_review(context: MCPRuntimeContext, arguments: Mapping[s
             "review": payload["review"],
         }
 
-    status = arguments.get("status", "correction_ready")
-    if not isinstance(status, str):
-        raise MCPToolError("status must be a string")
-    if status not in _REVIEW_STATUS_CHOICES:
-        allowed = ", ".join(_REVIEW_STATUS_CHOICES)
-        raise MCPToolError(f"status must be one of: {allowed}")
+    status = _parse_review_status(arguments, default=default_status)
     limit = _parse_int(
         arguments,
         key="limit",
@@ -691,14 +764,43 @@ def _handle_alice_memory_review(context: MCPRuntimeContext, arguments: Mapping[s
     }
 
 
-def _handle_alice_memory_correct(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+def _handle_alice_review_queue(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    return _review_queue_payload(
+        context,
+        arguments,
+        default_status="pending_review",
+    )
+
+
+def _handle_alice_memory_review(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    return _review_queue_payload(
+        context,
+        arguments,
+        default_status="correction_ready",
+    )
+
+
+def _review_apply_payload(
+    context: MCPRuntimeContext,
+    arguments: Mapping[str, object],
+    *,
+    allow_legacy_actions: bool,
+    include_action_resolution: bool,
+) -> JsonObject:
+    requested_action = _parse_required_text(arguments, "action")
+    resolved_action = _resolve_review_apply_action(
+        requested_action,
+        allow_legacy=allow_legacy_actions,
+    )
+    continuity_object_id = cast(UUID, _parse_review_item_id(arguments, required=True))
+
     with _store_context(context) as store:
-        return apply_continuity_correction(
+        payload = apply_continuity_correction(
             store,
             user_id=context.user_id,
-            continuity_object_id=_parse_required_uuid(arguments, "continuity_object_id"),
+            continuity_object_id=continuity_object_id,
             request=ContinuityCorrectionInput(
-                action=_parse_required_text(arguments, "action"),
+                action=resolved_action,
                 reason=_parse_optional_text(arguments, "reason"),
                 title=_parse_optional_text(arguments, "title"),
                 body=_parse_optional_json_object(arguments, "body"),
@@ -710,6 +812,34 @@ def _handle_alice_memory_correct(context: MCPRuntimeContext, arguments: Mapping[
                 replacement_confidence=_parse_optional_float(arguments, "replacement_confidence"),
             ),
         )
+
+    if not include_action_resolution:
+        return payload
+    return {
+        "review_action": {
+            "requested_action": requested_action,
+            "resolved_action": resolved_action,
+        },
+        **payload,
+    }
+
+
+def _handle_alice_review_apply(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    return _review_apply_payload(
+        context,
+        arguments,
+        allow_legacy_actions=True,
+        include_action_resolution=True,
+    )
+
+
+def _handle_alice_memory_correct(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    return _review_apply_payload(
+        context,
+        arguments,
+        allow_legacy_actions=True,
+        include_action_resolution=False,
+    )
 
 
 def _handle_alice_explain(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
@@ -1030,12 +1160,50 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
         },
     },
     {
-        "name": "alice_memory_review",
-        "description": "List correction review queue or fetch review detail for one continuity object.",
+        "name": "alice_review_queue",
+        "description": "List pending review queue items or fetch one review item detail with explanation metadata.",
         "inputSchema": {
             "type": "object",
             "additionalProperties": False,
             "properties": {
+                "review_item_id": {"type": "string", "format": "uuid"},
+                "continuity_object_id": {"type": "string", "format": "uuid"},
+                "status": {"type": "string", "enum": list(_REVIEW_STATUS_CHOICES)},
+                "limit": {"type": "integer", "minimum": 1, "maximum": MAX_CONTINUITY_REVIEW_LIMIT},
+            },
+        },
+    },
+    {
+        "name": "alice_review_apply",
+        "description": "Apply approve/reject/edit-and-approve/supersede-existing review actions deterministically.",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["action"],
+            "properties": {
+                "review_item_id": {"type": "string", "format": "uuid"},
+                "continuity_object_id": {"type": "string", "format": "uuid"},
+                "action": {"type": "string", "enum": list(_REVIEW_APPLY_ACTION_CHOICES)},
+                "reason": {"type": "string"},
+                "title": {"type": "string"},
+                "body": {"type": "object"},
+                "provenance": {"type": "object"},
+                "confidence": {"type": "number"},
+                "replacement_title": {"type": "string"},
+                "replacement_body": {"type": "object"},
+                "replacement_provenance": {"type": "object"},
+                "replacement_confidence": {"type": "number"},
+            },
+        },
+    },
+    {
+        "name": "alice_memory_review",
+        "description": "Legacy alias for review queue/detail (use alice_review_queue).",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "review_item_id": {"type": "string", "format": "uuid"},
                 "continuity_object_id": {"type": "string", "format": "uuid"},
                 "status": {"type": "string", "enum": list(_REVIEW_STATUS_CHOICES)},
                 "limit": {"type": "integer", "minimum": 1, "maximum": MAX_CONTINUITY_REVIEW_LIMIT},
@@ -1044,12 +1212,13 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
     },
     {
         "name": "alice_memory_correct",
-        "description": "Apply deterministic continuity correction actions and return correction evidence.",
+        "description": "Legacy alias for review apply (use alice_review_apply).",
         "inputSchema": {
             "type": "object",
             "additionalProperties": False,
             "required": ["continuity_object_id", "action"],
             "properties": {
+                "review_item_id": {"type": "string", "format": "uuid"},
                 "continuity_object_id": {"type": "string", "format": "uuid"},
                 "action": {"type": "string", "enum": list(CONTINUITY_CORRECTION_ACTIONS)},
                 "reason": {"type": "string"},
@@ -1137,6 +1306,8 @@ _TOOL_HANDLERS = {
     "alice_recent_decisions": _handle_alice_recent_decisions,
     "alice_recent_changes": _handle_alice_recent_changes,
     "alice_timeline": _handle_alice_timeline,
+    "alice_review_queue": _handle_alice_review_queue,
+    "alice_review_apply": _handle_alice_review_apply,
     "alice_memory_review": _handle_alice_memory_review,
     "alice_memory_correct": _handle_alice_memory_correct,
     "alice_explain": _handle_alice_explain,

--- a/docs/integrations/hermes-memory-provider.md
+++ b/docs/integrations/hermes-memory-provider.md
@@ -125,7 +125,7 @@ Use this split to avoid overlapping integrations:
 | Integration | Best for | Runtime shape |
 |---|---|---|
 | Alice memory provider | always-on continuity prefetch + memory tools inside Hermes memory stack | one external memory provider + built-in `MEMORY.md`/`USER.md` |
-| Alice MCP server | broad Alice tool surface in Hermes (`alice_recall`, `alice_resume`, write/correction flows) | MCP server attached under `mcp_servers` |
+| Alice MCP server | broad Alice tool surface in Hermes (`alice_recall`, `alice_resume`, `alice_review_queue`, `alice_review_apply`) | MCP server attached under `mcp_servers` |
 | Hermes Alice skill pack | policy and prompting guidance on when/how to call Alice tools | skill instructions layered on top of provider or MCP |
 
 Practical default:

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -33,14 +33,17 @@ MCP uses the same local runtime scope as CLI:
 - `alice_recent_decisions`
 - `alice_recent_changes`
 - `alice_timeline`
-- `alice_memory_review`
-- `alice_memory_correct`
+- `alice_review_queue`
+- `alice_review_apply`
+- `alice_memory_review` (legacy alias)
+- `alice_memory_correct` (legacy alias)
 - `alice_explain`
 - `alice_context_pack`
 
 `alice_explain` now accepts either `continuity_object_id` for evidence-chain inspection or `entity_id` plus optional `at` for temporal explain output.
 `alice_prefetch_context` provides an automation-oriented pre-turn context assembly surface using the same continuity resumption semantics shipped for `alice_resume`.
 `alice_capture_candidates` and `alice_commit_captures` provide the B2 bridge auto-capture pipeline over user/assistant turns with `manual`/`assist`/`auto` commit policy support.
+`alice_review_queue` and `alice_review_apply` provide B3 review operations (`approve`, `edit-and-approve`, `reject`, `supersede-existing`) with deterministic recall/resume effects after approved actions.
 
 ## Example: Claude Desktop MCP Config
 

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -20,7 +20,8 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "Phase 10 is complete and shipped.",
             "Phase 11 is complete and shipped:",
-            "`B2` Auto-Capture Pipeline is the active sprint",
+            "`B2` Auto-Capture Pipeline is shipped",
+            "`B3` Review Queue + Explainability is the active sprint",
             "Historical planning and control docs: [docs/archive/planning/2026-04-08-context-compaction/README.md]",
         ),
     ),
@@ -28,13 +29,13 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="ROADMAP.md",
         required_markers=(
             "Phase 11 remains baseline truth and is not future scope.",
-            "Bridge Sprint 2 (`B2`) is the active execution sprint.",
+            "Bridge Sprint 3 (`B3`) is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Bridge Sprint 2 (B2): Auto-Capture Pipeline",
+            "Bridge Sprint 3 (B3): Review Queue + Explainability",
             "Phase 10 is complete and shipped.",
             "Phase 11 is complete and shipped.",
         ),
@@ -52,7 +53,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
             "Phase 9 is shipped.",
             "Phase 10 is shipped.",
             "Phase 11 is shipped and remains baseline truth.",
-            "Bridge Sprint 2 (`B2`) is the active execution sprint.",
+            "Bridge Sprint 3 (`B3`) is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -94,7 +94,15 @@ class MCPClient:
             payload["params"] = params
 
         _write_mcp_message(self.process.stdin, payload)
-        response = _read_mcp_message(self.process.stdout)
+        try:
+            response = _read_mcp_message(self.process.stdout)
+        except RuntimeError as exc:
+            stderr_text = ""
+            if self.process.stderr is not None:
+                stderr_text = self.process.stderr.read().decode("utf-8", errors="replace")
+            if stderr_text.strip():
+                raise RuntimeError(f"{exc}\nMCP stderr:\n{stderr_text}") from exc
+            raise
         assert response.get("id") == request_id
         return response
 
@@ -208,7 +216,8 @@ def test_mcp_server_tool_calls_and_correction_flow(migrated_database_urls) -> No
         assert "alice_resume" in tool_names
         assert "alice_prefetch_context" in tool_names
         assert "alice_open_loops" in tool_names
-        assert "alice_memory_correct" in tool_names
+        assert "alice_review_queue" in tool_names
+        assert "alice_review_apply" in tool_names
 
         recall_before = _call_tool(
             client,
@@ -265,12 +274,33 @@ def test_mcp_server_tool_calls_and_correction_flow(migrated_database_urls) -> No
         assert open_loop_dashboard["summary"]["total_count"] == 1
         assert open_loop_dashboard["waiting_for"]["items"][0]["id"] == str(waiting_for["id"])
 
+        review_queue = _call_tool(
+            client,
+            name="alice_review_queue",
+            arguments={
+                "status": "correction_ready",
+                "limit": 20,
+            },
+        )
+        assert review_queue["isError"] is False
+        queue_payload = review_queue["structuredContent"]
+        queue_item = next(
+            item for item in queue_payload["items"] if item["id"] == str(legacy_decision["id"])
+        )
+        assert queue_item["explanation"]["trust"]["trust_class"] in {
+            "deterministic",
+            "llm_single_source",
+            "llm_corroborated",
+            "human_curated",
+        }
+        assert queue_item["explanation"]["proposal_rationale"]
+
         correction = _call_tool(
             client,
-            name="alice_memory_correct",
+            name="alice_review_apply",
             arguments={
-                "continuity_object_id": str(legacy_decision["id"]),
-                "action": "supersede",
+                "review_item_id": str(legacy_decision["id"]),
+                "action": "supersede-existing",
                 "reason": "Latest rollout decision supersedes legacy plan",
                 "replacement_title": "Decision: Updated rollout plan",
                 "replacement_body": {"decision_text": "Updated rollout plan"},
@@ -282,6 +312,7 @@ def test_mcp_server_tool_calls_and_correction_flow(migrated_database_urls) -> No
             },
         )
         assert correction["isError"] is False
+        assert correction["structuredContent"]["review_action"]["resolved_action"] == "supersede"
         replacement_id = correction["structuredContent"]["replacement_object"]["id"]
 
         recall_after = _call_tool(
@@ -314,5 +345,29 @@ def test_mcp_server_tool_calls_and_correction_flow(migrated_database_urls) -> No
         )
         assert resume_after["isError"] is False
         assert resume_after["structuredContent"]["brief"]["last_decision"]["item"]["id"] == replacement_id
+
+        rejected = _call_tool(
+            client,
+            name="alice_review_apply",
+            arguments={
+                "review_item_id": str(waiting_for["id"]),
+                "action": "reject",
+                "reason": "No longer needed",
+            },
+        )
+        assert rejected["isError"] is False
+        assert rejected["structuredContent"]["review_action"]["resolved_action"] == "delete"
+
+        recall_post_reject = _call_tool(
+            client,
+            name="alice_recall",
+            arguments={
+                "thread_id": str(thread_id),
+                "limit": 20,
+            },
+        )
+        assert recall_post_reject["isError"] is False
+        recall_rejected_payload = recall_post_reject["structuredContent"]
+        assert all(item["id"] != str(waiting_for["id"]) for item in recall_rejected_payload["items"])
     finally:
         client.close()

--- a/tests/unit/test_continuity_review.py
+++ b/tests/unit/test_continuity_review.py
@@ -225,6 +225,8 @@ def test_review_queue_filters_correction_ready_statuses() -> None:
         "total_count": 2,
         "order": ["updated_at_desc", "created_at_desc", "id_desc"],
     }
+    assert payload["items"][0]["explanation"]["proposal_rationale"]
+    assert payload["items"][0]["explanation"]["trust"]["confidence"] > 0.0
 
 
 def test_confirm_records_event_before_lifecycle_mutation() -> None:
@@ -280,6 +282,54 @@ def test_edit_delete_and_mark_stale_are_deterministic() -> None:
     assert edited["continuity_object"]["status"] == "active"
     assert marked_stale["continuity_object"]["status"] == "stale"
     assert deleted["continuity_object"]["status"] == "deleted"
+
+
+def test_review_action_aliases_map_to_deterministic_correction_semantics() -> None:
+    store = ContinuityReviewStoreStub()
+    approve_row = store.add_object(title="Decision: Approve me", status="stale")
+    edit_row = store.add_object(title="Decision: Needs edit", status="stale")
+    reject_row = store.add_object(title="Decision: Reject me", status="active")
+    supersede_row = store.add_object(title="Decision: Legacy", status="active")
+
+    approved = apply_continuity_correction(
+        store,  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        continuity_object_id=approve_row["id"],
+        request=ContinuityCorrectionInput(action="approve"),  # type: ignore[arg-type]
+    )
+    edited_and_approved = apply_continuity_correction(
+        store,  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        continuity_object_id=edit_row["id"],
+        request=ContinuityCorrectionInput(  # type: ignore[arg-type]
+            action="edit-and-approve",
+            title="Decision: Edited and approved",
+        ),
+    )
+    rejected = apply_continuity_correction(
+        store,  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        continuity_object_id=reject_row["id"],
+        request=ContinuityCorrectionInput(action="reject"),  # type: ignore[arg-type]
+    )
+    superseded = apply_continuity_correction(
+        store,  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        continuity_object_id=supersede_row["id"],
+        request=ContinuityCorrectionInput(  # type: ignore[arg-type]
+            action="supersede-existing",
+            replacement_title="Decision: Replacement",
+        ),
+    )
+
+    assert approved["correction_event"]["action"] == "confirm"
+    assert approved["continuity_object"]["status"] == "active"
+    assert edited_and_approved["correction_event"]["action"] == "edit"
+    assert edited_and_approved["continuity_object"]["title"] == "Decision: Edited and approved"
+    assert rejected["correction_event"]["action"] == "delete"
+    assert rejected["continuity_object"]["status"] == "deleted"
+    assert superseded["correction_event"]["action"] == "supersede"
+    assert superseded["continuity_object"]["status"] == "superseded"
 
 
 def test_supersede_creates_replacement_and_preserves_chain_links() -> None:

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -24,6 +24,8 @@ def test_mcp_tool_surface_is_adr_aligned_and_deterministic() -> None:
         "alice_recent_decisions",
         "alice_recent_changes",
         "alice_timeline",
+        "alice_review_queue",
+        "alice_review_apply",
         "alice_memory_review",
         "alice_memory_correct",
         "alice_explain",


### PR DESCRIPTION
## Summary
- add the B3 review surfaces alice_review_queue and alice_review_apply on top of the persisted B2 review items
- support approve, edit-and-approve, reject, and supersede-existing actions with deterministic continuity correction semantics
- expose explanation and provenance details so review items show why they were proposed and how approved actions affect later recall and resume behavior

## Scope Notes
- review actions map to shipped continuity semantics: approve -> confirm, edit-and-approve -> edit, reject -> delete, supersede-existing -> supersede
- keeps alice_memory_review and alice_memory_correct as compatibility aliases
- does not claim B4 packaging, docs closeout, or demo flows as shipped in B3

## Verification
- python3 scripts/check_control_doc_truth.py
- ./.venv/bin/python -m pytest tests/unit tests/integration -q
- ./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py

## Upgrade Overview
### Protected Areas
- [x] continuity APIs
- [x] memory schema
- [x] trust rules
- [x] evidence pipeline

### Compatibility Impact
This is an additive bridge-phase review layer on top of the shipped B2 capture pipeline. Existing provider and MCP workflows remain intact while explicit review queue and review apply surfaces are added for persisted review items.

### Migration / Rollout
Deploy the Alice review and MCP changes together so review queue payloads, explanation fields, and action semantics stay aligned across API, MCP, recall, and resume behavior. No new packaging or demo workflow is included in this sprint.

### Operator Action
Validate alice_review_queue ordering and filtering, then exercise approve, reject, edit-and-approve, and supersede-existing through alice_review_apply. Confirm approved actions change later recall and resumption output deterministically, and confirm rejected items do not behave like accepted continuity state.

### Validation
Branch-local verification passed:
- python3 scripts/check_control_doc_truth.py -> PASS
- ./.venv/bin/python -m pytest tests/unit tests/integration -q -> 1189 passed in 196.98s (0:03:16)
- ./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py -> PASS

### Rollback
Revert the squash merge commit to restore the pre-B3 review behavior, then re-run the review-specific tests, full suite, and Hermes smoke validation before redeploying.