### PR TITLE
ops: skip archive checksum verification when archive index is absent

### DIFF
--- a/scripts/run_archive_maintenance.py
+++ b/scripts/run_archive_maintenance.py
@@ -288,6 +288,20 @@ def _verify_archive_checksums(
     index_path: Path,
     checksum_manifest_path: Path,
 ) -> dict[str, object]:
+    if not index_path.exists():
+        return {
+            "status": "skipped",
+            "details": {
+                "verified_file_count": 0,
+                "previous_manifest_file_count": 0,
+                "manifest_mismatch_count": 0,
+                "checksum_manifest_path": _repo_relative(checksum_manifest_path),
+                "archive_index_path": _repo_relative(index_path),
+                "reason": "archive index not present; checksum verification skipped",
+            },
+            "errors": [],
+        }
+
     errors = verify_rc_archive.verify_archive_index(index_path=index_path)
     archive_paths, collection_errors = _collect_archive_paths(index_path)
     errors.extend(collection_errors)

--- a/tests/unit/test_archive_maintenance.py
+++ b/tests/unit/test_archive_maintenance.py
@@ -94,6 +94,18 @@ def test_verify_archive_checksums_detects_manifest_drift(tmp_path: Path) -> None
     assert any("archive checksum mismatch" in message for message in second["errors"])
 
 
+def test_verify_archive_checksums_skips_when_archive_index_is_absent(tmp_path: Path) -> None:
+    result = maintenance._verify_archive_checksums(  # type: ignore[attr-defined]
+        index_path=tmp_path / "missing" / "index.json",
+        checksum_manifest_path=tmp_path / "archive_checksum_manifest.json",
+    )
+
+    assert result["status"] == "skipped"
+    assert result["errors"] == []
+    assert result["details"]["verified_file_count"] == 0
+    assert result["details"]["reason"] == "archive index not present; checksum verification skipped"
+
+
 def test_collect_archive_paths_rejects_outside_allowed_root(tmp_path: Path) -> None:
     archive_dir = tmp_path / "archive"
     archive_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- treat archive checksum verification as skipped when the release archive index is not present in the checkout
- keep checksum verification strict once an archive index exists
- add a regression test for the missing-index maintenance path

## Testing
- /Users/samirusani/Desktop/Codex/AliceBot/.venv/bin/pytest tests/unit/test_archive_maintenance.py tests/integration/test_phase4_rc_archive.py

Closes #138