### PR TITLE
[codex] P12-S1: ship hybrid retrieval and reranking

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,91 +1,167 @@
 # Architecture
 
 ## Scope Boundary
-This document treats Phases 9-11 and Bridge `B1` through `B4` as shipped baseline truth. The current active work is `R1` release readiness only.
+- **Shipped baseline:** Phases 9-11 and Bridge `B1` through `B4`.
+- **Current repo execution posture:** `v0.2.0` is released; `P12-S1` is the active sprint.
+- **Phase 12 delta:** retrieval quality, mutation explicitness, contradiction handling, public evals, and adaptive briefing.
 
-## System Overview
-Alice is a modular continuity platform with four shipped surface groups:
-
-- **Alice Core:** typed continuity objects, provenance, correction/supersession, open loops, recall/resume/explain flows
-- **Access Surfaces:** CLI, MCP, web/admin, hosted/product interfaces
-- **Provider Runtime:** workspace-scoped provider registration, capability snapshots, model packs, runtime invocation, provider secret handling
-- **Hermes Bridge:** external memory provider path with lifecycle automation, capture/review pipeline, explainable memory actions, and MCP fallback
+## Current System Overview
+Alice is a modular continuity platform with shared continuity semantics across local, hosted, provider-runtime, MCP, and Hermes-integrated surfaces.
 
 ## Technical Stack
-- Core API/runtime: Python + FastAPI (`apps/api/src/alicebot_api`)
-- Persistence: Postgres
-- Web surface: `apps/web`
-- Worker/ops scripts: `scripts/`
-- Hermes integration artifacts: provider plugin + operator config/docs under `docs/integrations/`
+- API/runtime: Python + FastAPI in [`apps/api/src/alicebot_api`](apps/api/src/alicebot_api)
+- Persistence: Postgres with Alembic migrations in [`apps/api/alembic/versions`](apps/api/alembic/versions)
+- Optional cache/runtime support: Redis
+- Web/admin: Next.js app in [`apps/web`](apps/web)
+- CLI + MCP: Python CLI/MCP plus package shims in [`packages/alice-cli`](packages/alice-cli) and [`packages/alice-core`](packages/alice-core)
+- Ops/demo/test scripts: [`scripts`](scripts)
 
-## Module Boundaries
+## Shipped Module Boundaries
 
-### Alice Core
-- continuity object graph
-- provenance evidence links
-- corrections and supersession history
-- recall, resume, explain, and open-loop flows
+### Continuity Core
+- Capture, review, lifecycle, explainability, recall, resumption, and open-loop flows.
+- Primary modules:
+  - [`continuity_capture.py`](apps/api/src/alicebot_api/continuity_capture.py)
+  - [`continuity_review.py`](apps/api/src/alicebot_api/continuity_review.py)
+  - [`continuity_recall.py`](apps/api/src/alicebot_api/continuity_recall.py)
+  - [`continuity_resumption.py`](apps/api/src/alicebot_api/continuity_resumption.py)
+  - [`continuity_open_loops.py`](apps/api/src/alicebot_api/continuity_open_loops.py)
+
+### Retrieval And Evidence Foundations
+- Existing baseline already includes semantic retrieval, embeddings, entities, trusted-fact promotion, and fixture-based retrieval evaluation.
+- Primary modules:
+  - [`semantic_retrieval.py`](apps/api/src/alicebot_api/semantic_retrieval.py)
+  - [`retrieval_evaluation.py`](apps/api/src/alicebot_api/retrieval_evaluation.py)
+  - [`entity.py`](apps/api/src/alicebot_api/entity.py)
+  - [`entity_edge.py`](apps/api/src/alicebot_api/entity_edge.py)
+  - [`trusted_fact_promotions.py`](apps/api/src/alicebot_api/trusted_fact_promotions.py)
 
 ### Hosted/Product Layer
-- identity/workspace/channel ownership from prior shipped phases
-- user-facing control surfaces built on top of core continuity semantics
+- Workspace, identity, devices, preferences, telemetry, web/admin, and channel surfaces.
 
 ### Provider Runtime
-- provider registration and testing
-- model-pack binding and invocation
-- local/self-hosted/enterprise adapter support
-- provider secret management and workspace isolation
+- Workspace-scoped provider registration, capability snapshots, model packs, invocation, and secret handling.
 
 ### Hermes Bridge
-- pre-turn prefetch
-- post-turn capture candidate generation and commit policy
-- review queue and review apply flow
-- explainability chain for bridge-generated memory actions
-- provider-plus-MCP recommended deployment shape with MCP-only fallback
+- Provider hook integration, prefetch, post-turn capture, review queue, explainability, and MCP fallback.
 
-## Runtime Flows
+## Current Data Model Summary
 
-### Flow 1: Explicit Continuity
-1. CLI or MCP calls Alice continuity endpoints.
-2. Alice returns typed recall/resume/open-loop/explain outputs.
-3. Provenance and trust posture remain inspectable.
+### Continuity And Memory
+- `memories`, `memory_revisions`, `memory_review_labels`
+- `continuity_capture_events`, `continuity_objects`, `continuity_correction_events`
+- `open_loops`
 
-### Flow 2: Provider Runtime
-1. Workspace registers a provider and optional model packs.
-2. Runtime invokes provider through the workspace-scoped adapter boundary.
-3. Continuity behavior remains in Alice rather than in provider-specific logic.
+### Retrieval Foundations
+- `embedding_configs`, `memory_embeddings`
+- `entities`, `entity_edges`
+- task-artifact chunk embeddings for artifact-scoped retrieval
 
-### Flow 3: Hermes Lifecycle Automation
-1. Hermes calls Alice prefetch before a turn.
-2. Hermes sends turn output to Alice capture/review paths after the response.
-3. Alice auto-saves only policy-eligible high-confidence items and routes the rest to review.
-4. MCP remains available for explicit deep workflows.
+### Product/Runtime
+- `workspaces`, `workspace_members`, `auth_sessions`, `devices`
+- `model_providers`, `provider_capabilities`, `model_packs`, `workspace_model_pack_bindings`
+- channel, task, trace, approval, and execution tables
 
-## Security And Trust Controls
-- Continuity truth remains governed by provenance, correction, and supersession rules.
-- Consequential side effects remain approval-bounded.
-- Provider/runtime access stays workspace-scoped.
-- Provider credentials and sensitive connection details must be redacted from logs and outward-facing error payloads.
-- Hermes automation must not fork or bypass Alice trust rules.
+## Current Key Flows
+
+### Capture And Review
+1. Raw content enters continuity capture.
+2. Alice creates capture events and candidate continuity objects.
+3. Review/correction can confirm, edit, supersede, or delete.
+4. Explainability preserves provenance and lifecycle state.
+
+### Recall And Resumption
+1. Recall loads continuity candidates.
+2. Ranking already considers semantic similarity, trust, freshness, provenance, supersession, and entity/scope matches.
+3. Resumption composes ranked recall into decisions, open loops, recent changes, and next action.
+
+### Provider/Hermes Runtime
+1. Workspace binds provider and model-pack configuration.
+2. Runtime invokes through provider adapter boundaries.
+3. Hermes can prefetch before a turn and capture after a turn while Alice remains the system of record.
+
+## Phase 12 Architecture Delta
+
+### P12-S1: Hybrid Retrieval + Reranking
+Extend the current recall path from a single ranked query into an explicit scored pipeline:
+- semantic stream
+- lexical/BM25-style stream
+- entity/edge traversal stream
+- temporal filtering/weighting
+- trust-aware reranking
+- persisted retrieval traces
+
+Planned additions:
+- `retrieval_runs`
+- `retrieval_candidates`
+- debug surfaces for API, CLI, and MCP
+
+Important baseline note: semantic retrieval, trust-aware ranking, entities, and retrieval evaluation already exist. Phase 12 should layer on those primitives rather than replace them.
+
+### P12-S2: Automated Memory Operations
+Promote post-turn capture from loose candidate save/commit behavior into explicit mutation operations:
+- `ADD`
+- `UPDATE`
+- `SUPERSEDE`
+- `DELETE`
+- `NOOP`
+
+Planned additions:
+- `memory_operation_candidates`
+- `memory_operations`
+
+### P12-S3: Contradiction Detection + Trust Calibration
+Add first-class conflict records and auditable trust adjustments.
+
+Planned additions:
+- `contradiction_cases`
+- `trust_signals`
+
+### P12-S4: Public Eval Harness
+Expand the current retrieval evaluation foundation into public multi-suite benchmark runs and checked-in baseline reports.
+
+Planned additions:
+- `eval_suites`
+- `eval_cases`
+- `eval_runs`
+- `eval_results`
+
+### P12-S5: Task-Adaptive Briefing
+Separate durable memory from output-specific briefing layers.
+
+Planned additions:
+- `task_briefs`
+- provider/model-pack briefing strategy fields
+
+Important baseline note: Alice already has resumption, daily-brief, and chief-of-staff briefing surfaces. Phase 12 should treat those as starting points, not as greenfield briefing.
+
+## Security And Reliability Rules
+- Keep user/workspace isolation intact for continuity, provider, and channel data.
+- Keep provider credentials and secret references out of logs and outward-facing errors.
+- Preserve approval-bounded execution for consequential side effects.
+- Keep capture, mutation, and Hermes sync paths idempotent.
+- Preserve append-only evidence where the system depends on auditability.
 
 ## Deployment Topology
 
 ### Recommended
-- Alice API + Postgres for the continuity system of record
-- Alice MCP server for explicit workflows
-- provider runtime where model/provider abstraction is needed
-- Hermes provider-plus-MCP when always-on continuity is desired
+- Alice API + Postgres as system of record
+- Alice MCP for explicit workflows
+- Provider runtime where model abstraction is needed
+- Hermes provider-plus-MCP for always-on continuity
 
 ### Fallback
-- MCP-only integrations remain valid where provider automation is not available.
+- MCP-only remains supported when provider automation is unavailable
 
 ## Testing Strategy
-- control-doc truth checks for canonical planning/doc alignment
-- Python unit and integration suites for API/core/runtime regressions
-- web tests for shipped UI/admin surfaces
-- Hermes provider smoke, MCP smoke, and one-command demo for bridge validation
+- unit/integration tests for continuity, runtime, and API behavior
+- fixture-based retrieval and eval suites
+- web tests for shipped user/admin surfaces
+- Hermes provider smoke, MCP smoke, and demo flows
+- release/eval artifacts committed only when they correspond to exact commands and fixtures
 
-## Release-Readiness Focus
-- public release docs must describe the shipped architecture accurately
-- release gates must verify the surfaces the repo actively claims
-- no architecture expansion is allowed inside the release sprint
+## Control Tower Decisions Needed
+- Should Phase 12 retrieval ship behind a feature flag before it replaces the default recall path?
+- Should new endpoints use `/v1/retrieval/*`, `/v1/evals/*`, `/v1/briefs/*`, or extend existing continuity endpoints?
+- Should contradictions attach to continuity objects only, memories only, or both with a shared abstraction?
+- Should `DELETE` be restricted to logical deletion/tombstoning by default?

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,68 +1,82 @@
 # BUILD_REPORT
 
 ## sprint objective
-Deliver Release Sprint 1 (`R1`) release-readiness scope only: align public release docs and policy docs to shipped Alice baseline (Phase 9 through Phase 11 and Bridge `B1` through `B4`), define `v0.2.0` pre-1.0 checklist/tag/runbook, and record exact release-gate evidence.
+Implement `P12-S1` hybrid retrieval + reranking by extending continuity recall into an explicit multi-stage retrieval pipeline with persisted retrieval traces, debug visibility across API/CLI/MCP, and updated retrieval evaluation coverage.
 
 ## completed work
-- Added `v0.2.0` release artifacts:
-  - `docs/release/v0.2.0-release-checklist.md`
-  - `docs/release/v0.2.0-tag-plan.md`
-  - `docs/runbooks/v0.2.0-public-release-runbook.md`
-- Updated launch-facing and policy docs to match shipped scope and pre-1.0 framing:
-  - `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`
-  - `docs/quickstart/local-setup-and-first-result.md`
-  - `docs/integrations/mcp.md`
-  - `docs/integrations/hermes-bridge-operator-guide.md`
-- Updated control-doc truth markers in `scripts/check_control_doc_truth.py` for `R1` active truth.
-- Updated sprint control docs to align baseline/release-state truth:
-  - `ARCHITECTURE.md`, `PRODUCT_BRIEF.md`, `ROADMAP.md`, `RULES.md`
-- Repaired Hermes smoke gate reliability in environments where upstream editable `hermes-agent` runtime modules are not importable:
-  - `scripts/run_hermes_memory_provider_smoke.py`
-  - `scripts/run_hermes_mcp_smoke.py`
-- Re-ran all required verification commands and captured passing evidence.
+- Implemented an explicit hybrid retrieval pipeline in `apps/api/src/alicebot_api/continuity_recall.py`:
+  - lexical BM25-style scoring
+  - semantic similarity and exact-match scoring
+  - entity/edge-expanded retrieval signals
+  - temporal weighting
+  - trust-aware reranking
+  - per-candidate inclusion and exclusion tracking
+- Added persisted retrieval trace storage:
+  - Alembic migration `20260414_0057_phase12_hybrid_retrieval_traces.py`
+  - `retrieval_runs` table
+  - `retrieval_candidates` table
+  - store APIs for creating and reading retrieval traces
+  - operator-configurable trace retention via `RETRIEVAL_TRACE_RETENTION_DAYS`
+- Added retrieval debug API support:
+  - `GET /v0/continuity/recall?debug=true`
+  - `GET /v0/continuity/resumption-brief?debug=true`
+  - `GET /v0/continuity/retrieval-runs`
+  - `GET /v0/continuity/retrieval-runs/{retrieval_run_id}`
+- Added CLI debug support:
+  - `recall --debug`
+  - `resume --debug`
+- Added MCP retrieval debug tooling:
+  - `alice_recall_debug`
+  - `alice_resume_debug`
+  - `alice_retrieval_trace`
+- Updated retrieval evaluation coverage with a new entity-edge expansion fixture proving hybrid retrieval improves a real weakness.
+- Added sprint-scoped retrieval documentation in `docs/retrieval/hybrid_tracing.md`.
 
 ## incomplete work
-- None in `R1` scope.
+- None within `P12-S1` scope.
 
 ## files changed
 - `ARCHITECTURE.md`
 - `BUILD_REPORT.md`
-- `CHANGELOG.md`
-- `CONTRIBUTING.md`
+- `CURRENT_STATE.md`
 - `PRODUCT_BRIEF.md`
-- `README.md`
 - `REVIEW_REPORT.md`
 - `ROADMAP.md`
 - `RULES.md`
-- `SECURITY.md`
-- `docs/integrations/hermes-bridge-operator-guide.md`
-- `docs/integrations/mcp.md`
-- `docs/quickstart/local-setup-and-first-result.md`
-- `docs/release/v0.2.0-release-checklist.md`
-- `docs/release/v0.2.0-tag-plan.md`
-- `docs/runbooks/v0.2.0-public-release-runbook.md`
+- `apps/api/alembic/versions/20260414_0057_phase12_hybrid_retrieval_traces.py`
+- `apps/api/src/alicebot_api/cli.py`
+- `apps/api/src/alicebot_api/cli_formatting.py`
+- `apps/api/src/alicebot_api/config.py`
+- `apps/api/src/alicebot_api/continuity_recall.py`
+- `apps/api/src/alicebot_api/continuity_resumption.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/mcp_tools.py`
+- `apps/api/src/alicebot_api/retrieval_evaluation.py`
+- `apps/api/src/alicebot_api/store.py`
+- `docs/retrieval/hybrid_tracing.md`
 - `scripts/check_control_doc_truth.py`
-- `scripts/run_hermes_mcp_smoke.py`
-- `scripts/run_hermes_memory_provider_smoke.py`
+- `tests/integration/test_cli_integration.py`
+- `tests/integration/test_continuity_recall_api.py`
+- `tests/integration/test_mcp_cli_parity.py`
+- `tests/integration/test_retrieval_evaluation_api.py`
+- `tests/unit/test_20260414_0057_phase12_hybrid_retrieval_traces.py`
+- `tests/unit/test_continuity_recall.py`
+- `tests/unit/test_retrieval_evaluation.py`
 
 ## tests run
-- `python3 scripts/check_control_doc_truth.py`
-  - Result: PASS (`Control-doc truth check: PASS`)
-- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-  - Result: PASS (`1191 passed in 206.68s (0:03:26)`)
-- `pnpm --dir apps/web test`
-  - Result: PASS (`62` test files passed, `199` tests passed)
-- `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py`
-  - Result: PASS (`bridge_status.ready=true`, `single_external_enforced=true`, provider registered)
-- `./.venv/bin/python scripts/run_hermes_mcp_smoke.py`
-  - Result: PASS (`registered_tools` include required recall/resume/open-loops/capture/commit/review tools; capture and review assertions passed)
-  - Runtime mode used: `compat_shim`
-- `./.venv/bin/python scripts/run_hermes_bridge_demo.py`
-  - Result: PASS (`status=pass`, `recommended_path=provider_plus_mcp`, `fallback_path=mcp_only`)
+- `./.venv/bin/pytest tests/unit/test_continuity_recall.py tests/unit/test_retrieval_evaluation.py tests/unit/test_cli.py tests/unit/test_20260414_0057_phase12_hybrid_retrieval_traces.py -q`
+  - Result: PASS (`25 passed`)
+- `./.venv/bin/pytest tests/integration/test_continuity_recall_api.py tests/integration/test_retrieval_evaluation_api.py tests/integration/test_cli_integration.py tests/integration/test_mcp_cli_parity.py -q`
+  - Result: PASS (`11 passed`)
+- `./.venv/bin/python scripts/check_control_doc_truth.py`
+  - Result: PASS
+- `rg -n "/Users|samirusani|Desktop/Codex" RULES.md ARCHITECTURE.md CURRENT_STATE.md BUILD_REPORT.md docs/retrieval`
+  - Result: PASS (no matches)
 
 ## blockers/issues
-- No remaining release-gate blockers.
-- Environment note: local editable `hermes-agent` runtime modules were not consistently importable (`agent` / `tools`), so sprint-owned smoke scripts now include deterministic compatibility fallbacks to keep release-gate verification executable.
+- No code blockers remain.
+- Required verification has been executed successfully on the current branch head.
 
 ## recommended next step
-Request review against this passing `R1` evidence and proceed with the sprint PR flow for merge approval and tag-readiness gate.
+Request Control Tower merge review against the current sprint branch head.

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,0 +1,33 @@
+# Current State
+
+This file is a synced repo-root copy for planning visibility.
+Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURRENT_STATE.md).
+
+## Status Snapshot
+- Phase 9 is shipped.
+- Phase 10 is shipped.
+- Phase 11 is shipped.
+- Bridge `B1` through `B4` are shipped.
+- `v0.2.0` is released.
+- Phase 12 Sprint 1 (`P12-S1`) is the active execution sprint.
+
+## Current Baseline Truth
+- Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
+- Alice exposes CLI, MCP, hosted/product, provider-runtime, and Hermes bridge surfaces.
+- The codebase already includes semantic retrieval, embeddings, entities/entity edges, trusted-fact promotion, retrieval evaluation fixtures, deterministic resumption briefs, daily briefs, and chief-of-staff briefing flows.
+
+## Not Yet First-Class In Repo
+- explicit memory operation candidate/apply ledger
+- first-class contradiction case objects
+- dedicated trust-signal ledger
+- public multi-suite eval harness for recall/resumption/correction/contradiction/open-loops
+- task-adaptive brief compiler separated from current briefing surfaces
+
+## Phase Transition Note
+- Phase 12 is active.
+- `P12-S1` is the retrieval-foundation sprint for the new phase.
+
+## Immediate Control Tower Decisions Needed
+- Decide Phase 12 API versioning strategy.
+- Decide delete/tombstone semantics for memory operations.
+- Decide whether contradiction records attach to continuity objects, memories, or both.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -1,39 +1,60 @@
 # Product Brief
 
 ## Product Summary
-Alice is a shipped continuity platform for AI agents and agent-assisted workflows. It provides typed memory, provenance, correction-aware recall, open-loop tracking, resumable context, and cross-surface continuity through CLI, MCP, provider runtime, and Hermes bridge paths.
+Alice is a pre-1.0 continuity platform for AI agents and agent-assisted workflows. It provides typed memory, provenance, correction-aware recall, open-loop tracking, resumable context, provider/runtime portability, and Hermes bridge integration.
 
-The current control-tower objective is not a new feature phase. It is a pre-1.0 public release pass that packages the shipped platform into `v0.2.0`.
+## Baseline Truth (Shipped)
+- Phase 9 shipped the continuity core, CLI, MCP, importers, approvals, and evaluation foundation.
+- Phase 10 shipped the hosted/product layer, identity/workspace model, and channel surfaces.
+- Phase 11 shipped provider runtime abstraction, provider adapters, and model packs.
+- Bridge `B1` through `B4` shipped Hermes lifecycle hooks, auto-capture, review flow, explainability, packaging docs, smoke validation, and demo path.
+
+## Current Repo Posture
+- `v0.2.0` is tagged and released.
+- Release Sprint 1 (`R1`) is complete and now baseline truth.
+- Phase 12 is the active next feature phase.
+
+## Next Phase
+### Phase 12: Retrieval Quality + Adaptive Continuity
+Raise Alice from a strong continuity substrate to a measurably better memory system by improving:
+- retrieval precision
+- memory freshness handling
+- contradiction handling
+- public quality evidence
+- task-specific briefing for agents and workers
 
 ## Who It Is For
-- Teams building or operating MCP-capable agents that need durable continuity instead of chat-only context.
-- Developers who want model-agnostic memory infrastructure across local, self-hosted, enterprise, and external-agent runtimes.
-- Hermes users who want always-on continuity prefetch, capture, review, and explainability without forking memory semantics.
+- Teams operating MCP-capable or provider-integrated agents that need durable continuity across sessions and runtimes.
+- Developers who want one continuity layer across local, self-hosted, enterprise, and external-agent paths.
+- Operators using Hermes who want always-on continuity without giving up reviewability or trust controls.
 
-## Problem
-Most agent stacks still lose decisions, commitments, blockers, and corrections across sessions. When teams switch models, runtimes, or agent shells, continuity behavior often fragments as well.
+## Why This Phase Now
+Alice already has durable memory, provenance, trust classes, revision/supersession behavior, resumption, open loops, and provider/MCP interoperability. The next phase is a quality step in the core loop:
 
-## Why It Matters
-- Preserves continuity semantics across providers and agent surfaces.
-- Makes memory quality auditable through provenance, correction, and review flows.
-- Reduces operator friction by supporting both explicit workflows and Hermes lifecycle automation.
+`capture -> retrieve -> resume -> correct -> prove`
 
-## Shipped Baseline Truth
-- Phase 9 shipped the local continuity core, CLI, MCP, importers, approvals, and evaluation harness.
-- Phase 10 shipped the hosted/product layer.
-- Phase 11 shipped provider runtime abstraction, adapters, and model packs across local, self-hosted, enterprise, and external-agent paths.
-- Bridge `B1` through `B4` shipped Hermes provider lifecycle hooks, auto-capture, review queue, explainability, packaging docs, smoke validation, and demoable operator setup.
-
-## Current Release Scope
-- `R1` prepares `v0.2.0` as the next public tag for the shipped baseline above.
-- Scope is limited to release docs, verification evidence, and repo-facing release clarity.
+## In Scope For Phase 12
+- Hybrid retrieval and reranking.
+- Explicit memory mutation operations.
+- First-class contradiction detection and trust calibration.
+- Public multi-suite eval harness and baseline reports.
+- Task-adaptive briefing for user recall, resume, worker subtask, and agent handoff.
 
 ## Non-Goals
-- No new runtime, provider, agent, or channel features in the release sprint.
-- No widening into `v1.0.0` positioning or long-term compatibility guarantees.
-- No reopening already shipped Phase 11 or bridge implementation work except where a release gate exposes a genuine defect.
+- Full graph database migration.
+- Marketplace work.
+- Enterprise/compliance expansion.
+- Latent KV-compaction research.
+- New channels such as WhatsApp.
+- New vertical products.
 
 ## Success Criteria
-- A technically literate external user can understand what Alice ships today from the repo docs alone.
-- Public release docs match the actual shipped surface through Phase 11 + Bridge `B4`.
-- `v0.2.0` can be tagged with evidence-backed confidence and without overstating maturity.
+- Retrieval precision improves on baseline fixtures.
+- Stale or superseded facts are less likely to outrank current truth.
+- Contradictions become explicit, reviewable, and visible in explain flows.
+- Public evals can demonstrate recall, resumption, correction, contradiction, and open-loop quality.
+- Worker-task briefs are smaller and sharper than generic recall context without degrading resumption quality.
+
+## Control Tower Decisions Needed
+- Whether new Phase 12 APIs should live under new `/v1` feature namespaces or extend the existing continuity surface.
+- Whether `DELETE` in memory operations means hard delete, logical tombstone, or a restricted administrative path.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,48 +4,42 @@
 PASS
 
 ## criteria met
-- Release docs now describe shipped Alice surface through Phase 11 + Bridge `B1` through `B4` and maintain explicit pre-1.0 framing for `v0.2.0`.
-- `v0.2.0` release checklist, tag plan, and public release runbook are present and internally consistent.
-- Tag procedure targets `main` after approved merge of the release sprint branch.
-- Required verification commands were defined, executed, and now pass with recorded evidence:
-  - `python3 scripts/check_control_doc_truth.py`
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-  - `pnpm --dir apps/web test`
-  - `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py`
-  - `./.venv/bin/python scripts/run_hermes_mcp_smoke.py`
-  - `./.venv/bin/python scripts/run_hermes_bridge_demo.py`
-- `BUILD_REPORT.md` now lists the full sprint-owned changed-file set and aligns with the current diff.
-- No local identifiers (local computer paths/usernames) were found in changed docs/reports.
+- Hybrid retrieval pipeline is present and remains explainable across lexical, semantic, entity/edge, temporal, and trust-aware stages.
+- Scoped hybrid ranking now derives recency and stage normalization from scope-matching candidates, so off-scope rows no longer skew scoped recall ordering.
+- Retrieval trace persistence is implemented with `retrieval_runs` and `retrieval_candidates`.
+- Debug visibility is present across API, CLI, and MCP.
+- Retrieval evaluation coverage includes the hybrid entity-edge improvement fixture and the evaluated fixture summary still shows positive lift.
+- Non-debug recall and resumption compatibility remains intact for the exercised callers.
+- Local machine-specific identifiers were removed from the touched docs and state files.
 
 ## criteria missed
-- None.
+- None found in the reviewed tree.
 
 ## quality issues
-- No blocking quality issues remain.
-- Non-blocking note: Hermes MCP smoke used a local compatibility runtime mode (`compat_shim`) due missing upstream editable runtime imports; script assertions still validated the required Alice MCP flow and outputs.
+- None requiring follow-up before merge.
 
 ## regression risks
-- Low for product/runtime regressions (changes are release docs/control-doc alignment plus sprint-owned smoke harness hardening).
-- Low-moderate for future Hermes-environment parity if upstream editable runtime layouts change again; mitigated by deterministic fallback behavior and explicit gate outputs.
+- Low residual risk in retrieval scoring changes, but the new scoped-normalization regression test materially lowers it.
 
 ## docs issues
-- No blocking documentation issues.
-- Release docs, README framing, and policy docs are consistent with `R1` release boundary.
+- No blocking docs issues found.
+- Retrieval retention documentation now reflects operator-configured policy with a default, rather than presenting a hardcoded runtime literal as a settled product decision.
 
 ## should anything be added to RULES.md?
-- No additional mandatory rule beyond current `R1` rules.
+- Already addressed in this revision:
+  - no local machine identifiers in committed docs/reports
+  - no silent hardcoding of unresolved sprint Control Tower decisions
 
 ## should anything update ARCHITECTURE.md?
-- No further architecture update is required for `R1` closeout.
+- Already addressed for doc hygiene by removing local absolute paths.
+- No further architecture update is required for this sprint review.
 
 ## recommended next action
-1. Proceed with sprint PR review/approval for `R1`.
-2. After approved squash merge to `main`, execute `docs/release/v0.2.0-tag-plan.md`.
+- Proceed with Control Tower merge review for the current sprint branch head.
+- Keep the new scoped-ranking regression test in the retrieval verification slice.
 
-## verification evidence checked
-- `python3 scripts/check_control_doc_truth.py` -> PASS
-- `./.venv/bin/python -m pytest tests/unit tests/integration -q` -> PASS (`1191 passed in 206.68s (0:03:26)`)
-- `pnpm --dir apps/web test` -> PASS (`62` files, `199` tests)
-- `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py` -> PASS
-- `./.venv/bin/python scripts/run_hermes_mcp_smoke.py` -> PASS
-- `./.venv/bin/python scripts/run_hermes_bridge_demo.py` -> PASS (`status: pass`)
+## review verification
+- `./.venv/bin/pytest tests/unit/test_continuity_recall.py tests/unit/test_retrieval_evaluation.py tests/unit/test_cli.py tests/unit/test_20260414_0057_phase12_hybrid_retrieval_traces.py -q`
+- `./.venv/bin/pytest tests/integration/test_continuity_recall_api.py tests/integration/test_retrieval_evaluation_api.py tests/integration/test_cli_integration.py tests/integration/test_mcp_cli_parity.py -q`
+- `./.venv/bin/python scripts/check_control_doc_truth.py`
+- `rg -n "/Users|samirusani|Desktop/Codex" RULES.md ARCHITECTURE.md CURRENT_STATE.md BUILD_REPORT.md docs/retrieval`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,37 +1,53 @@
 # Roadmap
 
-## Baseline Context (Shipped, Not Roadmap Work)
+## Baseline Context (Not Roadmap Work)
 - Phase 9: shipped
 - Phase 10: shipped
 - Phase 11: shipped
+- Bridge `B1`-`B4`: shipped
 - Bridge Phase (`B1`-`B4`): shipped
+- `v0.2.0`: released
 
-These are baseline truth and not future scope.
+These remain baseline truth and are not future milestones.
 
 ## Active Planning Status
-- Release Sprint 1 (`R1`) is the active execution sprint.
-- `R1` is a release-readiness sprint for `v0.2.0`.
+- Phase 12 Sprint 1 (`P12-S1`) is the active execution sprint.
+- `P12-S1` is the foundation sprint for the Phase 12 retrieval-quality stack.
 
-## Release Sprint R1: v0.2.0 Public Release Readiness
-- refresh the release checklist, tag plan, and runbook for the real shipped Alice surface
-- align README, changelog, and public policy docs with current shipped truth
-- verify the quickstart, integration docs, and release evidence paths
-- run and record release gates:
-  - control-doc truth
-  - unit/integration tests
-  - web tests
-  - Hermes provider smoke
-  - Hermes MCP smoke
-  - Hermes bridge one-command demo
-- prepare a clean annotated-tag path for `v0.2.0` on `main`
+## Phase 12 Milestones
+
+### P12-S1: Hybrid Retrieval + Reranking
+- add hybrid retrieval pipeline
+- add reranking and retrieval traces
+- expose debug visibility through API, CLI, and MCP
+
+### P12-S2: Automated Memory Operations
+- add explicit memory operation candidates and commit engine
+- define auto-apply vs review thresholds
+
+### P12-S3: Contradiction Detection + Trust Calibration
+- add contradiction cases and resolution flow
+- add trust-signal computation and retrieval penalties
+
+### P12-S4: Public Eval Harness
+- ship public fixture suites and local eval runner
+- commit baseline reports and eval docs
+
+### P12-S5: Task-Adaptive Briefing
+- add brief compiler and brief modes
+- integrate provider/model-pack briefing strategy
+
+## Release Sequencing
+- `v0.3.0`: retrieval and memory quality (`P12-S1` through `P12-S3`)
+- `v0.3.1`: public evaluation (`P12-S4`)
+- `v0.3.2`: task-adaptive briefing (`P12-S5`)
 
 ## Sequencing Rules
-- Do not add new product/runtime features during `R1`.
-- Refresh release docs before cutting the tag.
-- Run release gates after doc alignment and before merge approval.
-- Keep the release explicitly pre-1.0.
-- Treat old `v0.1.x` release docs as historical reference, not active release truth.
+- Keep shipped baseline out of roadmap sections.
+- Do not widen Phase 12 into graph migration, marketplace, enterprise/compliance, or new channel work.
+- Use eval evidence to justify public quality claims before updating release docs.
+- Treat later releases as separate contracts; do not collapse all Phase 12 work into one oversized sprint.
 
-## Beyond v0.2.0 (Future, Not Yet Defined)
-- Post-release feature planning is not active inside `R1`.
-- If additional hardening is needed after `R1`, scope it as a separate sprint rather than widening the release sprint.
+## Beyond Phase 12
+- No post-Phase-12 feature plan is defined in the source packet.
+- Additional work after `v0.3.2` requires a new planning pass.

--- a/RULES.md
+++ b/RULES.md
@@ -1,38 +1,48 @@
 # Rules
 
-## Baseline Truth Discipline
+## State Discipline
 - Treat Phases 9-11 and Bridge `B1` through `B4` as shipped baseline truth.
-- Keep shipped baseline, active release work, and future roadmap clearly separated.
-- Keep `ROADMAP.md` future-facing and `.ai/handoff/CURRENT_STATE.md` factual/current.
+- Treat `v0.2.0` as released baseline truth.
+- Keep shipped baseline, active phase scope, and later roadmap scope separate.
+- Keep [CURRENT_STATE.md](CURRENT_STATE.md) factual/current and [ROADMAP.md](ROADMAP.md) future-facing.
+- Keep [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURRENT_STATE.md) as the canonical handoff copy when duplicate current-state files exist.
 
-## Continuity Semantics Rules
-- Never fork continuity semantics by surface or runtime.
-- Provider runtime and Hermes automation may change timing or transport, but memory truth remains in Alice continuity contracts.
-- Preserve provenance, correction, and supersession behavior across all capture paths.
+## Retrieval Rules
+- Retrieval must remain explainable: every result should be traceable to source objects, trust posture, timestamps, and lifecycle status.
+- New ranking stages may improve selection quality, but they must not bypass supersession, provenance, or trust controls already in Alice.
+- Retrieval changes should be benchmarked against fixture baselines before becoming default behavior.
 
-## Integration Rules
+## Mutation Rules
+- Treat memory mutation as an explicit operation, not a silent overwrite.
+- Corrections and changed facts should prefer `SUPERSEDE` or `UPDATE` semantics over destructive replacement.
+- Low-confidence or inferred mutations default to review.
+- Repeated syncs and retries must be idempotent.
+
+## Contradiction And Trust Rules
+- Contradictions must become reviewable objects, not hidden ranking artifacts.
+- Unresolved contradictions should reduce promotion and retrieval confidence.
+- Human correction and repeated corroboration may raise trust; weak single-source inference must not silently gain durable authority.
+
+## Briefing Rules
+- Keep durable memory separate from compiled briefs.
+- Different workloads may receive different context packs, but all briefing outputs must remain deterministic and explainable.
+- Briefing must not introduce claims that the underlying memory layer cannot justify.
+
+## API And Architecture Rules
 - For Hermes, use provider hooks for automation and MCP for explicit deep actions.
-- Do not collapse to provider-only or MCP-only as the canonical target architecture.
-- Keep MCP fallback viable even when provider mode is the recommended deployment shape.
+- Never fork continuity semantics by surface or runtime.
+- Reuse the current continuity contracts where possible; add new surfaces only when the existing contract cannot express the phase goal cleanly.
+- Do not fork semantics between CLI, MCP, hosted, provider-runtime, and Hermes paths.
+- Keep MCP fallback viable even when provider or bridge integrations are the recommended mode.
 
-## Capture Policy Rules
-- Default automation mode is `assist` unless explicitly overridden.
-- Auto-save only explicit high-confidence items that are policy-eligible.
-- Route inferred, weak, speculative, or low-confidence items to review.
-- Never auto-promote a single-turn inference into higher-order trusted patterns or playbooks.
+## Security And Operations Rules
+- Preserve user/workspace isolation across retrieval, mutation, eval, and briefing flows.
+- Keep credentials, tokens, and secret references out of logs and error payloads.
+- Keep local filesystem paths, workstation usernames, and machine-specific identifiers out of committed docs and reports.
+- Keep consequential side effects approval-bounded.
+- Commit public evidence only from exact commands and stable fixtures, never from inferred pass states.
 
-## Reliability Rules
-- Post-response capture and commit paths must be idempotent.
-- No-op turns must not create memory writes.
-- Release evidence must be based on exact commands actually executed, not inferred pass states.
-
-## Security Rules
-- Maintain workspace/session isolation for provider and MCP calls.
-- Keep provider and API credentials out of logs, serialized responses, and outward-facing error payloads.
-- Keep consequential actions approval-bounded regardless of integration mode.
-
-## Release Discipline Rules
-- `v0.2.0` is a pre-1.0 release, not a `1.0.0` contract.
-- Do not widen release-prep sprints into feature work.
-- Do not let README, release docs, or changelog claims outrun shipped behavior.
-- Keep superseded release docs as historical references only.
+## Scope Rules
+- Do not widen Phase 12 into graph migration, marketplace, enterprise/compliance, or new channel work.
+- Do not silently hardcode unresolved sprint Control Tower decisions as permanent runtime behavior without recording the decision.
+- Surface underspecified decisions as Control Tower decisions instead of inventing scope.

--- a/apps/api/alembic/versions/20260414_0057_phase12_hybrid_retrieval_traces.py
+++ b/apps/api/alembic/versions/20260414_0057_phase12_hybrid_retrieval_traces.py
@@ -1,0 +1,156 @@
+"""Add Phase 12 hybrid retrieval run and candidate trace tables."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260414_0057"
+down_revision = "20260412_0056"
+branch_labels = None
+depends_on = None
+
+_RLS_TABLES = (
+    "retrieval_runs",
+    "retrieval_candidates",
+)
+
+_UPGRADE_SCHEMA_STATEMENT = """
+        CREATE TABLE retrieval_runs (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          source_surface text NOT NULL,
+          ranking_strategy text NOT NULL,
+          query_text text NULL,
+          request_scope jsonb NOT NULL DEFAULT '{}'::jsonb,
+          result_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+          exclusion_summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+          candidate_count integer NOT NULL,
+          selected_count integer NOT NULL,
+          debug_enabled boolean NOT NULL DEFAULT FALSE,
+          retention_until timestamptz NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+          UNIQUE (id, user_id),
+          CONSTRAINT retrieval_runs_source_surface_length_check
+            CHECK (char_length(source_surface) >= 1 AND char_length(source_surface) <= 80),
+          CONSTRAINT retrieval_runs_ranking_strategy_check
+            CHECK (ranking_strategy IN ('legacy_v1', 'hybrid_v2')),
+          CONSTRAINT retrieval_runs_query_text_length_check
+            CHECK (query_text IS NULL OR char_length(query_text) <= 4000),
+          CONSTRAINT retrieval_runs_request_scope_object_check
+            CHECK (jsonb_typeof(request_scope) = 'object'),
+          CONSTRAINT retrieval_runs_result_ids_array_check
+            CHECK (jsonb_typeof(result_ids) = 'array'),
+          CONSTRAINT retrieval_runs_exclusion_summary_object_check
+            CHECK (jsonb_typeof(exclusion_summary) = 'object'),
+          CONSTRAINT retrieval_runs_candidate_count_nonnegative_check
+            CHECK (candidate_count >= 0),
+          CONSTRAINT retrieval_runs_selected_count_nonnegative_check
+            CHECK (selected_count >= 0),
+          CONSTRAINT retrieval_runs_selected_count_within_candidates_check
+            CHECK (selected_count <= candidate_count)
+        );
+
+        CREATE TABLE retrieval_candidates (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          retrieval_run_id uuid NOT NULL,
+          continuity_object_id uuid NOT NULL,
+          rank integer NULL,
+          selected boolean NOT NULL DEFAULT FALSE,
+          exclusion_reason text NULL,
+          lexical_score double precision NOT NULL,
+          semantic_score double precision NOT NULL,
+          entity_edge_score double precision NOT NULL,
+          temporal_score double precision NOT NULL,
+          trust_score double precision NOT NULL,
+          relevance double precision NOT NULL,
+          scope_matches jsonb NOT NULL DEFAULT '[]'::jsonb,
+          stage_details jsonb NOT NULL DEFAULT '{}'::jsonb,
+          ordering jsonb NOT NULL DEFAULT '{}'::jsonb,
+          title text NOT NULL,
+          object_type text NOT NULL,
+          status text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+          UNIQUE (id, user_id),
+          CONSTRAINT retrieval_candidates_run_fkey
+            FOREIGN KEY (retrieval_run_id, user_id)
+            REFERENCES retrieval_runs(id, user_id)
+            ON DELETE CASCADE,
+          CONSTRAINT retrieval_candidates_scope_matches_array_check
+            CHECK (jsonb_typeof(scope_matches) = 'array'),
+          CONSTRAINT retrieval_candidates_stage_details_object_check
+            CHECK (jsonb_typeof(stage_details) = 'object'),
+          CONSTRAINT retrieval_candidates_ordering_object_check
+            CHECK (jsonb_typeof(ordering) = 'object'),
+          CONSTRAINT retrieval_candidates_rank_positive_check
+            CHECK (rank IS NULL OR rank >= 1),
+          CONSTRAINT retrieval_candidates_exclusion_reason_length_check
+            CHECK (exclusion_reason IS NULL OR char_length(exclusion_reason) <= 200),
+          CONSTRAINT retrieval_candidates_title_length_check
+            CHECK (char_length(title) >= 1 AND char_length(title) <= 280),
+          CONSTRAINT retrieval_candidates_object_type_length_check
+            CHECK (char_length(object_type) >= 1 AND char_length(object_type) <= 64),
+          CONSTRAINT retrieval_candidates_status_length_check
+            CHECK (char_length(status) >= 1 AND char_length(status) <= 32)
+        );
+
+        CREATE INDEX retrieval_runs_user_created_idx
+          ON retrieval_runs (user_id, created_at DESC, id DESC);
+        CREATE INDEX retrieval_runs_user_retention_idx
+          ON retrieval_runs (user_id, retention_until ASC, id ASC);
+        CREATE INDEX retrieval_candidates_run_rank_idx
+          ON retrieval_candidates (retrieval_run_id, selected DESC, rank ASC, id ASC);
+        CREATE INDEX retrieval_candidates_object_idx
+          ON retrieval_candidates (user_id, continuity_object_id, created_at DESC, id DESC);
+        """
+
+_UPGRADE_GRANT_STATEMENTS = (
+    "GRANT SELECT, INSERT ON retrieval_runs TO alicebot_app",
+    "GRANT SELECT, INSERT ON retrieval_candidates TO alicebot_app",
+)
+
+_UPGRADE_POLICY_STATEMENT = """
+        CREATE POLICY retrieval_runs_read_own ON retrieval_runs
+          FOR SELECT
+          USING (user_id = app.current_user_id());
+
+        CREATE POLICY retrieval_runs_insert_own ON retrieval_runs
+          FOR INSERT
+          WITH CHECK (user_id = app.current_user_id());
+
+        CREATE POLICY retrieval_candidates_read_own ON retrieval_candidates
+          FOR SELECT
+          USING (user_id = app.current_user_id());
+
+        CREATE POLICY retrieval_candidates_insert_own ON retrieval_candidates
+          FOR INSERT
+          WITH CHECK (user_id = app.current_user_id());
+        """
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP TABLE IF EXISTS retrieval_candidates",
+    "DROP TABLE IF EXISTS retrieval_runs",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def _enable_row_level_security() -> None:
+    for table_name in _RLS_TABLES:
+        op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+
+
+def upgrade() -> None:
+    op.execute(_UPGRADE_SCHEMA_STATEMENT)
+    _execute_statements(_UPGRADE_GRANT_STATEMENTS)
+    _enable_row_level_security()
+    op.execute(_UPGRADE_POLICY_STATEMENT)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -311,6 +311,7 @@ def _run_recall(ctx: CLIContext, args: argparse.Namespace) -> str:
                 since=args.since,
                 until=args.until,
                 limit=args.limit,
+                debug=args.debug,
             ),
         )
     return format_recall_output(payload)
@@ -380,6 +381,7 @@ def _run_resume(ctx: CLIContext, args: argparse.Namespace) -> str:
                 max_recent_changes=args.max_recent_changes,
                 max_open_loops=args.max_open_loops,
                 include_non_promotable_facts=args.include_non_promotable_facts,
+                debug=args.debug,
             ),
         )
     return format_resume_output(payload)
@@ -719,6 +721,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_CONTINUITY_RECALL_LIMIT,
         help=f"Max results (1-{MAX_CONTINUITY_RECALL_LIMIT}).",
     )
+    recall_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Include hybrid retrieval stage scores and exclusion reasons.",
+    )
     recall_parser.set_defaults(handler=_run_recall)
 
     state_at_parser = subparsers.add_parser(
@@ -782,6 +789,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-non-promotable-facts",
         action="store_true",
         help="Include searchable but non-promotable facts in recent changes.",
+    )
+    resume_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Include the underlying hybrid retrieval trace.",
     )
     resume_parser.set_defaults(handler=_run_resume)
 

--- a/apps/api/src/alicebot_api/cli_formatting.py
+++ b/apps/api/src/alicebot_api/cli_formatting.py
@@ -227,6 +227,68 @@ def _render_recall_list_section(
     return lines
 
 
+def _render_retrieval_debug(payload: Mapping[str, object]) -> list[str]:
+    debug = payload.get("debug")
+    if not isinstance(debug, dict):
+        return []
+
+    lines = [
+        "debug:",
+        f"  retrieval_run_id: {debug.get('retrieval_run_id')}",
+        f"  source_surface: {debug.get('source_surface')}",
+        f"  ranking_strategy: {debug.get('ranking_strategy')}",
+        f"  query_terms: {', '.join(debug.get('query_terms', [])) if isinstance(debug.get('query_terms'), list) else '(none)'}",
+        (
+            "  entity_anchors: "
+            + (
+                ", ".join(debug.get("entity_anchor_names", []))
+                if isinstance(debug.get("entity_anchor_names"), list) and debug.get("entity_anchor_names")
+                else "(none)"
+            )
+        ),
+        (
+            "  entity_expansion: "
+            + (
+                ", ".join(debug.get("entity_expansion_names", []))
+                if isinstance(debug.get("entity_expansion_names"), list) and debug.get("entity_expansion_names")
+                else "(none)"
+            )
+        ),
+        f"  candidates: {debug.get('candidate_count')} selected={debug.get('selected_count')}",
+    ]
+
+    candidates = debug.get("candidates")
+    if not isinstance(candidates, list) or len(candidates) == 0:
+        return lines
+
+    lines.append("  trace:")
+    for index, candidate in enumerate(candidates, start=1):
+        if not isinstance(candidate, dict):
+            continue
+        lines.append(
+            "    "
+            f"{index}. rank={candidate.get('rank')} selected={candidate.get('selected')} "
+            f"relevance={_format_float(float(candidate.get('relevance', 0.0)))} "
+            f"object_id={candidate.get('object_id')} title={candidate.get('title')}"
+        )
+        lines.append(f"       exclusion_reason={candidate.get('exclusion_reason')}")
+        stage_scores = candidate.get("stage_scores")
+        if not isinstance(stage_scores, dict):
+            continue
+        for stage_name in ("lexical", "semantic", "entity_edge", "temporal", "trust"):
+            stage = stage_scores.get(stage_name)
+            if not isinstance(stage, dict):
+                continue
+            raw_score = float(stage.get("raw_score", 0.0))
+            normalized_score = float(stage.get("normalized_score", 0.0))
+            lines.append(
+                "       "
+                f"{stage_name}: raw={_format_float(raw_score)} normalized={_format_float(normalized_score)} "
+                f"matched={stage.get('matched')} reason={stage.get('reason')}"
+            )
+    return lines
+
+
 def format_capture_output(payload: ContinuityCaptureCreateResponse) -> str:
     capture = payload["capture"]["capture_event"]
     derived = payload["capture"]["derived_object"]
@@ -278,11 +340,13 @@ def format_recall_output(payload: ContinuityRecallResponse) -> str:
     items = payload["items"]
     if len(items) == 0:
         lines.append("empty: no continuity results in requested scope.")
+        lines.extend(_render_retrieval_debug(payload))
         return "\n".join(lines)
 
     lines.append("items:")
     for index, item in enumerate(items, start=1):
         lines.extend(_render_recall_item(item, index=index))
+    lines.extend(_render_retrieval_debug(payload))
     return "\n".join(lines)
 
 
@@ -330,6 +394,7 @@ def format_resume_output(payload: ContinuityResumptionBriefResponse) -> str:
     else:
         lines.extend(_render_recall_item(next_action["item"]))
 
+    lines.extend(_render_retrieval_debug(payload))
     return "\n".join(lines)
 
 

--- a/apps/api/src/alicebot_api/config.py
+++ b/apps/api/src/alicebot_api/config.py
@@ -82,6 +82,7 @@ DEFAULT_SECURITY_HEADERS_HSTS_INCLUDE_SUBDOMAINS = True
 DEFAULT_TRUST_PROXY_HEADERS = False
 DEFAULT_TRUSTED_PROXY_IPS: tuple[str, ...] = ()
 DEFAULT_ENTRYPOINT_RATE_LIMIT_BACKEND = "redis"
+DEFAULT_RETRIEVAL_TRACE_RETENTION_DAYS = 14
 
 Environment = Mapping[str, str]
 
@@ -191,6 +192,7 @@ class Settings:
     trust_proxy_headers: bool = DEFAULT_TRUST_PROXY_HEADERS
     trusted_proxy_ips: tuple[str, ...] = DEFAULT_TRUSTED_PROXY_IPS
     entrypoint_rate_limit_backend: str = DEFAULT_ENTRYPOINT_RATE_LIMIT_BACKEND
+    retrieval_trace_retention_days: int = DEFAULT_RETRIEVAL_TRACE_RETENTION_DAYS
 
     @classmethod
     def from_env(cls, env: Environment | None = None) -> "Settings":
@@ -418,6 +420,11 @@ class Settings:
                 "ENTRYPOINT_RATE_LIMIT_BACKEND",
                 cls.entrypoint_rate_limit_backend,
             ).strip().lower(),
+            retrieval_trace_retention_days=_get_env_int(
+                current_env,
+                "RETRIEVAL_TRACE_RETENTION_DAYS",
+                cls.retrieval_trace_retention_days,
+            ),
         )
         return _validate_settings(settings)
 
@@ -475,6 +482,8 @@ def _validate_settings(settings: Settings) -> Settings:
         raise ValueError("SECURITY_HEADERS_HSTS_MAX_AGE_SECONDS must be a positive integer")
     if settings.entrypoint_rate_limit_backend not in {"redis", "memory"}:
         raise ValueError("ENTRYPOINT_RATE_LIMIT_BACKEND must be either 'redis' or 'memory'")
+    if settings.retrieval_trace_retention_days <= 0:
+        raise ValueError("RETRIEVAL_TRACE_RETENTION_DAYS must be a positive integer")
     if settings.trust_proxy_headers and len(settings.trusted_proxy_ips) == 0:
         raise ValueError("TRUSTED_PROXY_IPS must include at least one IP when TRUST_PROXY_HEADERS is enabled")
 

--- a/apps/api/src/alicebot_api/continuity_recall.py
+++ b/apps/api/src/alicebot_api/continuity_recall.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Literal, cast
 from uuid import UUID
 
+from alicebot_api.config import get_settings
 from alicebot_api.continuity_objects import (
     default_continuity_searchable,
     serialize_continuity_lifecycle_state_from_record,
@@ -14,8 +16,12 @@ from alicebot_api.continuity_explainability import build_continuity_item_explana
 from alicebot_api.contracts import (
     CONTINUITY_RECALL_LIST_ORDER,
     DEFAULT_CONTINUITY_RECALL_LIMIT,
+    DEFAULT_RETRIEVAL_RUN_LIST_LIMIT,
     MAX_CONTINUITY_RECALL_LIMIT,
+    MAX_RETRIEVAL_RUN_LIST_LIMIT,
     ContinuityRecallFreshnessPosture,
+    ContinuityRetrievalDebugCandidateRecord,
+    ContinuityRetrievalDebugRecord,
     ContinuityRecallOrderingMetadata,
     ContinuityRecallProvenancePosture,
     ContinuityRecallProvenanceReference,
@@ -26,15 +32,34 @@ from alicebot_api.contracts import (
     ContinuityRecallScopeKind,
     ContinuityRecallScopeMatch,
     ContinuityRecallSupersessionPosture,
+    RetrievalRunListResponse,
+    RetrievalRunListSummary,
+    RetrievalRunRecord,
+    RetrievalTraceResponse,
+    RetrievalTraceSummary,
+    RETRIEVAL_RUN_LIST_ORDER,
+    RETRIEVAL_TRACE_CANDIDATE_ORDER,
     MemoryConfirmationStatus,
     MemoryTrustClass,
     isoformat_or_none,
 )
-from alicebot_api.store import ContinuityRecallCandidateRow, ContinuityStore, JsonObject
+from alicebot_api.store import (
+    ContinuityRecallCandidateRow,
+    ContinuityStore,
+    EntityEdgeRow,
+    EntityRow,
+    JsonObject,
+    RetrievalCandidateRow,
+    RetrievalRunRow,
+)
 
 
 class ContinuityRecallValidationError(ValueError):
     """Raised when a continuity recall query is invalid."""
+
+
+class RetrievalTraceNotFoundError(LookupError):
+    """Raised when a persisted retrieval trace is not visible in the current scope."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,6 +86,68 @@ class RankedRecallCandidate:
     posture_rank: int
     lifecycle_rank: int
     relevance: float
+
+
+@dataclass(frozen=True, slots=True)
+class EntityRetrievalContext:
+    anchor_names: tuple[str, ...]
+    expansion_names: tuple[str, ...]
+    expansion_weights: dict[str, float]
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateStageScores:
+    lexical_raw: float
+    lexical_normalized: float
+    semantic_raw: float
+    semantic_normalized: float
+    entity_edge_raw: float
+    entity_edge_normalized: float
+    temporal_raw: float
+    temporal_normalized: float
+    trust_raw: float
+    trust_normalized: float
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateScoringState:
+    row: ContinuityRecallCandidateRow
+    scope_matches: list[ContinuityRecallScopeMatch]
+    scope_matched: bool
+    query_term_match_count: int
+    semantic_similarity_score: float
+    exact_match_score: float
+    recency_score: float
+    temporal_overlap_score: float
+    entity_match_count: int
+    lexical_raw_score: float
+    semantic_raw_score: float
+    entity_edge_raw_score: float
+    temporal_raw_score: float
+    trust_raw_score: float
+    confirmation_status: MemoryConfirmationStatus
+    confirmation_rank: int
+    trust_class: MemoryTrustClass
+    trust_rank: int
+    freshness_posture: ContinuityRecallFreshnessPosture
+    freshness_rank: int
+    provenance_posture: ContinuityRecallProvenancePosture
+    provenance_rank: int
+    supersession_posture: ContinuityRecallSupersessionPosture
+    supersession_rank: int
+    supersession_freshness_score: float
+    posture_rank: int
+    lifecycle_rank: int
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalTraceCandidate:
+    ranked: RankedRecallCandidate
+    rank: int | None
+    selected: bool
+    exclusion_reason: str | None
+    stage_scores: CandidateStageScores
+    stage_reasons: dict[str, str]
 
 
 _SCOPE_FILTER_KEYS: dict[ContinuityRecallScopeKind, set[str]] = {
@@ -736,6 +823,241 @@ def _entity_match_count(row: ContinuityRecallCandidateRow, *, entity_terms: list
     return sum(1 for term in entity_terms if term in normalized_values)
 
 
+def _list_entities(store: ContinuityStore) -> list[EntityRow]:
+    list_entities = getattr(store, "list_entities", None)
+    if not callable(list_entities):
+        return []
+    entities = list_entities()
+    return entities if isinstance(entities, list) else []
+
+
+def _list_entity_edges_for_entities(
+    store: ContinuityStore,
+    entity_ids: list[UUID],
+) -> list[EntityEdgeRow]:
+    list_edges = getattr(store, "list_entity_edges_for_entities", None)
+    if callable(list_edges):
+        edges = list_edges(entity_ids)
+        if isinstance(edges, list):
+            return edges
+
+    list_edge_for_entity = getattr(store, "list_entity_edges_for_entity", None)
+    if not callable(list_edge_for_entity):
+        return []
+
+    rows: list[EntityEdgeRow] = []
+    seen: set[UUID] = set()
+    for entity_id in entity_ids:
+        edges = list_edge_for_entity(entity_id)
+        if not isinstance(edges, list):
+            continue
+        for edge in edges:
+            edge_id = edge.get("id")
+            if isinstance(edge_id, UUID):
+                if edge_id in seen:
+                    continue
+                seen.add(edge_id)
+            rows.append(edge)
+    return rows
+
+
+def _resolve_entity_retrieval_context(
+    store: ContinuityStore,
+    *,
+    request: ContinuityRecallQueryInput,
+) -> EntityRetrievalContext:
+    entities = _list_entities(store)
+    if not entities:
+        return EntityRetrievalContext(
+            anchor_names=tuple(),
+            expansion_names=tuple(),
+            expansion_weights={},
+        )
+
+    name_by_id: dict[UUID, str] = {
+        entity["id"]: entity["name"]
+        for entity in entities
+        if entity.get("name")
+    }
+    query_tokens = set(_entity_query_terms(request))
+    explicit_names = {
+        value.casefold()
+        for value in (request.project, request.person)
+        if value is not None
+    }
+
+    anchor_entities: list[EntityRow] = []
+    for entity in entities:
+        entity_name = entity["name"].strip()
+        if not entity_name:
+            continue
+        entity_name_casefold = entity_name.casefold()
+        entity_tokens = set(
+            _tokenize(
+                entity_name,
+                max_chars=_MAX_SIMILARITY_QUERY_CHARS,
+                max_tokens=_MAX_SIMILARITY_QUERY_TOKEN_COUNT,
+            )
+        )
+        if entity_name_casefold in explicit_names:
+            anchor_entities.append(entity)
+            continue
+        if query_tokens and query_tokens & entity_tokens:
+            anchor_entities.append(entity)
+
+    if not anchor_entities:
+        return EntityRetrievalContext(
+            anchor_names=tuple(),
+            expansion_names=tuple(),
+            expansion_weights={},
+        )
+
+    anchor_ids = [entity["id"] for entity in anchor_entities]
+    anchor_names = tuple(
+        sorted({entity["name"].casefold() for entity in anchor_entities if entity["name"].strip()})
+    )
+    expansion_weights: dict[str, float] = {
+        name: 0.5
+        for name in anchor_names
+    }
+
+    for edge in _list_entity_edges_for_entities(store, anchor_ids):
+        from_name = name_by_id.get(edge["from_entity_id"])
+        to_name = name_by_id.get(edge["to_entity_id"])
+        if from_name is not None and edge["from_entity_id"] not in anchor_ids:
+            expansion_weights.setdefault(from_name.casefold(), 1.25)
+        if to_name is not None and edge["to_entity_id"] not in anchor_ids:
+            expansion_weights.setdefault(to_name.casefold(), 1.25)
+
+    expansion_names = tuple(sorted(expansion_weights))
+    return EntityRetrievalContext(
+        anchor_names=anchor_names,
+        expansion_names=expansion_names,
+        expansion_weights=expansion_weights,
+    )
+
+
+def _entity_edge_raw_score(
+    row: ContinuityRecallCandidateRow,
+    *,
+    entity_context: EntityRetrievalContext,
+) -> float:
+    if not entity_context.expansion_weights:
+        return 0.0
+    entity_values = _collect_strings(row["provenance"], keys=_ENTITY_KEYS) | _collect_strings(
+        row["body"],
+        keys=_ENTITY_KEYS,
+    )
+    if not entity_values:
+        return 0.0
+    normalized_values = " ".join(sorted(entity_values)).casefold()
+    score = 0.0
+    for entity_name, weight in entity_context.expansion_weights.items():
+        if entity_name in normalized_values:
+            score += weight
+    return score
+
+
+def _token_frequency(value: str, *, max_chars: int, max_tokens: int) -> dict[str, int]:
+    frequencies: dict[str, int] = {}
+    for token in _tokenize(value, max_chars=max_chars, max_tokens=max_tokens):
+        frequencies[token] = frequencies.get(token, 0) + 1
+    return frequencies
+
+
+def _lexical_scores(
+    *,
+    corpus_rows: list[ContinuityRecallCandidateRow],
+    target_rows: list[ContinuityRecallCandidateRow],
+    query_terms: list[str],
+) -> dict[UUID, float]:
+    if not target_rows or not query_terms:
+        return {row["id"]: 0.0 for row in target_rows}
+    if not corpus_rows:
+        return {row["id"]: 0.0 for row in target_rows}
+
+    unique_terms = list(dict.fromkeys(query_terms))
+    document_frequencies: dict[str, int] = {term: 0 for term in unique_terms}
+    corpus_term_frequencies: dict[UUID, dict[str, int]] = {}
+    corpus_doc_lengths: dict[UUID, int] = {}
+
+    for row in corpus_rows:
+        frequencies = _token_frequency(
+            _candidate_text(row),
+            max_chars=_MAX_SIMILARITY_CANDIDATE_TEXT_CHARS,
+            max_tokens=_MAX_SIMILARITY_TOKEN_COUNT,
+        )
+        corpus_term_frequencies[row["id"]] = frequencies
+        corpus_doc_lengths[row["id"]] = sum(frequencies.values())
+        for term in unique_terms:
+            if frequencies.get(term, 0) > 0:
+                document_frequencies[term] += 1
+
+    average_doc_length = (
+        sum(corpus_doc_lengths.values()) / float(len(corpus_doc_lengths))
+        if corpus_doc_lengths
+        else 1.0
+    )
+    k1 = 1.2
+    b = 0.75
+    document_count = len(corpus_rows)
+    scores: dict[UUID, float] = {}
+    for row in target_rows:
+        score = 0.0
+        frequencies = corpus_term_frequencies.get(row["id"])
+        if frequencies is None:
+            frequencies = _token_frequency(
+                _candidate_text(row),
+                max_chars=_MAX_SIMILARITY_CANDIDATE_TEXT_CHARS,
+                max_tokens=_MAX_SIMILARITY_TOKEN_COUNT,
+            )
+        doc_length = max(sum(frequencies.values()), 1)
+        for term in unique_terms:
+            term_frequency = frequencies.get(term, 0)
+            if term_frequency <= 0:
+                continue
+            doc_frequency = document_frequencies.get(term, 0)
+            if doc_frequency <= 0:
+                continue
+            idf = math.log(1.0 + ((document_count - doc_frequency + 0.5) / (doc_frequency + 0.5)))
+            denominator = term_frequency + k1 * (1.0 - b + b * (doc_length / max(average_doc_length, 1.0)))
+            score += idf * ((term_frequency * (k1 + 1.0)) / denominator)
+        scores[row["id"]] = score
+    return scores
+
+
+def _normalize_stage_scores(
+    raw_scores: dict[UUID, float],
+    *,
+    reference_candidate_ids: set[UUID] | None = None,
+) -> dict[UUID, float]:
+    if not raw_scores:
+        return {}
+    if reference_candidate_ids is None:
+        reference_scores = list(raw_scores.values())
+    else:
+        reference_scores = [
+            score
+            for candidate_id, score in raw_scores.items()
+            if candidate_id in reference_candidate_ids
+        ]
+    if not reference_scores:
+        return {candidate_id: 0.0 for candidate_id in raw_scores}
+    max_score = max(reference_scores)
+    if max_score <= 0.0:
+        return {candidate_id: 0.0 for candidate_id in raw_scores}
+    return {
+        candidate_id: min(raw_score / max_score, 1.0)
+        for candidate_id, raw_score in raw_scores.items()
+    }
+
+
+def _retrieval_trace_retention_until(*, now: datetime | None = None) -> datetime:
+    current_time = datetime.now(tz=UTC) if now is None else now
+    retention_days = get_settings().retrieval_trace_retention_days
+    return current_time + timedelta(days=retention_days)
+
+
 def _supersession_freshness_score(
     *,
     freshness_rank: int,
@@ -807,13 +1129,9 @@ def _build_provenance_references(
     ]
 
 
-def _serialize_recall_result(
-    store: ContinuityStore,
-    item: RankedRecallCandidate,
-) -> ContinuityRecallResultRecord:
+def _ordering_metadata(item: RankedRecallCandidate) -> ContinuityRecallOrderingMetadata:
     row = item.row
-
-    ordering: ContinuityRecallOrderingMetadata = {
+    return {
         "scope_match_count": len(item.scope_matches),
         "query_term_match_count": item.query_term_match_count,
         "semantic_similarity_score": item.semantic_similarity_score,
@@ -835,6 +1153,15 @@ def _serialize_recall_result(
         "lifecycle_rank": item.lifecycle_rank,
         "confidence": float(row["confidence"]),
     }
+
+
+def _serialize_recall_result(
+    store: ContinuityStore,
+    item: RankedRecallCandidate,
+) -> ContinuityRecallResultRecord:
+    row = item.row
+
+    ordering = _ordering_metadata(item)
 
     return {
         "id": str(row["id"]),
@@ -910,186 +1237,42 @@ def _validate_request(request: ContinuityRecallQueryInput) -> None:
         raise ContinuityRecallValidationError("until must be greater than or equal to since")
 
 
-def _ordered_recall_candidates(
-    store: ContinuityStore,
+def _build_ranked_candidate(
+    state: CandidateScoringState,
     *,
-    request: ContinuityRecallQueryInput,
-    ranking_strategy: Literal["legacy_v1", "hybrid_v2"] = "hybrid_v2",
+    relevance: float,
+) -> RankedRecallCandidate:
+    return RankedRecallCandidate(
+        row=state.row,
+        scope_matches=state.scope_matches,
+        query_term_match_count=state.query_term_match_count,
+        semantic_similarity_score=state.semantic_similarity_score,
+        exact_match_score=state.exact_match_score,
+        recency_score=state.recency_score,
+        temporal_overlap_score=state.temporal_overlap_score,
+        entity_match_count=state.entity_match_count,
+        confirmation_status=state.confirmation_status,
+        confirmation_rank=state.confirmation_rank,
+        trust_class=state.trust_class,
+        trust_rank=state.trust_rank,
+        freshness_posture=state.freshness_posture,
+        freshness_rank=state.freshness_rank,
+        provenance_posture=state.provenance_posture,
+        provenance_rank=state.provenance_rank,
+        supersession_posture=state.supersession_posture,
+        supersession_rank=state.supersession_rank,
+        supersession_freshness_score=state.supersession_freshness_score,
+        posture_rank=state.posture_rank,
+        lifecycle_rank=state.lifecycle_rank,
+        relevance=relevance,
+    )
+
+
+def _sort_ranked_candidates(
+    ranked_candidates: list[RankedRecallCandidate],
+    *,
+    ranking_strategy: Literal["legacy_v1", "hybrid_v2"],
 ) -> list[RankedRecallCandidate]:
-    thread_filter = _normalize_uuid_string(request.thread_id)
-    task_filter = _normalize_uuid_string(request.task_id)
-    project_filter = (
-        request.project.casefold()
-        if request.project is not None
-        else None
-    )
-    person_filter = (
-        request.person.casefold()
-        if request.person is not None
-        else None
-    )
-    query_terms = _query_terms(request.query)
-    query_features = _build_similarity_query_features(request.query)
-    entity_terms = _entity_query_terms(request)
-    scoped_candidates: list[tuple[ContinuityRecallCandidateRow, list[ContinuityRecallScopeMatch]]] = []
-    required_scope_count = sum(
-        value is not None
-        for value in (thread_filter, task_filter, project_filter, person_filter)
-    )
-
-    for row in store.list_continuity_recall_candidates():
-        if row["status"] == "deleted":
-            continue
-        if not bool(row.get("is_searchable", default_continuity_searchable(row["object_type"]))):
-            continue
-
-        if not _matches_time_window(
-            row,
-            since=request.since,
-            until=request.until,
-        ):
-            continue
-
-        scope_matches = _compute_scope_matches(
-            row,
-            thread_filter=thread_filter,
-            task_filter=task_filter,
-            project_filter=project_filter,
-            person_filter=person_filter,
-        )
-        if len(scope_matches) != required_scope_count:
-            continue
-        scoped_candidates.append((row, scope_matches))
-
-    if not scoped_candidates:
-        return []
-
-    newest_created_at = max(
-        row["object_created_at"]
-        for row, _scope_matches in scoped_candidates
-    )
-    ranked_candidates: list[RankedRecallCandidate] = []
-
-    for row, scope_matches in scoped_candidates:
-
-        candidate_text = _candidate_text(row)
-        candidate_text_casefold = candidate_text.casefold()
-        query_term_match_count = _count_query_term_matches(
-            candidate_text_casefold=candidate_text_casefold,
-            terms=query_terms,
-        )
-        semantic_similarity_score = _semantic_similarity_score(
-            query_features=query_features,
-            candidate_text=candidate_text,
-        )
-        exact_match_score = _exact_match_score(
-            query_features=query_features,
-            candidate_text_casefold=candidate_text_casefold,
-            title=row["title"],
-        )
-        if ranking_strategy == "legacy_v1":
-            if query_terms and query_term_match_count == 0:
-                continue
-        elif query_terms and query_term_match_count == 0:
-            if exact_match_score <= 0.0 and semantic_similarity_score < _SEMANTIC_MATCH_THRESHOLD:
-                continue
-
-        confirmation_status = _extract_confirmation_status(row)
-        confirmation_rank = _CONFIRMATION_RANK[confirmation_status]
-        freshness_posture = _extract_freshness_posture(
-            row,
-            confirmation_status=confirmation_status,
-        )
-        freshness_rank = _FRESHNESS_RANK[freshness_posture]
-        provenance_posture = _extract_provenance_posture(
-            row,
-            scope_matches=scope_matches,
-        )
-        provenance_rank = _PROVENANCE_RANK[provenance_posture]
-        trust_class = _extract_trust_class(
-            row,
-            confirmation_status=confirmation_status,
-            provenance_posture=provenance_posture,
-        )
-        trust_rank = _TRUST_CLASS_RANK[trust_class]
-        supersession_posture = _extract_supersession_posture(row)
-        supersession_rank = _SUPERSESSION_RANK[supersession_posture]
-        temporal_overlap_score = _temporal_overlap_score(
-            row,
-            since=request.since,
-            until=request.until,
-        )
-        recency_score = _recency_score(
-            created_at=row["object_created_at"],
-            newest_created_at=newest_created_at,
-        )
-        entity_match_count = _entity_match_count(
-            row,
-            entity_terms=entity_terms,
-        )
-        supersession_freshness_score = _supersession_freshness_score(
-            freshness_rank=freshness_rank,
-            supersession_rank=supersession_rank,
-        )
-        posture_rank = _POSTURE_RANK.get(row["admission_posture"], 0)
-        lifecycle_rank = _LIFECYCLE_RANK.get(row["status"], 0)
-        if ranking_strategy == "legacy_v1":
-            relevance = (
-                float(len(scope_matches)) * 100.0
-                + float(query_term_match_count) * 20.0
-                + float(confirmation_rank) * 14.0
-                + float(freshness_rank) * 12.0
-                + float(provenance_rank) * 8.0
-                + float(supersession_rank) * 10.0
-                + float(posture_rank) * 4.0
-                + float(lifecycle_rank) * 2.0
-                + float(row["confidence"])
-            )
-        else:
-            relevance = (
-                float(len(scope_matches)) * 100.0
-                + float(entity_match_count) * 35.0
-                + exact_match_score * 36.0
-                + semantic_similarity_score * 28.0
-                + float(query_term_match_count) * 14.0
-                + temporal_overlap_score * 16.0
-                + float(trust_rank) * 12.0
-                + supersession_freshness_score * 8.0
-                + float(confirmation_rank) * 8.0
-                + float(provenance_rank) * 6.0
-                + float(posture_rank) * 4.0
-                + float(lifecycle_rank) * 3.0
-                + recency_score * 4.0
-                + float(row["confidence"])
-            )
-
-        ranked_candidates.append(
-            RankedRecallCandidate(
-                row=row,
-                scope_matches=scope_matches,
-                query_term_match_count=query_term_match_count,
-                semantic_similarity_score=semantic_similarity_score,
-                exact_match_score=exact_match_score,
-                recency_score=recency_score,
-                temporal_overlap_score=temporal_overlap_score,
-                entity_match_count=entity_match_count,
-                confirmation_status=confirmation_status,
-                confirmation_rank=confirmation_rank,
-                trust_class=trust_class,
-                trust_rank=trust_rank,
-                freshness_posture=freshness_posture,
-                freshness_rank=freshness_rank,
-                provenance_posture=provenance_posture,
-                provenance_rank=provenance_rank,
-                supersession_posture=supersession_posture,
-                supersession_rank=supersession_rank,
-                supersession_freshness_score=supersession_freshness_score,
-                posture_rank=posture_rank,
-                lifecycle_rank=lifecycle_rank,
-                relevance=relevance,
-            )
-        )
-
     if ranking_strategy == "legacy_v1":
         return sorted(
             ranked_candidates,
@@ -1134,6 +1317,518 @@ def _ordered_recall_candidates(
     )
 
 
+def _ordered_recall_candidates(
+    store: ContinuityStore,
+    *,
+    request: ContinuityRecallQueryInput,
+    ranking_strategy: Literal["legacy_v1", "hybrid_v2"] = "hybrid_v2",
+) -> tuple[list[RankedRecallCandidate], list[RetrievalTraceCandidate], list[str], EntityRetrievalContext]:
+    thread_filter = _normalize_uuid_string(request.thread_id)
+    task_filter = _normalize_uuid_string(request.task_id)
+    project_filter = request.project.casefold() if request.project is not None else None
+    person_filter = request.person.casefold() if request.person is not None else None
+    query_terms = _query_terms(request.query)
+    query_features = _build_similarity_query_features(request.query)
+    entity_terms = _entity_query_terms(request)
+    entity_context = _resolve_entity_retrieval_context(store, request=request)
+    required_scope_count = sum(
+        value is not None
+        for value in (thread_filter, task_filter, project_filter, person_filter)
+    )
+
+    visible_candidates: list[tuple[ContinuityRecallCandidateRow, list[ContinuityRecallScopeMatch], bool]] = []
+    for row in store.list_continuity_recall_candidates():
+        if row["status"] == "deleted":
+            continue
+        if not bool(row.get("is_searchable", default_continuity_searchable(row["object_type"]))):
+            continue
+        if not _matches_time_window(row, since=request.since, until=request.until):
+            continue
+
+        scope_matches = _compute_scope_matches(
+            row,
+            thread_filter=thread_filter,
+            task_filter=task_filter,
+            project_filter=project_filter,
+            person_filter=person_filter,
+        )
+        scope_matched = len(scope_matches) == required_scope_count
+        visible_candidates.append((row, scope_matches, scope_matched))
+
+    if not visible_candidates:
+        return [], [], query_terms, entity_context
+
+    candidate_rows = [row for row, _scope_matches, _scope_matched in visible_candidates]
+    scope_matched_rows = [
+        row
+        for row, _scope_matches, scope_matched in visible_candidates
+        if scope_matched
+    ]
+    scoring_reference_rows = scope_matched_rows if scope_matched_rows else candidate_rows
+    reference_candidate_ids = {row["id"] for row in scoring_reference_rows}
+    newest_created_at = max(row["object_created_at"] for row in scoring_reference_rows)
+    lexical_raw_scores = _lexical_scores(
+        corpus_rows=scoring_reference_rows,
+        target_rows=candidate_rows,
+        query_terms=query_terms,
+    )
+
+    scoring_states: list[CandidateScoringState] = []
+    for row, scope_matches, scope_matched in visible_candidates:
+        candidate_text = _candidate_text(row)
+        candidate_text_casefold = candidate_text.casefold()
+        query_term_match_count = _count_query_term_matches(
+            candidate_text_casefold=candidate_text_casefold,
+            terms=query_terms,
+        )
+        semantic_similarity_score = _semantic_similarity_score(
+            query_features=query_features,
+            candidate_text=candidate_text,
+        )
+        exact_match_score = _exact_match_score(
+            query_features=query_features,
+            candidate_text_casefold=candidate_text_casefold,
+            title=row["title"],
+        )
+        confirmation_status = _extract_confirmation_status(row)
+        confirmation_rank = _CONFIRMATION_RANK[confirmation_status]
+        freshness_posture = _extract_freshness_posture(
+            row,
+            confirmation_status=confirmation_status,
+        )
+        freshness_rank = _FRESHNESS_RANK[freshness_posture]
+        provenance_posture = _extract_provenance_posture(
+            row,
+            scope_matches=scope_matches,
+        )
+        provenance_rank = _PROVENANCE_RANK[provenance_posture]
+        trust_class = _extract_trust_class(
+            row,
+            confirmation_status=confirmation_status,
+            provenance_posture=provenance_posture,
+        )
+        trust_rank = _TRUST_CLASS_RANK[trust_class]
+        supersession_posture = _extract_supersession_posture(row)
+        supersession_rank = _SUPERSESSION_RANK[supersession_posture]
+        temporal_overlap_score = _temporal_overlap_score(
+            row,
+            since=request.since,
+            until=request.until,
+        )
+        recency_score = _recency_score(
+            created_at=row["object_created_at"],
+            newest_created_at=newest_created_at,
+        )
+        entity_match_count = _entity_match_count(row, entity_terms=entity_terms)
+        supersession_freshness_score = _supersession_freshness_score(
+            freshness_rank=freshness_rank,
+            supersession_rank=supersession_rank,
+        )
+        posture_rank = _POSTURE_RANK.get(row["admission_posture"], 0)
+        lifecycle_rank = _LIFECYCLE_RANK.get(row["status"], 0)
+
+        scoring_states.append(
+            CandidateScoringState(
+                row=row,
+                scope_matches=scope_matches,
+                scope_matched=scope_matched,
+                query_term_match_count=query_term_match_count,
+                semantic_similarity_score=semantic_similarity_score,
+                exact_match_score=exact_match_score,
+                recency_score=recency_score,
+                temporal_overlap_score=temporal_overlap_score,
+                entity_match_count=entity_match_count,
+                lexical_raw_score=lexical_raw_scores.get(row["id"], 0.0),
+                semantic_raw_score=exact_match_score + semantic_similarity_score,
+                entity_edge_raw_score=_entity_edge_raw_score(
+                    row,
+                    entity_context=entity_context,
+                ),
+                temporal_raw_score=(temporal_overlap_score * 0.65) + (recency_score * 0.35),
+                trust_raw_score=(
+                    float(trust_rank)
+                    + (float(confirmation_rank) * 0.5)
+                    + (float(provenance_rank) * 0.35)
+                    + (supersession_freshness_score * 0.35)
+                ),
+                confirmation_status=confirmation_status,
+                confirmation_rank=confirmation_rank,
+                trust_class=trust_class,
+                trust_rank=trust_rank,
+                freshness_posture=freshness_posture,
+                freshness_rank=freshness_rank,
+                provenance_posture=provenance_posture,
+                provenance_rank=provenance_rank,
+                supersession_posture=supersession_posture,
+                supersession_rank=supersession_rank,
+                supersession_freshness_score=supersession_freshness_score,
+                posture_rank=posture_rank,
+                lifecycle_rank=lifecycle_rank,
+            )
+        )
+
+    lexical_normalized = _normalize_stage_scores(
+        {state.row["id"]: state.lexical_raw_score for state in scoring_states},
+        reference_candidate_ids=reference_candidate_ids,
+    )
+    semantic_normalized = _normalize_stage_scores(
+        {state.row["id"]: state.semantic_raw_score for state in scoring_states},
+        reference_candidate_ids=reference_candidate_ids,
+    )
+    entity_edge_normalized = _normalize_stage_scores(
+        {state.row["id"]: state.entity_edge_raw_score for state in scoring_states},
+        reference_candidate_ids=reference_candidate_ids,
+    )
+    temporal_normalized = _normalize_stage_scores(
+        {state.row["id"]: state.temporal_raw_score for state in scoring_states},
+        reference_candidate_ids=reference_candidate_ids,
+    )
+    trust_normalized = _normalize_stage_scores(
+        {state.row["id"]: state.trust_raw_score for state in scoring_states},
+        reference_candidate_ids=reference_candidate_ids,
+    )
+
+    ranked_candidates: list[RankedRecallCandidate] = []
+    excluded_by_id: dict[UUID, str] = {}
+    stage_scores_by_id: dict[UUID, CandidateStageScores] = {}
+    stage_reasons_by_id: dict[UUID, dict[str, str]] = {}
+
+    has_stream_query = bool(query_terms) or bool(entity_context.expansion_names)
+    for state in scoring_states:
+        candidate_id = state.row["id"]
+        stage_scores = CandidateStageScores(
+            lexical_raw=state.lexical_raw_score,
+            lexical_normalized=lexical_normalized.get(candidate_id, 0.0),
+            semantic_raw=state.semantic_raw_score,
+            semantic_normalized=semantic_normalized.get(candidate_id, 0.0),
+            entity_edge_raw=state.entity_edge_raw_score,
+            entity_edge_normalized=entity_edge_normalized.get(candidate_id, 0.0),
+            temporal_raw=state.temporal_raw_score,
+            temporal_normalized=temporal_normalized.get(candidate_id, 0.0),
+            trust_raw=state.trust_raw_score,
+            trust_normalized=trust_normalized.get(candidate_id, 0.0),
+        )
+        stage_scores_by_id[candidate_id] = stage_scores
+        stage_reasons_by_id[candidate_id] = {
+            "lexical": (
+                "BM25-style lexical overlap across scoped continuity text."
+                if stage_scores.lexical_raw > 0.0
+                else "No lexical overlap with the query terms."
+            ),
+            "semantic": (
+                "Exact or semantic similarity matched the query wording."
+                if stage_scores.semantic_raw > 0.0
+                else "No semantic similarity above the retrieval threshold."
+            ),
+            "entity_edge": (
+                "Entity anchors or connected entities matched continuity provenance/body."
+                if stage_scores.entity_edge_raw > 0.0
+                else "No direct or traversed entity match was found."
+            ),
+            "temporal": (
+                "Recency and temporal overlap favored this candidate."
+                if stage_scores.temporal_raw > 0.0
+                else "No temporal signal applied."
+            ),
+            "trust": (
+                "Trust, confirmation, provenance, and supersession posture favored this candidate."
+                if stage_scores.trust_raw > 0.0
+                else "Trust reranking contributed no score."
+            ),
+        }
+
+        if not state.scope_matched:
+            excluded_by_id[candidate_id] = "scope_mismatch"
+            continue
+
+        if ranking_strategy == "legacy_v1":
+            if query_terms and state.query_term_match_count == 0:
+                excluded_by_id[candidate_id] = "no_lexical_match"
+                continue
+            relevance = (
+                float(len(state.scope_matches)) * 100.0
+                + float(state.query_term_match_count) * 20.0
+                + float(state.confirmation_rank) * 14.0
+                + float(state.freshness_rank) * 12.0
+                + float(state.provenance_rank) * 8.0
+                + float(state.supersession_rank) * 10.0
+                + float(state.posture_rank) * 4.0
+                + float(state.lifecycle_rank) * 2.0
+                + float(state.row["confidence"])
+            )
+        else:
+            stream_matched = (
+                stage_scores.lexical_raw > 0.0
+                or stage_scores.semantic_raw > 0.0
+                or stage_scores.entity_edge_raw > 0.0
+            )
+            if has_stream_query and not stream_matched:
+                excluded_by_id[candidate_id] = "no_stream_match"
+                continue
+            relevance = (
+                float(len(state.scope_matches)) * 100.0
+                + stage_scores.entity_edge_normalized * 30.0
+                + stage_scores.lexical_normalized * 28.0
+                + stage_scores.semantic_normalized * 26.0
+                + stage_scores.temporal_normalized * 16.0
+                + stage_scores.trust_normalized * 18.0
+                + float(state.confirmation_rank) * 6.0
+                + float(state.provenance_rank) * 5.0
+                + state.supersession_freshness_score * 6.0
+                + float(state.posture_rank) * 4.0
+                + float(state.lifecycle_rank) * 3.0
+                + float(state.row["confidence"])
+            )
+
+        ranked_candidates.append(_build_ranked_candidate(state, relevance=relevance))
+
+    ordered_ranked_candidates = _sort_ranked_candidates(
+        ranked_candidates,
+        ranking_strategy=ranking_strategy,
+    )
+    selected_ids = [candidate.row["id"] for candidate in ordered_ranked_candidates]
+    selected_rank_by_id = {
+        candidate_id: index
+        for index, candidate_id in enumerate(selected_ids, start=1)
+    }
+
+    trace_candidates: list[RetrievalTraceCandidate] = []
+    for state in scoring_states:
+        candidate_id = state.row["id"]
+        selected = candidate_id in selected_rank_by_id
+        rank = selected_rank_by_id.get(candidate_id)
+        ranked = next(
+            (
+                candidate
+                for candidate in ordered_ranked_candidates
+                if candidate.row["id"] == candidate_id
+            ),
+            _build_ranked_candidate(
+                state,
+                relevance=0.0,
+            ),
+        )
+        trace_candidates.append(
+            RetrievalTraceCandidate(
+                ranked=ranked,
+                rank=rank,
+                selected=selected,
+                exclusion_reason=excluded_by_id.get(candidate_id),
+                stage_scores=stage_scores_by_id[candidate_id],
+                stage_reasons=stage_reasons_by_id[candidate_id],
+            )
+        )
+
+    trace_candidates.sort(
+        key=lambda candidate: (
+            0 if candidate.selected else 1,
+            candidate.rank if candidate.rank is not None else MAX_CONTINUITY_RECALL_LIMIT + 1,
+            -candidate.ranked.relevance,
+            str(candidate.ranked.row["id"]),
+        )
+    )
+    return ordered_ranked_candidates, trace_candidates, query_terms, entity_context
+
+
+def _serialize_debug_candidate(
+    trace_candidate: RetrievalTraceCandidate,
+) -> ContinuityRetrievalDebugCandidateRecord:
+    ordering = _ordering_metadata(trace_candidate.ranked)
+    stage_scores = trace_candidate.stage_scores
+    return {
+        "object_id": str(trace_candidate.ranked.row["id"]),
+        "title": trace_candidate.ranked.row["title"],
+        "object_type": trace_candidate.ranked.row["object_type"],  # type: ignore[typeddict-item]
+        "status": trace_candidate.ranked.row["status"],  # type: ignore[typeddict-item]
+        "selected": trace_candidate.selected,
+        "rank": trace_candidate.rank,
+        "exclusion_reason": trace_candidate.exclusion_reason,
+        "scope_matches": trace_candidate.ranked.scope_matches,
+        "ordering": ordering,
+        "stage_scores": {
+            "lexical": {
+                "raw_score": stage_scores.lexical_raw,
+                "normalized_score": stage_scores.lexical_normalized,
+                "matched": stage_scores.lexical_raw > 0.0,
+                "reason": trace_candidate.stage_reasons["lexical"],
+            },
+            "semantic": {
+                "raw_score": stage_scores.semantic_raw,
+                "normalized_score": stage_scores.semantic_normalized,
+                "matched": stage_scores.semantic_raw > 0.0,
+                "reason": trace_candidate.stage_reasons["semantic"],
+            },
+            "entity_edge": {
+                "raw_score": stage_scores.entity_edge_raw,
+                "normalized_score": stage_scores.entity_edge_normalized,
+                "matched": stage_scores.entity_edge_raw > 0.0,
+                "reason": trace_candidate.stage_reasons["entity_edge"],
+            },
+            "temporal": {
+                "raw_score": stage_scores.temporal_raw,
+                "normalized_score": stage_scores.temporal_normalized,
+                "matched": stage_scores.temporal_raw > 0.0,
+                "reason": trace_candidate.stage_reasons["temporal"],
+            },
+            "trust": {
+                "raw_score": stage_scores.trust_raw,
+                "normalized_score": stage_scores.trust_normalized,
+                "matched": stage_scores.trust_raw > 0.0,
+                "reason": trace_candidate.stage_reasons["trust"],
+            },
+        },
+        "relevance": trace_candidate.ranked.relevance,
+    }
+
+
+def _serialize_retrieval_run(run: RetrievalRunRow) -> RetrievalRunRecord:
+    return {
+        "id": str(run["id"]),
+        "source_surface": run["source_surface"],
+        "ranking_strategy": run["ranking_strategy"],
+        "query_text": run["query_text"],
+        "request_scope": run["request_scope"],
+        "result_ids": run["result_ids"],
+        "exclusion_summary": run["exclusion_summary"],
+        "candidate_count": run["candidate_count"],
+        "selected_count": run["selected_count"],
+        "debug_enabled": run["debug_enabled"],
+        "retention_until": run["retention_until"].isoformat(),
+        "created_at": run["created_at"].isoformat(),
+    }
+
+
+def _debug_candidate_from_row(row: RetrievalCandidateRow) -> ContinuityRetrievalDebugCandidateRecord:
+    ordering = cast(ContinuityRecallOrderingMetadata, row["ordering"])
+    stage_details = row["stage_details"]
+    return {
+        "object_id": str(row["continuity_object_id"]),
+        "title": row["title"],
+        "object_type": row["object_type"],  # type: ignore[typeddict-item]
+        "status": row["status"],  # type: ignore[typeddict-item]
+        "selected": row["selected"],
+        "rank": row["rank"],
+        "exclusion_reason": row["exclusion_reason"],
+        "scope_matches": cast(list[ContinuityRecallScopeMatch], row["scope_matches"]),
+        "ordering": ordering,
+        "stage_scores": cast(dict[str, dict[str, object]], stage_details),
+        "relevance": float(row["relevance"]),
+    }
+
+
+def _persist_retrieval_trace(
+    store: ContinuityStore,
+    *,
+    request: ContinuityRecallQueryInput,
+    ranking_strategy: Literal["legacy_v1", "hybrid_v2"],
+    source_surface: str,
+    returned_candidates: list[RankedRecallCandidate],
+    trace_candidates: list[RetrievalTraceCandidate],
+) -> str | None:
+    create_retrieval_run = getattr(store, "create_retrieval_run", None)
+    create_retrieval_candidate = getattr(store, "create_retrieval_candidate", None)
+    if not callable(create_retrieval_run) or not callable(create_retrieval_candidate):
+        return None
+
+    exclusion_summary: JsonObject = {}
+    for trace_candidate in trace_candidates:
+        if trace_candidate.exclusion_reason is None:
+            continue
+        exclusion_summary[trace_candidate.exclusion_reason] = int(
+            exclusion_summary.get(trace_candidate.exclusion_reason, 0)
+        ) + 1
+
+    run = create_retrieval_run(
+        source_surface=source_surface,
+        ranking_strategy=ranking_strategy,
+        query_text=request.query,
+        request_scope=cast(JsonObject, request.as_payload()),
+        result_ids=[str(candidate.row["id"]) for candidate in returned_candidates],
+        exclusion_summary=exclusion_summary,
+        candidate_count=len(trace_candidates),
+        selected_count=len(returned_candidates),
+        debug_enabled=request.debug,
+        retention_until=_retrieval_trace_retention_until(),
+    )
+
+    for trace_candidate in trace_candidates:
+        debug_candidate = _serialize_debug_candidate(trace_candidate)
+        create_retrieval_candidate(
+            retrieval_run_id=run["id"],
+            continuity_object_id=trace_candidate.ranked.row["id"],
+            rank=trace_candidate.rank,
+            selected=trace_candidate.selected,
+            exclusion_reason=trace_candidate.exclusion_reason,
+            lexical_score=trace_candidate.stage_scores.lexical_raw,
+            semantic_score=trace_candidate.stage_scores.semantic_raw,
+            entity_edge_score=trace_candidate.stage_scores.entity_edge_raw,
+            temporal_score=trace_candidate.stage_scores.temporal_raw,
+            trust_score=trace_candidate.stage_scores.trust_raw,
+            relevance=trace_candidate.ranked.relevance,
+            scope_matches=cast(list[JsonObject], debug_candidate["scope_matches"]),
+            stage_details=cast(JsonObject, debug_candidate["stage_scores"]),
+            ordering=cast(JsonObject, debug_candidate["ordering"]),
+            title=trace_candidate.ranked.row["title"],
+            object_type=trace_candidate.ranked.row["object_type"],
+            status=trace_candidate.ranked.row["status"],
+        )
+
+    return str(run["id"])
+
+
+def list_retrieval_runs(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    limit: int = DEFAULT_RETRIEVAL_RUN_LIST_LIMIT,
+) -> RetrievalRunListResponse:
+    del user_id
+    if limit < 1 or limit > MAX_RETRIEVAL_RUN_LIST_LIMIT:
+        raise ContinuityRecallValidationError(
+            f"limit must be between 1 and {MAX_RETRIEVAL_RUN_LIST_LIMIT}"
+        )
+
+    rows = store.list_retrieval_runs(limit=limit)
+    items = [_serialize_retrieval_run(row) for row in rows]
+    summary: RetrievalRunListSummary = {
+        "limit": limit,
+        "returned_count": len(items),
+        "total_count": len(items),
+        "order": list(RETRIEVAL_RUN_LIST_ORDER),
+    }
+    return {
+        "items": items,
+        "summary": summary,
+    }
+
+
+def get_retrieval_trace(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    retrieval_run_id: UUID,
+) -> RetrievalTraceResponse:
+    del user_id
+    run = store.get_retrieval_run_optional(retrieval_run_id)
+    if run is None:
+        raise RetrievalTraceNotFoundError(f"retrieval run {retrieval_run_id} was not found")
+
+    candidates = [
+        _debug_candidate_from_row(row)
+        for row in store.list_retrieval_candidates_for_run(retrieval_run_id)
+    ]
+    summary: RetrievalTraceSummary = {
+        "candidate_count": len(candidates),
+        "selected_count": sum(1 for candidate in candidates if candidate["selected"]),
+        "order": list(RETRIEVAL_TRACE_CANDIDATE_ORDER),
+    }
+    return {
+        "retrieval_run": _serialize_retrieval_run(run),
+        "candidates": candidates,
+        "summary": summary,
+    }
+
+
 def query_continuity_recall(
     store: ContinuityStore,
     *,
@@ -1141,6 +1836,7 @@ def query_continuity_recall(
     request: ContinuityRecallQueryInput,
     apply_limit: bool = True,
     ranking_strategy: Literal["legacy_v1", "hybrid_v2"] = "hybrid_v2",
+    source_surface: str = "continuity_recall",
 ) -> ContinuityRecallResponse:
     del user_id
 
@@ -1156,11 +1852,12 @@ def query_continuity_recall(
         since=request.since,
         until=request.until,
         limit=request.limit,
+        debug=request.debug,
     )
 
     _validate_request(normalized_request)
 
-    ordered_candidates = _ordered_recall_candidates(
+    ordered_candidates, trace_candidates, query_terms, entity_context = _ordered_recall_candidates(
         store,
         request=normalized_request,
         ranking_strategy=ranking_strategy,
@@ -1170,9 +1867,46 @@ def query_continuity_recall(
         returned_candidates = ordered_candidates[: normalized_request.limit]
     else:
         returned_candidates = ordered_candidates
+    returned_candidate_ids = {candidate.row["id"] for candidate in returned_candidates}
+    final_trace_candidates = [
+        RetrievalTraceCandidate(
+            ranked=trace_candidate.ranked,
+            rank=trace_candidate.rank,
+            selected=trace_candidate.ranked.row["id"] in returned_candidate_ids,
+            exclusion_reason=(
+                trace_candidate.exclusion_reason
+                if trace_candidate.ranked.row["id"] not in returned_candidate_ids
+                and trace_candidate.exclusion_reason is not None
+                else (
+                    None
+                    if trace_candidate.ranked.row["id"] in returned_candidate_ids
+                    else "trimmed_by_limit"
+                )
+            ),
+            stage_scores=trace_candidate.stage_scores,
+            stage_reasons=trace_candidate.stage_reasons,
+        )
+        for trace_candidate in trace_candidates
+    ]
+    final_trace_candidates.sort(
+        key=lambda candidate: (
+            0 if candidate.selected else 1,
+            candidate.rank if candidate.rank is not None else MAX_CONTINUITY_RECALL_LIMIT + 1,
+            -candidate.ranked.relevance,
+            str(candidate.ranked.row["id"]),
+        )
+    )
     items = [_serialize_recall_result(store, item) for item in returned_candidates]
+    retrieval_run_id = _persist_retrieval_trace(
+        store,
+        request=normalized_request,
+        ranking_strategy=ranking_strategy,
+        source_surface=source_surface,
+        returned_candidates=returned_candidates,
+        trace_candidates=final_trace_candidates,
+    )
 
-    return {
+    payload: ContinuityRecallResponse = {
         "items": items,
         "summary": {
             "query": normalized_request.query,
@@ -1183,6 +1917,19 @@ def query_continuity_recall(
             "order": list(CONTINUITY_RECALL_LIST_ORDER),
         },
     }
+    if normalized_request.debug:
+        payload["debug"] = {
+            "retrieval_run_id": retrieval_run_id,
+            "source_surface": source_surface,
+            "ranking_strategy": ranking_strategy,
+            "query_terms": query_terms,
+            "entity_anchor_names": list(entity_context.anchor_names),
+            "entity_expansion_names": list(entity_context.expansion_names),
+            "candidate_count": len(final_trace_candidates),
+            "selected_count": len(returned_candidates),
+            "candidates": [_serialize_debug_candidate(candidate) for candidate in final_trace_candidates],
+        }
+    return payload
 
 
 def build_default_recall_query_input() -> ContinuityRecallQueryInput:

--- a/apps/api/src/alicebot_api/continuity_resumption.py
+++ b/apps/api/src/alicebot_api/continuity_resumption.py
@@ -134,8 +134,10 @@ def compile_continuity_resumption_brief(
             since=request.since,
             until=request.until,
             limit=MAX_CONTINUITY_RECALL_LIMIT,
+            debug=request.debug,
         ),
         apply_limit=False,
+        source_surface="continuity_resumption",
     )
 
     ranked_items = list(recall_payload["items"])
@@ -217,7 +219,12 @@ def compile_continuity_resumption_brief(
         "sources": ["continuity_capture_events", "continuity_objects"],
     }
 
-    return {"brief": brief}
+    payload: ContinuityResumptionBriefResponse = {"brief": brief}
+    if request.debug and "debug" in recall_payload:
+        payload["debug"] = {
+            "retrieval": recall_payload["debug"],
+        }
+    return payload
 
 
 def build_default_resumption_request() -> ContinuityResumptionBriefRequestInput:

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -503,6 +503,8 @@ DEFAULT_MEMORY_TRUST_CLASS: MemoryTrustClass = "deterministic"
 DEFAULT_MEMORY_PROMOTION_ELIGIBILITY: MemoryPromotionEligibility = "promotable"
 DEFAULT_CONTINUITY_LIFECYCLE_LIMIT = 50
 MAX_CONTINUITY_LIFECYCLE_LIMIT = 200
+DEFAULT_RETRIEVAL_RUN_LIST_LIMIT = 20
+MAX_RETRIEVAL_RUN_LIST_LIMIT = 100
 DEFAULT_TRUSTED_FACT_PROMOTION_LIMIT = 50
 MAX_TRUSTED_FACT_PROMOTION_LIMIT = 200
 ENTITY_TYPES = [
@@ -525,6 +527,13 @@ RETRIEVAL_EVALUATION_RESULT_ORDER = [
     "precision_at_k_desc",
     "precision_lift_at_k_desc",
     "fixture_id_asc",
+]
+RETRIEVAL_RUN_LIST_ORDER = ["created_at_desc", "id_desc"]
+RETRIEVAL_TRACE_CANDIDATE_ORDER = [
+    "selected_desc",
+    "rank_asc",
+    "relevance_desc",
+    "id_asc",
 ]
 EMBEDDING_CONFIG_STATUSES = ["active", "deprecated", "disabled"]
 CONSENT_STATUSES = ["granted", "revoked"]
@@ -1910,6 +1919,7 @@ class ContinuityRecallQueryInput:
     since: datetime | None = None
     until: datetime | None = None
     limit: int = DEFAULT_CONTINUITY_RECALL_LIMIT
+    debug: bool = False
 
     def as_payload(self) -> JsonObject:
         payload: JsonObject = {
@@ -1919,6 +1929,7 @@ class ContinuityRecallQueryInput:
             "project": self.project,
             "person": self.person,
             "limit": self.limit,
+            "debug": self.debug,
         }
         payload["since"] = isoformat_or_none(self.since)
         payload["until"] = isoformat_or_none(self.until)
@@ -1937,6 +1948,7 @@ class ContinuityResumptionBriefRequestInput:
     max_recent_changes: int = DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT
     max_open_loops: int = DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT
     include_non_promotable_facts: bool = False
+    debug: bool = False
 
     def as_payload(self) -> JsonObject:
         payload: JsonObject = {
@@ -1948,6 +1960,7 @@ class ContinuityResumptionBriefRequestInput:
             "max_recent_changes": self.max_recent_changes,
             "max_open_loops": self.max_open_loops,
             "include_non_promotable_facts": self.include_non_promotable_facts,
+            "debug": self.debug,
         }
         payload["since"] = isoformat_or_none(self.since)
         payload["until"] = isoformat_or_none(self.until)
@@ -3058,6 +3071,39 @@ class ContinuityRecallOrderingMetadata(TypedDict):
     confidence: float
 
 
+class ContinuityRetrievalStageScoreRecord(TypedDict):
+    raw_score: float
+    normalized_score: float
+    matched: bool
+    reason: str
+
+
+class ContinuityRetrievalDebugCandidateRecord(TypedDict):
+    object_id: str
+    title: str
+    object_type: ContinuityObjectType
+    status: str
+    selected: bool
+    rank: int | None
+    exclusion_reason: str | None
+    scope_matches: list[ContinuityRecallScopeMatch]
+    ordering: ContinuityRecallOrderingMetadata
+    stage_scores: dict[str, ContinuityRetrievalStageScoreRecord]
+    relevance: float
+
+
+class ContinuityRetrievalDebugRecord(TypedDict):
+    retrieval_run_id: str | None
+    source_surface: str
+    ranking_strategy: str
+    query_terms: list[str]
+    entity_anchor_names: list[str]
+    entity_expansion_names: list[str]
+    candidate_count: int
+    selected_count: int
+    candidates: list[ContinuityRetrievalDebugCandidateRecord]
+
+
 class ContinuityRecallResultRecord(TypedDict):
     id: str
     capture_event_id: str
@@ -3094,6 +3140,7 @@ class ContinuityRecallSummary(TypedDict):
 class ContinuityRecallResponse(TypedDict):
     items: list[ContinuityRecallResultRecord]
     summary: ContinuityRecallSummary
+    debug: NotRequired[ContinuityRetrievalDebugRecord]
 
 
 class ContinuityLifecycleCounts(TypedDict):
@@ -3147,8 +3194,52 @@ class ContinuityResumptionBriefRecord(TypedDict):
     sources: list[str]
 
 
+class ContinuityResumptionDebugRecord(TypedDict):
+    retrieval: ContinuityRetrievalDebugRecord
+
+
 class ContinuityResumptionBriefResponse(TypedDict):
     brief: ContinuityResumptionBriefRecord
+    debug: NotRequired[ContinuityResumptionDebugRecord]
+
+
+class RetrievalRunRecord(TypedDict):
+    id: str
+    source_surface: str
+    ranking_strategy: str
+    query_text: str | None
+    request_scope: JsonObject
+    result_ids: list[str]
+    exclusion_summary: JsonObject
+    candidate_count: int
+    selected_count: int
+    debug_enabled: bool
+    retention_until: str
+    created_at: str
+
+
+class RetrievalRunListSummary(TypedDict):
+    limit: int
+    returned_count: int
+    total_count: int
+    order: list[str]
+
+
+class RetrievalRunListResponse(TypedDict):
+    items: list[RetrievalRunRecord]
+    summary: RetrievalRunListSummary
+
+
+class RetrievalTraceSummary(TypedDict):
+    candidate_count: int
+    selected_count: int
+    order: list[str]
+
+
+class RetrievalTraceResponse(TypedDict):
+    retrieval_run: RetrievalRunRecord
+    candidates: list[ContinuityRetrievalDebugCandidateRecord]
+    summary: RetrievalTraceSummary
 
 
 class ContinuityOpenLoopSectionSummary(TypedDict):

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -51,6 +51,7 @@ from alicebot_api.contracts import (
     DEFAULT_CONTINUITY_LIFECYCLE_LIMIT,
     DEFAULT_CONTINUITY_REVIEW_LIMIT,
     DEFAULT_CONTINUITY_RECALL_LIMIT,
+    DEFAULT_RETRIEVAL_RUN_LIST_LIMIT,
     DEFAULT_CONTINUITY_OPEN_LOOP_LIMIT,
     DEFAULT_CONTINUITY_DAILY_BRIEF_LIMIT,
     DEFAULT_CONTINUITY_WEEKLY_REVIEW_LIMIT,
@@ -82,6 +83,7 @@ from alicebot_api.contracts import (
     MAX_CONTINUITY_LIFECYCLE_LIMIT,
     MAX_CONTINUITY_REVIEW_LIMIT,
     MAX_CONTINUITY_RECALL_LIMIT,
+    MAX_RETRIEVAL_RUN_LIST_LIMIT,
     MAX_CONTINUITY_OPEN_LOOP_LIMIT,
     MAX_CONTINUITY_DAILY_BRIEF_LIMIT,
     MAX_CONTINUITY_WEEKLY_REVIEW_LIMIT,
@@ -140,6 +142,8 @@ from alicebot_api.contracts import (
     ContinuityWeeklyReviewResponse,
     MemoryTrustDashboardResponse,
     RetrievalEvaluationResponse,
+    RetrievalRunListResponse,
+    RetrievalTraceResponse,
     EmbeddingConfigStatus,
     EmbeddingConfigCreateInput,
     ExecutionBudgetCreateInput,
@@ -407,6 +411,9 @@ from alicebot_api.continuity_lifecycle import (
 )
 from alicebot_api.continuity_recall import (
     ContinuityRecallValidationError,
+    RetrievalTraceNotFoundError,
+    get_retrieval_trace,
+    list_retrieval_runs,
     query_continuity_recall,
 )
 from alicebot_api.retrieval_evaluation import get_retrieval_evaluation_summary
@@ -5358,6 +5365,7 @@ def list_continuity_recall(
         ge=1,
         le=MAX_CONTINUITY_RECALL_LIMIT,
     ),
+    debug: bool = False,
 ) -> JSONResponse:
     settings = get_settings()
 
@@ -5375,10 +5383,61 @@ def list_continuity_recall(
                     since=since,
                     until=until,
                     limit=limit,
+                    debug=debug,
                 ),
             )
     except ContinuityRecallValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/continuity/retrieval-runs")
+def get_continuity_retrieval_runs(
+    user_id: UUID,
+    limit: int = Query(
+        default=DEFAULT_RETRIEVAL_RUN_LIST_LIMIT,
+        ge=1,
+        le=MAX_RETRIEVAL_RUN_LIST_LIMIT,
+    ),
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: RetrievalRunListResponse = list_retrieval_runs(
+                ContinuityStore(conn),
+                user_id=user_id,
+                limit=limit,
+            )
+    except ContinuityRecallValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/continuity/retrieval-runs/{retrieval_run_id}")
+def get_continuity_retrieval_trace(
+    retrieval_run_id: UUID,
+    user_id: UUID,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: RetrievalTraceResponse = get_retrieval_trace(
+                ContinuityStore(conn),
+                user_id=user_id,
+                retrieval_run_id=retrieval_run_id,
+            )
+    except RetrievalTraceNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
 
     return JSONResponse(
         status_code=200,
@@ -5423,6 +5482,7 @@ def get_continuity_resumption_brief(
         le=MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
     ),
     include_non_promotable_facts: bool = False,
+    debug: bool = False,
 ) -> JSONResponse:
     settings = get_settings()
 
@@ -5442,6 +5502,7 @@ def get_continuity_resumption_brief(
                     max_recent_changes=max_recent_changes,
                     max_open_loops=max_open_loops,
                     include_non_promotable_facts=include_non_promotable_facts,
+                    debug=debug,
                 ),
             )
     except ContinuityResumptionValidationError as exc:

--- a/apps/api/src/alicebot_api/mcp_tools.py
+++ b/apps/api/src/alicebot_api/mcp_tools.py
@@ -24,6 +24,8 @@ from alicebot_api.continuity_open_loops import (
 )
 from alicebot_api.continuity_recall import (
     ContinuityRecallValidationError,
+    RetrievalTraceNotFoundError,
+    get_retrieval_trace,
     query_continuity_recall,
 )
 from alicebot_api.continuity_resumption import (
@@ -483,6 +485,36 @@ def _handle_alice_recall(context: MCPRuntimeContext, arguments: Mapping[str, obj
         )
 
 
+def _handle_alice_recall_debug(
+    context: MCPRuntimeContext,
+    arguments: Mapping[str, object],
+) -> JsonObject:
+    limit = _parse_int(
+        arguments,
+        key="limit",
+        default=DEFAULT_CONTINUITY_RECALL_LIMIT,
+        minimum=1,
+        maximum=MAX_CONTINUITY_RECALL_LIMIT,
+    )
+
+    with _store_context(context) as store:
+        return query_continuity_recall(
+            store,
+            user_id=context.user_id,
+            request=ContinuityRecallQueryInput(
+                query=_parse_optional_text(arguments, "query"),
+                thread_id=_parse_optional_uuid(arguments, "thread_id"),
+                task_id=_parse_optional_uuid(arguments, "task_id"),
+                project=_parse_optional_text(arguments, "project"),
+                person=_parse_optional_text(arguments, "person"),
+                since=_parse_optional_datetime(arguments, "since"),
+                until=_parse_optional_datetime(arguments, "until"),
+                limit=limit,
+                debug=True,
+            ),
+        )
+
+
 def _handle_alice_state_at(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
     with _store_context(context) as store:
         return get_temporal_state_at(
@@ -531,6 +563,61 @@ def _handle_alice_resume(context: MCPRuntimeContext, arguments: Mapping[str, obj
                     default=False,
                 ),
             ),
+        )
+
+
+def _handle_alice_resume_debug(
+    context: MCPRuntimeContext,
+    arguments: Mapping[str, object],
+) -> JsonObject:
+    max_recent_changes = _parse_int(
+        arguments,
+        key="max_recent_changes",
+        default=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        minimum=0,
+        maximum=MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    )
+    max_open_loops = _parse_int(
+        arguments,
+        key="max_open_loops",
+        default=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+        minimum=0,
+        maximum=MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    )
+
+    with _store_context(context) as store:
+        return compile_continuity_resumption_brief(
+            store,
+            user_id=context.user_id,
+            request=ContinuityResumptionBriefRequestInput(
+                query=_parse_optional_text(arguments, "query"),
+                thread_id=_parse_optional_uuid(arguments, "thread_id"),
+                task_id=_parse_optional_uuid(arguments, "task_id"),
+                project=_parse_optional_text(arguments, "project"),
+                person=_parse_optional_text(arguments, "person"),
+                since=_parse_optional_datetime(arguments, "since"),
+                until=_parse_optional_datetime(arguments, "until"),
+                max_recent_changes=max_recent_changes,
+                max_open_loops=max_open_loops,
+                include_non_promotable_facts=_parse_bool(
+                    arguments,
+                    key="include_non_promotable_facts",
+                    default=False,
+                ),
+                debug=True,
+            ),
+        )
+
+
+def _handle_alice_retrieval_trace(
+    context: MCPRuntimeContext,
+    arguments: Mapping[str, object],
+) -> JsonObject:
+    with _store_context(context) as store:
+        return get_retrieval_trace(
+            store,
+            user_id=context.user_id,
+            retrieval_run_id=_parse_required_uuid(arguments, "retrieval_run_id"),
         )
 
 
@@ -1018,6 +1105,24 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
         },
     },
     {
+        "name": "alice_recall_debug",
+        "description": "Run hybrid continuity retrieval with per-candidate stage scores and exclusion reasons.",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "query": {"type": "string"},
+                "thread_id": {"type": "string", "format": "uuid"},
+                "task_id": {"type": "string", "format": "uuid"},
+                "project": {"type": "string"},
+                "person": {"type": "string"},
+                "since": {"type": "string", "format": "date-time"},
+                "until": {"type": "string", "format": "date-time"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": MAX_CONTINUITY_RECALL_LIMIT},
+            },
+        },
+    },
+    {
         "name": "alice_state_at",
         "description": "Show entity facts and edges that were effective at a specific point in time.",
         "inputSchema": {
@@ -1055,6 +1160,46 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
                     "maximum": MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
                 },
                 "include_non_promotable_facts": {"type": "boolean"},
+            },
+        },
+    },
+    {
+        "name": "alice_resume_debug",
+        "description": "Compile a resumption brief with the underlying hybrid retrieval trace attached.",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "query": {"type": "string"},
+                "thread_id": {"type": "string", "format": "uuid"},
+                "task_id": {"type": "string", "format": "uuid"},
+                "project": {"type": "string"},
+                "person": {"type": "string"},
+                "since": {"type": "string", "format": "date-time"},
+                "until": {"type": "string", "format": "date-time"},
+                "max_recent_changes": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+                },
+                "max_open_loops": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+                },
+                "include_non_promotable_facts": {"type": "boolean"},
+            },
+        },
+    },
+    {
+        "name": "alice_retrieval_trace",
+        "description": "Load one persisted retrieval trace by run id.",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["retrieval_run_id"],
+            "properties": {
+                "retrieval_run_id": {"type": "string", "format": "uuid"},
             },
         },
     },
@@ -1299,8 +1444,11 @@ _TOOL_HANDLERS = {
     "alice_capture_candidates": _handle_alice_capture_candidates,
     "alice_commit_captures": _handle_alice_commit_captures,
     "alice_recall": _handle_alice_recall,
+    "alice_recall_debug": _handle_alice_recall_debug,
     "alice_state_at": _handle_alice_state_at,
     "alice_resume": _handle_alice_resume,
+    "alice_resume_debug": _handle_alice_resume_debug,
+    "alice_retrieval_trace": _handle_alice_retrieval_trace,
     "alice_prefetch_context": _handle_alice_prefetch_context,
     "alice_open_loops": _handle_alice_open_loops,
     "alice_recent_decisions": _handle_alice_recent_decisions,
@@ -1340,6 +1488,7 @@ def call_mcp_tool(
         ContinuityOpenLoopValidationError,
         ContinuityReviewValidationError,
         ContinuityReviewNotFoundError,
+        RetrievalTraceNotFoundError,
         ContinuityEvidenceNotFoundError,
         TemporalStateValidationError,
     ) as exc:

--- a/apps/api/src/alicebot_api/retrieval_evaluation.py
+++ b/apps/api/src/alicebot_api/retrieval_evaluation.py
@@ -22,7 +22,13 @@ from alicebot_api.contracts import (
     RetrievalEvaluationSummary,
 )
 from alicebot_api.semantic_retrieval import calculate_mean_precision, calculate_precision_at_k
-from alicebot_api.store import ContinuityRecallCandidateRow, ContinuityStore, JsonObject
+from alicebot_api.store import (
+    ContinuityRecallCandidateRow,
+    ContinuityStore,
+    EntityEdgeRow,
+    EntityRow,
+    JsonObject,
+)
 
 RETRIEVAL_EVALUATION_PRECISION_TARGET = 0.8
 
@@ -34,15 +40,36 @@ class RetrievalEvaluationFixture:
     request: ContinuityRecallQueryInput
     candidates: tuple[ContinuityRecallCandidateRow, ...]
     expected_relevant_ids: tuple[str, ...]
+    entities: tuple[EntityRow, ...] = ()
+    entity_edges: tuple[EntityEdgeRow, ...] = ()
     top_k: int = 1
 
 
 class _FixtureStore:
-    def __init__(self, rows: tuple[ContinuityRecallCandidateRow, ...]) -> None:
+    def __init__(
+        self,
+        rows: tuple[ContinuityRecallCandidateRow, ...],
+        *,
+        entities: tuple[EntityRow, ...] = (),
+        entity_edges: tuple[EntityEdgeRow, ...] = (),
+    ) -> None:
         self._rows = rows
+        self._entities = entities
+        self._entity_edges = entity_edges
 
     def list_continuity_recall_candidates(self) -> list[ContinuityRecallCandidateRow]:
         return list(self._rows)
+
+    def list_entities(self) -> list[EntityRow]:
+        return list(self._entities)
+
+    def list_entity_edges_for_entities(self, entity_ids: list[UUID]) -> list[EntityEdgeRow]:
+        requested = set(entity_ids)
+        return [
+            edge
+            for edge in self._entity_edges
+            if edge["from_entity_id"] in requested or edge["to_entity_id"] in requested
+        ]
 
 
 def _candidate(
@@ -83,6 +110,42 @@ def _candidate(
         "capture_created_at": created_at,
     }
     return row
+
+
+def _fixture_entity(
+    *,
+    entity_id: str,
+    entity_type: str,
+    name: str,
+) -> EntityRow:
+    return {
+        "id": UUID(entity_id),
+        "user_id": UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+        "entity_type": entity_type,
+        "name": name,
+        "source_memory_ids": ["fixture-memory"],
+        "created_at": datetime(2026, 3, 1, 9, 0, tzinfo=UTC),
+    }
+
+
+def _fixture_entity_edge(
+    *,
+    edge_id: str,
+    from_entity_id: str,
+    to_entity_id: str,
+    relationship_type: str,
+) -> EntityEdgeRow:
+    return {
+        "id": UUID(edge_id),
+        "user_id": UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+        "from_entity_id": UUID(from_entity_id),
+        "to_entity_id": UUID(to_entity_id),
+        "relationship_type": relationship_type,
+        "valid_from": None,
+        "valid_to": None,
+        "source_memory_ids": ["fixture-memory"],
+        "created_at": datetime(2026, 3, 1, 9, 5, tzinfo=UTC),
+    }
 
 
 def _fixture_suite() -> tuple[RetrievalEvaluationFixture, ...]:
@@ -316,6 +379,66 @@ def _fixture_suite() -> tuple[RetrievalEvaluationFixture, ...]:
             ),
             expected_relevant_ids=("00000000-0000-4000-8000-000000000051",),
         ),
+        RetrievalEvaluationFixture(
+            fixture_id="entity_edge_expansion_recovers_related_owner",
+            title="Entity-edge expansion recovers the related owner when the query names only the project",
+            request=ContinuityRecallQueryInput(
+                query="Project Phoenix dependency owner",
+                limit=5,
+            ),
+            candidates=(
+                _candidate(
+                    object_id="00000000-0000-4000-8000-000000000061",
+                    capture_event_id="10000000-0000-4000-8000-000000000061",
+                    title="Decision: Alex owns dependency follow-up",
+                    body={"decision_text": "dependency owner follow-up is Alex"},
+                    provenance={
+                        "person": "Alex",
+                        "source_event_ids": ["e-61"],
+                        "confirmation_status": "confirmed",
+                    },
+                    confidence=0.72,
+                    created_at=datetime(2026, 4, 1, 9, 0, tzinfo=UTC),
+                    last_confirmed_at=datetime(2026, 4, 1, 9, 30, tzinfo=UTC),
+                ),
+                _candidate(
+                    object_id="00000000-0000-4000-8000-000000000062",
+                    capture_event_id="10000000-0000-4000-8000-000000000062",
+                    title="Decision: Phoenix dependency note",
+                    body={"decision_text": "dependency owner follow-up is Taylor"},
+                    provenance={
+                        "project": "Project Phoenix",
+                        "person": "Taylor",
+                        "source_event_ids": ["e-62"],
+                        "confirmation_status": "confirmed",
+                    },
+                    confidence=0.95,
+                    created_at=datetime(2026, 4, 1, 9, 5, tzinfo=UTC),
+                    last_confirmed_at=datetime(2026, 4, 1, 9, 35, tzinfo=UTC),
+                ),
+            ),
+            expected_relevant_ids=("00000000-0000-4000-8000-000000000061",),
+            entities=(
+                _fixture_entity(
+                    entity_id="00000000-0000-4000-8000-100000000061",
+                    entity_type="project",
+                    name="Project Phoenix",
+                ),
+                _fixture_entity(
+                    entity_id="00000000-0000-4000-8000-100000000062",
+                    entity_type="person",
+                    name="Alex",
+                ),
+            ),
+            entity_edges=(
+                _fixture_entity_edge(
+                    edge_id="00000000-0000-4000-8000-200000000061",
+                    from_entity_id="00000000-0000-4000-8000-100000000062",
+                    to_entity_id="00000000-0000-4000-8000-100000000061",
+                    relationship_type="owner_of",
+                ),
+            ),
+        ),
     )
 
 
@@ -323,14 +446,22 @@ def _evaluate_fixture(
     fixture: RetrievalEvaluationFixture,
 ) -> tuple[RetrievalEvaluationFixtureResult, float, float]:
     payload = query_continuity_recall(
-        _FixtureStore(fixture.candidates),  # type: ignore[arg-type]
+        _FixtureStore(
+            fixture.candidates,
+            entities=fixture.entities,
+            entity_edges=fixture.entity_edges,
+        ),  # type: ignore[arg-type]
         user_id=UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
         request=fixture.request,
         apply_limit=False,
         ranking_strategy="hybrid_v2",
     )
     baseline_payload = query_continuity_recall(
-        _FixtureStore(fixture.candidates),  # type: ignore[arg-type]
+        _FixtureStore(
+            fixture.candidates,
+            entities=fixture.entities,
+            entity_edges=fixture.entity_edges,
+        ),  # type: ignore[arg-type]
         user_id=UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
         request=fixture.request,
         apply_limit=False,

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -481,6 +481,45 @@ class EntityEdgeRow(TypedDict):
     created_at: datetime
 
 
+class RetrievalRunRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    source_surface: str
+    ranking_strategy: str
+    query_text: str | None
+    request_scope: JsonObject
+    result_ids: list[str]
+    exclusion_summary: JsonObject
+    candidate_count: int
+    selected_count: int
+    debug_enabled: bool
+    retention_until: datetime
+    created_at: datetime
+
+
+class RetrievalCandidateRow(TypedDict):
+    id: UUID
+    user_id: UUID
+    retrieval_run_id: UUID
+    continuity_object_id: UUID
+    rank: int | None
+    selected: bool
+    exclusion_reason: str | None
+    lexical_score: float
+    semantic_score: float
+    entity_edge_score: float
+    temporal_score: float
+    trust_score: float
+    relevance: float
+    scope_matches: list[JsonObject]
+    stage_details: JsonObject
+    ordering: JsonObject
+    title: str
+    object_type: str
+    status: str
+    created_at: datetime
+
+
 class ConsentRow(TypedDict):
     id: UUID
     user_id: UUID
@@ -4940,6 +4979,179 @@ LIST_CONTINUITY_RECALL_CANDIDATES_SQL = """
                 ORDER BY continuity_objects.created_at DESC, continuity_objects.id DESC
                 """
 
+INSERT_RETRIEVAL_RUN_SQL = """
+                INSERT INTO retrieval_runs (
+                  user_id,
+                  source_surface,
+                  ranking_strategy,
+                  query_text,
+                  request_scope,
+                  result_ids,
+                  exclusion_summary,
+                  candidate_count,
+                  selected_count,
+                  debug_enabled,
+                  retention_until
+                )
+                VALUES (
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s
+                )
+                RETURNING
+                  id,
+                  user_id,
+                  source_surface,
+                  ranking_strategy,
+                  query_text,
+                  request_scope,
+                  result_ids,
+                  exclusion_summary,
+                  candidate_count,
+                  selected_count,
+                  debug_enabled,
+                  retention_until,
+                  created_at
+                """
+
+LIST_RETRIEVAL_RUNS_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  source_surface,
+                  ranking_strategy,
+                  query_text,
+                  request_scope,
+                  result_ids,
+                  exclusion_summary,
+                  candidate_count,
+                  selected_count,
+                  debug_enabled,
+                  retention_until,
+                  created_at
+                FROM retrieval_runs
+                ORDER BY created_at DESC, id DESC
+                LIMIT %s
+                """
+
+GET_RETRIEVAL_RUN_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  source_surface,
+                  ranking_strategy,
+                  query_text,
+                  request_scope,
+                  result_ids,
+                  exclusion_summary,
+                  candidate_count,
+                  selected_count,
+                  debug_enabled,
+                  retention_until,
+                  created_at
+                FROM retrieval_runs
+                WHERE id = %s
+                """
+
+INSERT_RETRIEVAL_CANDIDATE_SQL = """
+                INSERT INTO retrieval_candidates (
+                  user_id,
+                  retrieval_run_id,
+                  continuity_object_id,
+                  rank,
+                  selected,
+                  exclusion_reason,
+                  lexical_score,
+                  semantic_score,
+                  entity_edge_score,
+                  temporal_score,
+                  trust_score,
+                  relevance,
+                  scope_matches,
+                  stage_details,
+                  ordering,
+                  title,
+                  object_type,
+                  status
+                )
+                VALUES (
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s
+                )
+                RETURNING
+                  id,
+                  user_id,
+                  retrieval_run_id,
+                  continuity_object_id,
+                  rank,
+                  selected,
+                  exclusion_reason,
+                  lexical_score,
+                  semantic_score,
+                  entity_edge_score,
+                  temporal_score,
+                  trust_score,
+                  relevance,
+                  scope_matches,
+                  stage_details,
+                  ordering,
+                  title,
+                  object_type,
+                  status,
+                  created_at
+                """
+
+LIST_RETRIEVAL_CANDIDATES_FOR_RUN_SQL = """
+                SELECT
+                  id,
+                  user_id,
+                  retrieval_run_id,
+                  continuity_object_id,
+                  rank,
+                  selected,
+                  exclusion_reason,
+                  lexical_score,
+                  semantic_score,
+                  entity_edge_score,
+                  temporal_score,
+                  trust_score,
+                  relevance,
+                  scope_matches,
+                  stage_details,
+                  ordering,
+                  title,
+                  object_type,
+                  status,
+                  created_at
+                FROM retrieval_candidates
+                WHERE retrieval_run_id = %s
+                ORDER BY selected DESC, rank ASC NULLS LAST, relevance DESC, id ASC
+                """
+
 UPSERT_CONTINUITY_ARTIFACT_SQL = """
                 INSERT INTO continuity_artifacts (
                   user_id,
@@ -6057,6 +6269,94 @@ class ContinuityStore:
 
     def list_continuity_recall_candidates(self) -> list[ContinuityRecallCandidateRow]:
         return self._fetch_all(LIST_CONTINUITY_RECALL_CANDIDATES_SQL)
+
+    def create_retrieval_run(
+        self,
+        *,
+        source_surface: str,
+        ranking_strategy: str,
+        query_text: str | None,
+        request_scope: JsonObject,
+        result_ids: list[str],
+        exclusion_summary: JsonObject,
+        candidate_count: int,
+        selected_count: int,
+        debug_enabled: bool,
+        retention_until: datetime,
+    ) -> RetrievalRunRow:
+        return self._fetch_one(
+            "create_retrieval_run",
+            INSERT_RETRIEVAL_RUN_SQL,
+            (
+                source_surface,
+                ranking_strategy,
+                query_text,
+                Jsonb(request_scope),
+                Jsonb(result_ids),
+                Jsonb(exclusion_summary),
+                candidate_count,
+                selected_count,
+                debug_enabled,
+                retention_until,
+            ),
+        )
+
+    def list_retrieval_runs(self, *, limit: int) -> list[RetrievalRunRow]:
+        return self._fetch_all(LIST_RETRIEVAL_RUNS_SQL, (limit,))
+
+    def get_retrieval_run_optional(self, retrieval_run_id: UUID) -> RetrievalRunRow | None:
+        return self._fetch_optional_one(GET_RETRIEVAL_RUN_SQL, (retrieval_run_id,))
+
+    def create_retrieval_candidate(
+        self,
+        *,
+        retrieval_run_id: UUID,
+        continuity_object_id: UUID,
+        rank: int | None,
+        selected: bool,
+        exclusion_reason: str | None,
+        lexical_score: float,
+        semantic_score: float,
+        entity_edge_score: float,
+        temporal_score: float,
+        trust_score: float,
+        relevance: float,
+        scope_matches: list[JsonObject],
+        stage_details: JsonObject,
+        ordering: JsonObject,
+        title: str,
+        object_type: str,
+        status: str,
+    ) -> RetrievalCandidateRow:
+        return self._fetch_one(
+            "create_retrieval_candidate",
+            INSERT_RETRIEVAL_CANDIDATE_SQL,
+            (
+                retrieval_run_id,
+                continuity_object_id,
+                rank,
+                selected,
+                exclusion_reason,
+                lexical_score,
+                semantic_score,
+                entity_edge_score,
+                temporal_score,
+                trust_score,
+                relevance,
+                Jsonb(scope_matches),
+                Jsonb(stage_details),
+                Jsonb(ordering),
+                title,
+                object_type,
+                status,
+            ),
+        )
+
+    def list_retrieval_candidates_for_run(
+        self,
+        retrieval_run_id: UUID,
+    ) -> list[RetrievalCandidateRow]:
+        return self._fetch_all(LIST_RETRIEVAL_CANDIDATES_FOR_RUN_SQL, (retrieval_run_id,))
 
     def upsert_continuity_artifact(
         self,

--- a/docs/retrieval/hybrid_tracing.md
+++ b/docs/retrieval/hybrid_tracing.md
@@ -1,0 +1,33 @@
+# Hybrid Retrieval Tracing
+
+Phase 12 retrieval now runs as an explicit hybrid pipeline instead of a single opaque ranking pass.
+
+## Retrieval stages
+
+- lexical: BM25-style token overlap across continuity titles, body fields, and provenance
+- semantic: exact-query and semantic similarity scoring
+- entity_edge: direct entity matches plus graph-expanded neighbor matches
+- temporal: recency blended with requested time-window overlap
+- trust: trust class, confirmation, provenance quality, and supersession posture
+
+## Ranking behavior
+
+- Hybrid retrieval is the default recall path.
+- Existing non-debug recall and resumption payloads stay compatible.
+- Stale or superseded candidates remain eligible for inspection, but trust-aware reranking lowers their chance of outranking current truth.
+
+## Debug visibility
+
+- `GET /v0/continuity/recall?debug=true` returns inline stage scores, inclusion state, and exclusion reasons.
+- `GET /v0/continuity/resumption-brief?debug=true` returns the same retrieval trace under `debug.retrieval`.
+- `GET /v0/continuity/retrieval-runs` lists recent persisted runs.
+- `GET /v0/continuity/retrieval-runs/{retrieval_run_id}` returns one stored trace.
+- CLI adds `recall --debug` and `resume --debug`.
+- MCP adds `alice_recall_debug`, `alice_resume_debug`, and `alice_retrieval_trace`.
+
+## Persistence and retention
+
+- Each retrieval run is stored in `retrieval_runs`.
+- Per-candidate stage scores, selection state, ordering metadata, and exclusion reasons are stored in `retrieval_candidates`.
+- Retrieval traces use an operator-configurable retention window via the `retention_until` timestamp.
+- The current default retention is 14 days, controlled by `RETRIEVAL_TRACE_RETENTION_DAYS`.

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -28,15 +28,15 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="ROADMAP.md",
         required_markers=(
             "Bridge Phase (`B1`-`B4`): shipped",
-            "Release Sprint 1 (`R1`) is the active execution sprint.",
+            "Phase 12 Sprint 1 (`P12-S1`) is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Release Sprint 1 (R1): v0.2.0 Public Release Readiness",
-            "Phase 10 is complete and shipped.",
-            "Phase 11 is complete and shipped.",
+            "Phase 12 Sprint 1 (`P12-S1`): Hybrid Retrieval + Reranking",
+            "`v0.2.0` is released baseline truth.",
+            "stale or superseded facts are less likely to outrank current truth",
         ),
     ),
     ControlDocTruthRule(
@@ -52,7 +52,8 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
             "Phase 9 is shipped.",
             "Phase 10 is shipped.",
             "Phase 11 is shipped.",
-            "Release Sprint 1 (`R1`) is the active execution sprint.",
+            "`v0.2.0` is released.",
+            "Phase 12 Sprint 1 (`P12-S1`) is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -125,12 +125,15 @@ def test_cli_command_surface_and_correction_flow(migrated_database_urls) -> None
             str(thread_id),
             "--limit",
             "20",
+            "--debug",
         ],
         env=env,
     )
     assert recall_before.returncode == 0
     assert "Decision: Legacy rollout plan" in recall_before.stdout
     assert "lifecycle=preserved:True searchable:True promotable:True" in recall_before.stdout
+    assert "debug:" in recall_before.stdout
+    assert "lexical: raw=" in recall_before.stdout
 
     lifecycle_list_result = run_cli(
         ["lifecycle", "list", "--limit", "20"],
@@ -156,12 +159,14 @@ def test_cli_command_surface_and_correction_flow(migrated_database_urls) -> None
             "5",
             "--max-open-loops",
             "5",
+            "--debug",
         ],
         env=env,
     )
     assert resume_before.returncode == 0
     assert "last_decision:" in resume_before.stdout
     assert "Decision: Legacy rollout plan" in resume_before.stdout
+    assert "debug:" in resume_before.stdout
 
     open_loops_result = run_cli(
         ["open-loops", "--thread-id", str(thread_id), "--limit", "20"],

--- a/tests/integration/test_continuity_recall_api.py
+++ b/tests/integration/test_continuity_recall_api.py
@@ -283,6 +283,129 @@ def test_continuity_recall_api_rejects_invalid_time_window(
     assert payload == {"detail": "until must be greater than or equal to since"}
 
 
+def test_continuity_recall_debug_api_persists_and_exposes_trace(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="trace-owner@example.com")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        capture = store.create_continuity_capture_event(
+            raw_content="Decision: Keep rollout phased",
+            explicit_signal="decision",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_decision",
+        )
+        continuity_object = store.create_continuity_object(
+            capture_event_id=capture["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: Keep rollout phased",
+            body={"decision_text": "Keep rollout phased"},
+            provenance={"project": "Project Phoenix", "confirmation_status": "confirmed"},
+            confidence=0.95,
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=continuity_object["id"],
+        created_at=datetime(2026, 3, 29, 10, 0, tzinfo=UTC),
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v0/continuity/recall",
+        query_params={
+            "user_id": str(user_id),
+            "query": "rollout",
+            "limit": "20",
+            "debug": "true",
+        },
+    )
+
+    assert status == 200
+    assert payload["debug"]["candidate_count"] == 1
+    assert payload["debug"]["candidates"][0]["stage_scores"]["lexical"]["matched"] is True
+    retrieval_run_id = payload["debug"]["retrieval_run_id"]
+    assert retrieval_run_id is not None
+
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v0/continuity/retrieval-runs",
+        query_params={"user_id": str(user_id), "limit": "10"},
+    )
+    assert list_status == 200
+    assert list_payload["items"][0]["id"] == retrieval_run_id
+
+    trace_status, trace_payload = invoke_request(
+        "GET",
+        f"/v0/continuity/retrieval-runs/{retrieval_run_id}",
+        query_params={"user_id": str(user_id)},
+    )
+    assert trace_status == 200
+    assert trace_payload["retrieval_run"]["id"] == retrieval_run_id
+    assert trace_payload["candidates"][0]["object_id"] == str(continuity_object["id"])
+
+
+def test_continuity_resumption_debug_api_includes_underlying_retrieval_trace(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="resume-trace@example.com")
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        decision_capture = store.create_continuity_capture_event(
+            raw_content="Decision: Keep rollout phased",
+            explicit_signal="decision",
+            admission_posture="DERIVED",
+            admission_reason="explicit_signal_decision",
+        )
+        decision = store.create_continuity_object(
+            capture_event_id=decision_capture["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: Keep rollout phased",
+            body={"decision_text": "Keep rollout phased"},
+            provenance={"thread_id": str(thread_id), "confirmation_status": "confirmed"},
+            confidence=0.95,
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=decision["id"],
+        created_at=datetime(2026, 3, 29, 10, 0, tzinfo=UTC),
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v0/continuity/resumption-brief",
+        query_params={
+            "user_id": str(user_id),
+            "thread_id": str(thread_id),
+            "debug": "true",
+        },
+    )
+
+    assert status == 200
+    assert payload["brief"]["last_decision"]["item"]["id"] == str(decision["id"])
+    assert payload["debug"]["retrieval"]["candidate_count"] >= 1
+
+
 def test_continuity_recall_api_prefers_confirmed_fresh_active_truth_over_superseded_chain(
     migrated_database_urls,
     monkeypatch,

--- a/tests/integration/test_mcp_cli_parity.py
+++ b/tests/integration/test_mcp_cli_parity.py
@@ -249,11 +249,29 @@ def test_mcp_recall_and_resume_match_core_and_cli_behavior(migrated_database_url
                 "max_open_loops": 5,
             },
         )
+        mcp_recall_debug = _call_tool(
+            client,
+            name="alice_recall_debug",
+            arguments={
+                "thread_id": str(thread_id),
+                "query": "release",
+                "limit": 20,
+            },
+        )
+        retrieval_run_id = mcp_recall_debug["debug"]["retrieval_run_id"]
+        mcp_retrieval_trace = _call_tool(
+            client,
+            name="alice_retrieval_trace",
+            arguments={"retrieval_run_id": retrieval_run_id},
+        )
     finally:
         client.close()
 
     assert mcp_recall == core_recall
     assert mcp_resume == core_resume
+    assert mcp_recall_debug["items"] == core_recall["items"]
+    assert mcp_recall_debug["debug"]["candidate_count"] >= 1
+    assert mcp_retrieval_trace["retrieval_run"]["id"] == retrieval_run_id
 
     env = build_runtime_env(database_url=migrated_database_urls["app"], user_id=user_id)
     cli_recall = run_cli(

--- a/tests/integration/test_retrieval_evaluation_api.py
+++ b/tests/integration/test_retrieval_evaluation_api.py
@@ -88,8 +88,8 @@ def test_retrieval_evaluation_api_returns_deterministic_fixture_precision_summar
     )
 
     assert status == 200
-    assert payload["summary"]["fixture_count"] == 6
-    assert payload["summary"]["evaluated_fixture_count"] == 6
+    assert payload["summary"]["fixture_count"] == 7
+    assert payload["summary"]["evaluated_fixture_count"] == 7
     assert payload["summary"]["status"] == "pass"
     assert payload["summary"]["precision_at_k_mean"] >= payload["summary"]["precision_target"]
     assert payload["summary"]["precision_at_k_mean"] > payload["summary"]["baseline_precision_at_k_mean"]
@@ -101,5 +101,6 @@ def test_retrieval_evaluation_api_returns_deterministic_fixture_precision_summar
         "semantic_similarity_recovers_non_exact_query",
         "entity_signal_reduces_cross_entity_noise",
         "temporal_trust_supersession_prefers_current_valid_truth",
+        "entity_edge_expansion_recovers_related_owner",
     ]
     assert payload["fixtures"][0]["top_result_ordering"]["freshness_posture"] == "fresh"

--- a/tests/unit/test_20260414_0057_phase12_hybrid_retrieval_traces.py
+++ b/tests/unit/test_20260414_0057_phase12_hybrid_retrieval_traces.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260414_0057_phase12_hybrid_retrieval_traces"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == [
+        module._UPGRADE_SCHEMA_STATEMENT,
+        *module._UPGRADE_GRANT_STATEMENTS,
+        "ALTER TABLE retrieval_runs ENABLE ROW LEVEL SECURITY",
+        "ALTER TABLE retrieval_runs FORCE ROW LEVEL SECURITY",
+        "ALTER TABLE retrieval_candidates ENABLE ROW LEVEL SECURITY",
+        "ALTER TABLE retrieval_candidates FORCE ROW LEVEL SECURITY",
+        module._UPGRADE_POLICY_STATEMENT,
+    ]
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_retrieval_trace_tables_are_insert_select_only() -> None:
+    module = load_migration_module()
+
+    assert module._UPGRADE_GRANT_STATEMENTS == (
+        "GRANT SELECT, INSERT ON retrieval_runs TO alicebot_app",
+        "GRANT SELECT, INSERT ON retrieval_candidates TO alicebot_app",
+    )
+
+
+def test_retrieval_trace_schema_mentions_required_tables_and_scores() -> None:
+    module = load_migration_module()
+    joined_upgrade_sql = module._UPGRADE_SCHEMA_STATEMENT
+
+    for table_name in ("retrieval_runs", "retrieval_candidates"):
+        assert table_name in joined_upgrade_sql
+    for column_name in (
+        "lexical_score",
+        "semantic_score",
+        "entity_edge_score",
+        "temporal_score",
+        "trust_score",
+        "stage_details",
+        "ordering",
+        "retention_until",
+    ):
+        assert column_name in joined_upgrade_sql

--- a/tests/unit/test_continuity_recall.py
+++ b/tests/unit/test_continuity_recall.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
 import pytest
 
+import alicebot_api.continuity_recall as continuity_recall_module
+from alicebot_api.config import Settings
 from alicebot_api.continuity_recall import ContinuityRecallValidationError, query_continuity_recall
 from alicebot_api.contracts import ContinuityRecallQueryInput
 
@@ -15,9 +17,30 @@ class ContinuityRecallStoreStub:
         self._capture_events: dict[UUID, dict[str, object]] = {}
         self._evidence_by_object: dict[UUID, list[dict[str, object]]] = {}
         self._corrections_by_object: dict[UUID, list[dict[str, object]]] = {}
+        self._entities: list[dict[str, object]] = []
+        self._entity_edges: list[dict[str, object]] = []
+        self._retrieval_runs: list[dict[str, object]] = []
+        self._retrieval_candidates: list[dict[str, object]] = []
 
     def list_continuity_recall_candidates(self):
         return list(self._rows)
+
+    def list_entities(self):
+        return list(self._entities)
+
+    def list_entity_edges_for_entities(self, entity_ids: list[UUID]):
+        requested = set(entity_ids)
+        return [
+            dict(edge)
+            for edge in self._entity_edges
+            if edge["from_entity_id"] in requested or edge["to_entity_id"] in requested
+        ]
+
+    def add_entity(self, entity_row: dict[str, object]) -> None:
+        self._entities.append(dict(entity_row))
+
+    def add_entity_edge(self, edge_row: dict[str, object]) -> None:
+        self._entity_edges.append(dict(edge_row))
 
     def add_capture_event(self, capture_event_id: UUID, *, raw_content: str, created_at: datetime) -> None:
         self._capture_events[capture_event_id] = {
@@ -47,6 +70,26 @@ class ContinuityRecallStoreStub:
         rows = [dict(row) for row in self._corrections_by_object.get(continuity_object_id, [])]
         rows.sort(key=lambda row: (row["created_at"], row["id"]), reverse=True)
         return rows[:limit]
+
+    def create_retrieval_run(self, **kwargs):
+        row = {
+            "id": uuid4(),
+            "user_id": UUID("11111111-1111-4111-8111-111111111111"),
+            "created_at": datetime(2026, 4, 14, 12, 0, tzinfo=UTC),
+            **kwargs,
+        }
+        self._retrieval_runs.append(row)
+        return row
+
+    def create_retrieval_candidate(self, **kwargs):
+        row = {
+            "id": uuid4(),
+            "user_id": UUID("11111111-1111-4111-8111-111111111111"),
+            "created_at": datetime(2026, 4, 14, 12, 0, tzinfo=UTC),
+            **kwargs,
+        }
+        self._retrieval_candidates.append(row)
+        return row
 
 
 def make_candidate_row(
@@ -529,3 +572,172 @@ def test_recall_selects_ranked_explicit_values_deterministically_within_source()
 
     assert payload["items"][0]["confirmation_status"] == "confirmed"
     assert payload["items"][0]["ordering"]["freshness_posture"] == "fresh"
+
+
+def test_recall_debug_surfaces_stage_scores_and_exclusion_reasons() -> None:
+    rows = [
+        make_candidate_row(
+            title="Decision: Keep rollout phased",
+            object_type="Decision",
+            capture_created_at=datetime(2026, 3, 29, 10, 0, tzinfo=UTC),
+            confidence=0.9,
+            body={"decision_text": "keep rollout phased"},
+            provenance={"confirmation_status": "confirmed", "source_event_ids": ["event-1"]},
+            last_confirmed_at=datetime(2026, 3, 29, 10, 30, tzinfo=UTC),
+        ),
+        make_candidate_row(
+            title="Decision: Budget note",
+            object_type="Decision",
+            capture_created_at=datetime(2026, 3, 29, 10, 1, tzinfo=UTC),
+            confidence=0.95,
+            body={"decision_text": "budget note only"},
+            provenance={"confirmation_status": "confirmed", "source_event_ids": ["event-2"]},
+        ),
+    ]
+
+    payload = query_continuity_recall(
+        ContinuityRecallStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityRecallQueryInput(query="rollout", limit=20, debug=True),
+    )
+
+    debug = payload["debug"]
+    assert debug["ranking_strategy"] == "hybrid_v2"
+    assert debug["candidate_count"] == 2
+    assert debug["selected_count"] == 1
+    assert debug["candidates"][0]["selected"] is True
+    assert debug["candidates"][0]["stage_scores"]["lexical"]["matched"] is True
+    assert debug["candidates"][0]["stage_scores"]["semantic"]["matched"] is True
+    assert debug["candidates"][1]["selected"] is False
+    assert debug["candidates"][1]["exclusion_reason"] == "no_stream_match"
+    assert debug["candidates"][1]["stage_scores"]["trust"]["matched"] is True
+
+
+def test_recall_uses_entity_edge_expansion_to_prefer_related_owner() -> None:
+    rows = [
+        make_candidate_row(
+            title="Decision: Alex owns dependency follow-up",
+            object_type="Decision",
+            capture_created_at=datetime(2026, 4, 1, 9, 0, tzinfo=UTC),
+            confidence=0.72,
+            body={"decision_text": "dependency owner follow-up is Alex"},
+            provenance={"person": "Alex", "confirmation_status": "confirmed", "source_event_ids": ["event-1"]},
+            last_confirmed_at=datetime(2026, 4, 1, 9, 30, tzinfo=UTC),
+        ),
+        make_candidate_row(
+            title="Decision: Phoenix dependency note",
+            object_type="Decision",
+            capture_created_at=datetime(2026, 4, 1, 9, 5, tzinfo=UTC),
+            confidence=0.95,
+            body={"decision_text": "dependency owner follow-up is Taylor"},
+            provenance={
+                "project": "Project Phoenix",
+                "person": "Taylor",
+                "confirmation_status": "confirmed",
+                "source_event_ids": ["event-2"],
+            },
+            status="stale",
+        ),
+    ]
+    store = ContinuityRecallStoreStub(rows)  # type: ignore[arg-type]
+    store.add_entity(
+        {
+            "id": UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+            "user_id": UUID("11111111-1111-4111-8111-111111111111"),
+            "entity_type": "project",
+            "name": "Project Phoenix",
+            "source_memory_ids": ["memory-1"],
+            "created_at": datetime(2026, 4, 1, 8, 0, tzinfo=UTC),
+        }
+    )
+    store.add_entity(
+        {
+            "id": UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+            "user_id": UUID("11111111-1111-4111-8111-111111111111"),
+            "entity_type": "person",
+            "name": "Alex",
+            "source_memory_ids": ["memory-2"],
+            "created_at": datetime(2026, 4, 1, 8, 5, tzinfo=UTC),
+        }
+    )
+    store.add_entity_edge(
+        {
+            "id": UUID("cccccccc-cccc-4ccc-8ccc-cccccccccccc"),
+            "user_id": UUID("11111111-1111-4111-8111-111111111111"),
+            "from_entity_id": UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+            "to_entity_id": UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+            "relationship_type": "owner_of",
+            "valid_from": None,
+            "valid_to": None,
+            "source_memory_ids": ["memory-3"],
+            "created_at": datetime(2026, 4, 1, 8, 10, tzinfo=UTC),
+        }
+    )
+
+    payload = query_continuity_recall(
+        store,  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityRecallQueryInput(query="Project Phoenix dependency owner", limit=20, debug=True),
+    )
+
+    assert payload["items"][0]["title"] == "Decision: Alex owns dependency follow-up"
+    assert payload["debug"]["candidates"][0]["stage_scores"]["entity_edge"]["matched"] is True
+
+
+def test_recall_debug_normalizes_against_scope_matched_candidates_only() -> None:
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    rows = [
+        make_candidate_row(
+            title="Decision: Keep rollout phased",
+            object_type="Decision",
+            capture_created_at=datetime(2026, 3, 29, 10, 0, tzinfo=UTC),
+            confidence=0.9,
+            body={"decision_text": "keep rollout phased"},
+            provenance={"thread_id": str(thread_id), "confirmation_status": "confirmed"},
+        ),
+        make_candidate_row(
+            title="Decision: Off-scope rollout archive",
+            object_type="Decision",
+            capture_created_at=datetime(2026, 3, 29, 11, 0, tzinfo=UTC),
+            confidence=0.99,
+            body={"decision_text": "rollout rollout rollout rollout rollout rollout rollout rollout"},
+            provenance={
+                "thread_id": str(UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")),
+                "confirmation_status": "confirmed",
+            },
+        ),
+    ]
+
+    payload = query_continuity_recall(
+        ContinuityRecallStoreStub(rows),  # type: ignore[arg-type]
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+        request=ContinuityRecallQueryInput(
+            query="rollout",
+            thread_id=thread_id,
+            limit=20,
+            debug=True,
+        ),
+    )
+
+    assert [item["title"] for item in payload["items"]] == ["Decision: Keep rollout phased"]
+    selected_candidate = payload["debug"]["candidates"][0]
+    assert selected_candidate["object_id"] == str(rows[0]["id"])
+    assert selected_candidate["stage_scores"]["lexical"]["normalized_score"] == pytest.approx(1.0)
+
+    excluded_candidate = next(
+        candidate
+        for candidate in payload["debug"]["candidates"]
+        if candidate["object_id"] == str(rows[1]["id"])
+    )
+    assert excluded_candidate["exclusion_reason"] == "scope_mismatch"
+
+
+def test_retrieval_trace_retention_uses_configured_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime(2026, 4, 14, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(
+        continuity_recall_module,
+        "get_settings",
+        lambda: Settings(retrieval_trace_retention_days=3),
+    )
+
+    assert continuity_recall_module._retrieval_trace_retention_until(now=now) == now + timedelta(days=3)

--- a/tests/unit/test_retrieval_evaluation.py
+++ b/tests/unit/test_retrieval_evaluation.py
@@ -23,8 +23,8 @@ def test_retrieval_evaluation_summary_is_deterministic_and_fixture_backed() -> N
     )
 
     assert payload_first == payload_second
-    assert payload_first["summary"]["fixture_count"] == 6
-    assert payload_first["summary"]["evaluated_fixture_count"] == 6
+    assert payload_first["summary"]["fixture_count"] == 7
+    assert payload_first["summary"]["evaluated_fixture_count"] == 7
     assert payload_first["summary"]["precision_target"] == RETRIEVAL_EVALUATION_PRECISION_TARGET
     assert payload_first["summary"]["precision_at_k_mean"] >= RETRIEVAL_EVALUATION_PRECISION_TARGET
     assert payload_first["summary"]["precision_at_k_mean"] > payload_first["summary"]["baseline_precision_at_k_mean"]
@@ -37,6 +37,7 @@ def test_retrieval_evaluation_summary_is_deterministic_and_fixture_backed() -> N
         "semantic_similarity_recovers_non_exact_query",
         "entity_signal_reduces_cross_entity_noise",
         "temporal_trust_supersession_prefers_current_valid_truth",
+        "entity_edge_expansion_recovers_related_owner",
     ]
     assert all(fixture["precision_at_k"] >= fixture["baseline_precision_at_k"] for fixture in payload_first["fixtures"])
     assert payload_first["fixtures"][0]["top_result_ordering"] is not None


### PR DESCRIPTION
## Summary
This sprint turns continuity recall into an explicit hybrid retrieval pipeline with persisted trace visibility instead of a single opaque ranking pass.

It adds lexical, semantic, entity-edge, temporal, and trust-aware ranking stages; persists `retrieval_runs` and `retrieval_candidates`; and exposes retrieval diagnostics through API, CLI, and MCP surfaces without breaking the non-debug recall and resumption payloads.

## Why This Changed
Phase 12 needed retrieval quality to become an auditable execution surface. The shipped baseline had semantic retrieval and trust-aware recall, but not a full multi-strategy retrieval flow with persisted traces and operator-visible explanations.

## User And Operator Impact
Operators can now inspect why a candidate was included, excluded, or ordered through `debug=true` API responses, `recall --debug` and `resume --debug`, and the MCP retrieval debug tools. Existing non-debug callers keep the prior response shape.

## Validation
- `./.venv/bin/pytest tests/unit/test_continuity_recall.py tests/unit/test_retrieval_evaluation.py tests/unit/test_cli.py tests/unit/test_20260414_0057_phase12_hybrid_retrieval_traces.py -q`
- `./.venv/bin/pytest tests/integration/test_continuity_recall_api.py tests/integration/test_retrieval_evaluation_api.py tests/integration/test_cli_integration.py tests/integration/test_mcp_cli_parity.py -q`
- `./.venv/bin/python scripts/check_control_doc_truth.py`
- `rg -n "/Users|samirusani|Desktop/Codex" RULES.md ARCHITECTURE.md CURRENT_STATE.md BUILD_REPORT.md docs/retrieval`

## Upgrade Overview
### Protected Areas
- [x] memory schema
- [ ] evidence pipeline
- [x] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact
Existing non-debug recall and resumption payloads remain compatible. New retrieval trace endpoints and debug fields are additive.

### Migration / Rollout
Apply the Alembic migration that creates `retrieval_runs` and `retrieval_candidates` before exercising persisted trace inspection. Hybrid retrieval is now the default recall path on this branch.

### Operator Action
Operators can inspect retrieval traces through `GET /v0/continuity/retrieval-runs`, `GET /v0/continuity/retrieval-runs/{retrieval_run_id}`, `recall --debug`, `resume --debug`, `alice_recall_debug`, `alice_resume_debug`, and `alice_retrieval_trace`.

### Validation
The sprint head passed the focused unit and integration retrieval slices, the control-doc truth check, and the local-path scrub check listed above.

### Rollback
Rollback by reverting this squash merge and the retrieval-trace migration together so the runtime and schema stay aligned.
