### PR TITLE
[codex] P13-S1: ship one-call continuity

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -1,93 +1,113 @@
 # Sprint Packet
 
 ## Sprint Title
-Phase 12 Closeout and `v0.3.2` Release Update
+P13-S1: One-Call Continuity
 
 ## Activation Note
 - This packet is active.
-- `v0.2.0` is the latest published tag.
-- `v0.3.2` is the current release target for the completed Phase 12 boundary.
-- Phase 12 implementation scope is complete through `P12-S1` to `P12-S5`.
+- `v0.3.2` is the latest published tag.
+- Phase 13 is active.
+- Phase 13 sequence is fixed for now:
+  - `P13-S1` One-Call Continuity
+  - `P13-S2` Alice Lite
+  - `P13-S3` Memory Hygiene + Conversation Health
 
 ## Sprint Type
-closeout
+feature
 
 ## Sprint Reason
-Phase 12 implementation is complete. The remaining work is not another product sprint. It is closeout:
-- summarize the completed phase clearly
-- align canonical docs to Phase 12 completion
-- update release docs from the old `v0.2.0` boundary to the new `v0.3.2` target
-- prepare the repo for either a `v0.3.2` tag or next-phase planning
+Phase 12 already shipped the quality substrate:
+- hybrid retrieval
+- explicit mutation
+- contradiction and trust handling
+- public evals
+- task-adaptive briefing
+
+The first Phase 13 job is to operationalize that work behind one primary integration surface so external agents do not need tool choreography to get strong continuity.
 
 ## Git Instructions
-- Branch Name: `codex/phase12-closeout-v0-3-2`
+- Branch Name: `codex/phase13-s1-one-call-continuity`
 - Base Branch: `main`
-- PR Strategy: one docs/control branch, one PR
+- PR Strategy: one implementation branch, one PR
 - Merge Policy: squash merge after review `PASS` and explicit approval
 
 ## Baseline To Preserve
-- shipped Phase 9 through Phase 11 baseline
+- shipped Phases 9-12 baseline
 - shipped Bridge `B1` through `B4`
-- shipped Phase 12 `P12-S1` through `P12-S5`
-- current published tag remains `v0.2.0` until a new tag is cut
+- published `v0.3.2` baseline
+- no semantic fork between API, CLI, MCP, hosted, provider-runtime, and Hermes paths
 
 ## Exact Goal
-Close Phase 12 cleanly and move the documented release boundary to `v0.3.2` without falsely claiming that the `v0.3.2` tag has already been cut.
+Create the primary one-call continuity surface:
+- API: `POST /v1/continuity/brief`
+- CLI: `alice brief`
+- MCP: `alice_brief`
+
+This should become the default integration endpoint for external agents and should compose existing retrieval, open-loop, contradiction, trust, and briefing systems into one strong response.
 
 ## In Scope
-- Phase 12 closeout packet
-- Phase 12 closeout summary
-- current-state and roadmap alignment for completed Phase 12
-- `v0.3.2` release checklist, tag plan, and runbook
-- README and public-doc release-boundary updates
-- changelog update for completed Phase 12
+- one-call continuity contract and assembly logic
+- `POST /v1/continuity/brief`
+- `alice brief`
+- `alice_brief`
+- supported brief types:
+  - `general`
+  - `resume`
+  - `agent_handoff`
+  - `coding_context`
+  - `operator_context`
+- continuity bundle output including:
+  - summary
+  - relevant facts
+  - recent changes
+  - open loops
+  - conflicts
+  - timeline highlights
+  - next suggested action
+  - provenance bundle
+  - trust posture
+- API/CLI/MCP parity tests and integration docs
 
 ## Out Of Scope
-- new product or runtime features
-- reopening any Phase 12 implementation sprint
-- tagging or publishing `v0.3.2` without explicit approval
-- defining the next phase in detail
+- Alice Lite packaging/profile work
+- hygiene or thread-health dashboards
+- new connectors or channels
+- new retrieval research
+- new provider/runtime substrate work unless directly required for this surface
 
 ## Proposed Files And Modules
-- `README.md`
-- `CHANGELOG.md`
-- `PRODUCT_BRIEF.md`
-- `ARCHITECTURE.md`
-- `ROADMAP.md`
-- `RULES.md`
-- `CURRENT_STATE.md`
-- `.ai/handoff/CURRENT_STATE.md`
-- `.ai/active/SPRINT_PACKET.md`
-- `docs/runbooks/phase12-closeout-packet.md`
-- `docs/phase12-closeout-summary.md`
-- `docs/release/v0.3.2-release-checklist.md`
-- `docs/release/v0.3.2-tag-plan.md`
-- `docs/runbooks/v0.3.2-public-release-runbook.md`
-- public docs that still hard-code the old `v0.2.0` release boundary
-- `scripts/check_control_doc_truth.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/cli.py`
+- `apps/api/src/alicebot_api/mcp_tools.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- one new continuity-brief assembly module if needed
+- `docs/integrations/`
+- `tests/unit/`
+- `tests/integration/`
 
 ## Planned Deliverables
-- Phase 12 closeout packet
-- Phase 12 closeout summary
-- `v0.3.2` release-target docs
-- canonical doc alignment to completed Phase 12
-- updated release-boundary references in public docs
+- API endpoint `POST /v1/continuity/brief`
+- CLI command `alice brief`
+- MCP tool `alice_brief`
+- one-call response contract
+- parity coverage and docs/examples for external runtimes
 
 ## Acceptance Criteria
-- Phase 12 is described as complete in canonical docs
-- The documented release target is `v0.3.2`
-- the docs do not falsely claim that `v0.3.2` is already tagged or published
-- closeout docs summarize what shipped in `P12-S1` through `P12-S5`
-- control-doc truth passes after the closeout update
+- an external agent can call one primary continuity surface and get a useful continuity bundle
+- the bundle includes summary, recent changes, open loops, conflicts, next action, provenance, and trust posture
+- the surface composes shipped Phase 12 systems rather than reimplementing them
+- API, CLI, and MCP surfaces stay semantically aligned
+- docs make this the default integration path for external agents
 
 ## Required Verification
 - `python3 scripts/check_control_doc_truth.py`
 - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+- targeted unit/integration coverage for API, CLI, and MCP parity of the new continuity brief surface
 
 ## Control Tower Decisions Needed
-- whether to tag and publish `v0.3.2` immediately after closeout
-- whether to run a dedicated release-readiness pass before the `v0.3.2` tag
-- what the next planned phase is after Phase 12
+- default `brief_type` and default inclusion posture for optional sections when the caller does not specify flags
+- whether timeline highlights are included by default or only on request
+- whether coding/operator context should differ only by selection strategy or also by response shape
 
 ## Exit Condition
-This closeout packet is complete when Phase 12 is summarized cleanly, canonical docs reflect completed Phase 12 truth, and the documented release target is updated to `v0.3.2` without claiming a tag that has not yet been cut.
+This sprint is complete when Alice exposes a single primary continuity call across API, CLI, and MCP that meaningfully reduces integration complexity without weakening continuity semantics.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -5,32 +5,27 @@
 - Phase 10 is shipped.
 - Phase 11 is shipped.
 - Bridge `B1` through `B4` are shipped.
-- `v0.2.0` is the latest published tag.
-- `v0.3.2` is the current release target.
-- Phase 12 Sprint 1 (`P12-S1`) is shipped.
-- Phase 12 Sprint 2 (`P12-S2`) is shipped.
-- Phase 12 Sprint 3 (`P12-S3`) is shipped.
-- Phase 12 Sprint 4 (`P12-S4`) is shipped.
-- Phase 12 Sprint 5 (`P12-S5`) is shipped.
-- Phase 12 closeout and `v0.3.2` release update are the active control packet.
+- Phase 12 is shipped.
+- `v0.3.2` is the latest published tag.
+- Phase 13 is active.
+- `P13-S1` One-Call Continuity is the active execution sprint.
+- `P13-S2` Alice Lite is planned next.
+- `P13-S3` Memory Hygiene + Conversation Health is planned after Alice Lite.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
 - Alice exposes CLI, MCP, hosted/product, provider-runtime, and Hermes bridge surfaces.
-- The codebase already includes semantic retrieval, embeddings, entities/entity edges, trusted-fact promotion, retrieval evaluation fixtures, deterministic resumption briefs, daily briefs, chief-of-staff briefing flows, and the shipped `P12-S1` hybrid retrieval/reranking foundation with retrieval traces.
-- The codebase also includes the shipped `P12-S2` memory mutation candidate and operation foundation, the shipped `P12-S3` contradiction/trust foundation, the shipped `P12-S4` public eval harness, and the shipped `P12-S5` task-adaptive briefing layer.
+- The shipped baseline now includes hybrid retrieval and reranking with traces, explicit memory mutation operations, contradiction/trust handling, the public eval harness, and task-adaptive briefing.
+- `v0.3.2` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
-- Phase 12 is complete.
-- `P12-S1` is complete and establishes the retrieval baseline.
-- `P12-S2` is complete and establishes the mutation baseline.
-- `P12-S3` is complete and establishes the contradiction/trust baseline.
-- `P12-S4` is complete and establishes the public-eval baseline.
-- `P12-S5` is complete and establishes the task-adaptive briefing baseline.
-- The active docs task is phase closeout, summary, and `v0.3.2` release-target alignment.
-- There are no remaining Phase 12 feature sprints.
+- Phase 12 is complete and remains baseline truth.
+- Phase 13 is the adoption and ergonomics phase on top of that baseline.
+- `P13-S1` is active and should create the primary one-call continuity surface across API, CLI, and MCP.
+- `P13-S2` should simplify startup and local adoption without semantic drift.
+- `P13-S3` should make hygiene and thread/conversation health visible and operationally useful.
 
 ## Immediate Control Tower Decisions Needed
-- Decide when to cut the `v0.3.2` tag and release.
-- Decide whether a dedicated release-readiness pass is needed before the tag.
-- Decide the next planned phase after Phase 12 closeout.
+- Decide whether the next public release should wrap the full Phase 13 sequence or ship incrementally.
+- Decide whether Alice Lite remains purely a lighter deployment profile in `P13-S2`.
+- Decide the threshold model for risky/stale thread health in `P13-S3`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 # Architecture
 
 ## Scope Boundary
-- **Shipped baseline:** Phases 9-11 and Bridge `B1` through `B4`.
-- **Current repo execution posture:** `v0.2.0` is the latest published tag; `v0.3.2` is the current release target; Phase 12 is complete.
-- **Active control-doc task:** Phase 12 closeout and `v0.3.2` release update.
+- **Shipped baseline:** Phases 9-12 and Bridge `B1` through `B4`.
+- **Current repo execution posture:** `v0.3.2` is the latest published tag; Phase 13 is active; `P13-S1` is the active execution sprint.
+- **Phase principle:** Phase 13 is an adoption layer on top of Phase 12, not a new substrate phase.
 
 ## Current System Overview
 Alice is a modular continuity platform with shared continuity semantics across local, hosted, provider-runtime, MCP, and Hermes-integrated surfaces.
@@ -28,13 +28,20 @@ Alice is a modular continuity platform with shared continuity semantics across l
   - [`continuity_open_loops.py`](apps/api/src/alicebot_api/continuity_open_loops.py)
 
 ### Retrieval And Evidence Foundations
-- Existing baseline already includes semantic retrieval, embeddings, entities, trusted-fact promotion, and fixture-based retrieval evaluation.
+- Shipped baseline includes semantic retrieval, embeddings, entities, trusted-fact promotion, fixture-based retrieval evaluation, hybrid retrieval streams, reranking, and persisted retrieval traces.
 - Primary modules:
   - [`semantic_retrieval.py`](apps/api/src/alicebot_api/semantic_retrieval.py)
   - [`retrieval_evaluation.py`](apps/api/src/alicebot_api/retrieval_evaluation.py)
   - [`entity.py`](apps/api/src/alicebot_api/entity.py)
   - [`entity_edge.py`](apps/api/src/alicebot_api/entity_edge.py)
   - [`trusted_fact_promotions.py`](apps/api/src/alicebot_api/trusted_fact_promotions.py)
+
+### Mutation, Trust, And Briefing Foundations
+- Shipped baseline includes explicit memory operations, contradiction cases, trust signals, public eval persistence, and task-adaptive briefing.
+- Primary modules:
+  - [`memory.py`](apps/api/src/alicebot_api/memory.py)
+  - [`task_briefing.py`](apps/api/src/alicebot_api/task_briefing.py)
+  - [`contracts.py`](apps/api/src/alicebot_api/contracts.py)
 
 ### Hosted/Product Layer
 - Workspace, identity, devices, preferences, telemetry, web/admin, and channel surfaces.
@@ -51,13 +58,17 @@ Alice is a modular continuity platform with shared continuity semantics across l
 - `memories`, `memory_revisions`, `memory_review_labels`
 - `continuity_capture_events`, `continuity_objects`, `continuity_correction_events`
 - `open_loops`
+- `memory_operation_candidates`, `memory_operations`
+- `contradiction_cases`, `trust_signals`
 
-### Retrieval Foundations
+### Retrieval And Evaluation
 - `embedding_configs`, `memory_embeddings`
 - `entities`, `entity_edges`
+- `retrieval_runs`, `retrieval_candidates`
+- `eval_suites`, `eval_cases`, `eval_runs`, `eval_results`
 - task-artifact chunk embeddings for artifact-scoped retrieval
 
-### Product/Runtime
+### Product / Runtime
 - `workspaces`, `workspace_members`, `auth_sessions`, `devices`
 - `model_providers`, `provider_capabilities`, `model_packs`, `workspace_model_pack_bindings`
 - `task_briefs`
@@ -73,75 +84,78 @@ Alice is a modular continuity platform with shared continuity semantics across l
 
 ### Recall And Resumption
 1. Recall loads continuity candidates.
-2. Ranking already considers semantic similarity, trust, freshness, provenance, supersession, and entity/scope matches.
+2. Ranking considers semantic similarity, lexical/entity signals, trust, freshness, provenance, and supersession.
 3. Resumption composes ranked recall into decisions, open loops, recent changes, and next action.
 
-### Provider/Hermes Runtime
+### Provider / Hermes Runtime
 1. Workspace binds provider and model-pack configuration.
 2. Runtime invokes through provider adapter boundaries.
 3. Hermes can prefetch before a turn and capture after a turn while Alice remains the system of record.
 
-## Phase 12 Architecture Delta
+## Phase 12 Baseline In Force
+- Hybrid retrieval and reranking are the recall baseline.
+- Explicit mutation operations are the memory-change baseline.
+- Contradiction cases and trust signals are the conflict/trust baseline.
+- The public eval harness is the quality-evidence baseline.
+- Task-adaptive briefing is the current compiled-context baseline.
 
-### P12-S1: Hybrid Retrieval + Reranking
-Shipped in `P12-S1`:
-- semantic stream
-- lexical/BM25-style stream
-- entity/edge traversal stream
-- temporal filtering/weighting
-- trust-aware reranking
-- persisted retrieval traces
+## Phase 13 Planned Delta
 
-Delivered additions:
-- `retrieval_runs`
-- `retrieval_candidates`
-- debug surfaces for API, CLI, and MCP
+### P13-S1: One-Call Continuity
+- Add the primary integration surface:
+  - API: `POST /v1/continuity/brief`
+  - CLI: `alice brief`
+  - MCP: `alice_brief`
+- Input should support:
+  - `query`
+  - optional `thread_id`
+  - optional `task_id`
+  - optional `project`
+  - optional `person`
+  - optional `since`
+  - optional `until`
+  - `brief_type`
+  - `max_relevant_facts`
+  - `max_recent_changes`
+  - `max_open_loops`
+  - `max_conflicts`
+  - `max_timeline_highlights`
+  - `include_non_promotable_facts`
+- Output should include:
+  - summary
+  - relevant facts
+  - recent changes
+  - open loops
+  - conflicts
+  - timeline highlights
+  - next suggested action
+  - provenance bundle
+  - trust posture
+- This surface must compose shipped Phase 12 layers rather than reimplement them.
 
-Important baseline note: `P12-S1` is now the retrieval baseline for the rest of Phase 12 and should not be reopened except where later sprint integration requires it.
+### P13-S2: Alice Lite
+- Add a lighter local deployment profile for solo users and builders.
+- Target outcomes:
+  - one-command local startup
+  - smaller-footprint profile
+  - sample workspace bootstrap
+  - faster first useful result
+- Alice Lite must remain a deployment/profile change, not a separate product or semantics fork.
+- SQLite or another embedded mode is not in scope unless semantics remain intact.
 
-### P12-S2: Automated Memory Operations
-Shipped in `P12-S2`:
-- `ADD`
-- `UPDATE`
-- `SUPERSEDE`
-- `DELETE`
-- `NOOP`
-
-Delivered additions:
-- `memory_operation_candidates`
-- `memory_operations`
-
-Important baseline note: `P12-S2` is now the mutation baseline for the rest of Phase 12 and should not be reopened except where later sprint integration requires it.
-
-### P12-S3: Contradiction Detection + Trust Calibration
-Shipped in `P12-S3`:
-
-Delivered additions:
-- `contradiction_cases`
-- `trust_signals`
-
-Important baseline note: `P12-S3` is now the contradiction/trust baseline for the rest of Phase 12 and should not be reopened except where later sprint integration requires it.
-
-### P12-S4: Public Eval Harness
-Shipped in `P12-S4`:
-
-Delivered additions:
-- `eval_suites`
-- `eval_cases`
-- `eval_runs`
-- `eval_results`
-
-Important baseline note: `P12-S4` is now the evaluation baseline for the rest of Phase 12 and should not be reopened except where later sprint integration requires it.
-Source-of-truth note: the checked-in fixture catalog defines the authoritative suite/case set and ordering; persisted eval suite/case rows are synchronized snapshots for execution and audit, not an independent planning surface.
-
-### P12-S5: Task-Adaptive Briefing
-Shipped in `P12-S5`:
-
-Delivered additions:
-- `task_briefs`
-- provider/model-pack briefing strategy fields
-
-Important baseline note: `P12-S5` closes the planned Phase 12 implementation scope. Existing resumption, daily-brief, and chief-of-staff briefing surfaces remain the starting points rather than being replaced wholesale.
+### P13-S3: Memory Hygiene + Conversation Health
+- Add visible hygiene surfaces for:
+  - duplicates
+  - stale facts
+  - unresolved contradictions
+  - weakly trusted memory
+  - review queue pressure
+- Add conversation/thread health surfaces for:
+  - recent threads
+  - stale threads
+  - risky threads
+  - thread activity / health posture
+- This work is visibility and operational legibility first, not new substrate work.
 
 ## Security And Reliability Rules
 - Keep user/workspace isolation intact for continuity, provider, and channel data.
@@ -149,6 +163,8 @@ Important baseline note: `P12-S5` closes the planned Phase 12 implementation sco
 - Preserve approval-bounded execution for consequential side effects.
 - Keep capture, mutation, and Hermes sync paths idempotent.
 - Preserve append-only evidence where the system depends on auditability.
+- Do not let the one-call continuity surface bypass provenance, trust, or supersession rules already enforced by the baseline.
+- Do not let Alice Lite weaken continuity semantics in exchange for easier install.
 
 ## Deployment Topology
 
@@ -158,16 +174,22 @@ Important baseline note: `P12-S5` closes the planned Phase 12 implementation sco
 - Provider runtime where model abstraction is needed
 - Hermes provider-plus-MCP for always-on continuity
 
+### Phase 13 Addition
+- Alice Lite should be a lighter deployment/profile around the same core runtime, not a separate architecture.
+
 ### Fallback
 - MCP-only remains supported when provider automation is unavailable
 
 ## Testing Strategy
 - unit/integration tests for continuity, runtime, and API behavior
 - fixture-based retrieval and eval suites
+- API/CLI/MCP parity tests for `P13-S1`
+- startup/smoke coverage for Alice Lite profile work in `P13-S2`
+- hygiene/thread-health tests for `P13-S3`
 - web tests for shipped user/admin surfaces
 - Hermes provider smoke, MCP smoke, and demo flows
-- release/eval artifacts committed only when they correspond to exact commands and fixtures
 
 ## Control Tower Decisions Needed
-- Whether `v0.3.2` should be tagged immediately or held until a dedicated release pass.
-- What the next planned phase is after the completed Phase 12 architecture baseline.
+- Whether Alice Lite can reduce services in `P13-S2` without harming semantics or release credibility.
+- Exact default payload posture for `/v1/continuity/brief`.
+- Threshold model for thread risk and health visibility in `P13-S3`.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,89 +1,71 @@
 # BUILD_REPORT
 
-## Objective
-Execute the `v0.3.2` release checklist against the completed Phase 12 baseline on `main`, record exact release-gate evidence, and determine whether the repo is ready for tagging.
+## Sprint Objective
 
-## Release Baseline
-- branch: `main`
-- `HEAD`: `60430b7`
-- latest published tag: `v0.2.0`
-- current release target: `v0.3.2`
-- merged implementation baseline:
-  - `P12-S1` `e019f72`
-  - `P12-S2` `0c849fd`
-  - `P12-S3` `6d10d1b`
-  - `P12-S4` `dd77643`
-  - `P12-S5` `de19350`
-- merged closeout / release-prep baseline:
-  - `2e68fcb` Phase 12 closeout and `v0.3.2` release prep
-  - `60430b7` bearer-auth follow-up for Phase 12 v1 APIs
+Implement `P13-S1: One-Call Continuity` by shipping one shared continuity bundle surface across:
 
-## Exact Commands Run
-- `docker compose up -d`
-  - Result: PASS
-  - Evidence: `alicebot-postgres`, `alicebot-redis`, and `alicebot-minio` reported `Running`
-- `./scripts/migrate.sh`
-  - Result: PASS
-  - Evidence: upgraded through `20260414_0061` (`Phase 12 task-adaptive briefing persistence and model-pack strategy fields`)
-- `./scripts/load_sample_data.sh`
-  - Result: PASS
-  - Evidence: fixture already present; returned `status=noop` for default user `00000000-0000-0000-0000-000000000001`
-- `env APP_RELOAD=false ALICEBOT_AUTH_USER_ID=00000000-0000-0000-0000-000000000001 ./scripts/api_dev.sh`
-  - Result: PASS
-  - Evidence: API served on `http://127.0.0.1:8000`
-- `curl -sS http://127.0.0.1:8000/healthz`
-  - Result: PASS
-  - Evidence: `{"status":"ok","environment":"development","services":{"database":{"status":"ok"}}...}`
+- API: `POST /v1/continuity/brief`
+- CLI: `alice brief`
+- MCP: `alice_brief`
+
+## Completed Work
+
+- Added a shared continuity brief assembler that composes existing resumption, recall, task-briefing, contradiction, and trust systems.
+- Added the one-call continuity request/response contract and supporting typed records.
+- Added authenticated API endpoint `POST /v1/continuity/brief`.
+- Added CLI command `brief` in the Python CLI surface and deterministic CLI rendering for the continuity bundle.
+- Added MCP tool `alice_brief` with input validation and stable schema.
+- Updated the Node `alice` wrapper so `alice brief` forwards to the Python CLI runtime without widening unrelated command behavior.
+- Added integration documentation that makes one-call continuity the default external-agent path.
+- Added targeted API, CLI, and MCP parity coverage for the new surface.
+- Added wrapper-level Node coverage for `alice brief`.
+- Updated active control docs required for the Phase 13 sprint packet and control-doc truth checks.
+
+## Incomplete Work
+
+- None for this sprint packet.
+
+## Files Changed
+
+- `.ai/active/SPRINT_PACKET.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `ARCHITECTURE.md`
+- `README.md`
+- `ROADMAP.md`
+- `RULES.md`
+- `CURRENT_STATE.md`
+- `PRODUCT_BRIEF.md`
+- `apps/api/src/alicebot_api/continuity_brief.py`
+- `apps/api/src/alicebot_api/contracts.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/cli.py`
+- `apps/api/src/alicebot_api/cli_formatting.py`
+- `apps/api/src/alicebot_api/mcp_tools.py`
+- `packages/alice-cli/bin/alice.js`
+- `packages/alice-cli/package.json`
+- `packages/alice-cli/test/alice.test.mjs`
+- `docs/integrations/one-call-continuity.md`
+- `docs/integrations/cli.md`
+- `docs/integrations/mcp.md`
+- `scripts/check_control_doc_truth.py`
+- `tests/integration/test_continuity_brief_api.py`
+- `tests/integration/test_mcp_cli_parity.py`
+- `tests/unit/test_cli.py`
+- `tests/unit/test_mcp.py`
+
+## Tests Run
+
+- `./.venv/bin/pytest tests/unit/test_cli.py tests/unit/test_mcp.py -q`
+- `./.venv/bin/pytest tests/integration/test_continuity_brief_api.py tests/integration/test_mcp_cli_parity.py -q`
 - `python3 scripts/check_control_doc_truth.py`
-  - Result: PASS
-- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-  - Result: PASS (`5 passed in 0.03s`)
-- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-  - Initial result: FAIL
-  - Failure: `tests/unit/test_memory.py::test_get_memory_trust_dashboard_summary_is_deterministic_and_uses_canonical_components`
-  - Root cause: stale expected retrieval fixture count (`6`) after the canonical retrieval fixture suite had already grown to `7`
-  - Remediation: updated the stale assertion in `tests/unit/test_memory.py`
-  - Re-run result: PASS (`1247 passed in 228.94s`)
-- `pnpm --dir apps/web test`
-  - Result: PASS (`199 passed`)
-- `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py`
-  - Result: PASS
-  - Evidence: provider registered, bridge ready, single external enforced
-- `./.venv/bin/python scripts/run_hermes_mcp_smoke.py`
-  - Result: PASS
-  - Evidence: recall/resume/review flow validated; review queue resolved cleanly
-- `./.venv/bin/python scripts/run_hermes_bridge_demo.py`
-  - Result: PASS
-  - Evidence: `recommended_path=provider_plus_mcp`, `fallback_path=mcp_only`, both smoke steps returned `0`
-- `./.venv/bin/python -m alicebot_api --database-url postgresql://alicebot_app:alicebot_app@localhost:5432/alicebot --user-id 00000000-0000-0000-0000-000000000001 evals run --report-path eval/baselines/public_eval_harness_v1.json`
-  - Result: PASS
-  - Evidence: report status `pass`, `suite_count=5`, `case_count=12`, `failed_case_count=0`, report digest `bf3ac58edc070a74bb6faa7a66536a08154d114494932c4d231a500e6899ed29`
+- `./.venv/bin/pytest tests/unit/test_control_doc_truth.py -q`
+- `node --test packages/alice-cli/test/alice.test.mjs`
 
-## Documentation / Public Repo Readiness
-- `README.md` aligned to completed Phase 12 and `v0.3.2` release target
-- `docs/quickstart/local-setup-and-first-result.md` aligned
-- `docs/integrations/mcp.md` aligned
-- `docs/integrations/hermes-bridge-operator-guide.md` aligned
-- `docs/evals/public_eval_harness.md` aligned
-- `docs/briefing/task-adaptive-briefing.md` aligned
-- `CONTRIBUTING.md`: present
-- `SECURITY.md`: present
-- `LICENSE`: present
-- `CHANGELOG.md` contains a Phase 12 closeout / `v0.3.2` release-target entry
+## Blockers/Issues
 
-## Files Changed During Checklist Execution
-- `BUILD_REPORT.md`
-- `REVIEW_REPORT.md`
-- `tests/unit/test_memory.py`
-
-## Outcome
-- All runtime, test, web, Hermes, and eval release gates now pass on the current working tree.
-- The only code-level issue uncovered by the checklist was a stale unit-test expectation; that has been corrected.
-- The repo is release-ready in substance, but the working tree is not clean because the report updates and the test expectation fix are not yet committed.
-
-## Remaining Before Tag
-- commit the release-evidence updates and the stale test fix
-- obtain explicit tag approval
+- No remaining implementation blockers.
+- The active Phase 13 sprint packet required control-doc alignment in addition to the implementation and test work.
 
 ## Recommended Next Step
-Commit the release-checklist fixes/evidence, verify the worktree is clean, then execute `docs/release/v0.3.2-tag-plan.md`.
+
+Start `P13-S2: Alice Lite`, using the new one-call continuity surface as the default continuity entrypoint for install, demo, and runtime integration flows.

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -8,32 +8,27 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - Phase 10 is shipped.
 - Phase 11 is shipped.
 - Bridge `B1` through `B4` are shipped.
-- `v0.2.0` is the latest published tag.
-- `v0.3.2` is the current release target.
-- Phase 12 Sprint 1 (`P12-S1`) is shipped.
-- Phase 12 Sprint 2 (`P12-S2`) is shipped.
-- Phase 12 Sprint 3 (`P12-S3`) is shipped.
-- Phase 12 Sprint 4 (`P12-S4`) is shipped.
-- Phase 12 Sprint 5 (`P12-S5`) is shipped.
-- Phase 12 closeout and `v0.3.2` release update are the active control packet.
+- Phase 12 is shipped.
+- `v0.3.2` is the latest published tag.
+- Phase 13 is active.
+- `P13-S1` One-Call Continuity is the active execution sprint.
+- `P13-S2` Alice Lite is planned next.
+- `P13-S3` Memory Hygiene + Conversation Health is planned after Alice Lite.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
 - Alice exposes CLI, MCP, hosted/product, provider-runtime, and Hermes bridge surfaces.
-- The codebase already includes semantic retrieval, embeddings, entities/entity edges, trusted-fact promotion, retrieval evaluation fixtures, deterministic resumption briefs, daily briefs, chief-of-staff briefing flows, and the shipped `P12-S1` hybrid retrieval/reranking foundation with retrieval traces.
-- The codebase also includes the shipped `P12-S2` memory mutation candidate and operation foundation, the shipped `P12-S3` contradiction/trust foundation, the shipped `P12-S4` public eval harness, and the shipped `P12-S5` task-adaptive briefing layer.
+- The shipped baseline now includes hybrid retrieval and reranking with traces, explicit memory mutation operations, contradiction/trust handling, the public eval harness, and task-adaptive briefing.
+- `v0.3.2` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
-- Phase 12 is complete.
-- `P12-S1` is complete and establishes the retrieval baseline.
-- `P12-S2` is complete and establishes the mutation baseline.
-- `P12-S3` is complete and establishes the contradiction/trust baseline.
-- `P12-S4` is complete and establishes the public-eval baseline.
-- `P12-S5` is complete and establishes the task-adaptive briefing baseline.
-- The active docs task is phase closeout, summary, and `v0.3.2` release-target alignment.
-- There are no remaining Phase 12 feature sprints.
+- Phase 12 is complete and remains baseline truth.
+- Phase 13 is the adoption and ergonomics phase on top of that baseline.
+- `P13-S1` is active and should create the primary one-call continuity surface across API, CLI, and MCP.
+- `P13-S2` should simplify startup and local adoption without semantic drift.
+- `P13-S3` should make hygiene and thread/conversation health visible and operationally useful.
 
 ## Immediate Control Tower Decisions Needed
-- Decide when to cut the `v0.3.2` tag and release.
-- Decide whether a dedicated release-readiness pass is needed before the tag.
-- Decide the next planned phase after Phase 12 closeout.
+- Decide whether the next public release should wrap the full Phase 13 sequence or ship incrementally.
+- Decide whether Alice Lite remains purely a lighter deployment profile in `P13-S2`.
+- Decide the threshold model for risky/stale thread health in `P13-S3`.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -3,65 +3,69 @@
 ## Product Summary
 Alice is a pre-1.0 continuity platform for AI agents and agent-assisted workflows. It provides typed memory, provenance, correction-aware recall, open-loop tracking, resumable context, provider/runtime portability, and Hermes bridge integration.
 
-## Baseline Truth (Shipped)
+## Shipped Baseline
 - Phase 9 shipped the continuity core, CLI, MCP, importers, approvals, and evaluation foundation.
 - Phase 10 shipped the hosted/product layer, identity/workspace model, and channel surfaces.
 - Phase 11 shipped provider runtime abstraction, provider adapters, and model packs.
 - Bridge `B1` through `B4` shipped Hermes lifecycle hooks, auto-capture, review flow, explainability, packaging docs, smoke validation, and demo path.
+- Phase 12 shipped hybrid retrieval and reranking, explicit memory mutation operations, contradiction/trust handling, the public eval harness, and task-adaptive briefing.
+- `v0.3.2` is the latest published pre-1.0 release tag.
 
 ## Current Repo Posture
-- `v0.2.0` is tagged and released.
-- `v0.3.2` is the current release target for the completed Phase 12 boundary.
-- Release Sprint 1 (`R1`) is complete and now baseline truth.
-- Phase 12 is complete.
-- `P12-S1` Hybrid Retrieval + Reranking is shipped.
-- `P12-S2` Automated Memory Operations is shipped.
-- `P12-S3` Contradiction Detection + Trust Calibration is shipped.
-- `P12-S4` Public Eval Harness is shipped.
-- `P12-S5` Task-Adaptive Briefing is shipped.
-- Phase 12 closeout and `v0.3.2` release update are the active control-doc task.
+- Phase 13 is active.
+- `P13-S1` One-Call Continuity is the active execution sprint.
+- `P13-S2` Alice Lite is sequenced next.
+- `P13-S3` Memory Hygiene + Conversation Health follows after Alice Lite.
+- Phase 13 is an adoption and ergonomics phase built on top of the shipped Phase 12 baseline.
 
-## Completed Phase
-### Phase 12: Retrieval Quality + Adaptive Continuity
-Raise Alice from a strong continuity substrate to a measurably better memory system by improving:
-- retrieval precision
-- memory freshness handling
-- contradiction handling
-- public quality evidence
-- task-specific briefing for agents and workers
-
-## Who It Is For
-- Teams operating MCP-capable or provider-integrated agents that need durable continuity across sessions and runtimes.
-- Developers who want one continuity layer across local, self-hosted, enterprise, and external-agent paths.
-- Operators using Hermes who want always-on continuity without giving up reviewability or trust controls.
+## Active Phase
+### Phase 13: Alice Lite + Integration Ergonomics
+Turn Alice from a powerful continuity system into an easier-to-adopt, easier-to-feel, and easier-to-integrate product for solo users, builders, and agent teams.
 
 ## Why This Phase Now
-Alice already has durable memory, provenance, trust classes, revision/supersession behavior, resumption, open loops, and provider/MCP interoperability. The next phase is a quality step in the core loop:
+Phase 12 improved Alice's internal quality:
+- hybrid retrieval
+- explicit memory mutation
+- contradiction and trust handling
+- public evals
+- task-adaptive briefing
 
-`capture -> retrieve -> resume -> correct -> prove`
+Phase 13 should make those gains easier to adopt:
+- simpler local install
+- a single continuity call for external runtimes
+- visible memory hygiene
+- visible conversation health
+- tighter docs and examples for real integrations
 
-## In Scope For Phase 12
-- Hybrid retrieval and reranking.
-- Explicit memory mutation operations.
-- First-class contradiction detection and trust calibration.
-- Public multi-suite eval harness and baseline reports.
-- Task-adaptive briefing for user recall, resume, worker subtask, and agent handoff.
+## Primary Users
+- Solo technical users who want fast setup, local-first usage, and useful continuity without heavy ops.
+- Agent builders who want one integration surface and less orchestration complexity.
+- Teams evaluating Alice who want obvious quality, visible hygiene, and quick demo value.
+
+## In Scope For Phase 13
+- One-call continuity API / CLI / MCP surface.
+- Alice Lite deployment profile and simplified local startup.
+- Memory hygiene visibility for duplicates, stale facts, unresolved contradictions, weak trust, and review backlog.
+- Conversation health visibility for recent threads, stale threads, risky threads, and thread activity.
+- Integration docs and demos for existing runtimes.
 
 ## Non-Goals
-- Full graph database migration.
-- Marketplace work.
-- Enterprise/compliance expansion.
-- Latent KV-compaction research.
-- New channels such as WhatsApp.
+- New channels.
+- New major connectors.
 - New vertical products.
+- Graph-database migration.
+- Marketplace work.
+- Large enterprise/admin features.
+- New provider/runtime substrate work unless directly required to support the Phase 13 deliverables.
+- Deep new memory research.
 
 ## Success Criteria
-- Retrieval precision improves on baseline fixtures.
-- Stale or superseded facts are less likely to outrank current truth.
-- Contradictions become explicit, reviewable, and visible in explain flows.
-- Public evals can demonstrate recall, resumption, correction, contradiction, and open-loop quality.
-- Worker-task briefs are smaller and sharper than generic recall context without degrading resumption quality.
+- A solo user can install Alice through a lightweight local path and get a useful continuity brief quickly.
+- An agent builder can call one main continuity surface instead of stitching together many tool calls.
+- Memory hygiene and conversation health become visible enough that stale/conflicting/risky states are obvious without deep system knowledge.
+- Alice feels simpler and more polished without weakening its continuity semantics.
 
 ## Control Tower Decisions Needed
-- When to cut and publish the `v0.3.2` tag/release.
-- What the next planned phase is after Phase 12 closeout.
+- Whether the next public release boundary should wrap the whole Phase 13 sequence or ship incrementally.
+- Whether Alice Lite in `P13-S2` should remain a deployment-profile change only or later justify an embedded mode.
+- Exact default inclusion behavior for `/v1/continuity/brief` when query, thread, and entity context all coexist.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ durable memory for agents, agent resumption, open loop tracking, local-first ai 
 
 Alice helps agents **remember what matters, resume interrupted work, explain why something is true, and improve when corrected**.
 
-`v0.3.2` is the current **pre-1.0 release target** for the completed Phase 12 boundary. The latest published tag remains `v0.2.0` until the `v0.3.2` release is cut.
+`v0.3.2` is the current **pre-1.0 public release**.
 
 Most assistants are still good only in the moment. They can answer the current prompt, but they struggle to preserve decisions, track open loops, recover context across sessions, and stay aligned after memory corrections.
 
@@ -27,9 +27,9 @@ It provides a **local-first memory and continuity engine** for capture, recall, 
 
 **Works across local, self-hosted, enterprise, and external-agent workflows via CLI, MCP, provider runtime, OpenClaw import, and Hermes integration.**
 
-## Release Boundary (`v0.3.2` Target)
+## Release Boundary (`v0.3.2`)
 
-Completed baseline included in this pre-1.0 release target:
+Completed baseline included in this pre-1.0 public release:
 
 - Phase 9 continuity core and deterministic local CLI/MCP/importer seams
 - Phase 10 hosted/product layer
@@ -44,6 +44,8 @@ Completed baseline included in this pre-1.0 release target:
 
 Historical planning/control artifacts remain available in:
 [docs/archive/planning/2026-04-08-context-compaction/README.md](docs/archive/planning/2026-04-08-context-compaction/README.md)
+
+Phase 13 planning is active on top of this released baseline.
 
 ## Why Alice exists
 
@@ -312,7 +314,7 @@ That means the system behaves consistently across local workflows, MCP-connected
 
 ## Scope Notes
 
-Included in the `v0.3.2` target:
+Included in the `v0.3.2` release:
 
 - local-first continuity core
 - CLI and MCP surfaces

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -3,81 +3,48 @@
 ## verdict
 PASS
 
-## review scope
-Review the completed `v0.3.2` release-checklist run on current `main`, including the one release-blocking failure encountered during the checklist and the remediation applied to clear it.
-
 ## criteria met
-- Runtime bring-up passed:
-  - containers running
-  - migrations applied through `20260414_0061`
-  - sample data present
-  - `/healthz` returned `status=ok`
-- Control-doc guardrails passed.
-- Full Python regression suite passed after remediation:
-  - final result `1247 passed`
-- Web test suite passed:
-  - final result `199 passed`
-- Hermes provider smoke passed.
-- Hermes MCP smoke passed.
-- Hermes bridge demo passed.
-- Public eval harness run passed:
-  - `suite_count=5`
-  - `case_count=12`
-  - `failed_case_count=0`
-  - overall status `pass`
-- Public docs and release-boundary docs remain coherent with the completed Phase 12 baseline and the `v0.3.2` release target.
-- `CONTRIBUTING.md`, `SECURITY.md`, and `LICENSE` are present.
+- `POST /v1/continuity/brief` is implemented and returns the required one-call continuity bundle.
+- `alice brief` is implemented in the CLI surface.
+- `alice_brief` is implemented in the MCP surface.
+- The bundle includes the sprint-required sections: summary, relevant facts, recent changes, open loops, conflicts, timeline highlights, next suggested action, provenance bundle, and trust posture.
+- The implementation composes existing Phase 12 systems instead of reimplementing them: task briefing, resumption, contradiction handling, trust, and recall are reused.
+- API, CLI, and MCP remain semantically aligned in the exercised parity paths.
+- Docs make the one-call continuity surface the default external-agent integration path.
+- Wrapper-level coverage was added for the shipped Node `alice brief` path.
+- Verification passed:
+  - `python3 scripts/check_control_doc_truth.py`
+  - `./.venv/bin/pytest tests/unit/test_control_doc_truth.py tests/unit/test_cli.py tests/unit/test_mcp.py -q`
+  - `./.venv/bin/pytest tests/integration/test_continuity_brief_api.py tests/integration/test_mcp_cli_parity.py -q`
+  - `node --test packages/alice-cli/test/alice.test.mjs`
+- I did not find local workstation identifiers, usernames, or machine-specific committed paths in the changed sprint files. The MCP docs still use an obvious placeholder absolute path, which is acceptable.
 
 ## criteria missed
-- None in the release gates themselves.
+- None.
 
-## release blocker encountered and resolved
-- The first full Python-suite run failed on:
-  - `tests/unit/test_memory.py::test_get_memory_trust_dashboard_summary_is_deterministic_and_uses_canonical_components`
-- Cause:
-  - stale test expectation for retrieval `fixture_count`
-  - canonical retrieval fixture suite now contains `7` fixtures, while the test still asserted `6`
-- Resolution:
-  - updated the stale assertion to `7`
-  - reran the targeted test successfully
-  - reran the full Python gate successfully
+## quality issues
+- No blocking quality issues remain for this sprint.
+- The Node wrapper behavior is now scoped to the sprinted `alice brief` surface instead of broadening unrelated commands.
+- `ARCHITECTURE.md` now matches the implemented P13-S1 contract closely enough for follow-on work.
+- `BUILD_REPORT.md` now reflects the real changed file set and verification more accurately.
 
-## residual risk
-- Low for the current code and docs state.
-- The remaining operational risk is procedural:
-  - the working tree is still dirty because the checklist evidence and test-fix changes are not yet committed
-  - explicit tag approval is still required
+## regression risks
+- Normal continuity-surface regression risk remains in shared retrieval/briefing code, but it is covered by the added API/MCP/CLI parity tests.
+- Wrapper behavior is now covered by direct Node tests, which reduces package-level regression risk for `alice brief`.
 
 ## docs issues
-- No blocking docs issue remains.
-- One checklist wording issue was identified during execution:
-  - release verification on merged `main` is valid per the tag plan, even though the checklist currently emphasizes a closeout/release-prep branch
+- No blocking docs issues remain for this sprint.
+- Future planning docs for later Phase 13 work are no longer coupled into the control-doc truth gate, which is the right scope boundary.
+
+## should anything be added to RULES.md?
+No additional rule is required to accept this sprint.
+
+The current rule set is sufficient after the follow-up fixes.
+
+## should anything update ARCHITECTURE.md?
+No further update is required for this sprint review.
+
+The P13-S1 contract description is now aligned with the implemented surface closely enough to proceed.
 
 ## recommended next action
-Commit the release-checklist evidence updates and the stale test fix, then proceed to the `v0.3.2` tag plan once explicit tag approval is granted.
-
-## reviewer verification
-- `docker compose up -d`
-  - Result: PASS
-- `./scripts/migrate.sh`
-  - Result: PASS
-- `./scripts/load_sample_data.sh`
-  - Result: PASS (`status=noop`)
-- `curl -sS http://127.0.0.1:8000/healthz`
-  - Result: PASS
-- `python3 scripts/check_control_doc_truth.py`
-  - Result: PASS
-- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-  - Result: PASS (`5 passed`)
-- `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-  - Result: PASS (`1247 passed`) after correcting one stale assertion in `tests/unit/test_memory.py`
-- `pnpm --dir apps/web test`
-  - Result: PASS (`199 passed`)
-- `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py`
-  - Result: PASS
-- `./.venv/bin/python scripts/run_hermes_mcp_smoke.py`
-  - Result: PASS
-- `./.venv/bin/python scripts/run_hermes_bridge_demo.py`
-  - Result: PASS
-- `./.venv/bin/python -m alicebot_api --database-url postgresql://alicebot_app:alicebot_app@localhost:5432/alicebot --user-id 00000000-0000-0000-0000-000000000001 evals run --report-path eval/baselines/public_eval_harness_v1.json`
-  - Result: PASS
+Start `P13-S2: Alice Lite`, using the new one-call continuity surface as the default continuity entrypoint for install, demo, and runtime integration flows.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,50 +6,47 @@
 - Phase 11: shipped
 - Bridge `B1`-`B4`: shipped
 - Bridge Phase (`B1`-`B4`): shipped
-- `v0.2.0`: released
 - Phase 12: shipped
-- `v0.3.2`: current release target
+- `v0.3.2`: released
 
 These remain baseline truth and are not future milestones.
 
 ## Active Planning Status
-- Phase 12 closeout and `v0.3.2` release update are the active control packet.
-- No remaining Phase 12 feature sprints are open.
+- Phase 13 is active.
+- `P13-S1` One-Call Continuity is the active execution sprint.
+- `P13-S2` Alice Lite is queued next.
+- `P13-S3` Memory Hygiene + Conversation Health follows after Alice Lite.
 
-## Phase 12 Completed Milestones
+## Phase 13 Planned Milestones
 
-### P12-S1: Hybrid Retrieval + Reranking
-- add hybrid retrieval pipeline
-- add reranking and retrieval traces
-- expose debug visibility through API, CLI, and MCP
+### P13-S1: One-Call Continuity
+- ship `POST /v1/continuity/brief`
+- ship matching CLI `alice brief`
+- ship matching MCP `alice_brief`
+- return one continuity bundle containing summary, recent changes, open loops, conflicts, next action, provenance, and trust posture
+- make this the default integration surface for external agents
 
-### P12-S2: Automated Memory Operations
-- add explicit memory operation candidates and commit engine
-- define auto-apply vs review thresholds
+### P13-S2: Alice Lite
+- add one-command local startup
+- add smaller-footprint deployment profile
+- tighten quickstart and first-result path
+- keep semantics aligned with the full Alice baseline
 
-### P12-S3: Contradiction Detection + Trust Calibration
-- add contradiction cases and resolution flow
-- add trust-signal computation and retrieval penalties
-
-### P12-S4: Public Eval Harness
-- ship public fixture suites and local eval runner
-- commit baseline reports and eval docs
-
-### P12-S5: Task-Adaptive Briefing
-- add brief compiler and brief modes
-- integrate provider/model-pack briefing strategy
-
-## Release Sequencing Applied
-- `v0.3.0`: retrieval and memory quality (`P12-S1` through `P12-S3`)
-- `v0.3.1`: public evaluation (`P12-S4`)
-- `v0.3.2`: task-adaptive briefing (`P12-S5`)
+### P13-S3: Memory Hygiene + Conversation Health
+- surface duplicates, stale facts, unresolved contradictions, and review queue pressure
+- surface recent threads, stale threads, risky threads, and thread health
+- improve operational visibility without adding new substrate work
 
 ## Sequencing Rules
-- Keep shipped baseline out of roadmap sections.
-- Do not widen Phase 12 into graph migration, marketplace, enterprise/compliance, or new channel work.
-- Use eval evidence to justify public quality claims before updating release docs.
-- Treat later releases as separate contracts; do not collapse all Phase 12 work into one oversized sprint.
+- Phase 13 is an adoption layer on top of the shipped Phase 12 baseline.
+- Prioritize one-call continuity first, then Alice Lite, then hygiene and conversation health.
+- Do not add new substrate work unless it is required to support those deliverables.
+- Judge every Phase 13 change against three questions:
+  - does this reduce integration complexity?
+  - does this improve first-run experience?
+  - does this make memory quality more visible?
+- Do not widen Phase 13 into retrieval research, graph-database migration, new channels, new provider/runtime work, marketplace work, or enterprise/admin expansion.
 
-## Beyond Phase 12
-- No post-Phase-12 feature plan is currently defined.
-- The next step is either cutting the `v0.3.2` release or planning the next phase.
+## Beyond Phase 13
+- No post-Phase-13 feature plan is currently defined.
+- The next step after Phase 13 is to decide the next release boundary and the next phase.

--- a/RULES.md
+++ b/RULES.md
@@ -1,50 +1,46 @@
 # Rules
 
 ## State Discipline
-- Treat Phases 9-11 and Bridge `B1` through `B4` as shipped baseline truth.
-- Treat `v0.2.0` as released baseline truth.
-- Treat `v0.3.2` as the current completed release target until the next tag is cut.
+- Treat Phases 9-12 and Bridge `B1` through `B4` as shipped baseline truth.
+- Treat `v0.3.2` as released baseline truth.
 - Keep shipped baseline, active phase scope, and later roadmap scope separate.
 - Keep [CURRENT_STATE.md](CURRENT_STATE.md) factual/current and [ROADMAP.md](ROADMAP.md) future-facing.
 - Keep [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURRENT_STATE.md) as the canonical handoff copy when duplicate current-state files exist.
 
-## Retrieval Rules
-- Retrieval must remain explainable: every result should be traceable to source objects, trust posture, timestamps, and lifecycle status.
-- New ranking stages may improve selection quality, but they must not bypass supersession, provenance, or trust controls already in Alice.
-- Retrieval changes should be benchmarked against fixture baselines before becoming default behavior.
+## Phase 13 Rules
+- Phase 13 is an adoption layer on top of the shipped `v0.3.2` baseline.
+- Prioritize one-call continuity first, then Alice Lite, then hygiene and conversation health.
+- Only admit new substrate work when it is required to support those deliverables.
+- If a proposed Phase 13 change does not reduce integration complexity, improve first-run experience, or make memory quality more visible, it probably does not belong in Phase 13.
 
-## Mutation Rules
-- Treat memory mutation as an explicit operation, not a silent overwrite.
-- Corrections and changed facts should prefer `SUPERSEDE` or `UPDATE` semantics over destructive replacement.
-- Low-confidence or inferred mutations default to review.
-- Repeated syncs and retries must be idempotent.
+## Continuity Surface Rules
+- One-call continuity must compose existing retrieval, contradiction, trust, recent-change, open-loop, and briefing layers rather than fork them.
+- One-call continuity output must remain explainable, provenance-backed, and trust-aware.
+- Do not fork continuity semantics between API, CLI, MCP, hosted, provider-runtime, and Hermes paths.
 
-## Contradiction And Trust Rules
-- Contradictions must become reviewable objects, not hidden ranking artifacts.
-- Unresolved contradictions should reduce promotion and retrieval confidence.
-- Human correction and repeated corroboration may raise trust; weak single-source inference must not silently gain durable authority.
+## Alice Lite Rules
+- Alice Lite is a deployment profile, not a separate product.
+- Alice Lite must preserve the same continuity semantics as the full baseline.
+- Do not move to SQLite or another embedded mode unless no semantics degrade, no retrieval features materially regress, and no explain/provenance breakage is introduced.
 
-## Briefing Rules
-- Keep durable memory separate from compiled briefs.
-- Different workloads may receive different context packs, but all briefing outputs must remain deterministic and explainable.
-- Briefing must not introduce claims that the underlying memory layer cannot justify.
+## Hygiene And Thread Health Rules
+- Hygiene surfaces should make duplicates, stale facts, contradictions, weak trust, and review pressure visible without inventing a second memory system.
+- Thread health should be diagnostic and operational, not a separate durable truth ontology.
+- Visibility comes before cleverness. Make risky or stale states obvious before adding more scoring complexity.
 
-## API And Architecture Rules
+## API And Integration Rules
 - For Hermes, use provider hooks for automation and MCP for explicit deep actions.
-- Never fork continuity semantics by surface or runtime.
-- Reuse the current continuity contracts where possible; add new surfaces only when the existing contract cannot express the phase goal cleanly.
-- Do not fork semantics between CLI, MCP, hosted, provider-runtime, and Hermes paths.
 - Keep MCP fallback viable even when provider or bridge integrations are the recommended mode.
+- Reuse the current continuity contracts where possible; add new surfaces only when the existing contract cannot express the phase goal cleanly.
 
 ## Security And Operations Rules
-- Preserve user/workspace isolation across retrieval, mutation, eval, and briefing flows.
+- Preserve user/workspace isolation across retrieval, mutation, eval, briefing, hygiene, and thread-health flows.
 - Keep credentials, tokens, and secret references out of logs and error payloads.
 - Keep local filesystem paths, workstation usernames, and machine-specific identifiers out of committed docs and reports.
 - Keep consequential side effects approval-bounded.
 - Commit public evidence only from exact commands and stable fixtures, never from inferred pass states.
-- When a checked-in fixture catalog is declared canonical, runtime sync must prune removed definitions or read directly from the catalog as the source of truth.
 
 ## Scope Rules
-- Do not widen Phase 12 into graph migration, marketplace, enterprise/compliance, or new channel work.
-- Do not silently hardcode unresolved sprint Control Tower decisions as permanent runtime behavior without recording the decision.
+- Do not widen Phase 13 into retrieval research, graph migration, new channels, new provider/runtime work, marketplace work, or enterprise/admin expansion.
+- Do not silently hardcode unresolved Control Tower decisions as permanent runtime behavior without recording the decision.
 - Surface underspecified decisions as Control Tower decisions instead of inventing scope.

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -16,6 +16,7 @@ import psycopg
 from alicebot_api.cli_formatting import (
     format_artifact_detail_output,
     format_capture_output,
+    format_continuity_brief_output,
     format_contradiction_case_detail_output,
     format_contradiction_case_list_output,
     format_contradiction_sync_output,
@@ -47,6 +48,10 @@ from alicebot_api.config import Settings, get_settings
 from alicebot_api.continuity_capture import (
     ContinuityCaptureValidationError,
     capture_continuity_input,
+)
+from alicebot_api.continuity_brief import (
+    ContinuityBriefValidationError,
+    compile_continuity_brief,
 )
 from alicebot_api.continuity_evidence import (
     ContinuityEvidenceNotFoundError,
@@ -102,7 +107,11 @@ from alicebot_api.contracts import (
     CONTINUITY_CAPTURE_EXPLICIT_SIGNALS,
     CONTINUITY_CORRECTION_ACTIONS,
     CONTRADICTION_RESOLUTION_ACTIONS,
+    CONTINUITY_BRIEF_TYPE_ORDER,
     DEFAULT_CONTINUITY_CAPTURE_LIMIT,
+    DEFAULT_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+    DEFAULT_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+    DEFAULT_CONTINUITY_BRIEF_TIMELINE_LIMIT,
     DEFAULT_CONTINUITY_LIFECYCLE_LIMIT,
     DEFAULT_CONTINUITY_OPEN_LOOP_LIMIT,
     DEFAULT_CONTINUITY_RECALL_LIMIT,
@@ -115,6 +124,9 @@ from alicebot_api.contracts import (
     MAX_CONTINUITY_REVIEW_LIMIT,
     MAX_CONTINUITY_OPEN_LOOP_LIMIT,
     MAX_CONTINUITY_RECALL_LIMIT,
+    MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+    MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+    MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT,
     MAX_CONTINUITY_LIFECYCLE_LIMIT,
     MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
     MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
@@ -125,6 +137,7 @@ from alicebot_api.contracts import (
     ContradictionResolveInput,
     ContradictionSyncInput,
     ContinuityCaptureCreateInput,
+    ContinuityBriefRequestInput,
     ContinuityCorrectionInput,
     ContinuityLifecycleQueryInput,
     ContinuityOpenLoopDashboardQueryInput,
@@ -273,6 +286,51 @@ def _add_task_brief_arguments(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=None,
         help=f"Optional explicit token budget (1-{MAX_TASK_BRIEF_TOKEN_BUDGET}).",
+    )
+
+
+def _add_continuity_brief_arguments(parser: argparse.ArgumentParser) -> None:
+    _add_scope_filter_arguments(parser)
+    parser.add_argument(
+        "--brief-type",
+        choices=CONTINUITY_BRIEF_TYPE_ORDER,
+        default="general",
+        help="One-call continuity brief type.",
+    )
+    parser.add_argument(
+        "--max-relevant-facts",
+        type=int,
+        default=DEFAULT_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+        help=f"Maximum relevant facts ({0}-{MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT}).",
+    )
+    parser.add_argument(
+        "--max-recent-changes",
+        type=int,
+        default=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        help=f"Maximum recent changes ({0}-{MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT}).",
+    )
+    parser.add_argument(
+        "--max-open-loops",
+        type=int,
+        default=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+        help=f"Maximum open loops ({0}-{MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT}).",
+    )
+    parser.add_argument(
+        "--max-conflicts",
+        type=int,
+        default=DEFAULT_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+        help=f"Maximum open conflicts ({0}-{MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT}).",
+    )
+    parser.add_argument(
+        "--max-timeline-highlights",
+        type=int,
+        default=DEFAULT_CONTINUITY_BRIEF_TIMELINE_LIMIT,
+        help=f"Maximum timeline highlights ({0}-{MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT}).",
+    )
+    parser.add_argument(
+        "--include-non-promotable-facts",
+        action="store_true",
+        help="Include searchable but non-promotable facts where the brief type allows it.",
     )
 
 
@@ -547,6 +605,31 @@ def _run_resume(ctx: CLIContext, args: argparse.Namespace) -> str:
             ),
         )
     return format_resume_output(payload)
+
+
+def _run_brief(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _store_context(ctx) as store:
+        payload = compile_continuity_brief(
+            store,
+            user_id=ctx.user_id,
+            request=ContinuityBriefRequestInput(
+                brief_type=args.brief_type,
+                query=args.query,
+                thread_id=args.thread_id,
+                task_id=args.task_id,
+                project=args.project,
+                person=args.person,
+                since=args.since,
+                until=args.until,
+                max_relevant_facts=args.max_relevant_facts,
+                max_recent_changes=args.max_recent_changes,
+                max_open_loops=args.max_open_loops,
+                max_conflicts=args.max_conflicts,
+                max_timeline_highlights=args.max_timeline_highlights,
+                include_non_promotable_facts=args.include_non_promotable_facts,
+            ),
+        )
+    return format_continuity_brief_output(payload)
 
 
 def _task_brief_request_from_args(args: argparse.Namespace) -> TaskBriefCompileRequestInput:
@@ -1142,6 +1225,13 @@ def build_parser() -> argparse.ArgumentParser:
     mutation_operations_parser.add_argument("--sync-fingerprint", default=None, help="Optional sync fingerprint.")
     mutation_operations_parser.set_defaults(handler=_run_mutation_operations)
 
+    brief_parser = subparsers.add_parser(
+        "brief",
+        help="Compile the primary one-call continuity brief.",
+    )
+    _add_continuity_brief_arguments(brief_parser)
+    brief_parser.set_defaults(handler=_run_brief)
+
     recall_parser = subparsers.add_parser("recall", help="Recall continuity objects.")
     _add_scope_filter_arguments(recall_parser)
     recall_parser.add_argument(
@@ -1605,6 +1695,37 @@ def _validate_arguments(args: argparse.Namespace) -> None:
             minimum=1,
             maximum=MAX_TEMPORAL_TIMELINE_LIMIT,
         )
+    elif args.command == "brief":
+        _validate_limit(
+            args.max_relevant_facts,
+            option_name="--max-relevant-facts",
+            minimum=0,
+            maximum=MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+        )
+        _validate_limit(
+            args.max_recent_changes,
+            option_name="--max-recent-changes",
+            minimum=0,
+            maximum=MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        )
+        _validate_limit(
+            args.max_open_loops,
+            option_name="--max-open-loops",
+            minimum=0,
+            maximum=MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+        )
+        _validate_limit(
+            args.max_conflicts,
+            option_name="--max-conflicts",
+            minimum=0,
+            maximum=MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+        )
+        _validate_limit(
+            args.max_timeline_highlights,
+            option_name="--max-timeline-highlights",
+            minimum=0,
+            maximum=MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT,
+        )
     elif args.command == "lifecycle" and args.lifecycle_command == "list":
         _validate_limit(
             args.limit,
@@ -1686,6 +1807,7 @@ def main(argv: list[str] | None = None) -> int:
         ContinuityLifecycleValidationError,
         ContinuityLifecycleNotFoundError,
         ContinuityRecallValidationError,
+        ContinuityBriefValidationError,
         ContinuityResumptionValidationError,
         ContinuityOpenLoopValidationError,
         ContinuityReviewValidationError,

--- a/apps/api/src/alicebot_api/cli_formatting.py
+++ b/apps/api/src/alicebot_api/cli_formatting.py
@@ -5,6 +5,7 @@ from typing import Mapping, Sequence
 
 from alicebot_api.contracts import (
     ContinuityArtifactDetailResponse,
+    ContinuityBriefResponse,
     ContinuityCaptureCreateResponse,
     ContinuityCorrectionApplyResponse,
     ContradictionCaseDetailResponse,
@@ -426,6 +427,121 @@ def format_resume_output(payload: ContinuityResumptionBriefResponse) -> str:
         lines.extend(_render_recall_item(next_action["item"]))
 
     lines.extend(_render_retrieval_debug(payload))
+    return "\n".join(lines)
+
+
+def format_continuity_brief_output(payload: ContinuityBriefResponse) -> str:
+    brief = payload["brief"]
+    lines = [
+        "continuity brief",
+        f"brief_type: {brief['brief_type']}",
+        f"assembly_version: {brief['assembly_version']}",
+        f"scope: {_format_scope(brief['scope'])}",
+        f"summary: {brief['summary']}",
+        (
+            "selection_strategy: "
+            f"mode={brief['selection_strategy']['task_brief_mode']} "
+            f"provider={brief['selection_strategy']['provider_strategy']} "
+            f"model_pack={brief['selection_strategy']['model_pack_strategy']} "
+            f"token_budget={brief['selection_strategy']['token_budget']} "
+            f"budget_source={brief['selection_strategy']['budget_source']}"
+        ),
+        (
+            "trust_posture: "
+            f"confidence={brief['trust_posture']['confidence_posture']} "
+            f"average_confidence={_format_float(brief['trust_posture']['average_confidence'])} "
+            f"strongest_trust_class={brief['trust_posture']['strongest_trust_class']} "
+            f"weakest_provenance={brief['trust_posture']['weakest_provenance_posture']} "
+            f"active_signals={brief['trust_posture']['active_signal_count']} "
+            f"open_conflicts={brief['trust_posture']['open_conflict_count']}"
+        ),
+        f"trust_rationale: {brief['trust_posture']['rationale']}",
+        (
+            "provenance_bundle: "
+            f"source_objects={brief['provenance_bundle']['summary']['source_object_count']} "
+            f"references={brief['provenance_bundle']['summary']['reference_count']} "
+            f"reference_kinds={brief['provenance_bundle']['summary']['reference_kind_count']}"
+        ),
+        f"sources: {', '.join(brief['sources'])}",
+    ]
+
+    lines.extend(
+        _render_recall_list_section(
+            title="relevant_facts",
+            items=brief["relevant_facts"]["items"],
+            limit=brief["relevant_facts"]["summary"]["limit"],
+            total_count=brief["relevant_facts"]["summary"]["total_count"],
+            order=brief["relevant_facts"]["summary"]["order"],
+            empty_message=brief["relevant_facts"]["empty_state"]["message"],
+        )
+    )
+    lines.extend(
+        _render_recall_list_section(
+            title="recent_changes",
+            items=brief["recent_changes"]["items"],
+            limit=brief["recent_changes"]["summary"]["limit"],
+            total_count=brief["recent_changes"]["summary"]["total_count"],
+            order=brief["recent_changes"]["summary"]["order"],
+            empty_message=brief["recent_changes"]["empty_state"]["message"],
+        )
+    )
+    lines.extend(
+        _render_recall_list_section(
+            title="open_loops",
+            items=brief["open_loops"]["items"],
+            limit=brief["open_loops"]["summary"]["limit"],
+            total_count=brief["open_loops"]["summary"]["total_count"],
+            order=brief["open_loops"]["summary"]["order"],
+            empty_message=brief["open_loops"]["empty_state"]["message"],
+        )
+    )
+
+    lines.append("conflicts:")
+    if len(brief["conflicts"]["items"]) == 0:
+        lines.append(f"  empty: {brief['conflicts']['empty_state']['message']}")
+    else:
+        lines.append(
+            "  "
+            f"returned={brief['conflicts']['summary']['returned_count']} "
+            f"total={brief['conflicts']['summary']['total_count']} "
+            f"limit={brief['conflicts']['summary']['limit']}"
+        )
+        for index, case in enumerate(brief["conflicts"]["items"], start=1):
+            lines.append(
+                "  "
+                f"{index}. [{case['kind']}|{case['status']}] "
+                f"{case['continuity_object']['title']} <> {case['counterpart_object']['title']}"
+            )
+            lines.append(f"    case_id={case['id']} rationale={case['rationale']}")
+
+    lines.append("timeline_highlights:")
+    if len(brief["timeline_highlights"]["items"]) == 0:
+        lines.append(f"  empty: {brief['timeline_highlights']['empty_state']['message']}")
+    else:
+        for index, item in enumerate(brief["timeline_highlights"]["items"], start=1):
+            lines.append(
+                "  "
+                f"{index}. [{item['object_type']}|{item['status']}] {item['title']} "
+                f"created_at={item['created_at']} source_section={item['source_section']}"
+            )
+
+    lines.append("next_suggested_action:")
+    lines.append(f"  title: {brief['next_suggested_action']['title']}")
+    lines.append(f"  object_type: {brief['next_suggested_action']['object_type']}")
+    lines.append(f"  continuity_object_id: {brief['next_suggested_action']['continuity_object_id']}")
+    lines.append(f"  confidence_posture: {brief['next_suggested_action']['confidence_posture']}")
+    lines.append(f"  reason: {brief['next_suggested_action']['reason']}")
+    lines.append(
+        "  provenance_refs: "
+        + (
+            "; ".join(
+                f"{ref['source_kind']}:{ref['source_id']}"
+                for ref in brief["next_suggested_action"]["provenance_references"]
+            )
+            if brief["next_suggested_action"]["provenance_references"]
+            else "(none)"
+        )
+    )
     return "\n".join(lines)
 
 

--- a/apps/api/src/alicebot_api/continuity_brief.py
+++ b/apps/api/src/alicebot_api/continuity_brief.py
@@ -1,0 +1,670 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from alicebot_api.continuity_contradictions import list_contradiction_cases
+from alicebot_api.continuity_resumption import compile_continuity_resumption_brief
+from alicebot_api.continuity_trust import list_trust_signals
+from alicebot_api.contracts import (
+    CONTINUITY_BRIEF_ASSEMBLY_VERSION_V0,
+    CONTINUITY_BRIEF_TYPE_ORDER,
+    CONTRADICTION_CASE_LIST_ORDER,
+    DEFAULT_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+    DEFAULT_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+    DEFAULT_CONTINUITY_BRIEF_TIMELINE_LIMIT,
+    DEFAULT_CONTINUITY_REVIEW_LIMIT,
+    DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+    MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+    MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT,
+    MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    TASK_BRIEF_SECTION_ITEM_ORDER,
+    ChiefOfStaffRecommendationConfidencePosture,
+    ContinuityBriefConflictSection,
+    ContinuityBriefConflictSummary,
+    ContinuityBriefProvenanceBundle,
+    ContinuityBriefProvenanceSummary,
+    ContinuityBriefRecord,
+    ContinuityBriefRelevantFactsSection,
+    ContinuityBriefRelevantFactsSummary,
+    ContinuityBriefRequestInput,
+    ContinuityBriefResponse,
+    ContinuityBriefSelectionStrategyRecord,
+    ContinuityBriefSuggestedActionRecord,
+    ContinuityBriefTimelineHighlightRecord,
+    ContinuityBriefTimelineSection,
+    ContinuityBriefTrustPostureRecord,
+    ContinuityRecallProvenancePosture,
+    ContinuityRecallProvenanceReference,
+    ContinuityRecallResultRecord,
+    ContinuityResumptionBriefRequestInput,
+    ContinuityResumptionEmptyState,
+    ContinuityResumptionListSection,
+    ContradictionCaseListQueryInput,
+    ContradictionCaseRecord,
+    MemoryTrustClass,
+    TaskBriefCompileRequestInput,
+    TaskBriefMode,
+    TrustSignalListQueryInput,
+    TrustSignalRecord,
+)
+from alicebot_api.store import ContinuityStore
+from alicebot_api.task_briefing import compile_task_brief_record
+
+
+class ContinuityBriefValidationError(ValueError):
+    """Raised when a continuity brief request is invalid."""
+
+
+_BRIEF_TYPE_TO_MODE: dict[str, tuple[TaskBriefMode, str | None]] = {
+    "general": ("user_recall", None),
+    "resume": ("resume", None),
+    "agent_handoff": ("agent_handoff", None),
+    "coding_context": ("worker_subtask", "compact"),
+    "operator_context": ("agent_handoff", "detailed"),
+}
+_TRUST_CLASS_RANK: dict[MemoryTrustClass, int] = {
+    "human_curated": 4,
+    "deterministic": 3,
+    "llm_corroborated": 2,
+    "llm_single_source": 1,
+}
+_PROVENANCE_RANK: dict[ContinuityRecallProvenancePosture, int] = {
+    "strong": 3,
+    "partial": 2,
+    "weak": 1,
+    "missing": 0,
+}
+_SOURCE_PRECEDENCE = {
+    "recent_changes": 0,
+    "open_loops": 1,
+    "relevant_facts": 2,
+    "next_suggested_action": 3,
+}
+
+
+def _build_empty_state(*, is_empty: bool, message: str) -> ContinuityResumptionEmptyState:
+    return {
+        "is_empty": is_empty,
+        "message": message,
+    }
+
+
+def _dedupe_items(items: list[ContinuityRecallResultRecord]) -> list[ContinuityRecallResultRecord]:
+    deduped: list[ContinuityRecallResultRecord] = []
+    seen_ids: set[str] = set()
+    for item in items:
+        item_id = item["id"]
+        if item_id in seen_ids:
+            continue
+        seen_ids.add(item_id)
+        deduped.append(item)
+    return deduped
+
+
+def _recency_sort_key(item: ContinuityRecallResultRecord) -> tuple[str, str]:
+    return (item["created_at"], item["id"])
+
+
+def _validate_request(request: ContinuityBriefRequestInput) -> None:
+    if request.brief_type not in CONTINUITY_BRIEF_TYPE_ORDER:
+        raise ContinuityBriefValidationError(
+            "brief_type must be one of: " + ", ".join(CONTINUITY_BRIEF_TYPE_ORDER)
+        )
+    if request.max_relevant_facts < 0 or request.max_relevant_facts > MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT:
+        raise ContinuityBriefValidationError(
+            "max_relevant_facts must be between "
+            f"0 and {MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT}"
+        )
+    if request.max_recent_changes < 0 or request.max_recent_changes > MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT:
+        raise ContinuityBriefValidationError(
+            "max_recent_changes must be between "
+            f"0 and {MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT}"
+        )
+    if request.max_open_loops < 0 or request.max_open_loops > MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT:
+        raise ContinuityBriefValidationError(
+            "max_open_loops must be between "
+            f"0 and {MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT}"
+        )
+    if request.max_conflicts < 0 or request.max_conflicts > MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT:
+        raise ContinuityBriefValidationError(
+            f"max_conflicts must be between 0 and {MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT}"
+        )
+    if request.max_timeline_highlights < 0 or request.max_timeline_highlights > MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT:
+        raise ContinuityBriefValidationError(
+            "max_timeline_highlights must be between "
+            f"0 and {MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT}"
+        )
+    if request.since is not None and request.until is not None and request.until < request.since:
+        raise ContinuityBriefValidationError("until must be greater than or equal to since")
+
+
+def _task_brief_request_for(request: ContinuityBriefRequestInput) -> TaskBriefCompileRequestInput:
+    task_brief_mode, model_pack_strategy = _BRIEF_TYPE_TO_MODE[request.brief_type]
+    return TaskBriefCompileRequestInput(
+        mode=task_brief_mode,
+        query=request.query,
+        thread_id=request.thread_id,
+        task_id=request.task_id,
+        project=request.project,
+        person=request.person,
+        since=request.since,
+        until=request.until,
+        include_non_promotable_facts=request.include_non_promotable_facts,
+        provider_strategy=f"continuity_brief.{request.brief_type}",
+        model_pack_strategy=model_pack_strategy,
+    )
+
+
+def _build_relevant_facts_section(
+    *,
+    task_brief_mode: TaskBriefMode,
+    candidates: list[ContinuityRecallResultRecord],
+    limit: int,
+) -> ContinuityBriefRelevantFactsSection:
+    items = candidates[:limit] if limit > 0 else []
+    summary: ContinuityBriefRelevantFactsSummary = {
+        "limit": limit,
+        "returned_count": len(items),
+        "total_count": len(candidates),
+        "order": list(TASK_BRIEF_SECTION_ITEM_ORDER),
+        "task_brief_mode": task_brief_mode,
+    }
+    return {
+        "items": items,
+        "summary": summary,
+        "empty_state": _build_empty_state(
+            is_empty=len(items) == 0,
+            message="No relevant facts found in the requested scope.",
+        ),
+    }
+
+
+def _collect_open_conflict_ids(items: list[ContinuityRecallResultRecord]) -> list[str]:
+    seen: set[str] = set()
+    collected: list[str] = []
+    for item in items:
+        contradictions = item["explanation"]["contradictions"]
+        for case_id in contradictions["open_case_ids"]:
+            if case_id in seen:
+                continue
+            seen.add(case_id)
+            collected.append(case_id)
+    return collected
+
+
+def _build_conflict_section(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    items: list[ContinuityRecallResultRecord],
+    limit: int,
+) -> ContinuityBriefConflictSection:
+    open_case_ids = _collect_open_conflict_ids(items)
+    if limit <= 0 or len(open_case_ids) == 0:
+        empty_summary: ContinuityBriefConflictSummary = {
+            "limit": limit,
+            "returned_count": 0,
+            "total_count": len(open_case_ids),
+            "order": list(CONTRADICTION_CASE_LIST_ORDER),
+        }
+        return {
+            "items": [],
+            "summary": empty_summary,
+            "empty_state": _build_empty_state(
+                is_empty=True,
+                message="No open conflicts found in the requested scope.",
+            ),
+        }
+
+    seen_case_ids: set[str] = set()
+    gathered: list[ContradictionCaseRecord] = []
+    for item in items:
+        contradiction_payload = list_contradiction_cases(
+            store,
+            user_id=user_id,
+            request=ContradictionCaseListQueryInput(
+                status="open",
+                limit=MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+                continuity_object_id=UUID(item["id"]),
+            ),
+        )
+        for case in contradiction_payload["items"]:
+            if case["id"] in seen_case_ids:
+                continue
+            seen_case_ids.add(case["id"])
+            gathered.append(case)
+
+    gathered.sort(key=lambda case: (case["updated_at"], case["id"]), reverse=True)
+    limited_items = gathered[:limit]
+    summary: ContinuityBriefConflictSummary = {
+        "limit": limit,
+        "returned_count": len(limited_items),
+        "total_count": len(open_case_ids),
+        "order": list(CONTRADICTION_CASE_LIST_ORDER),
+    }
+    return {
+        "items": limited_items,
+        "summary": summary,
+        "empty_state": _build_empty_state(
+            is_empty=len(limited_items) == 0,
+            message="No open conflicts found in the requested scope.",
+        ),
+    }
+
+
+def _build_timeline_section(
+    *,
+    relevant_facts: list[ContinuityRecallResultRecord],
+    recent_changes: ContinuityResumptionListSection,
+    open_loops: ContinuityResumptionListSection,
+    next_action: ContinuityRecallResultRecord | None,
+    limit: int,
+) -> ContinuityBriefTimelineSection:
+    timeline_candidates: list[tuple[str, ContinuityRecallResultRecord]] = []
+    timeline_candidates.extend(("recent_changes", item) for item in recent_changes["items"])
+    timeline_candidates.extend(("open_loops", item) for item in open_loops["items"])
+    timeline_candidates.extend(("relevant_facts", item) for item in relevant_facts)
+    if next_action is not None:
+        timeline_candidates.append(("next_suggested_action", next_action))
+
+    by_id: dict[str, tuple[str, ContinuityRecallResultRecord]] = {}
+    for source_section, item in timeline_candidates:
+        existing = by_id.get(item["id"])
+        if existing is None:
+            by_id[item["id"]] = (source_section, item)
+            continue
+        if _SOURCE_PRECEDENCE[source_section] < _SOURCE_PRECEDENCE[existing[0]]:
+            by_id[item["id"]] = (source_section, item)
+
+    ordered = sorted(
+        by_id.values(),
+        key=lambda candidate: (candidate[1]["created_at"], candidate[1]["id"]),
+        reverse=True,
+    )
+    limited = ordered[:limit] if limit > 0 else []
+    items: list[ContinuityBriefTimelineHighlightRecord] = [
+        {
+            "continuity_object_id": item["id"],
+            "title": item["title"],
+            "object_type": item["object_type"],
+            "status": item["status"],
+            "created_at": item["created_at"],
+            "source_section": source_section,
+        }
+        for source_section, item in limited
+    ]
+    return {
+        "items": items,
+        "summary": {
+            "limit": limit,
+            "returned_count": len(items),
+            "total_count": len(ordered),
+            "order": ["created_at_desc", "id_desc"],
+        },
+        "empty_state": _build_empty_state(
+            is_empty=len(items) == 0,
+            message="No timeline highlights found in the requested scope.",
+        ),
+    }
+
+
+def _collect_provenance_bundle(items: list[ContinuityRecallResultRecord]) -> ContinuityBriefProvenanceBundle:
+    source_object_ids = sorted({item["id"] for item in items})
+    reference_pairs = sorted(
+        {
+            (reference["source_kind"], reference["source_id"])
+            for item in items
+            for reference in item["provenance_references"]
+        }
+    )
+    references: list[ContinuityRecallProvenanceReference] = [
+        {
+            "source_kind": source_kind,
+            "source_id": source_id,
+        }
+        for source_kind, source_id in reference_pairs
+    ]
+    summary: ContinuityBriefProvenanceSummary = {
+        "source_object_count": len(source_object_ids),
+        "reference_count": len(references),
+        "reference_kind_count": len({reference["source_kind"] for reference in references}),
+    }
+    return {
+        "source_object_ids": source_object_ids,
+        "references": references,
+        "summary": summary,
+    }
+
+
+def _strongest_trust_class(items: list[ContinuityRecallResultRecord]) -> MemoryTrustClass | None:
+    strongest: MemoryTrustClass | None = None
+    strongest_rank = -1
+    for item in items:
+        trust_class = item["ordering"]["trust_class"]
+        rank = _TRUST_CLASS_RANK[trust_class]
+        if rank > strongest_rank:
+            strongest = trust_class
+            strongest_rank = rank
+    return strongest
+
+
+def _weakest_provenance_posture(
+    items: list[ContinuityRecallResultRecord],
+) -> ContinuityRecallProvenancePosture | None:
+    weakest: ContinuityRecallProvenancePosture | None = None
+    weakest_rank = 99
+    for item in items:
+        posture = item["ordering"]["provenance_posture"]
+        rank = _PROVENANCE_RANK[posture]
+        if rank < weakest_rank:
+            weakest = posture
+            weakest_rank = rank
+    return weakest
+
+
+def _confidence_posture(average_confidence: float) -> ChiefOfStaffRecommendationConfidencePosture:
+    if average_confidence >= 0.8:
+        return "high"
+    if average_confidence >= 0.55:
+        return "medium"
+    return "low"
+
+
+def _collect_active_signals(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    items: list[ContinuityRecallResultRecord],
+) -> list[TrustSignalRecord]:
+    seen_signal_ids: set[str] = set()
+    gathered: list[TrustSignalRecord] = []
+    for item in items:
+        payload = list_trust_signals(
+            store,
+            user_id=user_id,
+            request=TrustSignalListQueryInput(
+                limit=DEFAULT_CONTINUITY_REVIEW_LIMIT,
+                continuity_object_id=UUID(item["id"]),
+                signal_state="active",
+            ),
+            sync_first=True,
+        )
+        for signal in payload["items"]:
+            if signal["id"] in seen_signal_ids:
+                continue
+            seen_signal_ids.add(signal["id"])
+            gathered.append(signal)
+    gathered.sort(key=lambda signal: (signal["updated_at"], signal["id"]), reverse=True)
+    return gathered
+
+
+def _build_trust_posture(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    items: list[ContinuityRecallResultRecord],
+    open_conflict_count: int,
+) -> ContinuityBriefTrustPostureRecord:
+    if len(items) == 0:
+        return {
+            "confidence_posture": "low",
+            "average_confidence": 0.0,
+            "strongest_trust_class": None,
+            "weakest_provenance_posture": None,
+            "active_signal_count": 0,
+            "positive_signal_count": 0,
+            "negative_signal_count": 0,
+            "neutral_signal_count": 0,
+            "open_conflict_count": open_conflict_count,
+            "rationale": "No continuity items matched the requested scope.",
+        }
+
+    active_signals = _collect_active_signals(
+        store,
+        user_id=user_id,
+        items=items,
+    )
+    average_confidence = sum(item["confidence"] for item in items) / len(items)
+    strongest_trust_class = _strongest_trust_class(items)
+    weakest_provenance = _weakest_provenance_posture(items)
+    positive_signal_count = sum(1 for signal in active_signals if signal["direction"] == "positive")
+    negative_signal_count = sum(1 for signal in active_signals if signal["direction"] == "negative")
+    neutral_signal_count = sum(1 for signal in active_signals if signal["direction"] == "neutral")
+
+    posture = _confidence_posture(average_confidence)
+    reasons: list[str] = []
+    if open_conflict_count > 0:
+        reasons.append(f"{open_conflict_count} open conflict(s) remain")
+    if negative_signal_count > 0:
+        reasons.append(f"{negative_signal_count} negative trust signal(s) are active")
+    if weakest_provenance in {"weak", "missing"}:
+        reasons.append(f"provenance posture is {weakest_provenance}")
+
+    if posture == "high" and reasons:
+        posture = "medium"
+    if (
+        average_confidence < 0.55
+        or open_conflict_count > 1
+        or negative_signal_count > 1
+        or weakest_provenance == "missing"
+    ):
+        posture = "low"
+
+    rationale = (
+        "; ".join(reasons)
+        if reasons
+        else "Selected continuity items have consistent trust and provenance signals."
+    )
+    return {
+        "confidence_posture": posture,
+        "average_confidence": average_confidence,
+        "strongest_trust_class": strongest_trust_class,
+        "weakest_provenance_posture": weakest_provenance,
+        "active_signal_count": len(active_signals),
+        "positive_signal_count": positive_signal_count,
+        "negative_signal_count": negative_signal_count,
+        "neutral_signal_count": neutral_signal_count,
+        "open_conflict_count": open_conflict_count,
+        "rationale": rationale,
+    }
+
+
+def _build_next_suggested_action(
+    *,
+    next_action_item: ContinuityRecallResultRecord | None,
+    open_loop_items: list[ContinuityRecallResultRecord],
+    relevant_facts: list[ContinuityRecallResultRecord],
+    confidence_posture: ChiefOfStaffRecommendationConfidencePosture,
+) -> ContinuityBriefSuggestedActionRecord:
+    target: ContinuityRecallResultRecord | None = next_action_item
+    reason = "Selected explicit next action from continuity resumption."
+    if target is None and open_loop_items:
+        target = open_loop_items[0]
+        reason = "No explicit next action found; selected the highest-priority open loop."
+    if target is None and relevant_facts:
+        target = relevant_facts[0]
+        reason = "No explicit next action or open loop found; selected the top relevant fact."
+    if target is None:
+        return {
+            "continuity_object_id": None,
+            "title": "No suggested action available.",
+            "object_type": None,
+            "reason": "No relevant continuity items matched the requested scope.",
+            "confidence_posture": confidence_posture,
+            "provenance_references": [],
+        }
+    return {
+        "continuity_object_id": target["id"],
+        "title": target["title"],
+        "object_type": target["object_type"],
+        "reason": reason,
+        "confidence_posture": confidence_posture,
+        "provenance_references": list(target["provenance_references"]),
+    }
+
+
+def _brief_summary(
+    *,
+    brief_type: str,
+    relevant_facts: ContinuityBriefRelevantFactsSection,
+    open_loops: ContinuityResumptionListSection,
+    conflicts: ContinuityBriefConflictSection,
+    next_action: ContinuityBriefSuggestedActionRecord,
+) -> str:
+    if relevant_facts["items"]:
+        focus = "; ".join(item["title"] for item in relevant_facts["items"][:2])
+    else:
+        focus = "No relevant facts."
+    return (
+        f"{brief_type.replace('_', ' ')} brief. "
+        f"Focus: {focus} "
+        f"Open loops={open_loops['summary']['total_count']}, "
+        f"conflicts={conflicts['summary']['total_count']}. "
+        f"Next: {next_action['title']}"
+    )
+
+
+def compile_continuity_brief(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: ContinuityBriefRequestInput,
+) -> ContinuityBriefResponse:
+    _validate_request(request)
+
+    task_brief_request = _task_brief_request_for(request)
+    task_brief = compile_task_brief_record(
+        store,
+        user_id=user_id,
+        request=task_brief_request,
+    )
+    relevant_fact_candidates = _dedupe_items(
+        [
+            item
+            for section in task_brief["sections"]
+            for item in section["items"]
+        ]
+    )
+    relevant_facts = _build_relevant_facts_section(
+        task_brief_mode=task_brief["mode"],
+        candidates=relevant_fact_candidates,
+        limit=request.max_relevant_facts,
+    )
+
+    resumption_payload = compile_continuity_resumption_brief(
+        store,
+        user_id=user_id,
+        request=ContinuityResumptionBriefRequestInput(
+            query=request.query,
+            thread_id=request.thread_id,
+            task_id=request.task_id,
+            project=request.project,
+            person=request.person,
+            since=request.since,
+            until=request.until,
+            max_recent_changes=request.max_recent_changes,
+            max_open_loops=request.max_open_loops,
+            include_non_promotable_facts=request.include_non_promotable_facts,
+            debug=False,
+        ),
+    )
+    resumption_brief = resumption_payload["brief"]
+    included_items = _dedupe_items(
+        relevant_facts["items"]
+        + list(resumption_brief["recent_changes"]["items"])
+        + list(resumption_brief["open_loops"]["items"])
+        + (
+            []
+            if resumption_brief["last_decision"]["item"] is None
+            else [resumption_brief["last_decision"]["item"]]
+        )
+        + (
+            []
+            if resumption_brief["next_action"]["item"] is None
+            else [resumption_brief["next_action"]["item"]]
+        )
+    )
+    conflict_section = _build_conflict_section(
+        store,
+        user_id=user_id,
+        items=included_items,
+        limit=request.max_conflicts,
+    )
+    trust_posture = _build_trust_posture(
+        store,
+        user_id=user_id,
+        items=included_items,
+        open_conflict_count=conflict_section["summary"]["total_count"],
+    )
+    next_suggested_action = _build_next_suggested_action(
+        next_action_item=resumption_brief["next_action"]["item"],
+        open_loop_items=list(resumption_brief["open_loops"]["items"]),
+        relevant_facts=list(relevant_facts["items"]),
+        confidence_posture=trust_posture["confidence_posture"],
+    )
+    timeline_highlights = _build_timeline_section(
+        relevant_facts=list(relevant_facts["items"]),
+        recent_changes=resumption_brief["recent_changes"],
+        open_loops=resumption_brief["open_loops"],
+        next_action=resumption_brief["next_action"]["item"],
+        limit=request.max_timeline_highlights,
+    )
+    provenance_bundle = _collect_provenance_bundle(included_items)
+    selection_strategy: ContinuityBriefSelectionStrategyRecord = {
+        "task_brief_mode": task_brief["mode"],
+        "provider_strategy": task_brief["strategy"]["provider_strategy"],
+        "model_pack_strategy": task_brief["strategy"]["model_pack_strategy"],
+        "token_budget": task_brief["strategy"]["token_budget"],
+        "budget_source": task_brief["strategy"]["budget_source"],
+    }
+    brief: ContinuityBriefRecord = {
+        "assembly_version": CONTINUITY_BRIEF_ASSEMBLY_VERSION_V0,
+        "brief_type": request.brief_type,
+        "scope": resumption_brief["scope"],
+        "summary": _brief_summary(
+            brief_type=request.brief_type,
+            relevant_facts=relevant_facts,
+            open_loops=resumption_brief["open_loops"],
+            conflicts=conflict_section,
+            next_action=next_suggested_action,
+        ),
+        "selection_strategy": selection_strategy,
+        "relevant_facts": relevant_facts,
+        "recent_changes": resumption_brief["recent_changes"],
+        "open_loops": resumption_brief["open_loops"],
+        "conflicts": conflict_section,
+        "timeline_highlights": timeline_highlights,
+        "next_suggested_action": next_suggested_action,
+        "provenance_bundle": provenance_bundle,
+        "trust_posture": trust_posture,
+        "sources": [
+            "continuity_capture_events",
+            "continuity_objects",
+            "retrieval_runs",
+            "contradiction_cases",
+            "trust_signals",
+            "task_briefs",
+        ],
+    }
+    return {"brief": brief}
+
+
+def build_default_continuity_brief_request() -> ContinuityBriefRequestInput:
+    return ContinuityBriefRequestInput(
+        brief_type="general",
+        max_relevant_facts=DEFAULT_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+        max_recent_changes=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        max_open_loops=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+        max_conflicts=DEFAULT_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+        max_timeline_highlights=DEFAULT_CONTINUITY_BRIEF_TIMELINE_LIMIT,
+    )
+
+
+__all__ = [
+    "ContinuityBriefValidationError",
+    "build_default_continuity_brief_request",
+    "compile_continuity_brief",
+]

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -207,6 +207,13 @@ ModelPackBindingSource = Literal["manual", "runtime_override"]
 ModelPackBriefingStrategy = Literal["balanced", "compact", "detailed"]
 ModelFinishReason = Literal["completed", "incomplete"]
 TaskBriefMode = Literal["user_recall", "resume", "worker_subtask", "agent_handoff"]
+ContinuityBriefType = Literal[
+    "general",
+    "resume",
+    "agent_handoff",
+    "coding_context",
+    "operator_context",
+]
 ExplicitPreferencePattern = Literal[
     "i_like",
     "i_dont_like",
@@ -413,6 +420,12 @@ DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT = 5
 MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT = 20
 DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT = 5
 MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT = 20
+DEFAULT_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT = 6
+MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT = 20
+DEFAULT_CONTINUITY_BRIEF_CONFLICT_LIMIT = 5
+MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT = 20
+DEFAULT_CONTINUITY_BRIEF_TIMELINE_LIMIT = 5
+MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT = 20
 DEFAULT_CONTINUITY_OPEN_LOOP_LIMIT = 20
 MAX_CONTINUITY_OPEN_LOOP_LIMIT = 100
 DEFAULT_CONTINUITY_DAILY_BRIEF_LIMIT = 3
@@ -445,6 +458,7 @@ RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0 = "resumption_brief_v0"
 CONTINUITY_RESUMPTION_BRIEF_ASSEMBLY_VERSION_V0 = "continuity_resumption_brief_v0"
 TASK_BRIEF_ASSEMBLY_VERSION_V0 = "task_brief_v0"
 TASK_BRIEF_COMPARISON_VERSION_V0 = "task_brief_comparison_v0"
+CONTINUITY_BRIEF_ASSEMBLY_VERSION_V0 = "continuity_brief_v0"
 CONTINUITY_DAILY_BRIEF_ASSEMBLY_VERSION_V0 = "continuity_daily_brief_v0"
 CONTINUITY_WEEKLY_REVIEW_ASSEMBLY_VERSION_V0 = "continuity_weekly_review_v0"
 CHIEF_OF_STAFF_PRIORITY_BRIEF_ASSEMBLY_VERSION_V0 = "chief_of_staff_priority_brief_v0"
@@ -467,6 +481,13 @@ TASK_BRIEF_MODE_ORDER: list[TaskBriefMode] = [
     "resume",
     "worker_subtask",
     "agent_handoff",
+]
+CONTINUITY_BRIEF_TYPE_ORDER: list[ContinuityBriefType] = [
+    "general",
+    "resume",
+    "agent_handoff",
+    "coding_context",
+    "operator_context",
 ]
 TASK_BRIEF_SECTION_ITEM_ORDER = ["created_at_desc", "id_desc"]
 MODEL_PACK_BRIEFING_STRATEGIES: list[ModelPackBriefingStrategy] = [
@@ -2168,6 +2189,43 @@ class ContinuityResumptionBriefRequestInput:
 
 
 @dataclass(frozen=True, slots=True)
+class ContinuityBriefRequestInput:
+    brief_type: ContinuityBriefType = "general"
+    query: str | None = None
+    thread_id: UUID | None = None
+    task_id: UUID | None = None
+    project: str | None = None
+    person: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    max_relevant_facts: int = DEFAULT_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT
+    max_recent_changes: int = DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT
+    max_open_loops: int = DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT
+    max_conflicts: int = DEFAULT_CONTINUITY_BRIEF_CONFLICT_LIMIT
+    max_timeline_highlights: int = DEFAULT_CONTINUITY_BRIEF_TIMELINE_LIMIT
+    include_non_promotable_facts: bool = False
+
+    def as_payload(self) -> JsonObject:
+        payload: JsonObject = {
+            "brief_type": self.brief_type,
+            "query": self.query,
+            "thread_id": None if self.thread_id is None else str(self.thread_id),
+            "task_id": None if self.task_id is None else str(self.task_id),
+            "project": self.project,
+            "person": self.person,
+            "max_relevant_facts": self.max_relevant_facts,
+            "max_recent_changes": self.max_recent_changes,
+            "max_open_loops": self.max_open_loops,
+            "max_conflicts": self.max_conflicts,
+            "max_timeline_highlights": self.max_timeline_highlights,
+            "include_non_promotable_facts": self.include_non_promotable_facts,
+        }
+        payload["since"] = isoformat_or_none(self.since)
+        payload["until"] = isoformat_or_none(self.until)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
 class TaskBriefCompileRequestInput:
     mode: TaskBriefMode
     query: str | None = None
@@ -3629,6 +3687,111 @@ class ContinuityResumptionDebugRecord(TypedDict):
 class ContinuityResumptionBriefResponse(TypedDict):
     brief: ContinuityResumptionBriefRecord
     debug: NotRequired[ContinuityResumptionDebugRecord]
+
+
+class ContinuityBriefRelevantFactsSummary(TypedDict):
+    limit: int
+    returned_count: int
+    total_count: int
+    order: list[str]
+    task_brief_mode: TaskBriefMode
+
+
+class ContinuityBriefRelevantFactsSection(TypedDict):
+    items: list[ContinuityRecallResultRecord]
+    summary: ContinuityBriefRelevantFactsSummary
+    empty_state: ContinuityResumptionEmptyState
+
+
+class ContinuityBriefConflictSummary(TypedDict):
+    limit: int
+    returned_count: int
+    total_count: int
+    order: list[str]
+
+
+class ContinuityBriefConflictSection(TypedDict):
+    items: list[ContradictionCaseRecord]
+    summary: ContinuityBriefConflictSummary
+    empty_state: ContinuityResumptionEmptyState
+
+
+class ContinuityBriefTimelineHighlightRecord(TypedDict):
+    continuity_object_id: str
+    title: str
+    object_type: ContinuityObjectType
+    status: str
+    created_at: str
+    source_section: str
+
+
+class ContinuityBriefTimelineSection(TypedDict):
+    items: list[ContinuityBriefTimelineHighlightRecord]
+    summary: ResumptionBriefSectionSummary
+    empty_state: ContinuityResumptionEmptyState
+
+
+class ContinuityBriefSuggestedActionRecord(TypedDict):
+    continuity_object_id: str | None
+    title: str
+    object_type: ContinuityObjectType | None
+    reason: str
+    confidence_posture: ChiefOfStaffRecommendationConfidencePosture
+    provenance_references: list[ContinuityRecallProvenanceReference]
+
+
+class ContinuityBriefSelectionStrategyRecord(TypedDict):
+    task_brief_mode: TaskBriefMode
+    provider_strategy: str
+    model_pack_strategy: str
+    token_budget: int
+    budget_source: str
+
+
+class ContinuityBriefProvenanceSummary(TypedDict):
+    source_object_count: int
+    reference_count: int
+    reference_kind_count: int
+
+
+class ContinuityBriefProvenanceBundle(TypedDict):
+    source_object_ids: list[str]
+    references: list[ContinuityRecallProvenanceReference]
+    summary: ContinuityBriefProvenanceSummary
+
+
+class ContinuityBriefTrustPostureRecord(TypedDict):
+    confidence_posture: ChiefOfStaffRecommendationConfidencePosture
+    average_confidence: float
+    strongest_trust_class: MemoryTrustClass | None
+    weakest_provenance_posture: ContinuityRecallProvenancePosture | None
+    active_signal_count: int
+    positive_signal_count: int
+    negative_signal_count: int
+    neutral_signal_count: int
+    open_conflict_count: int
+    rationale: str
+
+
+class ContinuityBriefRecord(TypedDict):
+    assembly_version: str
+    brief_type: ContinuityBriefType
+    scope: ContinuityRecallScopeFilters
+    summary: str
+    selection_strategy: ContinuityBriefSelectionStrategyRecord
+    relevant_facts: ContinuityBriefRelevantFactsSection
+    recent_changes: ContinuityResumptionListSection
+    open_loops: ContinuityResumptionListSection
+    conflicts: ContinuityBriefConflictSection
+    timeline_highlights: ContinuityBriefTimelineSection
+    next_suggested_action: ContinuityBriefSuggestedActionRecord
+    provenance_bundle: ContinuityBriefProvenanceBundle
+    trust_posture: ContinuityBriefTrustPostureRecord
+    sources: list[str]
+
+
+class ContinuityBriefResponse(TypedDict):
+    brief: ContinuityBriefRecord
 
 
 class TaskBriefEmptyState(TypedDict):

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -28,6 +28,10 @@ except Exception:  # pragma: no cover - optional dependency for local-only test 
 
 from alicebot_api.compiler import compile_and_persist_trace, compile_resumption_brief
 from alicebot_api.config import Settings, get_settings
+from alicebot_api.continuity_brief import (
+    ContinuityBriefValidationError,
+    compile_continuity_brief,
+)
 from alicebot_api.contracts import (
     AGENT_PROFILE_LIST_ORDER,
     ApprovalApproveInput,
@@ -48,6 +52,9 @@ from alicebot_api.contracts import (
     DEFAULT_AGENT_PROFILE_ID,
     DEFAULT_CALENDAR_EVENT_LIST_LIMIT,
     DEFAULT_CONTINUITY_CAPTURE_LIMIT,
+    DEFAULT_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+    DEFAULT_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+    DEFAULT_CONTINUITY_BRIEF_TIMELINE_LIMIT,
     DEFAULT_CONTINUITY_LIFECYCLE_LIMIT,
     DEFAULT_CONTINUITY_REVIEW_LIMIT,
     DEFAULT_CONTINUITY_RECALL_LIMIT,
@@ -80,6 +87,9 @@ from alicebot_api.contracts import (
     MAX_RESUMPTION_BRIEF_OPEN_LOOP_LIMIT,
     MAX_ARTIFACT_CHUNK_RETRIEVAL_LIMIT,
     MAX_CALENDAR_EVENT_LIST_LIMIT,
+    MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+    MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+    MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT,
     MAX_CONTINUITY_CAPTURE_LIMIT,
     MAX_CONTINUITY_LIFECYCLE_LIMIT,
     MAX_CONTINUITY_REVIEW_LIMIT,
@@ -97,6 +107,8 @@ from alicebot_api.contracts import (
     MAX_SEMANTIC_MEMORY_RETRIEVAL_LIMIT,
     ContextCompilerLimits,
     ContinuityArtifactDetailResponse,
+    ContinuityBriefRequestInput,
+    ContinuityBriefResponse,
     ContinuityCaptureCandidatesInput,
     ContinuityCaptureCommitInput,
     ContinuityCaptureCreateInput,
@@ -1146,6 +1158,45 @@ class MemoryOperationCommitRequest(BaseModel):
     candidate_ids: list[UUID] = Field(default_factory=list)
     sync_fingerprint: str | None = Field(default=None, min_length=1, max_length=200)
     include_review_required: bool = False
+
+
+class ContinuityBriefRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    brief_type: str = Field(default="general", min_length=1, max_length=40)
+    query: str | None = Field(default=None, min_length=1, max_length=4000)
+    thread_id: UUID | None = None
+    task_id: UUID | None = None
+    project: str | None = Field(default=None, min_length=1, max_length=200)
+    person: str | None = Field(default=None, min_length=1, max_length=200)
+    since: datetime | None = None
+    until: datetime | None = None
+    max_relevant_facts: int = Field(
+        default=DEFAULT_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+        ge=0,
+        le=MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+    )
+    max_recent_changes: int = Field(
+        default=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        ge=0,
+        le=MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    )
+    max_open_loops: int = Field(
+        default=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+        ge=0,
+        le=MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+    )
+    max_conflicts: int = Field(
+        default=DEFAULT_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+        ge=0,
+        le=MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+    )
+    max_timeline_highlights: int = Field(
+        default=DEFAULT_CONTINUITY_BRIEF_TIMELINE_LIMIT,
+        ge=0,
+        le=MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT,
+    )
+    include_non_promotable_facts: bool = False
 
 
 class ContinuityCorrectionRequest(BaseModel):
@@ -6022,6 +6073,52 @@ def get_continuity_resumption_brief(
     except ContinuityResumptionValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
     except ContinuityRecallValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.post("/v1/continuity/brief")
+def post_continuity_brief(
+    http_request: Request,
+    request: ContinuityBriefRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        user_id = _resolve_authenticated_v1_user_id(settings, http_request)
+        with user_connection(settings.database_url, user_id) as conn:
+            payload: ContinuityBriefResponse = compile_continuity_brief(
+                ContinuityStore(conn),
+                user_id=user_id,
+                request=ContinuityBriefRequestInput(
+                    brief_type=request.brief_type,  # type: ignore[arg-type]
+                    query=request.query,
+                    thread_id=request.thread_id,
+                    task_id=request.task_id,
+                    project=request.project,
+                    person=request.person,
+                    since=request.since,
+                    until=request.until,
+                    max_relevant_facts=request.max_relevant_facts,
+                    max_recent_changes=request.max_recent_changes,
+                    max_open_loops=request.max_open_loops,
+                    max_conflicts=request.max_conflicts,
+                    max_timeline_highlights=request.max_timeline_highlights,
+                    include_non_promotable_facts=request.include_non_promotable_facts,
+                ),
+            )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except (
+        ContinuityBriefValidationError,
+        ContinuityRecallValidationError,
+        ContinuityResumptionValidationError,
+        TaskBriefValidationError,
+    ) as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
     return JSONResponse(

--- a/apps/api/src/alicebot_api/mcp_tools.py
+++ b/apps/api/src/alicebot_api/mcp_tools.py
@@ -13,6 +13,10 @@ from alicebot_api.continuity_capture import (
     capture_continuity_input,
     commit_continuity_captures,
 )
+from alicebot_api.continuity_brief import (
+    ContinuityBriefValidationError,
+    compile_continuity_brief,
+)
 from alicebot_api.continuity_evidence import (
     ContinuityEvidenceNotFoundError,
     build_continuity_explain,
@@ -59,9 +63,13 @@ from alicebot_api.contracts import (
     CONTINUITY_CAPTURE_COMMIT_MODES,
     CONTINUITY_CAPTURE_EXPLICIT_SIGNALS,
     CONTINUITY_CORRECTION_ACTIONS,
+    CONTINUITY_BRIEF_TYPE_ORDER,
     CONTRADICTION_RESOLUTION_ACTIONS,
     CONTINUITY_REVIEW_QUEUE_ORDER,
     CONTINUITY_RESUMPTION_RECENT_CHANGE_ORDER,
+    DEFAULT_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+    DEFAULT_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+    DEFAULT_CONTINUITY_BRIEF_TIMELINE_LIMIT,
     DEFAULT_CONTINUITY_OPEN_LOOP_LIMIT,
     DEFAULT_CONTINUITY_RECALL_LIMIT,
     DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
@@ -69,6 +77,9 @@ from alicebot_api.contracts import (
     DEFAULT_TASK_BRIEF_TOKEN_BUDGET,
     DEFAULT_CONTINUITY_REVIEW_LIMIT,
     DEFAULT_TEMPORAL_TIMELINE_LIMIT,
+    MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+    MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+    MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT,
     MAX_CONTINUITY_OPEN_LOOP_LIMIT,
     MAX_CONTINUITY_RECALL_LIMIT,
     MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
@@ -79,6 +90,7 @@ from alicebot_api.contracts import (
     ContinuityCaptureCandidatesInput,
     ContinuityCaptureCommitInput,
     ContinuityCaptureCreateInput,
+    ContinuityBriefRequestInput,
     ContradictionCaseListQueryInput,
     ContradictionResolveInput,
     ContradictionSyncInput,
@@ -308,6 +320,65 @@ def _parse_task_brief_request(arguments: Mapping[str, object], *, mode_key: str 
         provider_strategy=_parse_optional_text(arguments, "provider_strategy"),
         model_pack_strategy=_parse_optional_text(arguments, "model_pack_strategy"),
         token_budget=parsed_token_budget,
+    )
+
+
+def _parse_continuity_brief_request(arguments: Mapping[str, object]) -> ContinuityBriefRequestInput:
+    brief_type_value = arguments.get("brief_type", "general")
+    if not isinstance(brief_type_value, str) or brief_type_value.strip() == "":
+        raise MCPToolError("brief_type must be a string")
+    brief_type = brief_type_value.strip()
+    if brief_type not in CONTINUITY_BRIEF_TYPE_ORDER:
+        raise MCPToolError("brief_type must be one of: " + ", ".join(CONTINUITY_BRIEF_TYPE_ORDER))
+    return ContinuityBriefRequestInput(
+        brief_type=brief_type,  # type: ignore[arg-type]
+        query=_parse_optional_text(arguments, "query"),
+        thread_id=_parse_optional_uuid(arguments, "thread_id"),
+        task_id=_parse_optional_uuid(arguments, "task_id"),
+        project=_parse_optional_text(arguments, "project"),
+        person=_parse_optional_text(arguments, "person"),
+        since=_parse_optional_datetime(arguments, "since"),
+        until=_parse_optional_datetime(arguments, "until"),
+        max_relevant_facts=_parse_int(
+            arguments,
+            key="max_relevant_facts",
+            default=DEFAULT_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+            minimum=0,
+            maximum=MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+        ),
+        max_recent_changes=_parse_int(
+            arguments,
+            key="max_recent_changes",
+            default=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+            minimum=0,
+            maximum=MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+        ),
+        max_open_loops=_parse_int(
+            arguments,
+            key="max_open_loops",
+            default=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+            minimum=0,
+            maximum=MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+        ),
+        max_conflicts=_parse_int(
+            arguments,
+            key="max_conflicts",
+            default=DEFAULT_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+            minimum=0,
+            maximum=MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+        ),
+        max_timeline_highlights=_parse_int(
+            arguments,
+            key="max_timeline_highlights",
+            default=DEFAULT_CONTINUITY_BRIEF_TIMELINE_LIMIT,
+            minimum=0,
+            maximum=MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT,
+        ),
+        include_non_promotable_facts=_parse_bool(
+            arguments,
+            key="include_non_promotable_facts",
+            default=False,
+        ),
     )
 
 
@@ -774,6 +845,15 @@ def _handle_alice_resume_debug(
                 ),
                 debug=True,
             ),
+        )
+
+
+def _handle_alice_brief(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    with _store_context(context) as store:
+        return compile_continuity_brief(
+            store,
+            user_id=context.user_id,
+            request=_parse_continuity_brief_request(arguments),
         )
 
 
@@ -1564,6 +1644,53 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
         },
     },
     {
+        "name": "alice_brief",
+        "description": "Compile the primary one-call continuity brief for general, resume, handoff, coding, or operator contexts.",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "brief_type": {
+                    "type": "string",
+                    "enum": CONTINUITY_BRIEF_TYPE_ORDER,
+                },
+                "query": {"type": "string"},
+                "thread_id": {"type": "string", "format": "uuid"},
+                "task_id": {"type": "string", "format": "uuid"},
+                "project": {"type": "string"},
+                "person": {"type": "string"},
+                "since": {"type": "string", "format": "date-time"},
+                "until": {"type": "string", "format": "date-time"},
+                "max_relevant_facts": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_CONTINUITY_BRIEF_RELEVANT_FACT_LIMIT,
+                },
+                "max_recent_changes": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+                },
+                "max_open_loops": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+                },
+                "max_conflicts": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_CONTINUITY_BRIEF_CONFLICT_LIMIT,
+                },
+                "max_timeline_highlights": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_CONTINUITY_BRIEF_TIMELINE_LIMIT,
+                },
+                "include_non_promotable_facts": {"type": "boolean"},
+            },
+        },
+    },
+    {
         "name": "alice_task_brief",
         "description": "Compile and persist one task-adaptive brief for recall, resume, worker, or handoff workloads.",
         "inputSchema": {
@@ -1961,6 +2088,7 @@ _TOOL_HANDLERS = {
     "alice_state_at": _handle_alice_state_at,
     "alice_resume": _handle_alice_resume,
     "alice_resume_debug": _handle_alice_resume_debug,
+    "alice_brief": _handle_alice_brief,
     "alice_task_brief": _handle_alice_task_brief,
     "alice_task_brief_show": _handle_alice_task_brief_show,
     "alice_task_brief_compare": _handle_alice_task_brief_compare,
@@ -2004,6 +2132,7 @@ def call_mcp_tool(
     except (
         ContinuityCaptureValidationError,
         ContinuityRecallValidationError,
+        ContinuityBriefValidationError,
         ContinuityResumptionValidationError,
         ContinuityOpenLoopValidationError,
         ContinuityReviewValidationError,

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -19,15 +19,19 @@ alicebot --help
 ## Core Commands
 
 ```bash
+alice brief --brief-type general --query local-first
 ./.venv/bin/python -m alicebot_api status
 ./.venv/bin/python -m alicebot_api capture "Decision: Keep Alice local-first for verification." --explicit-signal decision
 ./.venv/bin/python -m alicebot_api recall --query local-first --limit 5
 ./.venv/bin/python -m alicebot_api resume --max-recent-changes 5 --max-open-loops 5
+./.venv/bin/python -m alicebot_api brief --brief-type general --query local-first
 ./.venv/bin/python -m alicebot_api open-loops
 ./.venv/bin/python -m alicebot_api state-at <entity_id> --at 2026-03-12T09:45:00+00:00
 ./.venv/bin/python -m alicebot_api timeline <entity_id> --limit 20
 ./.venv/bin/python -m alicebot_api explain --entity-id <entity_id> --at 2026-03-12T09:45:00+00:00
 ```
+
+`brief` is the default external-agent continuity entrypoint. It assembles relevant facts, recent changes, open loops, conflicts, timeline highlights, provenance, trust posture, and a next suggested action in one call.
 
 ## Temporal History Commands
 
@@ -54,3 +58,4 @@ See tests:
 - `tests/integration/test_mcp_cli_parity.py`
 - `tests/integration/test_mcp_server.py`
 - `tests/integration/test_temporal_state_mcp_cli.py`
+- `docs/integrations/one-call-continuity.md`

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -23,6 +23,7 @@ MCP uses the same local runtime scope as CLI:
 
 ## Shipped Tool Surface
 
+- `alice_brief`
 - `alice_capture`
 - `alice_capture_candidates`
 - `alice_commit_captures`
@@ -41,6 +42,7 @@ MCP uses the same local runtime scope as CLI:
 - `alice_explain`
 - `alice_context_pack`
 
+`alice_brief` is the default external-agent continuity lookup. It returns one continuity bundle with relevant facts, recent changes, open loops, conflicts, timeline highlights, provenance, trust posture, and a next suggested action.
 `alice_explain` now accepts either `continuity_object_id` for evidence-chain inspection or `entity_id` plus optional `at` for temporal explain output.
 `alice_prefetch_context` provides an automation-oriented pre-turn context assembly surface using the same continuity resumption semantics shipped for `alice_resume`.
 `alice_capture_candidates` and `alice_commit_captures` provide the B2 bridge auto-capture pipeline over user/assistant turns with `manual`/`assist`/`auto` commit policy support.
@@ -89,6 +91,7 @@ One-command bridge demo:
 - tool set is intentionally narrow and stable
 - tool output is deterministic for parity testing
 - MCP does not widen core product semantics beyond the shipped Phase 12 baseline and Bridge `B1` through `B4`
+- `alice_brief` is the preferred first call for external runtimes that need continuity in one request
 
 See tests:
 
@@ -96,3 +99,4 @@ See tests:
 - `tests/integration/test_mcp_server.py`
 - `tests/integration/test_temporal_state_mcp_cli.py`
 - `tests/integration/test_openclaw_mcp_integration.py`
+- `docs/integrations/one-call-continuity.md`

--- a/docs/integrations/one-call-continuity.md
+++ b/docs/integrations/one-call-continuity.md
@@ -1,0 +1,96 @@
+# One-Call Continuity
+
+Phase 13 makes one continuity call the default integration path for external agents:
+
+- API: `POST /v1/continuity/brief`
+- CLI: `alice brief`
+- MCP: `alice_brief`
+
+This surface composes the shipped recall, resumption, contradiction, trust, and task-briefing systems into one response bundle so callers do not need tool choreography.
+
+## Defaults
+
+- default `brief_type`: `general`
+- timeline highlights: included by default
+- `coding_context` and `operator_context` keep the same response shape as other brief types and differ by selection strategy only
+
+## Supported Brief Types
+
+- `general`
+- `resume`
+- `agent_handoff`
+- `coding_context`
+- `operator_context`
+
+## Response Bundle
+
+Every one-call brief returns:
+
+- `summary`
+- `relevant_facts`
+- `recent_changes`
+- `open_loops`
+- `conflicts`
+- `timeline_highlights`
+- `next_suggested_action`
+- `provenance_bundle`
+- `trust_posture`
+
+## API
+
+`POST /v1/continuity/brief` uses the authenticated `v1` API surface.
+
+Example:
+
+```bash
+curl -X POST http://localhost:8000/v1/continuity/brief \
+  -H "Authorization: Bearer $ALICE_SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "brief_type": "general",
+    "thread_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    "query": "deploy",
+    "max_relevant_facts": 6,
+    "max_recent_changes": 5,
+    "max_open_loops": 5,
+    "max_conflicts": 5,
+    "max_timeline_highlights": 5
+  }'
+```
+
+## CLI
+
+If you installed the Node wrapper package:
+
+```bash
+alice brief --brief-type general --query deploy
+```
+
+If you are running directly from the repository Python runtime:
+
+```bash
+./.venv/bin/python -m alicebot_api brief --brief-type general --query deploy
+```
+
+## MCP
+
+`alice_brief` is now the default MCP continuity lookup for external agents.
+
+Example:
+
+```json
+{
+  "name": "alice_brief",
+  "arguments": {
+    "brief_type": "coding_context",
+    "thread_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    "query": "deploy"
+  }
+}
+```
+
+## When To Use Other Surfaces
+
+- use `alice_recall` when you only need ranked facts
+- use `alice_resume` when you only need the legacy resumption layout
+- use `alice_task_brief` when you explicitly want persisted task-adaptive briefing output

--- a/packages/alice-cli/bin/alice.js
+++ b/packages/alice-cli/bin/alice.js
@@ -6,6 +6,37 @@ const args = process.argv.slice(2);
 const version = "0.3.2";
 const defaultPythonCommand = process.platform === "win32" ? "python" : "python3";
 
+function forwardToPython(moduleName, moduleArgs, errorLabel) {
+  const pythonCommand = process.env.ALICEBOT_PYTHON || defaultPythonCommand;
+  const child = spawn(
+    pythonCommand,
+    ["-m", moduleName, ...moduleArgs],
+    {
+      stdio: "inherit",
+      env: process.env,
+    },
+  );
+
+  child.on("error", (error) => {
+    console.error(
+      `Failed to start ${errorLabel} using "${pythonCommand}": ${error.message}
+Set ALICEBOT_PYTHON to your Alice Python runtime (for example: /abs/path/.venv/bin/python).`,
+    );
+    process.exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (typeof code === "number") {
+      process.exit(code);
+    }
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(1);
+  });
+}
+
 if (args.includes("--version") || args.includes("-v")) {
   console.log(version);
   process.exit(0);
@@ -16,6 +47,7 @@ if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
 
 Usage:
   alice hello
+  alice brief [alicebot-args...]
   alice mcp [alicebot-mcp-args...]
   alice --help
   alice --version`);
@@ -37,34 +69,9 @@ Install dependencies with npm install.`,
 }
 
 if (args[0] === "mcp") {
-  const pythonCommand = process.env.ALICEBOT_PYTHON || defaultPythonCommand;
-  const child = spawn(
-    pythonCommand,
-    ["-m", "alicebot_api.mcp_server", ...args.slice(1)],
-    {
-      stdio: "inherit",
-      env: process.env,
-    },
-  );
-
-  child.on("error", (error) => {
-    console.error(
-      `Failed to start Alice MCP server using "${pythonCommand}": ${error.message}
-Set ALICEBOT_PYTHON to your Alice Python runtime (for example: /abs/path/.venv/bin/python).`,
-    );
-    process.exit(1);
-  });
-
-  child.on("exit", (code, signal) => {
-    if (typeof code === "number") {
-      process.exit(code);
-    }
-    if (signal) {
-      process.kill(process.pid, signal);
-      return;
-    }
-    process.exit(1);
-  });
+  forwardToPython("alicebot_api.mcp_server", args.slice(1), "Alice MCP server");
+} else if (args[0] === "brief") {
+  forwardToPython("alicebot_api", args, "Alice CLI");
 } else {
   console.error(`Unknown command: ${args[0]}
 Run "alice --help" for usage.`);

--- a/packages/alice-cli/package.json
+++ b/packages/alice-cli/package.json
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "scripts": {
-    "test": "node ./bin/alice.js --help"
+    "test": "node --test ./test/alice.test.mjs"
   },
   "keywords": [
     "alice",

--- a/packages/alice-cli/test/alice.test.mjs
+++ b/packages/alice-cli/test/alice.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const binPath = path.join(packageRoot, "bin", "alice.js");
+
+function makeFakePython() {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "alice-cli-test-"));
+  const logPath = path.join(tempDir, "args.log");
+  const scriptPath = path.join(tempDir, "fake-python");
+  const script = `#!/bin/sh
+printf '%s\n' "$@" > "${logPath}"
+exit 0
+`;
+  writeFileSync(scriptPath, script, "utf8");
+  chmodSync(scriptPath, 0o755);
+  return { logPath, scriptPath };
+}
+
+test("alice brief forwards to the Python CLI module", () => {
+  const { logPath, scriptPath } = makeFakePython();
+  const result = spawnSync(
+    process.execPath,
+    [binPath, "brief", "--query", "deploy"],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        ALICEBOT_PYTHON: scriptPath,
+      },
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 0);
+  const forwardedArgs = result.error ? [] : readFileSync(logPath, "utf8").trim().split("\n");
+  assert.deepEqual(forwardedArgs, ["-m", "alicebot_api", "brief", "--query", "deploy"]);
+});
+
+test("alice rejects unknown commands", () => {
+  const result = spawnSync(
+    process.execPath,
+    [binPath, "status"],
+    {
+      cwd: packageRoot,
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unknown command: status/);
+});

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -18,51 +18,43 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
     ControlDocTruthRule(
         relative_path="README.md",
         required_markers=(
-            "`v0.3.2` is the current **pre-1.0 release target** for the completed Phase 12 boundary.",
-            "## Release Boundary (`v0.3.2` Target)",
-            "Bridge `B1` through `B4` provider contract, auto-capture flow, review/explainability flow, and bridge docs/smoke validation",
+            "`v0.3.2` is the current **pre-1.0 public release**.",
+            "## Release Boundary (`v0.3.2`)",
             "Phase 12 retrieval quality stack:",
+            "Phase 13 planning is active on top of this released baseline.",
             "Historical planning/control artifacts remain available in:",
         ),
     ),
     ControlDocTruthRule(
         relative_path="ROADMAP.md",
         required_markers=(
-            "Bridge Phase (`B1`-`B4`): shipped",
-            "Phase 12 closeout and `v0.3.2` release update are the active control packet.",
+            "`v0.3.2`: released",
+            "Phase 13 is active.",
+            "### P13-S1: One-Call Continuity",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Phase 12 Closeout and `v0.3.2` Release Update",
-            "`v0.2.0` is the latest published tag.",
-            "The documented release target is `v0.3.2`",
+            "P13-S1: One-Call Continuity",
+            "`v0.3.2` is the latest published tag.",
+            "POST /v1/continuity/brief",
         ),
     ),
     ControlDocTruthRule(
         relative_path="RULES.md",
         required_markers=(
-            "For Hermes, use provider hooks for automation and MCP for explicit deep actions.",
-            "Never fork continuity semantics by surface or runtime.",
+            "Phase 13 is an adoption layer on top of the shipped `v0.3.2` baseline.",
+            "Alice Lite is a deployment profile, not a separate product.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/handoff/CURRENT_STATE.md",
         required_markers=(
-            "Phase 9 is shipped.",
-            "Phase 10 is shipped.",
-            "Phase 11 is shipped.",
-            "`v0.2.0` is the latest published tag.",
-            "`v0.3.2` is the current release target.",
-            "Phase 12 closeout and `v0.3.2` release update are the active control packet.",
-        ),
-    ),
-    ControlDocTruthRule(
-        relative_path="docs/runbooks/phase12-closeout-packet.md",
-        required_markers=(
-            "# Phase 12 Closeout Packet",
-            "This runbook is the source-of-truth closeout packet for the accepted Phase 12 baseline through `P12-S5`.",
+            "Phase 12 is shipped.",
+            "`v0.3.2` is the latest published tag.",
+            "Phase 13 is active.",
+            "`P13-S1` One-Call Continuity is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(

--- a/tests/integration/test_continuity_brief_api.py
+++ b/tests/integration/test_continuity_brief_api.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from typing import Any
+from urllib.parse import urlencode
+from uuid import UUID
+
+import anyio
+import psycopg
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+from alicebot_api.continuity_contradictions import sync_contradictions
+from alicebot_api.contracts import ContradictionSyncInput
+from alicebot_api.db import user_connection
+from alicebot_api.store import ContinuityStore
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+        request_received = True
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    request_headers = [(b"content-type", b"application/json")]
+    for key, value in (headers or {}).items():
+        request_headers.append((key.lower().encode(), value.encode()))
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": request_headers,
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def auth_header(session_token: str) -> dict[str, str]:
+    return {"authorization": f"Bearer {session_token}"}
+
+
+def bootstrap_authenticated_user(database_url: str, *, email: str) -> tuple[UUID, str]:
+    start_status, start_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/start",
+        payload={"email": email},
+    )
+    assert start_status == 200
+
+    verify_status, verify_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/verify",
+        payload={
+            "challenge_token": start_payload["challenge"]["challenge_token"],
+            "device_label": "Continuity Brief Test Device",
+            "device_key": f"device-{email}",
+        },
+    )
+    assert verify_status == 200
+
+    user_id = UUID(verify_payload["user_account"]["id"])
+    with user_connection(database_url, user_id) as conn:
+        ContinuityStore(conn).create_user(user_id, email, email.split("@", 1)[0].title())
+    return user_id, verify_payload["session_token"]
+
+
+def set_continuity_timestamps(
+    admin_database_url: str,
+    *,
+    continuity_object_id: UUID,
+    created_at: datetime,
+) -> None:
+    with psycopg.connect(admin_database_url, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE continuity_objects SET created_at = %s, updated_at = %s WHERE id = %s",
+                (created_at, created_at, continuity_object_id),
+            )
+
+
+def test_continuity_brief_api_returns_one_call_bundle(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(database_url=migrated_database_urls["app"]),
+    )
+
+    user_id, session_token = bootstrap_authenticated_user(
+        migrated_database_urls["app"],
+        email="continuity-brief@example.com",
+    )
+    thread_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+
+        fact_one = store.create_continuity_object(
+            capture_event_id=store.create_continuity_capture_event(
+                raw_content="Decision: Deployment owner is Operations",
+                explicit_signal="decision",
+                admission_posture="DERIVED",
+                admission_reason="explicit_signal_decision",
+            )["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: Deployment owner is Operations",
+            body={
+                "fact_key": "deployment_owner",
+                "fact_value": "Operations",
+                "decision_text": "Deployment owner is Operations",
+            },
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["brief-api-1"]},
+            confidence=0.92,
+        )
+        fact_two = store.create_continuity_object(
+            capture_event_id=store.create_continuity_capture_event(
+                raw_content="Decision: Deployment owner is Engineering",
+                explicit_signal="decision",
+                admission_posture="DERIVED",
+                admission_reason="explicit_signal_decision",
+            )["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: Deployment owner is Engineering",
+            body={
+                "fact_key": "deployment_owner",
+                "fact_value": "Engineering",
+                "decision_text": "Deployment owner is Engineering",
+            },
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["brief-api-2"]},
+            confidence=0.88,
+        )
+        blocker = store.create_continuity_object(
+            capture_event_id=store.create_continuity_capture_event(
+                raw_content="Blocker: Missing deployment credentials",
+                explicit_signal="blocker",
+                admission_posture="DERIVED",
+                admission_reason="explicit_signal_blocker",
+            )["id"],
+            object_type="Blocker",
+            status="active",
+            title="Blocker: Missing deployment credentials",
+            body={"blocker_text": "Missing deployment credentials"},
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["brief-api-3"]},
+            confidence=0.9,
+        )
+        decision = store.create_continuity_object(
+            capture_event_id=store.create_continuity_capture_event(
+                raw_content="Decision: Keep deploy rollout phased",
+                explicit_signal="decision",
+                admission_posture="DERIVED",
+                admission_reason="explicit_signal_decision",
+            )["id"],
+            object_type="Decision",
+            status="active",
+            title="Decision: Keep deploy rollout phased",
+            body={"decision_text": "Keep deploy rollout phased"},
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["brief-api-4"]},
+            confidence=0.96,
+        )
+        next_action = store.create_continuity_object(
+            capture_event_id=store.create_continuity_capture_event(
+                raw_content="Next Action: Draft deploy checklist",
+                explicit_signal="next_action",
+                admission_posture="DERIVED",
+                admission_reason="explicit_signal_next_action",
+            )["id"],
+            object_type="NextAction",
+            status="active",
+            title="Next Action: Draft deploy checklist",
+            body={"action_text": "Draft deploy checklist"},
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["brief-api-5"]},
+            confidence=0.95,
+        )
+        sync_contradictions(
+            store,
+            user_id=user_id,
+            request=ContradictionSyncInput(limit=20),
+        )
+
+    for continuity_object_id, created_at in (
+        (fact_one["id"], datetime(2026, 4, 10, 9, 0, tzinfo=UTC)),
+        (fact_two["id"], datetime(2026, 4, 10, 9, 5, tzinfo=UTC)),
+        (blocker["id"], datetime(2026, 4, 10, 9, 10, tzinfo=UTC)),
+        (decision["id"], datetime(2026, 4, 10, 9, 15, tzinfo=UTC)),
+        (next_action["id"], datetime(2026, 4, 10, 9, 20, tzinfo=UTC)),
+    ):
+        set_continuity_timestamps(
+            migrated_database_urls["admin"],
+            continuity_object_id=continuity_object_id,
+            created_at=created_at,
+        )
+
+    status, payload = invoke_request(
+        "POST",
+        "/v1/continuity/brief",
+        payload={
+            "brief_type": "agent_handoff",
+            "thread_id": str(thread_id),
+            "query": "deployment",
+            "max_relevant_facts": 4,
+            "max_recent_changes": 4,
+            "max_open_loops": 3,
+            "max_conflicts": 3,
+            "max_timeline_highlights": 4,
+        },
+        headers=auth_header(session_token),
+    )
+
+    assert status == 200
+    brief = payload["brief"]
+    assert brief["assembly_version"] == "continuity_brief_v0"
+    assert brief["brief_type"] == "agent_handoff"
+    assert brief["selection_strategy"]["task_brief_mode"] == "agent_handoff"
+    assert brief["summary"].startswith("agent handoff brief.")
+    assert brief["relevant_facts"]["summary"]["returned_count"] >= 1
+    assert brief["recent_changes"]["summary"]["returned_count"] >= 1
+    assert brief["open_loops"]["summary"]["total_count"] == 1
+    assert brief["conflicts"]["summary"]["total_count"] >= 1
+    assert brief["timeline_highlights"]["summary"]["returned_count"] >= 1
+    assert brief["next_suggested_action"]["title"] == "Next Action: Draft deploy checklist"
+    assert brief["trust_posture"]["open_conflict_count"] >= 1
+    assert brief["trust_posture"]["active_signal_count"] >= 1
+    assert brief["provenance_bundle"]["summary"]["reference_count"] >= 1

--- a/tests/integration/test_mcp_cli_parity.py
+++ b/tests/integration/test_mcp_cli_parity.py
@@ -12,9 +12,14 @@ from uuid import UUID, uuid4
 
 import psycopg
 
+from alicebot_api.continuity_brief import compile_continuity_brief
 from alicebot_api.continuity_recall import query_continuity_recall
 from alicebot_api.continuity_resumption import compile_continuity_resumption_brief
-from alicebot_api.contracts import ContinuityRecallQueryInput, ContinuityResumptionBriefRequestInput
+from alicebot_api.contracts import (
+    ContinuityBriefRequestInput,
+    ContinuityRecallQueryInput,
+    ContinuityResumptionBriefRequestInput,
+)
 from alicebot_api.db import user_connection
 from alicebot_api.store import ContinuityStore
 
@@ -289,6 +294,157 @@ def test_mcp_recall_and_resume_match_core_and_cli_behavior(migrated_database_url
     assert cli_resume.returncode == 0
     assert core_resume["brief"]["last_decision"]["item"]["title"] in cli_resume.stdout
     assert core_resume["brief"]["next_action"]["item"]["title"] in cli_resume.stdout
+
+
+def test_mcp_one_call_brief_matches_core_and_cli_surface(migrated_database_urls) -> None:
+    user_id = seed_user(migrated_database_urls["app"], email="mcp-one-call@example.com")
+    thread_id = UUID("cccccccc-cccc-4ccc-8ccc-cccccccccccc")
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        fact_one = store.create_continuity_object(
+            capture_event_id=store.create_continuity_capture_event(
+                raw_content="Fact: Deploy owner is Platform",
+                explicit_signal="remember_this",
+                admission_posture="DERIVED",
+                admission_reason="explicit_signal_memory",
+            )["id"],
+            object_type="MemoryFact",
+            status="active",
+            title="Fact: Deploy owner is Platform",
+            body={"fact_key": "deploy_owner", "fact_value": "Platform"},
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["brief-parity-1"]},
+            confidence=0.9,
+        )
+        fact_two = store.create_continuity_object(
+            capture_event_id=store.create_continuity_capture_event(
+                raw_content="Fact: Deploy owner is Infrastructure",
+                explicit_signal="remember_this",
+                admission_posture="DERIVED",
+                admission_reason="explicit_signal_memory",
+            )["id"],
+            object_type="MemoryFact",
+            status="active",
+            title="Fact: Deploy owner is Infrastructure",
+            body={"fact_key": "deploy_owner", "fact_value": "Infrastructure"},
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["brief-parity-2"]},
+            confidence=0.86,
+        )
+        blocker = store.create_continuity_object(
+            capture_event_id=store.create_continuity_capture_event(
+                raw_content="Blocker: Await deploy approval",
+                explicit_signal="blocker",
+                admission_posture="DERIVED",
+                admission_reason="explicit_signal_blocker",
+            )["id"],
+            object_type="Blocker",
+            status="active",
+            title="Blocker: Await deploy approval",
+            body={"blocker_text": "Await deploy approval"},
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["brief-parity-3"]},
+            confidence=0.91,
+        )
+        next_action = store.create_continuity_object(
+            capture_event_id=store.create_continuity_capture_event(
+                raw_content="Next Action: Send deploy plan",
+                explicit_signal="next_action",
+                admission_posture="DERIVED",
+                admission_reason="explicit_signal_next_action",
+            )["id"],
+            object_type="NextAction",
+            status="active",
+            title="Next Action: Send deploy plan",
+            body={"action_text": "Send deploy plan"},
+            provenance={"thread_id": str(thread_id), "source_event_ids": ["brief-parity-4"]},
+            confidence=0.95,
+        )
+
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=fact_one["id"],
+        created_at=datetime(2026, 4, 3, 9, 0, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=fact_two["id"],
+        created_at=datetime(2026, 4, 3, 9, 5, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=blocker["id"],
+        created_at=datetime(2026, 4, 3, 9, 10, tzinfo=UTC),
+    )
+    set_continuity_timestamps(
+        migrated_database_urls["admin"],
+        continuity_object_id=next_action["id"],
+        created_at=datetime(2026, 4, 3, 9, 15, tzinfo=UTC),
+    )
+
+    with user_connection(migrated_database_urls["app"], user_id) as conn:
+        store = ContinuityStore(conn)
+        core_brief = compile_continuity_brief(
+            store,
+            user_id=user_id,
+            request=ContinuityBriefRequestInput(
+                brief_type="coding_context",
+                thread_id=thread_id,
+                query="deploy",
+                max_relevant_facts=4,
+                max_recent_changes=4,
+                max_open_loops=3,
+                max_conflicts=3,
+                max_timeline_highlights=4,
+            ),
+        )
+
+    client = start_mcp_client(database_url=migrated_database_urls["app"], user_id=user_id)
+    try:
+        mcp_brief = _call_tool(
+            client,
+            name="alice_brief",
+            arguments={
+                "brief_type": "coding_context",
+                "thread_id": str(thread_id),
+                "query": "deploy",
+                "max_relevant_facts": 4,
+                "max_recent_changes": 4,
+                "max_open_loops": 3,
+                "max_conflicts": 3,
+                "max_timeline_highlights": 4,
+            },
+        )
+    finally:
+        client.close()
+
+    assert mcp_brief == core_brief
+
+    env = build_runtime_env(database_url=migrated_database_urls["app"], user_id=user_id)
+    cli_brief = run_cli(
+        [
+            "brief",
+            "--brief-type",
+            "coding_context",
+            "--thread-id",
+            str(thread_id),
+            "--query",
+            "deploy",
+            "--max-relevant-facts",
+            "4",
+            "--max-recent-changes",
+            "4",
+            "--max-open-loops",
+            "3",
+            "--max-conflicts",
+            "3",
+            "--max-timeline-highlights",
+            "4",
+        ],
+        env=env,
+    )
+    assert cli_brief.returncode == 0
+    assert core_brief["brief"]["next_suggested_action"]["title"] in cli_brief.stdout
+    assert "confidence=" in cli_brief.stdout
+    assert "conflicts:" in cli_brief.stdout
 
 
 def test_mcp_task_brief_compare_smoke_matches_cli_surface(migrated_database_urls) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -19,6 +19,7 @@ def test_parser_routes_required_commands() -> None:
         (["mutations", "candidates"], "_run_mutation_candidates"),
         (["mutations", "commit"], "_run_mutation_commit"),
         (["mutations", "operations"], "_run_mutation_operations"),
+        (["brief"], "_run_brief"),
         (["recall"], "_run_recall"),
         (["state-at", continuity_object_id], "_run_state_at"),
         (["timeline", continuity_object_id], "_run_timeline"),

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -25,6 +25,7 @@ def test_mcp_tool_surface_is_adr_aligned_and_deterministic() -> None:
         "alice_state_at",
         "alice_resume",
         "alice_resume_debug",
+        "alice_brief",
         "alice_task_brief",
         "alice_task_brief_show",
         "alice_task_brief_compare",


### PR DESCRIPTION
## Summary

This PR ships `P13-S1: One-Call Continuity` by adding one primary continuity surface across the three supported integration paths:

- API: `POST /v1/continuity/brief`
- CLI: `alice brief`
- MCP: `alice_brief`

The implementation adds a shared continuity brief assembler, reuses the existing Phase 12 retrieval, resumption, contradiction, trust, and briefing systems, and makes the new one-call surface the default documented path for external agents.

## Validation

- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/pytest tests/unit/test_control_doc_truth.py tests/unit/test_cli.py tests/unit/test_mcp.py -q`
- `./.venv/bin/pytest tests/integration/test_continuity_brief_api.py tests/integration/test_mcp_cli_parity.py -q`
- `node --test packages/alice-cli/test/alice.test.mjs`

## Upgrade Overview

### Protected Areas

- [x] memory schema
- [ ] evidence pipeline
- [x] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact

This is additive at the surface level: it introduces a new primary continuity endpoint across API, CLI, and MCP without removing the underlying Phase 12 continuity systems it composes. The main behavioral shift is that docs and integration guidance now point external agents at the one-call brief surface instead of requiring tool choreography across multiple lower-level endpoints.

### Migration / Rollout

No data migration or backfill is required. Rollout is application-only: deploy the new API/CLI/MCP surface, then treat the one-call brief as the default external integration path in docs and runtime examples. Existing lower-level continuity surfaces remain available.

### Operator Action

No manual operator action is required beyond normal deploy and smoke validation. External runtime integrations that want the simplified path can switch to `POST /v1/continuity/brief`, `alice brief`, or `alice_brief` when convenient.

### Validation

The sprint was validated with targeted parity coverage across the shipped surfaces and control-doc truth checks:

- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/pytest tests/unit/test_control_doc_truth.py tests/unit/test_cli.py tests/unit/test_mcp.py -q`
- `./.venv/bin/pytest tests/integration/test_continuity_brief_api.py tests/integration/test_mcp_cli_parity.py -q`
- `node --test packages/alice-cli/test/alice.test.mjs`

### Rollback

Rollback is straightforward: revert commit `fe81611880eed5006138ee24736fa73682ab13f5` to remove the new one-call continuity surface and restore the prior Phase 12-only continuity entrypoints. Because the change is additive and does not require schema migration, rollback does not require compensating data steps.
