### PR TITLE
[codex] Require bearer auth for Phase 12 v1 APIs

### DIFF
--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -1125,7 +1125,8 @@ class ContinuityCaptureCommitRequest(BaseModel):
 
 
 class MemoryOperationGenerateRequest(BaseModel):
-    user_id: UUID
+    model_config = ConfigDict(extra="forbid")
+
     user_content: str = Field(default="", max_length=4000)
     assistant_content: str = Field(default="", max_length=4000)
     mode: str = Field(default="assist", min_length=1, max_length=20)
@@ -1140,7 +1141,8 @@ class MemoryOperationGenerateRequest(BaseModel):
 
 
 class MemoryOperationCommitRequest(BaseModel):
-    user_id: UUID
+    model_config = ConfigDict(extra="forbid")
+
     candidate_ids: list[UUID] = Field(default_factory=list)
     sync_fingerprint: str | None = Field(default=None, min_length=1, max_length=200)
     include_review_required: bool = False
@@ -1161,13 +1163,15 @@ class ContinuityCorrectionRequest(BaseModel):
 
 
 class ContradictionDetectRequest(BaseModel):
-    user_id: UUID
+    model_config = ConfigDict(extra="forbid")
+
     continuity_object_id: UUID | None = None
     limit: int = Field(default=DEFAULT_CONTINUITY_REVIEW_LIMIT, ge=1, le=MAX_CONTINUITY_REVIEW_LIMIT)
 
 
 class ContradictionResolveRequest(BaseModel):
-    user_id: UUID
+    model_config = ConfigDict(extra="forbid")
+
     action: str = Field(min_length=1, max_length=60)
     note: str | None = Field(default=None, min_length=1, max_length=1000)
 
@@ -2550,6 +2554,17 @@ def _extract_bearer_token(request: Request) -> str:
     if scheme.lower() != "bearer" or token.strip() == "":
         raise AuthSessionInvalidError("authorization header must use Bearer token format")
     return token.strip()
+
+
+def _resolve_authenticated_v1_user_id(settings: Settings, request: Request) -> UUID:
+    session_token = _extract_bearer_token(request)
+    with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+        with conn.transaction():
+            resolution = resolve_auth_session(conn, session_token=session_token)
+    user_account_id = resolution["user_account"]["id"]
+    if not isinstance(user_account_id, UUID):
+        raise RuntimeError("authenticated hosted user context is invalid")
+    return user_account_id
 
 
 def _serialize_hosted_session_payload(
@@ -4908,14 +4923,18 @@ def commit_continuity_capture_candidates(request: ContinuityCaptureCommitRequest
 
 
 @app.post("/v1/memory/operations/candidates/generate")
-def generate_memory_operation_candidates_endpoint(request: MemoryOperationGenerateRequest) -> JSONResponse:
+def generate_memory_operation_candidates_endpoint(
+    http_request: Request,
+    request: MemoryOperationGenerateRequest,
+) -> JSONResponse:
     settings = get_settings()
 
     try:
-        with user_connection(settings.database_url, request.user_id) as conn:
+        user_id = _resolve_authenticated_v1_user_id(settings, http_request)
+        with user_connection(settings.database_url, user_id) as conn:
             payload = generate_memory_operation_candidates(
                 ContinuityStore(conn),
-                user_id=request.user_id,
+                user_id=user_id,
                 request=MemoryOperationGenerateInput(
                     user_content=request.user_content,
                     assistant_content=request.assistant_content,
@@ -4930,6 +4949,8 @@ def generate_memory_operation_candidates_endpoint(request: MemoryOperationGenera
                     target_continuity_object_id=request.target_continuity_object_id,
                 ),
             )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
     except MemoryMutationValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
     except ContinuityCaptureValidationError as exc:
@@ -4943,7 +4964,7 @@ def generate_memory_operation_candidates_endpoint(request: MemoryOperationGenera
 
 @app.get("/v1/memory/operations/candidates")
 def list_memory_operation_candidates_endpoint(
-    user_id: UUID,
+    request: Request,
     limit: int = Query(default=DEFAULT_CONTINUITY_CAPTURE_LIMIT, ge=1, le=100),
     policy_action: str | None = Query(default=None, min_length=1, max_length=40),
     operation_type: str | None = Query(default=None, min_length=1, max_length=40),
@@ -4952,6 +4973,7 @@ def list_memory_operation_candidates_endpoint(
     settings = get_settings()
 
     try:
+        user_id = _resolve_authenticated_v1_user_id(settings, request)
         with user_connection(settings.database_url, user_id) as conn:
             payload = list_memory_operation_candidates(
                 ContinuityStore(conn),
@@ -4963,6 +4985,8 @@ def list_memory_operation_candidates_endpoint(
                     sync_fingerprint=sync_fingerprint,
                 ),
             )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
     except MemoryMutationValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -4973,20 +4997,26 @@ def list_memory_operation_candidates_endpoint(
 
 
 @app.post("/v1/memory/operations/commit")
-def commit_memory_operations_endpoint(request: MemoryOperationCommitRequest) -> JSONResponse:
+def commit_memory_operations_endpoint(
+    http_request: Request,
+    request: MemoryOperationCommitRequest,
+) -> JSONResponse:
     settings = get_settings()
 
     try:
-        with user_connection(settings.database_url, request.user_id) as conn:
+        user_id = _resolve_authenticated_v1_user_id(settings, http_request)
+        with user_connection(settings.database_url, user_id) as conn:
             payload = commit_memory_operations(
                 ContinuityStore(conn),
-                user_id=request.user_id,
+                user_id=user_id,
                 request=MemoryOperationCommitInput(
                     candidate_ids=request.candidate_ids,
                     sync_fingerprint=request.sync_fingerprint,
                     include_review_required=request.include_review_required,
                 ),
             )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
     except MemoryMutationValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -4998,13 +5028,14 @@ def commit_memory_operations_endpoint(request: MemoryOperationCommitRequest) -> 
 
 @app.get("/v1/memory/operations")
 def list_memory_operations_endpoint(
-    user_id: UUID,
+    request: Request,
     limit: int = Query(default=DEFAULT_CONTINUITY_CAPTURE_LIMIT, ge=1, le=100),
     sync_fingerprint: str | None = Query(default=None, min_length=1, max_length=200),
 ) -> JSONResponse:
     settings = get_settings()
 
     try:
+        user_id = _resolve_authenticated_v1_user_id(settings, request)
         with user_connection(settings.database_url, user_id) as conn:
             payload = list_memory_operations(
                 ContinuityStore(conn),
@@ -5014,6 +5045,8 @@ def list_memory_operations_endpoint(
                     sync_fingerprint=sync_fingerprint,
                 ),
             )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
     except MemoryMutationValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -5193,20 +5226,24 @@ def get_continuity_explain_endpoint(
 
 @app.post("/v1/contradictions/detect")
 def detect_contradictions_endpoint(
+    http_request: Request,
     request: ContradictionDetectRequest,
 ) -> JSONResponse:
     settings = get_settings()
 
     try:
-        with user_connection(settings.database_url, request.user_id) as conn:
+        user_id = _resolve_authenticated_v1_user_id(settings, http_request)
+        with user_connection(settings.database_url, user_id) as conn:
             payload: ContradictionSyncResponse = sync_contradictions(
                 ContinuityStore(conn),
-                user_id=request.user_id,
+                user_id=user_id,
                 request=ContradictionSyncInput(
                     continuity_object_id=request.continuity_object_id,
                     limit=request.limit,
                 ),
             )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
     except ContinuityContradictionValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -5215,7 +5252,7 @@ def detect_contradictions_endpoint(
 
 @app.get("/v1/contradictions/cases")
 def list_contradiction_cases_endpoint(
-    user_id: UUID,
+    request: Request,
     status: str = Query(default="open", min_length=1, max_length=40),
     continuity_object_id: UUID | None = None,
     limit: int = Query(
@@ -5227,6 +5264,7 @@ def list_contradiction_cases_endpoint(
     settings = get_settings()
 
     try:
+        user_id = _resolve_authenticated_v1_user_id(settings, request)
         with user_connection(settings.database_url, user_id) as conn:
             payload: ContradictionCaseListResponse = list_contradiction_cases(
                 ContinuityStore(conn),
@@ -5237,6 +5275,8 @@ def list_contradiction_cases_endpoint(
                     continuity_object_id=continuity_object_id,
                 ),
             )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
     except ContinuityContradictionValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -5246,17 +5286,20 @@ def list_contradiction_cases_endpoint(
 @app.get("/v1/contradictions/cases/{contradiction_case_id}")
 def get_contradiction_case_endpoint(
     contradiction_case_id: UUID,
-    user_id: UUID,
+    request: Request,
 ) -> JSONResponse:
     settings = get_settings()
 
     try:
+        user_id = _resolve_authenticated_v1_user_id(settings, request)
         with user_connection(settings.database_url, user_id) as conn:
             payload: ContradictionCaseDetailResponse = get_contradiction_case(
                 ContinuityStore(conn),
                 user_id=user_id,
                 contradiction_case_id=contradiction_case_id,
             )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
     except ContinuityContradictionNotFoundError as exc:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
 
@@ -5266,21 +5309,25 @@ def get_contradiction_case_endpoint(
 @app.post("/v1/contradictions/cases/{contradiction_case_id}/resolve")
 def resolve_contradiction_case_endpoint(
     contradiction_case_id: UUID,
+    http_request: Request,
     request: ContradictionResolveRequest,
 ) -> JSONResponse:
     settings = get_settings()
 
     try:
-        with user_connection(settings.database_url, request.user_id) as conn:
+        user_id = _resolve_authenticated_v1_user_id(settings, http_request)
+        with user_connection(settings.database_url, user_id) as conn:
             payload: ContradictionResolveResponse = resolve_contradiction_case(
                 ContinuityStore(conn),
-                user_id=request.user_id,
+                user_id=user_id,
                 contradiction_case_id=contradiction_case_id,
                 request=ContradictionResolveInput(
                     action=request.action,  # type: ignore[arg-type]
                     note=request.note,
                 ),
             )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
     except ContinuityContradictionValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
     except ContinuityContradictionNotFoundError as exc:
@@ -5291,7 +5338,7 @@ def resolve_contradiction_case_endpoint(
 
 @app.get("/v1/trust/signals")
 def list_trust_signals_endpoint(
-    user_id: UUID,
+    request: Request,
     continuity_object_id: UUID | None = None,
     signal_state: str = Query(default="active", min_length=1, max_length=40),
     signal_type: str | None = Query(default=None, min_length=1, max_length=40),
@@ -5303,17 +5350,21 @@ def list_trust_signals_endpoint(
 ) -> JSONResponse:
     settings = get_settings()
 
-    with user_connection(settings.database_url, user_id) as conn:
-        payload: TrustSignalListResponse = list_trust_signals(
-            ContinuityStore(conn),
-            user_id=user_id,
-            request=TrustSignalListQueryInput(
-                limit=limit,
-                continuity_object_id=continuity_object_id,
-                signal_state=signal_state,  # type: ignore[arg-type]
-                signal_type=signal_type,  # type: ignore[arg-type]
-            ),
-        )
+    try:
+        user_id = _resolve_authenticated_v1_user_id(settings, request)
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: TrustSignalListResponse = list_trust_signals(
+                ContinuityStore(conn),
+                user_id=user_id,
+                request=TrustSignalListQueryInput(
+                    limit=limit,
+                    continuity_object_id=continuity_object_id,
+                    signal_state=signal_state,  # type: ignore[arg-type]
+                    signal_type=signal_type,  # type: ignore[arg-type]
+                ),
+            )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
 
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
@@ -5829,14 +5880,18 @@ def get_continuity_retrieval_evaluation(user_id: UUID) -> JSONResponse:
 
 
 @app.get("/v1/evals/suites")
-def get_public_eval_suites(user_id: UUID) -> JSONResponse:
+def get_public_eval_suites(request: Request) -> JSONResponse:
     settings = get_settings()
 
-    with user_connection(settings.database_url, user_id) as conn:
-        payload: PublicEvalSuiteDefinitionListResponse = list_public_eval_suites(
-            ContinuityStore(conn),
-            user_id=user_id,
-        )
+    try:
+        user_id = _resolve_authenticated_v1_user_id(settings, request)
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: PublicEvalSuiteDefinitionListResponse = list_public_eval_suites(
+                ContinuityStore(conn),
+                user_id=user_id,
+            )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
 
     return JSONResponse(
         status_code=200,
@@ -5846,18 +5901,21 @@ def get_public_eval_suites(user_id: UUID) -> JSONResponse:
 
 @app.post("/v1/evals/runs")
 def create_public_eval_run(
-    user_id: UUID,
+    request: Request,
     suite_key: list[str] | None = Query(default=None),
 ) -> JSONResponse:
     settings = get_settings()
 
     try:
+        user_id = _resolve_authenticated_v1_user_id(settings, request)
         with user_connection(settings.database_url, user_id) as conn:
             payload: PublicEvalRunDetailResponse = run_public_evals(
                 ContinuityStore(conn),
                 user_id=user_id,
                 suite_keys=suite_key,
             )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -5869,17 +5927,21 @@ def create_public_eval_run(
 
 @app.get("/v1/evals/runs")
 def get_public_eval_runs(
-    user_id: UUID,
+    request: Request,
     limit: int = Query(default=20, ge=1, le=100),
 ) -> JSONResponse:
     settings = get_settings()
 
-    with user_connection(settings.database_url, user_id) as conn:
-        payload: PublicEvalRunListResponse = list_public_eval_runs(
-            ContinuityStore(conn),
-            user_id=user_id,
-            limit=limit,
-        )
+    try:
+        user_id = _resolve_authenticated_v1_user_id(settings, request)
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: PublicEvalRunListResponse = list_public_eval_runs(
+                ContinuityStore(conn),
+                user_id=user_id,
+                limit=limit,
+            )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
 
     return JSONResponse(
         status_code=200,
@@ -5890,17 +5952,20 @@ def get_public_eval_runs(
 @app.get("/v1/evals/runs/{eval_run_id}")
 def get_public_eval_run_detail(
     eval_run_id: UUID,
-    user_id: UUID,
+    request: Request,
 ) -> JSONResponse:
     settings = get_settings()
 
     try:
+        user_id = _resolve_authenticated_v1_user_id(settings, request)
         with user_connection(settings.database_url, user_id) as conn:
             payload: PublicEvalRunDetailResponse = get_public_eval_run(
                 ContinuityStore(conn),
                 user_id=user_id,
                 eval_run_id=eval_run_id,
             )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
     except LookupError as exc:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
 

--- a/tests/integration/test_contradictions_api.py
+++ b/tests/integration/test_contradictions_api.py
@@ -21,6 +21,7 @@ def invoke_request(
     *,
     query_params: dict[str, str] | None = None,
     payload: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
 ) -> tuple[int, dict[str, Any]]:
     messages: list[dict[str, object]] = []
     encoded_body = b"" if payload is None else json.dumps(payload).encode()
@@ -37,6 +38,10 @@ def invoke_request(
         messages.append(message)
 
     query_string = urlencode(query_params or {}).encode()
+    request_headers = [(b"content-type", b"application/json")]
+    for key, value in (headers or {}).items():
+        request_headers.append((key.lower().encode(), value.encode()))
+
     scope = {
         "type": "http",
         "asgi": {"version": "3.0"},
@@ -46,7 +51,7 @@ def invoke_request(
         "path": path,
         "raw_path": path.encode(),
         "query_string": query_string,
-        "headers": [(b"content-type", b"application/json")],
+        "headers": request_headers,
         "client": ("testclient", 50000),
         "server": ("testserver", 80),
         "root_path": "",
@@ -70,6 +75,35 @@ def seed_user(database_url: str, *, email: str) -> UUID:
     return user_id
 
 
+def auth_header(session_token: str) -> dict[str, str]:
+    return {"authorization": f"Bearer {session_token}"}
+
+
+def bootstrap_authenticated_user(database_url: str, *, email: str) -> tuple[UUID, str]:
+    start_status, start_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/start",
+        payload={"email": email},
+    )
+    assert start_status == 200
+
+    verify_status, verify_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/verify",
+        payload={
+            "challenge_token": start_payload["challenge"]["challenge_token"],
+            "device_label": "Contradictions Test Device",
+            "device_key": f"device-{email}",
+        },
+    )
+    assert verify_status == 200
+
+    user_id = UUID(verify_payload["user_account"]["id"])
+    with user_connection(database_url, user_id) as conn:
+        ContinuityStore(conn).create_user(user_id, email, email.split("@", 1)[0].title())
+    return user_id, verify_payload["session_token"]
+
+
 def set_continuity_timestamp(
     admin_database_url: str,
     *,
@@ -88,7 +122,16 @@ def test_contradictions_api_detects_surfaces_penalties_and_resolves(
     migrated_database_urls,
     monkeypatch,
 ) -> None:
-    user_id = seed_user(migrated_database_urls["app"], email="contradictions-api@example.com")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    user_id, session_token = bootstrap_authenticated_user(
+        migrated_database_urls["app"],
+        email="contradictions-api@example.com",
+    )
     thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
 
     with user_connection(migrated_database_urls["app"], user_id) as conn:
@@ -170,16 +213,11 @@ def test_contradictions_api_detects_surfaces_penalties_and_resolves(
         created_at=datetime(2026, 4, 14, 9, 10, tzinfo=UTC),
     )
 
-    monkeypatch.setattr(
-        main_module,
-        "get_settings",
-        lambda: Settings(database_url=migrated_database_urls["app"]),
-    )
-
     detect_status, detect_payload = invoke_request(
         "POST",
         "/v1/contradictions/detect",
-        payload={"user_id": str(user_id), "limit": 20},
+        payload={"limit": 20},
+        headers=auth_header(session_token),
     )
     assert detect_status == 200
     assert detect_payload["summary"]["open_case_count"] == 1
@@ -222,11 +260,11 @@ def test_contradictions_api_detects_surfaces_penalties_and_resolves(
         "GET",
         "/v1/trust/signals",
         query_params={
-            "user_id": str(user_id),
             "continuity_object_id": str(canary_object["id"]),
             "signal_state": "active",
             "limit": "20",
         },
+        headers=auth_header(session_token),
     )
     assert trust_status == 200
     assert trust_payload["summary"]["returned_count"] == 1
@@ -238,10 +276,10 @@ def test_contradictions_api_detects_surfaces_penalties_and_resolves(
         "POST",
         f"/v1/contradictions/cases/{contradiction_case_id}/resolve",
         payload={
-            "user_id": str(user_id),
             "action": "confirm_primary",
             "note": "Primary record remains current.",
         },
+        headers=auth_header(session_token),
     )
     assert resolve_status == 200
     assert resolve_payload["contradiction_case"]["status"] == "resolved"
@@ -251,7 +289,7 @@ def test_contradictions_api_detects_surfaces_penalties_and_resolves(
     detail_status, detail_payload = invoke_request(
         "GET",
         f"/v1/contradictions/cases/{contradiction_case_id}",
-        query_params={"user_id": str(user_id)},
+        headers=auth_header(session_token),
     )
     assert detail_status == 200
     assert detail_payload["contradiction_case"]["status"] == "resolved"
@@ -260,12 +298,31 @@ def test_contradictions_api_detects_surfaces_penalties_and_resolves(
         "GET",
         "/v1/trust/signals",
         query_params={
-            "user_id": str(user_id),
             "continuity_object_id": str(canary_object["id"]),
             "signal_state": "active",
             "limit": "20",
         },
+        headers=auth_header(session_token),
     )
     assert active_trust_after_status == 200
     assert active_trust_after_payload["items"] == []
 
+
+def test_contradictions_api_requires_bearer_auth(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v1/contradictions/cases",
+        query_params={"status": "open", "limit": "20"},
+    )
+
+    assert status == 401
+    assert payload == {"detail": "authorization bearer token is required"}

--- a/tests/integration/test_memory_mutations_api.py
+++ b/tests/integration/test_memory_mutations_api.py
@@ -19,6 +19,7 @@ def invoke_request(
     *,
     query_params: dict[str, str] | None = None,
     payload: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
 ) -> tuple[int, dict[str, Any]]:
     messages: list[dict[str, object]] = []
     encoded_body = b"" if payload is None else json.dumps(payload).encode()
@@ -35,6 +36,10 @@ def invoke_request(
         messages.append(message)
 
     query_string = urlencode(query_params or {}).encode()
+    request_headers = [(b"content-type", b"application/json")]
+    for key, value in (headers or {}).items():
+        request_headers.append((key.lower().encode(), value.encode()))
+
     scope = {
         "type": "http",
         "asgi": {"version": "3.0"},
@@ -44,7 +49,7 @@ def invoke_request(
         "path": path,
         "raw_path": path.encode(),
         "query_string": query_string,
-        "headers": [(b"content-type", b"application/json")],
+        "headers": request_headers,
         "client": ("testclient", 50000),
         "server": ("testserver", 80),
         "root_path": "",
@@ -61,18 +66,49 @@ def invoke_request(
     return start_message["status"], json.loads(body)
 
 
-def seed_user(database_url: str, *, email: str) -> UUID:
-    user_id = uuid4()
+def auth_header(session_token: str) -> dict[str, str]:
+    return {"authorization": f"Bearer {session_token}"}
+
+
+def bootstrap_authenticated_user(database_url: str, *, email: str) -> tuple[UUID, str]:
+    start_status, start_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/start",
+        payload={"email": email},
+    )
+    assert start_status == 200
+
+    verify_status, verify_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/verify",
+        payload={
+            "challenge_token": start_payload["challenge"]["challenge_token"],
+            "device_label": "Memory Mutation Test Device",
+            "device_key": f"device-{email}",
+        },
+    )
+    assert verify_status == 200
+
+    user_id = UUID(verify_payload["user_account"]["id"])
     with user_connection(database_url, user_id) as conn:
         ContinuityStore(conn).create_user(user_id, email, email.split("@", 1)[0].title())
-    return user_id
+    return user_id, verify_payload["session_token"]
 
 
 def test_memory_mutation_api_generates_commits_and_replays_idempotently(
     migrated_database_urls,
     monkeypatch,
 ) -> None:
-    user_id = seed_user(migrated_database_urls["app"], email="mutations@example.com")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    user_id, session_token = bootstrap_authenticated_user(
+        migrated_database_urls["app"],
+        email="mutations@example.com",
+    )
     thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
 
     with user_connection(migrated_database_urls["app"], user_id) as conn:
@@ -93,23 +129,17 @@ def test_memory_mutation_api_generates_commits_and_replays_idempotently(
             confidence=0.95,
         )
 
-    monkeypatch.setattr(
-        main_module,
-        "get_settings",
-        lambda: Settings(database_url=migrated_database_urls["app"]),
-    )
-
     generate_status, generate_payload = invoke_request(
         "POST",
         "/v1/memory/operations/candidates/generate",
         payload={
-            "user_id": str(user_id),
             "user_content": "Correction: Updated rollout plan",
             "assistant_content": "",
             "mode": "assist",
             "sync_fingerprint": "mutation-api-sync-001",
             "thread_id": str(thread_id),
         },
+        headers=auth_header(session_token),
     )
     assert generate_status == 200
     assert generate_payload["summary"] == {
@@ -126,9 +156,9 @@ def test_memory_mutation_api_generates_commits_and_replays_idempotently(
         "POST",
         "/v1/memory/operations/commit",
         payload={
-            "user_id": str(user_id),
             "candidate_ids": [candidate_id],
         },
+        headers=auth_header(session_token),
     )
     assert commit_status == 200
     assert commit_payload["summary"]["applied_count"] == 1
@@ -142,10 +172,10 @@ def test_memory_mutation_api_generates_commits_and_replays_idempotently(
         "GET",
         "/v1/memory/operations",
         query_params={
-            "user_id": str(user_id),
             "sync_fingerprint": "mutation-api-sync-001",
             "limit": "20",
         },
+        headers=auth_header(session_token),
     )
     assert operations_status == 200
     assert operations_payload["summary"]["returned_count"] == 1
@@ -155,13 +185,13 @@ def test_memory_mutation_api_generates_commits_and_replays_idempotently(
         "POST",
         "/v1/memory/operations/candidates/generate",
         payload={
-            "user_id": str(user_id),
             "user_content": "Correction: Updated rollout plan",
             "assistant_content": "",
             "mode": "assist",
             "sync_fingerprint": "mutation-api-sync-001",
             "thread_id": str(thread_id),
         },
+        headers=auth_header(session_token),
     )
     assert second_generate_status == 200
     assert second_generate_payload["items"][0]["id"] == candidate_id
@@ -170,9 +200,9 @@ def test_memory_mutation_api_generates_commits_and_replays_idempotently(
         "POST",
         "/v1/memory/operations/commit",
         payload={
-            "user_id": str(user_id),
             "candidate_ids": [candidate_id],
         },
+        headers=auth_header(session_token),
     )
     assert second_commit_status == 200
     assert second_commit_payload["summary"]["duplicate_count"] == 1
@@ -196,20 +226,22 @@ def test_memory_mutation_add_commit_preserves_scope_for_recall(
     migrated_database_urls,
     monkeypatch,
 ) -> None:
-    user_id = seed_user(migrated_database_urls["app"], email="mutations-add@example.com")
-    thread_id = UUID("dddddddd-dddd-4ddd-8ddd-dddddddddddd")
-
     monkeypatch.setattr(
         main_module,
         "get_settings",
         lambda: Settings(database_url=migrated_database_urls["app"]),
     )
 
+    user_id, session_token = bootstrap_authenticated_user(
+        migrated_database_urls["app"],
+        email="mutations-add@example.com",
+    )
+    thread_id = UUID("dddddddd-dddd-4ddd-8ddd-dddddddddddd")
+
     generate_status, generate_payload = invoke_request(
         "POST",
         "/v1/memory/operations/candidates/generate",
         payload={
-            "user_id": str(user_id),
             "user_content": "Decision: Finalize beta launch checklist",
             "assistant_content": "",
             "mode": "assist",
@@ -218,6 +250,7 @@ def test_memory_mutation_add_commit_preserves_scope_for_recall(
             "project": "apollo",
             "person": "alex",
         },
+        headers=auth_header(session_token),
     )
     assert generate_status == 200
     assert generate_payload["summary"]["operation_types"] == ["ADD"]
@@ -227,9 +260,9 @@ def test_memory_mutation_add_commit_preserves_scope_for_recall(
         "POST",
         "/v1/memory/operations/commit",
         payload={
-            "user_id": str(user_id),
             "candidate_ids": [candidate_id],
         },
+        headers=auth_header(session_token),
     )
     assert commit_status == 200
     assert commit_payload["summary"]["applied_count"] == 1
@@ -262,8 +295,36 @@ def test_memory_mutation_api_rejects_unknown_mode(
     migrated_database_urls,
     monkeypatch,
 ) -> None:
-    user_id = seed_user(migrated_database_urls["app"], email="mutations-invalid-mode@example.com")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
 
+    _user_id, session_token = bootstrap_authenticated_user(
+        migrated_database_urls["app"],
+        email="mutations-invalid-mode@example.com",
+    )
+
+    status, payload = invoke_request(
+        "POST",
+        "/v1/memory/operations/candidates/generate",
+        payload={
+            "user_content": "Decision: Reject invalid mode input",
+            "assistant_content": "",
+            "mode": "banana",
+        },
+        headers=auth_header(session_token),
+    )
+
+    assert status == 400
+    assert payload == {"detail": "mode must be one of: manual, assist, auto"}
+
+
+def test_memory_mutation_api_requires_bearer_auth(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(
         main_module,
         "get_settings",
@@ -271,15 +332,10 @@ def test_memory_mutation_api_rejects_unknown_mode(
     )
 
     status, payload = invoke_request(
-        "POST",
-        "/v1/memory/operations/candidates/generate",
-        payload={
-            "user_id": str(user_id),
-            "user_content": "Decision: Reject invalid mode input",
-            "assistant_content": "",
-            "mode": "banana",
-        },
+        "GET",
+        "/v1/memory/operations",
+        query_params={"limit": "20"},
     )
 
-    assert status == 400
-    assert payload == {"detail": "mode must be one of: manual, assist, auto"}
+    assert status == 401
+    assert payload == {"detail": "authorization bearer token is required"}

--- a/tests/integration/test_public_evals_api.py
+++ b/tests/integration/test_public_evals_api.py
@@ -18,8 +18,11 @@ def invoke_request(
     path: str,
     *,
     query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
 ) -> tuple[int, dict[str, Any]]:
     messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
     request_received = False
 
     async def receive() -> dict[str, object]:
@@ -27,12 +30,16 @@ def invoke_request(
         if request_received:
             return {"type": "http.disconnect"}
         request_received = True
-        return {"type": "http.request", "body": b"", "more_body": False}
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
 
     async def send(message: dict[str, object]) -> None:
         messages.append(message)
 
     query_string = urlencode(query_params or {}).encode()
+    request_headers = [(b"content-type", b"application/json")]
+    for key, value in (headers or {}).items():
+        request_headers.append((key.lower().encode(), value.encode()))
+
     scope = {
         "type": "http",
         "asgi": {"version": "3.0"},
@@ -42,7 +49,7 @@ def invoke_request(
         "path": path,
         "raw_path": path.encode(),
         "query_string": query_string,
-        "headers": [(b"content-type", b"application/json")],
+        "headers": request_headers,
         "client": ("testclient", 50000),
         "server": ("testserver", 80),
         "root_path": "",
@@ -59,29 +66,54 @@ def invoke_request(
     return start_message["status"], json.loads(body)
 
 
-def seed_user(database_url: str, *, email: str) -> UUID:
-    user_id = uuid4()
+def auth_header(session_token: str) -> dict[str, str]:
+    return {"authorization": f"Bearer {session_token}"}
+
+
+def bootstrap_authenticated_user(database_url: str, *, email: str) -> tuple[UUID, str]:
+    start_status, start_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/start",
+        payload={"email": email},
+    )
+    assert start_status == 200
+
+    verify_status, verify_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/verify",
+        payload={
+            "challenge_token": start_payload["challenge"]["challenge_token"],
+            "device_label": "Public Eval Test Device",
+            "device_key": f"device-{email}",
+        },
+    )
+    assert verify_status == 200
+
+    user_id = UUID(verify_payload["user_account"]["id"])
     with user_connection(database_url, user_id) as conn:
         ContinuityStore(conn).create_user(user_id, email, email.split("@", 1)[0].title())
-    return user_id
+    return user_id, verify_payload["session_token"]
 
 
 def test_public_eval_api_runs_lists_and_reads_persisted_report(
     migrated_database_urls,
     monkeypatch,
 ) -> None:
-    user_id = seed_user(migrated_database_urls["app"], email="public-evals@example.com")
-
     monkeypatch.setattr(
         main_module,
         "get_settings",
         lambda: Settings(database_url=migrated_database_urls["app"]),
     )
 
+    _user_id, session_token = bootstrap_authenticated_user(
+        migrated_database_urls["app"],
+        email="public-evals@example.com",
+    )
+
     suites_status, suites_payload = invoke_request(
         "GET",
         "/v1/evals/suites",
-        query_params={"user_id": str(user_id)},
+        headers=auth_header(session_token),
     )
     assert suites_status == 200
     assert suites_payload["summary"]["suite_count"] == 5
@@ -90,7 +122,7 @@ def test_public_eval_api_runs_lists_and_reads_persisted_report(
     run_status, run_payload = invoke_request(
         "POST",
         "/v1/evals/runs",
-        query_params={"user_id": str(user_id)},
+        headers=auth_header(session_token),
     )
     assert run_status == 200
     assert run_payload["run"]["status"] == "pass"
@@ -101,7 +133,8 @@ def test_public_eval_api_runs_lists_and_reads_persisted_report(
     runs_status, runs_payload = invoke_request(
         "GET",
         "/v1/evals/runs",
-        query_params={"user_id": str(user_id), "limit": "10"},
+        query_params={"limit": "10"},
+        headers=auth_header(session_token),
     )
     assert runs_status == 200
     assert runs_payload["summary"]["returned_count"] == 1
@@ -110,7 +143,7 @@ def test_public_eval_api_runs_lists_and_reads_persisted_report(
     detail_status, detail_payload = invoke_request(
         "GET",
         f"/v1/evals/runs/{eval_run_id}",
-        query_params={"user_id": str(user_id)},
+        headers=auth_header(session_token),
     )
     assert detail_status == 200
     assert detail_payload["run"]["report_digest"] == run_payload["run"]["report_digest"]
@@ -122,8 +155,32 @@ def test_public_eval_api_rejects_unknown_suite_key(
     migrated_database_urls,
     monkeypatch,
 ) -> None:
-    user_id = seed_user(migrated_database_urls["app"], email="public-evals-invalid-suite@example.com")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
 
+    _user_id, session_token = bootstrap_authenticated_user(
+        migrated_database_urls["app"],
+        email="public-evals-invalid-suite@example.com",
+    )
+
+    status, payload = invoke_request(
+        "POST",
+        "/v1/evals/runs",
+        query_params={"suite_key": "missing_suite"},
+        headers=auth_header(session_token),
+    )
+
+    assert status == 400
+    assert payload["detail"] == "unknown suite_key values: missing_suite"
+
+
+def test_public_eval_api_requires_bearer_auth(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(
         main_module,
         "get_settings",
@@ -131,10 +188,9 @@ def test_public_eval_api_rejects_unknown_suite_key(
     )
 
     status, payload = invoke_request(
-        "POST",
-        "/v1/evals/runs",
-        query_params={"user_id": str(user_id), "suite_key": "missing_suite"},
+        "GET",
+        "/v1/evals/suites",
     )
 
-    assert status == 400
-    assert payload["detail"] == "unknown suite_key values: missing_suite"
+    assert status == 401
+    assert payload == {"detail": "authorization bearer token is required"}


### PR DESCRIPTION
## Summary

This PR hardens the Phase 12 v1 API surface so authenticated user identity is derived from the bearer session instead of being accepted from client-provided `user_id` fields.

It removes client-supplied identity from the affected request shapes, resolves the acting user from the authenticated session server-side, and updates integration coverage to exercise bearer-authenticated access and missing-token rejection.

## Validation

- `./.venv/bin/pytest tests/integration/test_memory_mutations_api.py tests/integration/test_contradictions_api.py tests/integration/test_public_evals_api.py -q`
- Result: `9 passed in 6.65s`

## Upgrade Overview

### Protected Areas

- [ ] memory schema
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact

Behavior-changing for unauthenticated or impersonating clients: the affected v1 endpoints no longer accept caller-provided `user_id` values and now require a valid bearer session. Authenticated clients using the intended hosted flow continue to work, but callers that relied on direct `user_id` injection will now receive `401` or auth-derived behavior instead of acting on arbitrary users.

### Migration / Rollout

No schema or data migration is required. Rollout is application-only: deploy the API change, then verify that hosted clients send `Authorization: Bearer <token>` on the affected endpoints. There are no feature flags or backfills associated with this change.

### Operator Action

No manual operator action is required beyond normal deploy verification. If any internal client still sends `user_id` directly to these endpoints, update it to use the existing authenticated session flow before relying on the hardened behavior in production.

### Validation

Validated with the focused integration slice covering memory operations, contradictions, and public eval API flows under bearer auth, plus explicit `401` assertions for missing bearer tokens:

- `./.venv/bin/pytest tests/integration/test_memory_mutations_api.py tests/integration/test_contradictions_api.py tests/integration/test_public_evals_api.py -q`
- Result: `9 passed in 6.65s`

### Rollback

Rollback is straightforward: revert commit `737336b9d6c288bef2a48849486680112b1aeed4` to restore the prior request contract. That would reopen the impersonation risk, so rollback should be limited to an emergency compatibility regression and followed by a corrected forward fix.
