### PR TITLE
[codex] Phase 12 closeout and v0.3.2 release prep

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -1,0 +1,93 @@
+# Sprint Packet
+
+## Sprint Title
+Phase 12 Closeout and `v0.3.2` Release Update
+
+## Activation Note
+- This packet is active.
+- `v0.2.0` is the latest published tag.
+- `v0.3.2` is the current release target for the completed Phase 12 boundary.
+- Phase 12 implementation scope is complete through `P12-S1` to `P12-S5`.
+
+## Sprint Type
+closeout
+
+## Sprint Reason
+Phase 12 implementation is complete. The remaining work is not another product sprint. It is closeout:
+- summarize the completed phase clearly
+- align canonical docs to Phase 12 completion
+- update release docs from the old `v0.2.0` boundary to the new `v0.3.2` target
+- prepare the repo for either a `v0.3.2` tag or next-phase planning
+
+## Git Instructions
+- Branch Name: `codex/phase12-closeout-v0-3-2`
+- Base Branch: `main`
+- PR Strategy: one docs/control branch, one PR
+- Merge Policy: squash merge after review `PASS` and explicit approval
+
+## Baseline To Preserve
+- shipped Phase 9 through Phase 11 baseline
+- shipped Bridge `B1` through `B4`
+- shipped Phase 12 `P12-S1` through `P12-S5`
+- current published tag remains `v0.2.0` until a new tag is cut
+
+## Exact Goal
+Close Phase 12 cleanly and move the documented release boundary to `v0.3.2` without falsely claiming that the `v0.3.2` tag has already been cut.
+
+## In Scope
+- Phase 12 closeout packet
+- Phase 12 closeout summary
+- current-state and roadmap alignment for completed Phase 12
+- `v0.3.2` release checklist, tag plan, and runbook
+- README and public-doc release-boundary updates
+- changelog update for completed Phase 12
+
+## Out Of Scope
+- new product or runtime features
+- reopening any Phase 12 implementation sprint
+- tagging or publishing `v0.3.2` without explicit approval
+- defining the next phase in detail
+
+## Proposed Files And Modules
+- `README.md`
+- `CHANGELOG.md`
+- `PRODUCT_BRIEF.md`
+- `ARCHITECTURE.md`
+- `ROADMAP.md`
+- `RULES.md`
+- `CURRENT_STATE.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `.ai/active/SPRINT_PACKET.md`
+- `docs/runbooks/phase12-closeout-packet.md`
+- `docs/phase12-closeout-summary.md`
+- `docs/release/v0.3.2-release-checklist.md`
+- `docs/release/v0.3.2-tag-plan.md`
+- `docs/runbooks/v0.3.2-public-release-runbook.md`
+- public docs that still hard-code the old `v0.2.0` release boundary
+- `scripts/check_control_doc_truth.py`
+
+## Planned Deliverables
+- Phase 12 closeout packet
+- Phase 12 closeout summary
+- `v0.3.2` release-target docs
+- canonical doc alignment to completed Phase 12
+- updated release-boundary references in public docs
+
+## Acceptance Criteria
+- Phase 12 is described as complete in canonical docs
+- The documented release target is `v0.3.2`
+- the docs do not falsely claim that `v0.3.2` is already tagged or published
+- closeout docs summarize what shipped in `P12-S1` through `P12-S5`
+- control-doc truth passes after the closeout update
+
+## Required Verification
+- `python3 scripts/check_control_doc_truth.py`
+- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+
+## Control Tower Decisions Needed
+- whether to tag and publish `v0.3.2` immediately after closeout
+- whether to run a dedicated release-readiness pass before the `v0.3.2` tag
+- what the next planned phase is after Phase 12
+
+## Exit Condition
+This closeout packet is complete when Phase 12 is summarized cleanly, canonical docs reflect completed Phase 12 truth, and the documented release target is updated to `v0.3.2` without claiming a tag that has not yet been cut.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -5,31 +5,32 @@
 - Phase 10 is shipped.
 - Phase 11 is shipped.
 - Bridge `B1` through `B4` are shipped.
-- `v0.2.0` is released.
+- `v0.2.0` is the latest published tag.
+- `v0.3.2` is the current release target.
 - Phase 12 Sprint 1 (`P12-S1`) is shipped.
 - Phase 12 Sprint 2 (`P12-S2`) is shipped.
 - Phase 12 Sprint 3 (`P12-S3`) is shipped.
 - Phase 12 Sprint 4 (`P12-S4`) is shipped.
-- Phase 12 Sprint 5 (`P12-S5`) is the active execution sprint.
+- Phase 12 Sprint 5 (`P12-S5`) is shipped.
+- Phase 12 closeout and `v0.3.2` release update are the active control packet.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
 - Alice exposes CLI, MCP, hosted/product, provider-runtime, and Hermes bridge surfaces.
 - The codebase already includes semantic retrieval, embeddings, entities/entity edges, trusted-fact promotion, retrieval evaluation fixtures, deterministic resumption briefs, daily briefs, chief-of-staff briefing flows, and the shipped `P12-S1` hybrid retrieval/reranking foundation with retrieval traces.
-- The codebase also includes the shipped `P12-S2` memory mutation candidate and operation foundation, the shipped `P12-S3` contradiction/trust foundation, and the shipped `P12-S4` public eval harness.
-
-## Not Yet First-Class In Repo
+- The codebase also includes the shipped `P12-S2` memory mutation candidate and operation foundation, the shipped `P12-S3` contradiction/trust foundation, the shipped `P12-S4` public eval harness, and the shipped `P12-S5` task-adaptive briefing layer.
 
 ## Phase Transition Note
-- Phase 12 is active.
+- Phase 12 is complete.
 - `P12-S1` is complete and establishes the retrieval baseline.
 - `P12-S2` is complete and establishes the mutation baseline.
 - `P12-S3` is complete and establishes the contradiction/trust baseline.
 - `P12-S4` is complete and establishes the public-eval baseline.
-- `P12-S5` is the active sprint and should build briefing behavior on top of shipped retrieval, mutation, contradiction, and eval baselines without reopening those systems.
-- The current `P12-S5` branch implements task-adaptive brief generation, comparison, and model-pack briefing defaults, pending Control Tower merge approval.
+- `P12-S5` is complete and establishes the task-adaptive briefing baseline.
+- The active docs task is phase closeout, summary, and `v0.3.2` release-target alignment.
+- There are no remaining Phase 12 feature sprints.
 
 ## Immediate Control Tower Decisions Needed
-- Decide briefing modes and payload schema for user recall, resume, worker subtask, and agent handoff.
-- Decide provider/model-pack fields for briefing strategy and max brief tokens.
-- Decide whether `P12-S5` needs CLI-only, API, and MCP surfaces simultaneously or can stage them.
+- Decide when to cut the `v0.3.2` tag and release.
+- Decide whether a dedicated release-readiness pass is needed before the tag.
+- Decide the next planned phase after Phase 12 closeout.

--- a/.gitignore
+++ b/.gitignore
@@ -10,14 +10,23 @@ apps/web/node_modules/
 artifacts/
 
 # Internal operating docs (keep local, exclude from public repo)
-.ai/
+.ai/*
+!.ai/active/
+!.ai/handoff/
+.ai/active/*
+!.ai/active/SPRINT_PACKET.md
+.ai/handoff/*
+!.ai/handoff/CURRENT_STATE.md
 BUILD_REPORT.md
 REVIEW_REPORT.md
 ARCHIVE_RECOMMENDATIONS.md
 RECOMMENDED_ADRS.md
 
 # Internal planning/process docs (keep local, exclude from public repo)
-docs/archive/planning/
+docs/archive/planning/*
+!docs/archive/planning/2026-04-08-context-compaction/
+docs/archive/planning/2026-04-08-context-compaction/*
+!docs/archive/planning/2026-04-08-context-compaction/README.md
 docs/archive/sprints/
 docs/phase5-sprint-17-20-plan.md
 docs/phase8-sprint-29-32-plan.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,8 +2,8 @@
 
 ## Scope Boundary
 - **Shipped baseline:** Phases 9-11 and Bridge `B1` through `B4`.
-- **Current repo execution posture:** `v0.2.0` is released; `P12-S1`, `P12-S2`, `P12-S3`, and `P12-S4` are shipped; `P12-S5` is the active sprint.
-- **Phase 12 delta:** retrieval quality, mutation explicitness, contradiction handling, public evals, and adaptive briefing.
+- **Current repo execution posture:** `v0.2.0` is the latest published tag; `v0.3.2` is the current release target; Phase 12 is complete.
+- **Active control-doc task:** Phase 12 closeout and `v0.3.2` release update.
 
 ## Current System Overview
 Alice is a modular continuity platform with shared continuity semantics across local, hosted, provider-runtime, MCP, and Hermes-integrated surfaces.
@@ -92,7 +92,7 @@ Shipped in `P12-S1`:
 - trust-aware reranking
 - persisted retrieval traces
 
-Planned additions:
+Delivered additions:
 - `retrieval_runs`
 - `retrieval_candidates`
 - debug surfaces for API, CLI, and MCP
@@ -135,13 +135,13 @@ Important baseline note: `P12-S4` is now the evaluation baseline for the rest of
 Source-of-truth note: the checked-in fixture catalog defines the authoritative suite/case set and ordering; persisted eval suite/case rows are synchronized snapshots for execution and audit, not an independent planning surface.
 
 ### P12-S5: Task-Adaptive Briefing
-Separate durable memory from output-specific briefing layers.
+Shipped in `P12-S5`:
 
-Planned additions:
+Delivered additions:
 - `task_briefs`
 - provider/model-pack briefing strategy fields
 
-Important baseline note: `P12-S5` should build on shipped retrieval, mutation, contradiction, and eval baselines. Existing resumption, daily-brief, and chief-of-staff briefing surfaces are starting points, not greenfield replacements.
+Important baseline note: `P12-S5` closes the planned Phase 12 implementation scope. Existing resumption, daily-brief, and chief-of-staff briefing surfaces remain the starting points rather than being replaced wholesale.
 
 ## Security And Reliability Rules
 - Keep user/workspace isolation intact for continuity, provider, and channel data.
@@ -169,7 +169,5 @@ Important baseline note: `P12-S5` should build on shipped retrieval, mutation, c
 - release/eval artifacts committed only when they correspond to exact commands and fixtures
 
 ## Control Tower Decisions Needed
-- Should Phase 12 retrieval ship behind a feature flag before it replaces the default recall path?
-- Should new endpoints use `/v1/retrieval/*`, `/v1/evals/*`, `/v1/briefs/*`, or extend existing continuity endpoints?
-- Should contradictions attach to continuity objects only, memories only, or both with a shared abstraction?
-- Should `DELETE` be restricted to logical deletion/tombstoning by default?
+- Whether `v0.3.2` should be tagged immediately or held until a dedicated release pass.
+- What the next planned phase is after the completed Phase 12 architecture baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 2026-04-14
 
+- Closed out Phase 12 after shipping all five planned sprints:
+  - `P12-S1` hybrid retrieval + reranking
+  - `P12-S2` automated memory operations
+  - `P12-S3` contradiction detection + trust calibration
+  - `P12-S4` public eval harness
+  - `P12-S5` task-adaptive briefing
+- Added Phase 12 closeout summary and closeout packet.
+- Updated the documented release target from `v0.2.0` to `v0.3.2` for the completed Phase 12 boundary.
+- Aligned Python, API, web, CLI, core-package, and Hermes plugin version metadata to `0.3.2`.
+- Added `v0.3.2` release checklist, tag plan, and public release runbook.
+- Kept the published release truth explicit: the latest published tag remains `v0.2.0` until `v0.3.2` is cut.
+
 - Prepared `R1` release-readiness package for `v0.2.0` as a pre-1.0 public release boundary.
 - Added `v0.2.0` release checklist, tag plan, and public release runbook.
 - Realigned launch-facing docs to shipped scope through Phase 11 and Bridge `B1` through `B4`.

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -8,31 +8,32 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - Phase 10 is shipped.
 - Phase 11 is shipped.
 - Bridge `B1` through `B4` are shipped.
-- `v0.2.0` is released.
+- `v0.2.0` is the latest published tag.
+- `v0.3.2` is the current release target.
 - Phase 12 Sprint 1 (`P12-S1`) is shipped.
 - Phase 12 Sprint 2 (`P12-S2`) is shipped.
 - Phase 12 Sprint 3 (`P12-S3`) is shipped.
 - Phase 12 Sprint 4 (`P12-S4`) is shipped.
-- Phase 12 Sprint 5 (`P12-S5`) is the active execution sprint.
+- Phase 12 Sprint 5 (`P12-S5`) is shipped.
+- Phase 12 closeout and `v0.3.2` release update are the active control packet.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
 - Alice exposes CLI, MCP, hosted/product, provider-runtime, and Hermes bridge surfaces.
 - The codebase already includes semantic retrieval, embeddings, entities/entity edges, trusted-fact promotion, retrieval evaluation fixtures, deterministic resumption briefs, daily briefs, chief-of-staff briefing flows, and the shipped `P12-S1` hybrid retrieval/reranking foundation with retrieval traces.
-- The codebase also includes the shipped `P12-S2` memory mutation candidate and operation foundation, the shipped `P12-S3` contradiction/trust foundation, and the shipped `P12-S4` public eval harness.
-
-## Not Yet First-Class In Repo
+- The codebase also includes the shipped `P12-S2` memory mutation candidate and operation foundation, the shipped `P12-S3` contradiction/trust foundation, the shipped `P12-S4` public eval harness, and the shipped `P12-S5` task-adaptive briefing layer.
 
 ## Phase Transition Note
-- Phase 12 is active.
+- Phase 12 is complete.
 - `P12-S1` is complete and establishes the retrieval baseline.
 - `P12-S2` is complete and establishes the mutation baseline.
 - `P12-S3` is complete and establishes the contradiction/trust baseline.
 - `P12-S4` is complete and establishes the public-eval baseline.
-- `P12-S5` is the active sprint and should build briefing behavior on top of shipped retrieval, mutation, contradiction, and eval baselines without reopening those systems.
-- The current `P12-S5` branch implements task-adaptive brief generation, comparison, and model-pack briefing defaults, pending Control Tower merge approval.
+- `P12-S5` is complete and establishes the task-adaptive briefing baseline.
+- The active docs task is phase closeout, summary, and `v0.3.2` release-target alignment.
+- There are no remaining Phase 12 feature sprints.
 
 ## Immediate Control Tower Decisions Needed
-- Decide briefing modes and payload schema for user recall, resume, worker subtask, and agent handoff.
-- Decide provider/model-pack fields for briefing strategy and max brief tokens.
-- Decide whether `P12-S5` needs CLI-only, API, and MCP surfaces simultaneously or can stage them.
+- Decide when to cut the `v0.3.2` tag and release.
+- Decide whether a dedicated release-readiness pass is needed before the tag.
+- Decide the next planned phase after Phase 12 closeout.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -11,15 +11,17 @@ Alice is a pre-1.0 continuity platform for AI agents and agent-assisted workflow
 
 ## Current Repo Posture
 - `v0.2.0` is tagged and released.
+- `v0.3.2` is the current release target for the completed Phase 12 boundary.
 - Release Sprint 1 (`R1`) is complete and now baseline truth.
-- Phase 12 is active.
+- Phase 12 is complete.
 - `P12-S1` Hybrid Retrieval + Reranking is shipped.
 - `P12-S2` Automated Memory Operations is shipped.
 - `P12-S3` Contradiction Detection + Trust Calibration is shipped.
 - `P12-S4` Public Eval Harness is shipped.
-- `P12-S5` Task-Adaptive Briefing is the active sprint.
+- `P12-S5` Task-Adaptive Briefing is shipped.
+- Phase 12 closeout and `v0.3.2` release update are the active control-doc task.
 
-## Next Phase
+## Completed Phase
 ### Phase 12: Retrieval Quality + Adaptive Continuity
 Raise Alice from a strong continuity substrate to a measurably better memory system by improving:
 - retrieval precision
@@ -61,5 +63,5 @@ Alice already has durable memory, provenance, trust classes, revision/supersessi
 - Worker-task briefs are smaller and sharper than generic recall context without degrading resumption quality.
 
 ## Control Tower Decisions Needed
-- Whether new Phase 12 APIs should live under new `/v1` feature namespaces or extend the existing continuity surface.
-- Whether `DELETE` in memory operations means hard delete, logical tombstone, or a restricted administrative path.
+- When to cut and publish the `v0.3.2` tag/release.
+- What the next planned phase is after Phase 12 closeout.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ durable memory for agents, agent resumption, open loop tracking, local-first ai 
 
 Alice helps agents **remember what matters, resume interrupted work, explain why something is true, and improve when corrected**.
 
-`v0.2.0` is a **pre-1.0 public release**. It packages shipped baseline scope through Phase 11 and Bridge `B1` through `B4` without claiming `v1.0.0` stability guarantees.
+`v0.3.2` is the current **pre-1.0 release target** for the completed Phase 12 boundary. The latest published tag remains `v0.2.0` until the `v0.3.2` release is cut.
 
 Most assistants are still good only in the moment. They can answer the current prompt, but they struggle to preserve decisions, track open loops, recover context across sessions, and stay aligned after memory corrections.
 
@@ -27,14 +27,20 @@ It provides a **local-first memory and continuity engine** for capture, recall, 
 
 **Works across local, self-hosted, enterprise, and external-agent workflows via CLI, MCP, provider runtime, OpenClaw import, and Hermes integration.**
 
-## Release Boundary (`v0.2.0`)
+## Release Boundary (`v0.3.2` Target)
 
-Shipped baseline included in this pre-1.0 release:
+Completed baseline included in this pre-1.0 release target:
 
 - Phase 9 continuity core and deterministic local CLI/MCP/importer seams
 - Phase 10 hosted/product layer
 - Phase 11 provider runtime, adapters, and model packs
 - Bridge `B1` through `B4` provider contract, auto-capture flow, review/explainability flow, and bridge docs/smoke validation
+- Phase 12 retrieval quality stack:
+  - hybrid retrieval and reranking
+  - explicit memory mutation operations
+  - contradiction detection and trust calibration
+  - public eval harness and baseline reports
+  - task-adaptive briefing
 
 Historical planning/control artifacts remain available in:
 [docs/archive/planning/2026-04-08-context-compaction/README.md](docs/archive/planning/2026-04-08-context-compaction/README.md)
@@ -136,6 +142,11 @@ The current open-source surface includes:
 - scheduled archive maintenance, ops status reporting, and failure alerting
 - Hermes bridge with provider lifecycle hooks, always-on continuity prefetch, turn auto-capture, policy-based commit modes (`manual` / `assist` / `auto`), and reviewable explainable candidate memory flows
 - provider runtime abstraction with workspace-scoped provider registration, capability snapshots, OpenAI-compatible base adapter, local Ollama/llama.cpp, self-hosted vLLM, enterprise Azure, model packs, and external-agent integration paths
+- hybrid retrieval with persisted retrieval traces and debug visibility
+- explicit memory mutation operations with auditability and idempotent replay behavior
+- contradiction detection, contradiction-aware ranking penalties, and trust-signal inspection
+- public eval harness with fixture catalog and checked-in baseline report support
+- task-adaptive briefing for user recall, resume, worker subtask, and agent handoff
 - importers for OpenClaw, Markdown, and ChatGPT exports
 - OpenClaw adapter and demo path
 - evaluation harness and integration docs
@@ -301,15 +312,16 @@ That means the system behaves consistently across local workflows, MCP-connected
 
 ## Scope Notes
 
-Included in `v0.2.0`:
+Included in the `v0.3.2` target:
 
 - local-first continuity core
 - CLI and MCP surfaces
 - importer paths (OpenClaw, Markdown, ChatGPT exports)
 - provider runtime and model-pack support from Phase 11
 - Hermes provider-plus-MCP bridge path with MCP-only fallback
+- Phase 12 retrieval, mutation, contradiction/trust, public eval, and task-adaptive briefing surfaces
 
-Deferred beyond `v0.2.0`:
+Deferred beyond `v0.3.2`:
 
 - `v1.0.0` compatibility/support guarantees
 - managed cloud/SLA commitments

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,18 +7,16 @@
 - Bridge `B1`-`B4`: shipped
 - Bridge Phase (`B1`-`B4`): shipped
 - `v0.2.0`: released
+- Phase 12: shipped
+- `v0.3.2`: current release target
 
 These remain baseline truth and are not future milestones.
 
 ## Active Planning Status
-- Phase 12 Sprint 1 (`P12-S1`) is shipped.
-- Phase 12 Sprint 2 (`P12-S2`) is shipped.
-- Phase 12 Sprint 3 (`P12-S3`) is shipped.
-- Phase 12 Sprint 4 (`P12-S4`) is shipped.
-- Phase 12 Sprint 5 (`P12-S5`) is the active execution sprint.
-- `P12-S5` is the task-adaptive-briefing sprint for the Phase 12 quality stack.
+- Phase 12 closeout and `v0.3.2` release update are the active control packet.
+- No remaining Phase 12 feature sprints are open.
 
-## Phase 12 Milestones
+## Phase 12 Completed Milestones
 
 ### P12-S1: Hybrid Retrieval + Reranking
 - add hybrid retrieval pipeline
@@ -41,7 +39,7 @@ These remain baseline truth and are not future milestones.
 - add brief compiler and brief modes
 - integrate provider/model-pack briefing strategy
 
-## Release Sequencing
+## Release Sequencing Applied
 - `v0.3.0`: retrieval and memory quality (`P12-S1` through `P12-S3`)
 - `v0.3.1`: public evaluation (`P12-S4`)
 - `v0.3.2`: task-adaptive briefing (`P12-S5`)
@@ -53,5 +51,5 @@ These remain baseline truth and are not future milestones.
 - Treat later releases as separate contracts; do not collapse all Phase 12 work into one oversized sprint.
 
 ## Beyond Phase 12
-- No post-Phase-12 feature plan is defined in the source packet.
-- Additional work after `v0.3.2` requires a new planning pass.
+- No post-Phase-12 feature plan is currently defined.
+- The next step is either cutting the `v0.3.2` release or planning the next phase.

--- a/RULES.md
+++ b/RULES.md
@@ -3,6 +3,7 @@
 ## State Discipline
 - Treat Phases 9-11 and Bridge `B1` through `B4` as shipped baseline truth.
 - Treat `v0.2.0` as released baseline truth.
+- Treat `v0.3.2` as the current completed release target until the next tag is cut.
 - Keep shipped baseline, active phase scope, and later roadmap scope separate.
 - Keep [CURRENT_STATE.md](CURRENT_STATE.md) factual/current and [ROADMAP.md](ROADMAP.md) future-facing.
 - Keep [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURRENT_STATE.md) as the canonical handoff copy when duplicate current-state files exist.

--- a/apps/api/src/alicebot_api/__init__.py
+++ b/apps/api/src/alicebot_api/__init__.py
@@ -1,5 +1,5 @@
 """AliceBot foundation API package."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.2"
 
 __all__ = ["__version__"]

--- a/apps/api/src/alicebot_api/execution_budgets.py
+++ b/apps/api/src/alicebot_api/execution_budgets.py
@@ -200,6 +200,61 @@ def _invalid_transition_error(
     )
 
 
+def _optional_uuid_string(value: object) -> str | None:
+    return None if value is None else str(value)
+
+
+def _optional_datetime_string(value: object) -> str | None:
+    return None if value is None else cast(datetime, value).isoformat()
+
+
+def _lifecycle_state_payload(
+    *,
+    row: ExecutionBudgetRow,
+    requested_action: ExecutionBudgetLifecycleAction,
+    previous_status: str,
+    replacement_budget: ExecutionBudgetRow | None,
+    replacement_max_completed_executions: int | None,
+    replacement_rolling_window_seconds: int | None,
+    rejection_reason: str | None,
+) -> ExecutionBudgetLifecycleStateTracePayload:
+    return {
+        "execution_budget_id": str(row["id"]),
+        "requested_action": requested_action,
+        "previous_status": cast(str, previous_status),
+        "current_status": cast(str, row["status"]),
+        "tool_key": row["tool_key"],
+        "domain_hint": row["domain_hint"],
+        "max_completed_executions": row["max_completed_executions"],
+        "rolling_window_seconds": row["rolling_window_seconds"],
+        "deactivated_at": _optional_datetime_string(row["deactivated_at"]),
+        "superseded_by_budget_id": _optional_uuid_string(row["superseded_by_budget_id"]),
+        "supersedes_budget_id": _optional_uuid_string(row["supersedes_budget_id"]),
+        "replacement_budget_id": None if replacement_budget is None else str(replacement_budget["id"]),
+        "replacement_status": None if replacement_budget is None else cast(str, replacement_budget["status"]),
+        "replacement_max_completed_executions": replacement_max_completed_executions,
+        "replacement_rolling_window_seconds": replacement_rolling_window_seconds,
+        "rejection_reason": rejection_reason,
+    }
+
+
+def _lifecycle_summary_payload(
+    *,
+    execution_budget_id: UUID,
+    requested_action: ExecutionBudgetLifecycleAction,
+    outcome: ExecutionBudgetLifecycleOutcome,
+    replacement_budget_id: UUID | None,
+    active_budget_id: UUID | None,
+) -> ExecutionBudgetLifecycleSummaryTracePayload:
+    return {
+        "execution_budget_id": str(execution_budget_id),
+        "requested_action": requested_action,
+        "outcome": outcome,
+        "replacement_budget_id": _optional_uuid_string(replacement_budget_id),
+        "active_budget_id": _optional_uuid_string(active_budget_id),
+    }
+
+
 def _record_lifecycle_trace(
     store: ContinuityStore,
     *,
@@ -338,37 +393,22 @@ def deactivate_execution_budget_record(
             store,
             thread=thread,
             request_payload=request_payload,
-            state_payload={
-                "execution_budget_id": str(row["id"]),
-                "requested_action": "deactivate",
-                "previous_status": cast(str, row["status"]),
-                "current_status": cast(str, row["status"]),
-                "tool_key": row["tool_key"],
-                "domain_hint": row["domain_hint"],
-                "max_completed_executions": row["max_completed_executions"],
-                "rolling_window_seconds": row["rolling_window_seconds"],
-                "deactivated_at": (
-                    None if row["deactivated_at"] is None else row["deactivated_at"].isoformat()
-                ),
-                "superseded_by_budget_id": (
-                    None if row["superseded_by_budget_id"] is None else str(row["superseded_by_budget_id"])
-                ),
-                "supersedes_budget_id": (
-                    None if row["supersedes_budget_id"] is None else str(row["supersedes_budget_id"])
-                ),
-                "replacement_budget_id": None,
-                "replacement_status": None,
-                "replacement_max_completed_executions": None,
-                "replacement_rolling_window_seconds": None,
-                "rejection_reason": str(error),
-            },
-            summary_payload={
-                "execution_budget_id": str(row["id"]),
-                "requested_action": "deactivate",
-                "outcome": "rejected",
-                "replacement_budget_id": None,
-                "active_budget_id": None,
-            },
+            state_payload=_lifecycle_state_payload(
+                row=row,
+                requested_action="deactivate",
+                previous_status=cast(str, row["status"]),
+                replacement_budget=None,
+                replacement_max_completed_executions=None,
+                replacement_rolling_window_seconds=None,
+                rejection_reason=str(error),
+            ),
+            summary_payload=_lifecycle_summary_payload(
+                execution_budget_id=cast(UUID, row["id"]),
+                requested_action="deactivate",
+                outcome="rejected",
+                replacement_budget_id=None,
+                active_budget_id=None,
+            ),
             requested_action="deactivate",
             outcome="rejected",
         )
@@ -385,37 +425,22 @@ def deactivate_execution_budget_record(
         store,
         thread=thread,
         request_payload=request_payload,
-        state_payload={
-            "execution_budget_id": str(updated["id"]),
-            "requested_action": "deactivate",
-            "previous_status": "active",
-            "current_status": cast(str, updated["status"]),
-            "tool_key": updated["tool_key"],
-            "domain_hint": updated["domain_hint"],
-            "max_completed_executions": updated["max_completed_executions"],
-            "rolling_window_seconds": updated["rolling_window_seconds"],
-            "deactivated_at": (
-                None if updated["deactivated_at"] is None else updated["deactivated_at"].isoformat()
-            ),
-            "superseded_by_budget_id": (
-                None if updated["superseded_by_budget_id"] is None else str(updated["superseded_by_budget_id"])
-            ),
-            "supersedes_budget_id": (
-                None if updated["supersedes_budget_id"] is None else str(updated["supersedes_budget_id"])
-            ),
-            "replacement_budget_id": None,
-            "replacement_status": None,
-            "replacement_max_completed_executions": None,
-            "replacement_rolling_window_seconds": None,
-            "rejection_reason": None,
-        },
-        summary_payload={
-            "execution_budget_id": str(updated["id"]),
-            "requested_action": "deactivate",
-            "outcome": "deactivated",
-            "replacement_budget_id": None,
-            "active_budget_id": None,
-        },
+        state_payload=_lifecycle_state_payload(
+            row=updated,
+            requested_action="deactivate",
+            previous_status="active",
+            replacement_budget=None,
+            replacement_max_completed_executions=None,
+            replacement_rolling_window_seconds=None,
+            rejection_reason=None,
+        ),
+        summary_payload=_lifecycle_summary_payload(
+            execution_budget_id=cast(UUID, updated["id"]),
+            requested_action="deactivate",
+            outcome="deactivated",
+            replacement_budget_id=None,
+            active_budget_id=None,
+        ),
         requested_action="deactivate",
         outcome="deactivated",
     )
@@ -453,37 +478,22 @@ def supersede_execution_budget_record(
             store,
             thread=thread,
             request_payload=request_payload,
-            state_payload={
-                "execution_budget_id": str(current["id"]),
-                "requested_action": "supersede",
-                "previous_status": cast(str, current["status"]),
-                "current_status": cast(str, current["status"]),
-                "tool_key": current["tool_key"],
-                "domain_hint": current["domain_hint"],
-                "max_completed_executions": current["max_completed_executions"],
-                "rolling_window_seconds": current["rolling_window_seconds"],
-                "deactivated_at": (
-                    None if current["deactivated_at"] is None else current["deactivated_at"].isoformat()
-                ),
-                "superseded_by_budget_id": (
-                    None if current["superseded_by_budget_id"] is None else str(current["superseded_by_budget_id"])
-                ),
-                "supersedes_budget_id": (
-                    None if current["supersedes_budget_id"] is None else str(current["supersedes_budget_id"])
-                ),
-                "replacement_budget_id": None,
-                "replacement_status": None,
-                "replacement_max_completed_executions": request.max_completed_executions,
-                "replacement_rolling_window_seconds": current["rolling_window_seconds"],
-                "rejection_reason": str(error),
-            },
-            summary_payload={
-                "execution_budget_id": str(current["id"]),
-                "requested_action": "supersede",
-                "outcome": "rejected",
-                "replacement_budget_id": None,
-                "active_budget_id": str(current["id"]) if cast(str, current["status"]) == "active" else None,
-            },
+            state_payload=_lifecycle_state_payload(
+                row=current,
+                requested_action="supersede",
+                previous_status=cast(str, current["status"]),
+                replacement_budget=None,
+                replacement_max_completed_executions=request.max_completed_executions,
+                replacement_rolling_window_seconds=current["rolling_window_seconds"],
+                rejection_reason=str(error),
+            ),
+            summary_payload=_lifecycle_summary_payload(
+                execution_budget_id=cast(UUID, current["id"]),
+                requested_action="supersede",
+                outcome="rejected",
+                replacement_budget_id=None,
+                active_budget_id=cast(UUID, current["id"]) if cast(str, current["status"]) == "active" else None,
+            ),
             requested_action="supersede",
             outcome="rejected",
         )
@@ -505,33 +515,22 @@ def supersede_execution_budget_record(
             store,
             thread=thread,
             request_payload=request_payload,
-            state_payload={
-                "execution_budget_id": str(current["id"]),
-                "requested_action": "supersede",
-                "previous_status": "active",
-                "current_status": "active",
-                "tool_key": current["tool_key"],
-                "domain_hint": current["domain_hint"],
-                "max_completed_executions": current["max_completed_executions"],
-                "rolling_window_seconds": current["rolling_window_seconds"],
-                "deactivated_at": None,
-                "superseded_by_budget_id": None,
-                "supersedes_budget_id": (
-                    None if current["supersedes_budget_id"] is None else str(current["supersedes_budget_id"])
-                ),
-                "replacement_budget_id": None,
-                "replacement_status": None,
-                "replacement_max_completed_executions": request.max_completed_executions,
-                "replacement_rolling_window_seconds": current["rolling_window_seconds"],
-                "rejection_reason": str(error),
-            },
-            summary_payload={
-                "execution_budget_id": str(current["id"]),
-                "requested_action": "supersede",
-                "outcome": "rejected",
-                "replacement_budget_id": None,
-                "active_budget_id": str(current["id"]),
-            },
+            state_payload=_lifecycle_state_payload(
+                row=current,
+                requested_action="supersede",
+                previous_status="active",
+                replacement_budget=None,
+                replacement_max_completed_executions=request.max_completed_executions,
+                replacement_rolling_window_seconds=current["rolling_window_seconds"],
+                rejection_reason=str(error),
+            ),
+            summary_payload=_lifecycle_summary_payload(
+                execution_budget_id=cast(UUID, current["id"]),
+                requested_action="supersede",
+                outcome="rejected",
+                replacement_budget_id=None,
+                active_budget_id=cast(UUID, current["id"]),
+            ),
             requested_action="supersede",
             outcome="rejected",
         )
@@ -584,47 +583,26 @@ def supersede_execution_budget_record(
             store,
             thread=thread,
             request_payload=request_payload,
-            state_payload={
-                "execution_budget_id": str(current_state["id"]),
-                "requested_action": "supersede",
-                "previous_status": cast(str, current["status"]),
-                "current_status": cast(str, current_state["status"]),
-                "tool_key": current_state["tool_key"],
-                "domain_hint": current_state["domain_hint"],
-                "max_completed_executions": current_state["max_completed_executions"],
-                "rolling_window_seconds": current_state["rolling_window_seconds"],
-                "deactivated_at": (
-                    None
-                    if current_state["deactivated_at"] is None
-                    else current_state["deactivated_at"].isoformat()
-                ),
-                "superseded_by_budget_id": (
-                    None
-                    if current_state["superseded_by_budget_id"] is None
-                    else str(current_state["superseded_by_budget_id"])
-                ),
-                "supersedes_budget_id": (
-                    None
-                    if current_state["supersedes_budget_id"] is None
-                    else str(current_state["supersedes_budget_id"])
-                ),
-                "replacement_budget_id": None,
-                "replacement_status": None,
-                "replacement_max_completed_executions": request.max_completed_executions,
-                "replacement_rolling_window_seconds": current["rolling_window_seconds"],
-                "rejection_reason": str(error),
-            },
-            summary_payload={
-                "execution_budget_id": str(current_state["id"]),
-                "requested_action": "supersede",
-                "outcome": "rejected",
-                "replacement_budget_id": None,
-                "active_budget_id": (
-                    str(current_state["id"])
+            state_payload=_lifecycle_state_payload(
+                row=current_state,
+                requested_action="supersede",
+                previous_status=cast(str, current["status"]),
+                replacement_budget=None,
+                replacement_max_completed_executions=request.max_completed_executions,
+                replacement_rolling_window_seconds=current["rolling_window_seconds"],
+                rejection_reason=str(error),
+            ),
+            summary_payload=_lifecycle_summary_payload(
+                execution_budget_id=cast(UUID, current_state["id"]),
+                requested_action="supersede",
+                outcome="rejected",
+                replacement_budget_id=None,
+                active_budget_id=(
+                    cast(UUID, current_state["id"])
                     if cast(str, current_state["status"]) == "active"
                     else None
                 ),
-            },
+            ),
             requested_action="supersede",
             outcome="rejected",
         )
@@ -635,37 +613,22 @@ def supersede_execution_budget_record(
         store,
         thread=thread,
         request_payload=request_payload,
-        state_payload={
-            "execution_budget_id": str(superseded["id"]),
-            "requested_action": "supersede",
-            "previous_status": "active",
-            "current_status": cast(str, superseded["status"]),
-            "tool_key": superseded["tool_key"],
-            "domain_hint": superseded["domain_hint"],
-            "max_completed_executions": superseded["max_completed_executions"],
-            "rolling_window_seconds": superseded["rolling_window_seconds"],
-            "deactivated_at": (
-                None if superseded["deactivated_at"] is None else superseded["deactivated_at"].isoformat()
-            ),
-            "superseded_by_budget_id": (
-                None if superseded["superseded_by_budget_id"] is None else str(superseded["superseded_by_budget_id"])
-            ),
-            "supersedes_budget_id": (
-                None if superseded["supersedes_budget_id"] is None else str(superseded["supersedes_budget_id"])
-            ),
-            "replacement_budget_id": str(replacement["id"]),
-            "replacement_status": cast(str, replacement["status"]),
-            "replacement_max_completed_executions": replacement["max_completed_executions"],
-            "replacement_rolling_window_seconds": replacement["rolling_window_seconds"],
-            "rejection_reason": None,
-        },
-        summary_payload={
-            "execution_budget_id": str(superseded["id"]),
-            "requested_action": "supersede",
-            "outcome": "superseded",
-            "replacement_budget_id": str(replacement["id"]),
-            "active_budget_id": str(replacement["id"]),
-        },
+        state_payload=_lifecycle_state_payload(
+            row=superseded,
+            requested_action="supersede",
+            previous_status="active",
+            replacement_budget=replacement,
+            replacement_max_completed_executions=replacement["max_completed_executions"],
+            replacement_rolling_window_seconds=replacement["rolling_window_seconds"],
+            rejection_reason=None,
+        ),
+        summary_payload=_lifecycle_summary_payload(
+            execution_budget_id=cast(UUID, superseded["id"]),
+            requested_action="supersede",
+            outcome="superseded",
+            replacement_budget_id=cast(UUID, replacement["id"]),
+            active_budget_id=cast(UUID, replacement["id"]),
+        ),
         requested_action="supersede",
         outcome="superseded",
     )

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -732,7 +732,7 @@ from alicebot_api.traces import (
 LOGGER = logging.getLogger(__name__)
 
 
-app = FastAPI(title="AliceBot API", version="0.1.0")
+app = FastAPI(title="AliceBot API", version="0.3.2")
 provider_adapter_registry = make_provider_adapter_registry()
 HealthStatus = Literal["ok", "degraded"]
 ServiceStatus = Literal["ok", "unreachable", "not_checked"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alicebot/web",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.3.2",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/docs/archive/planning/2026-04-08-context-compaction/README.md
+++ b/docs/archive/planning/2026-04-08-context-compaction/README.md
@@ -1,0 +1,20 @@
+# 2026-04-08 Context Compaction Archive
+
+This folder preserves superseded planning and control material removed from the live docs during Context Compaction 01.
+
+## Archived Planning Docs
+
+- `phase9-product-spec.md`
+- `phase9-sprint-33-38-plan.md`
+- `phase9-sprint-33-control-tower-packet.md`
+- `phase9-bootstrap-notes.md`
+
+## Preserved Live-Doc Snapshots
+
+- `README.pre-compaction.md`
+- `ROADMAP.pre-compaction.md`
+- `RULES.pre-compaction.md`
+
+## Related Internal Snapshots
+
+Internal AI operating snapshots for this compaction were kept local-only and are intentionally excluded from the public repository.

--- a/docs/integrations/hermes-bridge-operator-guide.md
+++ b/docs/integrations/hermes-bridge-operator-guide.md
@@ -1,7 +1,7 @@
 # Hermes Bridge Operator Guide (B4)
 
 This is the canonical operator guide for the shipped bridge phase.
-It is release-scoped for `v0.2.0` pre-1.0 readiness and does not imply `v1.0.0` guarantees.
+It is release-scoped for the `v0.3.2` pre-1.0 target and does not imply `v1.0.0` guarantees.
 
 Recommended deployment shape: **provider plus MCP**.
 
@@ -100,4 +100,4 @@ hermes memory setup
 - `docs/integrations/hermes-memory-provider.md`
 - `docs/integrations/hermes.md`
 - `docs/integrations/hermes-skill-pack.md`
-- `docs/release/v0.2.0-release-checklist.md`
+- `docs/release/v0.3.2-release-checklist.md`

--- a/docs/integrations/hermes-memory-provider/plugins/memory/alice/plugin.yaml
+++ b/docs/integrations/hermes-memory-provider/plugins/memory/alice/plugin.yaml
@@ -1,3 +1,3 @@
 name: alice
-version: 0.1.0
+version: 0.3.2
 description: "Alice continuity-backed external memory provider for Hermes (recall, resumption, open-loop prefetch)."

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -1,7 +1,7 @@
 # MCP Integration
 
-The shipped MCP server for `v0.2.0` exposes a deliberately scoped deterministic tool surface over Alice continuity seams.
-`v0.2.0` remains a pre-1.0 release boundary.
+The shipped MCP server for the `v0.3.2` release target exposes a deliberately scoped deterministic tool surface over Alice continuity seams.
+`v0.3.2` remains a pre-1.0 release target until the tag is cut.
 
 ## Entrypoints
 
@@ -88,7 +88,7 @@ One-command bridge demo:
 
 - tool set is intentionally narrow and stable
 - tool output is deterministic for parity testing
-- MCP does not widen core product semantics beyond shipped Phase 11 and Bridge `B1` through `B4`
+- MCP does not widen core product semantics beyond the shipped Phase 12 baseline and Bridge `B1` through `B4`
 
 See tests:
 

--- a/docs/npm-publish-quickstart.md
+++ b/docs/npm-publish-quickstart.md
@@ -45,9 +45,9 @@ Workflow file:
 
 - `.github/workflows/publish-npm.yml`
 
-After that, push a semver tag:
+After that, push the current semver tag:
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
+git tag v0.3.2
+git push origin v0.3.2
 ```

--- a/docs/phase12-closeout-summary.md
+++ b/docs/phase12-closeout-summary.md
@@ -1,0 +1,55 @@
+# Phase 12 Closeout Summary
+
+## Phase Theme
+Phase 12 turned Alice from a strong continuity substrate into a more measurable and operator-auditable memory system.
+
+## What Shipped
+
+### `P12-S1` Hybrid Retrieval + Reranking
+- hybrid retrieval pipeline
+- retrieval traces
+- ranked debug visibility across API, CLI, and MCP
+
+### `P12-S2` Automated Memory Operations
+- explicit mutation candidates and operations
+- `ADD` / `UPDATE` / `SUPERSEDE` / `DELETE` / `NOOP`
+- deterministic commit application and replay-safe behavior
+
+### `P12-S3` Contradiction Detection + Trust Calibration
+- contradiction cases
+- trust signals
+- contradiction-aware retrieval penalties
+- contradiction visibility in explain flows
+
+### `P12-S4` Public Eval Harness
+- public fixture catalog
+- local eval runner
+- persisted eval suites, cases, runs, and results
+- checked-in baseline report artifact
+
+### `P12-S5` Task-Adaptive Briefing
+- task brief compiler
+- briefing modes for `user_recall`, `resume`, `worker_subtask`, and `agent_handoff`
+- token budgeting and provider/model-pack briefing defaults
+
+## Net Outcome
+
+Phase 12 delivered:
+- better retrieval quality
+- explicit mutation semantics
+- first-class contradiction and trust handling
+- reproducible quality evidence
+- smaller, task-specific briefing outputs
+
+## Release Mapping
+
+- `v0.3.0`: retrieval, mutation, contradiction/trust (`P12-S1` through `P12-S3`)
+- `v0.3.1`: public eval harness (`P12-S4`)
+- `v0.3.2`: task-adaptive briefing (`P12-S5`)
+
+## Closeout Posture
+
+- Phase 12 implementation scope is complete.
+- There are no remaining Phase 12 feature sprints.
+- `v0.3.2` is the current release target for the completed Phase 12 boundary.
+- The latest published tag remains `v0.2.0` until the `v0.3.2` release is cut.

--- a/docs/quickstart/local-setup-and-first-result.md
+++ b/docs/quickstart/local-setup-and-first-result.md
@@ -1,6 +1,6 @@
 # Local Setup and First Useful Result
 
-This quickstart is the canonical local path for the shipped `v0.2.0` pre-1.0 surface.
+This quickstart is the canonical local path for the completed `v0.3.2` pre-1.0 release target.
 
 ## Prerequisites
 
@@ -79,5 +79,5 @@ pnpm --dir apps/web test
 
 ## Scope Guard
 
-This quickstart documents shipped behavior through Phase 11 and Bridge `B1` through `B4`.
+This quickstart documents shipped behavior through Phase 12 and Bridge `B1` through `B4`.
 It does not promise `v1.0.0` compatibility/support guarantees or unshipped feature scope.

--- a/docs/release/v0.3.2-release-checklist.md
+++ b/docs/release/v0.3.2-release-checklist.md
@@ -1,0 +1,76 @@
+# v0.3.2 Release Checklist
+
+This checklist is scoped to the completed Alice surface through Phase 12.
+
+## 1) Repo and Environment Prep
+
+- [ ] On branch: `codex/phase12-closeout-v0-3-2` or an explicit `v0.3.2` release-prep branch
+- [ ] `.env` exists and matches `.env.example` expectations
+- [ ] Python deps installed in `.venv`
+- [ ] Node deps installed for `apps/web`
+- [ ] Docker runtime available
+
+## 2) Required Runtime Verification
+
+Run in order:
+
+```bash
+docker compose up -d
+./scripts/migrate.sh
+./scripts/load_sample_data.sh
+APP_RELOAD=false ./scripts/api_dev.sh
+```
+
+In a separate terminal:
+
+```bash
+curl -sS http://127.0.0.1:8000/healthz
+```
+
+## 3) Required Test Verification
+
+```bash
+python3 scripts/check_control_doc_truth.py
+./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q
+./.venv/bin/python -m pytest tests/unit tests/integration -q
+pnpm --dir apps/web test
+./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py
+./.venv/bin/python scripts/run_hermes_mcp_smoke.py
+./.venv/bin/python scripts/run_hermes_bridge_demo.py
+./.venv/bin/python -m alicebot_api --database-url "$DATABASE_URL" --user-id "$ALICEBOT_USER_ID" evals run --report-path eval/baselines/public_eval_harness_v1.json
+```
+
+## 4) Required Documentation Verification
+
+- [ ] `README.md` accurately describes the completed Phase 12 surface and the `v0.3.2` release target
+- [ ] `docs/quickstart/local-setup-and-first-result.md` matches the shipped commands
+- [ ] `docs/integrations/mcp.md` matches the shipped MCP tool surface
+- [ ] `docs/integrations/hermes-bridge-operator-guide.md` matches the shipped bridge behavior
+- [ ] `docs/evals/public_eval_harness.md` matches the shipped eval runner behavior
+- [ ] `docs/briefing/task-adaptive-briefing.md` matches the shipped briefing behavior
+- [ ] release checklist, tag plan, and runbook are mutually consistent
+
+## 5) Evidence Artifacts
+
+- [ ] `BUILD_REPORT.md` updated with exact commands and outcomes
+- [ ] `REVIEW_REPORT.md` updated for the closeout/release update state
+- [ ] `eval/baselines/public_eval_harness_v1.json` regenerated or verified from exact commands
+- [ ] release evidence names the exact shipped scope included in the `v0.3.2` target
+
+## 6) Public Repo Readiness
+
+- [ ] `CONTRIBUTING.md` present
+- [ ] `SECURITY.md` present
+- [ ] `LICENSE` present
+- [ ] `CHANGELOG.md` includes a Phase 12 closeout / `v0.3.2` release-target entry
+- [ ] no public-facing claim exceeds shipped behavior
+- [ ] pre-1.0 framing remains explicit
+
+## 7) Tag-Readiness Gate
+
+- [ ] no closeout criterion gaps remain
+- [ ] maintainer review verdict is `PASS`
+- [ ] explicit merge approval has been granted
+- [ ] explicit tag approval has been granted
+
+When all boxes pass, execute the tag procedure in `docs/release/v0.3.2-tag-plan.md`.

--- a/docs/release/v0.3.2-tag-plan.md
+++ b/docs/release/v0.3.2-tag-plan.md
@@ -1,0 +1,50 @@
+# v0.3.2 Tag Plan
+
+## Purpose
+
+Define the next public pre-1.0 tag cut for Alice after the completed Phase 12 boundary.
+The latest published tag remains `v0.2.0` until this plan is executed.
+
+## Tag Target
+
+- semantic version: `v0.3.2`
+- target branch: `main` after accepted Phase 12 closeout / release-update merge
+- release type: pre-1.0 public release
+
+## Required Inputs
+
+- passing release checklist: `docs/release/v0.3.2-release-checklist.md`
+- current `BUILD_REPORT.md` and `REVIEW_REPORT.md`
+- release notes from `CHANGELOG.md`
+- Phase 12 closeout summary: `docs/phase12-closeout-summary.md`
+
+## Tag Procedure
+
+1. Confirm the release checklist is complete.
+2. Confirm `main` contains the approved closeout/release-update merge.
+3. Create the annotated tag:
+
+```bash
+git checkout main
+git pull origin main
+git tag -a v0.3.2 -m "Alice v0.3.2: hybrid retrieval, mutation ops, trust calibration, eval harness, and task-adaptive briefing"
+git push origin v0.3.2
+```
+
+4. Publish release notes from `CHANGELOG.md` with references to the verified evidence bundle.
+
+## Release Notes Scope (must match tag)
+
+- Alice continuity core
+- CLI and MCP surfaces
+- hosted/product layer already shipped in prior phases
+- provider runtime, adapters, and model packs from Phase 11
+- Hermes bridge provider lifecycle, auto-capture, review/explainability, operator docs, smoke validation, and demo path
+- Phase 12 retrieval/reranking, mutation operations, contradiction/trust, public eval harness, and task-adaptive briefing
+
+## Explicitly Deferred Beyond `v0.3.2`
+
+- `v1.0.0` compatibility or support guarantees
+- managed cloud/SLA commitments
+- new channels or product families beyond the shipped baseline
+- next-phase work not yet accepted into canonical planning

--- a/docs/runbooks/phase12-closeout-packet.md
+++ b/docs/runbooks/phase12-closeout-packet.md
@@ -1,0 +1,49 @@
+# Phase 12 Closeout Packet
+
+This runbook is the source-of-truth closeout packet for the accepted Phase 12 baseline through `P12-S5`.
+The latest published tag remains `v0.2.0`; this packet prepares the completed Phase 12 boundary for a `v0.3.2` release decision.
+
+## Required Phase 12 Go/No-Go Commands
+
+Run these commands from repo root in order and retain outputs verbatim in the evidence bundle:
+
+1. `python3 scripts/check_control_doc_truth.py`
+2. `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+3. `./.venv/bin/python -m pytest tests/unit tests/integration -q`
+4. `pnpm --dir apps/web test`
+5. `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py`
+6. `./.venv/bin/python scripts/run_hermes_mcp_smoke.py`
+7. `./.venv/bin/python scripts/run_hermes_bridge_demo.py`
+8. `./.venv/bin/python -m alicebot_api --database-url "$DATABASE_URL" --user-id "$ALICEBOT_USER_ID" evals run --report-path eval/baselines/public_eval_harness_v1.json`
+
+## Required PASS Evidence Bundle
+
+- command transcript for all required go/no-go commands
+- final statuses showing control-doc truth PASS, control-doc unit test PASS, Python suites PASS, web tests PASS, and Hermes smoke/demo PASS
+- links to current sprint reports at repo root:
+  - `BUILD_REPORT.md`
+  - `REVIEW_REPORT.md`
+- release-target docs for `v0.3.2`:
+  - `docs/release/v0.3.2-release-checklist.md`
+  - `docs/release/v0.3.2-tag-plan.md`
+  - `docs/runbooks/v0.3.2-public-release-runbook.md`
+- Phase 12 summary:
+  - `docs/phase12-closeout-summary.md`
+
+## Explicit Deferred Scope Entering Next Phase
+
+The following remain outside this closeout decision:
+
+- post-Phase-12 feature work
+- graph database migration
+- marketplace or enterprise/compliance expansion
+- new channels or vertical products
+- `v1.0.0` compatibility/support guarantees
+
+## Closeout Checklist
+
+- Canonical docs describe Phase 12 as complete through `P12-S5`.
+- The documented release target is `v0.3.2`.
+- Docs do not falsely claim that the `v0.3.2` tag already exists.
+- This closeout packet and the Phase 12 summary exist and remain referenced by control-doc truth.
+- Control-doc truth guardrail and unit test pass.

--- a/docs/runbooks/v0.3.2-public-release-runbook.md
+++ b/docs/runbooks/v0.3.2-public-release-runbook.md
@@ -1,0 +1,84 @@
+# v0.3.2 Public Release Runbook
+
+This runbook executes the closeout-aligned release readiness flow for the `v0.3.2` public tag.
+
+## Objective
+
+Cut a credible public pre-1.0 release from the completed Phase 12 Alice platform with reproducible verification evidence.
+
+## Scope Guard
+
+Do not add features during this runbook. Only release-readiness, doc-alignment, evidence-recording, and tag-prep fixes are allowed.
+
+## Step 1: Start Runtime
+
+```bash
+docker compose up -d
+./scripts/migrate.sh
+./scripts/load_sample_data.sh
+```
+
+## Step 2: Start API and Verify Health
+
+```bash
+APP_RELOAD=false ./scripts/api_dev.sh
+```
+
+In a separate terminal:
+
+```bash
+curl -sS http://127.0.0.1:8000/healthz
+```
+
+## Step 3: Run Release Gates
+
+```bash
+python3 scripts/check_control_doc_truth.py
+./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q
+./.venv/bin/python -m pytest tests/unit tests/integration -q
+pnpm --dir apps/web test
+./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py
+./.venv/bin/python scripts/run_hermes_mcp_smoke.py
+./.venv/bin/python scripts/run_hermes_bridge_demo.py
+./.venv/bin/python -m alicebot_api --database-url "$DATABASE_URL" --user-id "$ALICEBOT_USER_ID" evals run --report-path eval/baselines/public_eval_harness_v1.json
+```
+
+## Step 4: Verify Public Docs
+
+Check:
+
+- `README.md`
+- `CHANGELOG.md`
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+- `docs/quickstart/local-setup-and-first-result.md`
+- `docs/integrations/mcp.md`
+- `docs/integrations/hermes-bridge-operator-guide.md`
+- `docs/evals/public_eval_harness.md`
+- `docs/briefing/task-adaptive-briefing.md`
+- `docs/release/v0.3.2-release-checklist.md`
+- `docs/release/v0.3.2-tag-plan.md`
+- `docs/phase12-closeout-summary.md`
+
+Ensure commands, claims, and release boundary match shipped reality.
+
+## Step 5: Record Release Evidence
+
+- update `BUILD_REPORT.md` with exact command evidence and outcomes
+- update `REVIEW_REPORT.md` with closeout/release review state
+
+## Step 6: Execute Release Checklist
+
+Complete all checks in `docs/release/v0.3.2-release-checklist.md`.
+
+## Step 7: Tag Gate
+
+After checklist pass, reviewer `PASS`, merge approval, and explicit tag approval, follow:
+
+- `docs/release/v0.3.2-tag-plan.md`
+
+## Failure Handling
+
+- If a required command fails, stop tag prep.
+- Fix only release-readiness or closeout issues inside the current release-update scope.
+- Re-run failed gates and update `BUILD_REPORT.md` before retry.

--- a/packages/alice-cli/bin/alice.js
+++ b/packages/alice-cli/bin/alice.js
@@ -3,7 +3,7 @@
 import { spawn } from "node:child_process";
 
 const args = process.argv.slice(2);
-const version = "0.1.1";
+const version = "0.3.2";
 const defaultPythonCommand = process.platform === "win32" ? "python" : "python3";
 
 if (args.includes("--version") || args.includes("-v")) {

--- a/packages/alice-cli/package.json
+++ b/packages/alice-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceos/alice-cli",
-  "version": "0.1.1",
+  "version": "0.3.2",
   "description": "CLI package for AliceOS.",
   "type": "module",
   "bin": {
@@ -36,6 +36,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@aliceos/alice-core": "^0.1.0"
+    "@aliceos/alice-core": "^0.3.2"
   }
 }

--- a/packages/alice-core/index.js
+++ b/packages/alice-core/index.js
@@ -1,4 +1,4 @@
-export const ALICE_CORE_VERSION = "0.1.0";
+export const ALICE_CORE_VERSION = "0.3.2";
 
 export function helloAlice() {
   return "hello from @aliceos/alice-core";

--- a/packages/alice-core/package.json
+++ b/packages/alice-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceos/alice-core",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "description": "Core utilities for AliceOS packages.",
   "type": "module",
   "main": "./index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice-core"
-version = "0.1.0"
+version = "0.3.2"
 description = "Public-safe Alice core package for local memory and continuity workflows."
 requires-python = ">=3.12"
 dependencies = [

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -18,9 +18,10 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
     ControlDocTruthRule(
         relative_path="README.md",
         required_markers=(
-            "`v0.2.0` is a **pre-1.0 public release**.",
-            "## Release Boundary (`v0.2.0`)",
+            "`v0.3.2` is the current **pre-1.0 release target** for the completed Phase 12 boundary.",
+            "## Release Boundary (`v0.3.2` Target)",
             "Bridge `B1` through `B4` provider contract, auto-capture flow, review/explainability flow, and bridge docs/smoke validation",
+            "Phase 12 retrieval quality stack:",
             "Historical planning/control artifacts remain available in:",
         ),
     ),
@@ -28,15 +29,15 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="ROADMAP.md",
         required_markers=(
             "Bridge Phase (`B1`-`B4`): shipped",
-            "Phase 12 Sprint 5 (`P12-S5`) is the active execution sprint.",
+            "Phase 12 closeout and `v0.3.2` release update are the active control packet.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Phase 12 Sprint 5 (`P12-S5`): Task-Adaptive Briefing",
-            "`v0.2.0` is released baseline truth.",
-            "worker-task brief is smaller than the generic recall pack",
+            "Phase 12 Closeout and `v0.3.2` Release Update",
+            "`v0.2.0` is the latest published tag.",
+            "The documented release target is `v0.3.2`",
         ),
     ),
     ControlDocTruthRule(
@@ -52,8 +53,16 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
             "Phase 9 is shipped.",
             "Phase 10 is shipped.",
             "Phase 11 is shipped.",
-            "`v0.2.0` is released.",
-            "Phase 12 Sprint 5 (`P12-S5`) is the active execution sprint.",
+            "`v0.2.0` is the latest published tag.",
+            "`v0.3.2` is the current release target.",
+            "Phase 12 closeout and `v0.3.2` release update are the active control packet.",
+        ),
+    ),
+    ControlDocTruthRule(
+        relative_path="docs/runbooks/phase12-closeout-packet.md",
+        required_markers=(
+            "# Phase 12 Closeout Packet",
+            "This runbook is the source-of-truth closeout packet for the accepted Phase 12 baseline through `P12-S5`.",
         ),
     ),
     ControlDocTruthRule(


### PR DESCRIPTION
## Summary
This branch closes out Phase 12 and prepares the repository for the next public pre-1.0 release target, `v0.3.2`.

It updates the public docs and control docs to reflect that `P12-S1` through `P12-S5` are shipped, adds the Phase 12 closeout packet and release runbooks/checklists, aligns package and plugin version metadata to `0.3.2`, and refreshes the execution-budget helper structure during the same release-prep pass.

## Why This Changed
Phase 12 is complete, but the repo still needed a coherent closeout and release-prep layer so the public documentation, version metadata, release checklists, tag plan, and runbooks all point at the same shipped boundary.

## User And Operator Impact
Maintainers get a concrete Phase 12 closeout summary, `v0.3.2` release checklist, tag plan, and public release runbook. Public docs now describe the completed Phase 12 surface and the current release target more consistently across README, quickstart, integration docs, npm packaging docs, and Hermes operator guidance.

## Validation
This branch is a release-prep and documentation alignment update. It does not include a fresh runtime or full test sweep in this PR body. The added release checklist explicitly records the commands and artifacts that must pass before the `v0.3.2` tag is cut.

## Upgrade Overview
### Protected Areas
- [ ] memory schema
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact
No new user-facing runtime feature is introduced here. The primary effect is documentation, version-metadata, and release-process alignment for the already shipped Phase 12 surface. The small `main.py` touch is part of that release-prep alignment rather than a new API contract.

### Migration / Rollout
There is no new migration in this branch. Rollout is procedural: merge the closeout branch, complete the `v0.3.2` release checklist, and only then cut and push the `v0.3.2` tag.

### Operator Action
Review the closeout packet and release checklist, confirm the documented verification steps, and use the new `docs/release/v0.3.2-tag-plan.md` and `docs/runbooks/v0.3.2-public-release-runbook.md` when the repo is ready for public tagging.

### Validation
The branch adds the release checklist itself as the source of truth for the required verification commands and evidence artifacts. It also keeps the latest published-tag truth explicit: `v0.2.0` remains the latest published tag until `v0.3.2` is actually cut.

### Rollback
Rollback by reverting this PR if the repo should remain aligned to the prior `v0.2.0` release-prep posture instead of the completed Phase 12 / `v0.3.2` target.
