### PR TITLE
[codex] P13-S3: ship memory hygiene and conversation health

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -1,7 +1,7 @@
 # Sprint Packet
 
 ## Sprint Title
-P13-S2: Alice Lite
+P13-S3: Memory Hygiene + Conversation Health
 
 ## Activation Note
 - This packet is active.
@@ -9,17 +9,17 @@ P13-S2: Alice Lite
 - Phase 13 is active.
 - Phase 13 sequence is fixed for now:
   - `P13-S1` One-Call Continuity (shipped)
-  - `P13-S2` Alice Lite
+  - `P13-S2` Alice Lite (shipped)
   - `P13-S3` Memory Hygiene + Conversation Health
 
 ## Sprint Type
 feature
 
 ## Sprint Reason
-`P13-S1` already shipped the one-call continuity surface. The next job is to make Alice easier to start, lighter to run locally, and faster to understand in the first ten minutes without creating a second product or weakening semantics.
+`P13-S1` already reduced integration complexity, and `P13-S2` already reduced startup friction. The final Phase 13 sprint should make memory quality and conversation risk visible enough that Alice feels polished, legible, and operationally trustworthy.
 
 ## Git Instructions
-- Branch Name: `codex/phase13-s2-alice-lite`
+- Branch Name: `codex/phase13-s3-memory-hygiene-conversation-health`
 - Base Branch: `main`
 - PR Strategy: one implementation branch, one PR
 - Merge Policy: squash merge after review `PASS` and explicit approval
@@ -29,67 +29,69 @@ feature
 - shipped Bridge `B1` through `B4`
 - published `v0.3.2` baseline
 - shipped `P13-S1` one-call continuity surface
+- shipped `P13-S2` Alice Lite profile
 - no semantic fork between API, CLI, MCP, hosted, provider-runtime, and Hermes paths
 
 ## Exact Goal
-Create Alice Lite as a lighter deployment and onboarding profile:
-- one-command local startup
-- smaller-footprint deployment profile
-- simplified quickstart
-- sample workspace/bootstrap path
-- faster first useful result
+Make memory hygiene and conversation health visible and actionable:
+- duplicates
+- stale facts
+- unresolved contradictions
+- weakly trusted memory
+- review queue pressure
+- recent threads
+- stale threads
+- risky threads
+- thread health posture
 
-Alice Lite must use the same continuity semantics and the same one-call continuity entrypoint already shipped in `P13-S1`.
+This sprint should improve operational legibility without adding new substrate work.
 
 ## In Scope
-- lighter local startup path
-- smaller-footprint profile for local/dev use
-- quickstart and first-result tightening
-- sample workspace/bootstrap flow
-- docs and scripts that make the one-call continuity surface the default demo/integration entrypoint
-- startup/smoke verification for the Lite profile
+- hygiene visibility for duplicates, stale facts, unresolved contradictions, weak trust, and review pressure
+- conversation/thread health visibility for recent, stale, and risky threads
+- bounded UI/API/CLI surfaces needed to inspect those states
+- prioritization or summary views that make the quality/risk posture obvious
+- tests and docs for the new hygiene and conversation-health surfaces
 
 ## Out Of Scope
-- hygiene or thread-health dashboards
 - new connectors or channels
 - new retrieval research
 - graph or persistence rearchitecture
-- SQLite or embedded-mode redesign unless it is strictly necessary and semantics remain intact
-- new provider/runtime substrate work unless directly required for the lighter profile
+- new provider/runtime substrate work
+- deeper Alice Lite packaging work
+- new continuity-surface work beyond what is required to expose the quality/health views
 
 ## Proposed Files And Modules
-- `README.md`
-- `docs/quickstart/`
-- `scripts/`
-- local startup/profile config files
-- `docker-compose` / deployment-profile files if needed
-- startup/smoke tests
-- docs that describe Lite as a profile, not a separate product
+- `apps/api/src/alicebot_api/`
+- `apps/web/` if UI surfaces are part of the implemented sprint
+- `docs/memory/` or related docs paths
+- `tests/unit/`
+- `tests/integration/`
+- control docs if sprint status updates are needed
 
 ## Planned Deliverables
-- one-command local start for Alice Lite
-- smaller-footprint local/dev profile
-- simplified quickstart and fast first useful result
-- docs/examples that use the shipped one-call continuity surface as the default Alice demo path
-- smoke coverage for the Lite path
+- memory hygiene surfaces
+- conversation health surfaces
+- prioritization/summary outputs for stale, risky, contradictory, or review-heavy states
+- docs and tests that make those surfaces usable and trustworthy
 
 ## Acceptance Criteria
-- a solo builder can start Alice more easily through a lighter local path
-- Alice Lite preserves the same continuity semantics as the full baseline
-- the shipped one-call continuity surface remains the default integration/demo entrypoint
-- quickstart and first-result path are materially simpler than before
-- Lite is clearly documented as a deployment profile, not a separate product
+- duplicates, stale facts, unresolved contradictions, weak trust, and review pressure are visible and actionable
+- stale or risky conversations are visible without deep system knowledge
+- the sprint improves quality visibility without introducing new substrate work
+- the shipped one-call continuity surface and Alice Lite path remain intact and non-forked
+- the result feels like visibility/polish work, not a fourth hidden architecture sprint
 
 ## Required Verification
 - `python3 scripts/check_control_doc_truth.py`
 - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-- targeted startup/smoke coverage for the Lite path
-- any docs/quickstart verification required by the implemented Lite profile
+- targeted unit/integration coverage for the hygiene and conversation-health surfaces
+- any UI/API/CLI verification required by the implemented sprint surface
 
 ## Control Tower Decisions Needed
-- whether Alice Lite can reduce services or bootstrap steps without harming semantics or release credibility
-- whether Lite is strictly Docker-profile based or also exposes a scripted local bootstrap path
-- what the canonical "first useful result" flow is for Lite
+- threshold model for risky/stale thread health
+- whether review queue pressure is summarized only at a global level or also per thread/workspace slice
+- whether the first shipped thread-health surface is API-only, UI-visible, or both
 
 ## Exit Condition
-This sprint is complete when Alice offers a meaningfully simpler local/dev startup path and first-run experience while preserving the shipped continuity semantics and one-call continuity surface.
+This sprint is complete when Alice makes memory hygiene and conversation health clearly visible and operationally useful without weakening the shipped continuity semantics or expanding into new substrate work.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -9,24 +9,25 @@
 - `v0.3.2` is the latest published tag.
 - Phase 13 is active.
 - `P13-S1` One-Call Continuity is shipped.
-- `P13-S2` Alice Lite is the active execution sprint.
-- `P13-S3` Memory Hygiene + Conversation Health is planned after Alice Lite.
+- `P13-S2` Alice Lite is shipped.
+- `P13-S3` Memory Hygiene + Conversation Health is the active execution sprint.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
 - Alice exposes CLI, MCP, hosted/product, provider-runtime, and Hermes bridge surfaces.
 - The shipped baseline now includes hybrid retrieval and reranking with traces, explicit memory mutation operations, contradiction/trust handling, the public eval harness, and task-adaptive briefing.
 - The shipped baseline also now includes the one-call continuity surface across API, CLI, and MCP from `P13-S1`.
+- The shipped baseline also now includes the lighter Alice Lite startup/profile path from `P13-S2`.
 - `v0.3.2` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
 - Phase 12 is complete and remains baseline truth.
 - Phase 13 is the adoption and ergonomics phase on top of that baseline.
 - `P13-S1` is complete and established the primary one-call continuity surface across API, CLI, and MCP.
-- `P13-S2` is active and should simplify startup and local adoption without semantic drift.
-- `P13-S3` should make hygiene and thread/conversation health visible and operationally useful.
+- `P13-S2` is complete and established the lighter Alice Lite startup/profile path without semantic drift.
+- `P13-S3` is active and should make hygiene and thread/conversation health visible and operationally useful.
 
 ## Immediate Control Tower Decisions Needed
 - Decide whether the next public release should wrap the full Phase 13 sequence or ship incrementally.
-- Decide whether Alice Lite remains purely a lighter deployment profile in `P13-S2`.
 - Decide the threshold model for risky/stale thread health in `P13-S3`.
+- Decide whether the first shipped thread-health surface is API-only, UI-visible, or both.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Scope Boundary
 - **Shipped baseline:** Phases 9-12 and Bridge `B1` through `B4`.
-- **Current repo execution posture:** `v0.3.2` is the latest published tag; Phase 13 is active; `P13-S1` is shipped; `P13-S2` is the active execution sprint.
+- **Current repo execution posture:** `v0.3.2` is the latest published tag; Phase 13 is active; `P13-S1` is shipped; `P13-S2` is shipped; `P13-S3` is the active execution sprint.
 - **Phase principle:** Phase 13 is an adoption layer on top of Phase 12, not a new substrate phase.
 
 ## Current System Overview
@@ -135,7 +135,7 @@ Alice is a modular continuity platform with shared continuity semantics across l
 - This surface must compose shipped Phase 12 layers rather than reimplement them.
 
 ### P13-S2: Alice Lite
-- Status: active
+- Status: shipped
 - Add a lighter local deployment profile for solo users and builders.
 - Target outcomes:
   - one-command local startup
@@ -146,7 +146,7 @@ Alice is a modular continuity platform with shared continuity semantics across l
 - SQLite or another embedded mode is not in scope unless semantics remain intact.
 
 ### P13-S3: Memory Hygiene + Conversation Health
-- Status: queued
+- Status: active
 - Add visible hygiene surfaces for:
   - duplicates
   - stale facts

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,45 +1,44 @@
 # BUILD_REPORT
 
 - sprint objective
-  - Implement `P13-S2` Alice Lite as a lighter local/dev startup and onboarding profile while preserving the shipped continuity semantics and one-call continuity entrypoint.
+  - Implement `P13-S3` Memory Hygiene + Conversation Health by making duplicate facts, stale facts, unresolved contradictions, weak trust, review pressure, recent threads, stale threads, risky threads, and overall thread posture visible through bounded API, web, and CLI status surfaces.
 - completed work
-  - Added `docker-compose.lite.yml` with a Lite Postgres-only local profile.
-  - Added `.env.lite.example` for the Lite entrypoint-rate-limit and reload defaults.
-  - Added `scripts/alice_lite_up.sh` for one-command Lite startup, migration, sample-data load, and API launch.
-  - Added `scripts/bootstrap_alice_lite_workspace.py` for the sample hosted workspace bootstrap flow plus first one-call continuity result without printing session tokens.
-  - Added `scripts/run_alice_lite_smoke.py` for Lite health and one-call CLI smoke verification.
-  - Updated `scripts/api_dev.sh` so the Lite entrypoint-rate-limit override survives `.env` loading.
-  - Updated `README.md` and `docs/quickstart/local-setup-and-first-result.md` so Alice Lite is the default quickstart/demo path, `brief` is the default first useful result, and the Lite prerequisites stay scoped to the Lite path.
-  - Updated Phase 13 control docs and architecture docs so `P13-S1` is recorded as shipped and `P13-S2` as active.
-  - Added focused unit coverage for the Lite profile assets, including token-output guardrails and quickstart scope checks.
+  - Added `GET /v0/memories/hygiene-dashboard` with grouped duplicate detection, stale-fact visibility, unresolved contradiction counts, weak-trust counts, review-queue pressure, and actionable focus items.
+  - Added `GET /v0/threads/health-dashboard` with recent/stale/risky thread summaries, deterministic thresholds, per-thread reasons, and recommended actions.
+  - Extended `alicebot status` to include memory-hygiene posture and thread-health posture from the same canonical dashboard builders.
+  - Added a memory hygiene panel to the memory review workspace.
+  - Added a thread health panel to the continuity workspace.
+  - Added focused unit coverage for memory hygiene aggregation and thread health aggregation.
+  - Added focused web page coverage for the new memory and continuity dashboard panels.
+  - Added `docs/memory/p13-s3-memory-hygiene-conversation-health.md` documenting the shipped surfaces and threshold model.
 - incomplete work
-  - None identified during implementation.
+  - None identified within sprint scope.
 - files changed
-  - `.ai/active/SPRINT_PACKET.md`
-  - `.ai/handoff/CURRENT_STATE.md`
-  - `BUILD_REPORT.md`
-  - `CURRENT_STATE.md`
-  - `PRODUCT_BRIEF.md`
-  - `.env.lite.example`
-  - `ARCHITECTURE.md`
-  - `README.md`
-  - `ROADMAP.md`
-  - `docker-compose.lite.yml`
-  - `docs/quickstart/local-setup-and-first-result.md`
-  - `scripts/check_control_doc_truth.py`
-  - `scripts/alice_lite_up.sh`
-  - `scripts/api_dev.sh`
-  - `scripts/bootstrap_alice_lite_workspace.py`
-  - `scripts/run_alice_lite_smoke.py`
-  - `tests/unit/test_phase13_alice_lite_assets.py`
+  - `apps/api/src/alicebot_api/cli.py`
+  - `apps/api/src/alicebot_api/cli_formatting.py`
+  - `apps/api/src/alicebot_api/contracts.py`
+  - `apps/api/src/alicebot_api/conversation_health.py`
+  - `apps/api/src/alicebot_api/main.py`
+  - `apps/api/src/alicebot_api/memory.py`
+  - `apps/web/app/continuity/page.test.tsx`
+  - `apps/web/app/continuity/page.tsx`
+  - `apps/web/app/memories/page.test.tsx`
+  - `apps/web/app/memories/page.tsx`
+  - `apps/web/components/memory-hygiene-dashboard.tsx`
+  - `apps/web/components/thread-health-dashboard.tsx`
+  - `apps/web/lib/api.ts`
+  - `docs/memory/p13-s3-memory-hygiene-conversation-health.md`
+  - `tests/unit/test_conversation_health.py`
+  - `tests/unit/test_main.py`
+  - `tests/unit/test_memory.py`
 - tests run
   - `python3 scripts/check_control_doc_truth.py`
   - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-  - `./.venv/bin/python -m pytest tests/unit/test_phase13_alice_lite_assets.py -q`
-  - live `./scripts/alice_lite_up.sh` startup verification against `docker-compose.lite.yml`
-  - live `./.venv/bin/python scripts/bootstrap_alice_lite_workspace.py`
-  - live `./.venv/bin/python scripts/run_alice_lite_smoke.py`
+  - `./.venv/bin/python -m pytest tests/unit/test_memory.py tests/unit/test_conversation_health.py tests/unit/test_main.py -q`
+  - `./.venv/bin/python -m pytest tests/unit/test_events.py -q`
+  - `./.venv/bin/python -m pytest tests/unit/test_cli.py -q`
+  - `pnpm test app/memories/page.test.tsx app/continuity/page.test.tsx` (run from `apps/web`)
 - blockers/issues
-  - No implementation blockers remained after fixing the authenticated-user sample-data seeding path, aligning the smoke matcher with the current CLI formatter output, and removing the bootstrap-token log leak from the sample flow.
+  - The sprint packet left thread-health thresholds and first-surface scope open. Implementation uses a bounded deterministic model: recent within 24h, stale after 72h, risky at score `>= 2`, and ships the first surface in both API and web.
 - recommended next step
-  - Review whether the full-stack quickstart should also link to the Lite profile now that Lite is the default local/dev onboarding path.
+  - Validate the risk-score thresholds against live operator usage and adjust only the scoring constants if the first dashboard proves too noisy or too quiet.

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -12,24 +12,25 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - `v0.3.2` is the latest published tag.
 - Phase 13 is active.
 - `P13-S1` One-Call Continuity is shipped.
-- `P13-S2` Alice Lite is the active execution sprint.
-- `P13-S3` Memory Hygiene + Conversation Health is planned after Alice Lite.
+- `P13-S2` Alice Lite is shipped.
+- `P13-S3` Memory Hygiene + Conversation Health is the active execution sprint.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
 - Alice exposes CLI, MCP, hosted/product, provider-runtime, and Hermes bridge surfaces.
 - The shipped baseline now includes hybrid retrieval and reranking with traces, explicit memory mutation operations, contradiction/trust handling, the public eval harness, and task-adaptive briefing.
 - The shipped baseline also now includes the one-call continuity surface across API, CLI, and MCP from `P13-S1`.
+- The shipped baseline also now includes the lighter Alice Lite startup/profile path from `P13-S2`.
 - `v0.3.2` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
 - Phase 12 is complete and remains baseline truth.
 - Phase 13 is the adoption and ergonomics phase on top of that baseline.
 - `P13-S1` is complete and established the primary one-call continuity surface across API, CLI, and MCP.
-- `P13-S2` is active and should simplify startup and local adoption without semantic drift.
-- `P13-S3` should make hygiene and thread/conversation health visible and operationally useful.
+- `P13-S2` is complete and established the lighter Alice Lite startup/profile path without semantic drift.
+- `P13-S3` is active and should make hygiene and thread/conversation health visible and operationally useful.
 
 ## Immediate Control Tower Decisions Needed
 - Decide whether the next public release should wrap the full Phase 13 sequence or ship incrementally.
-- Decide whether Alice Lite remains purely a lighter deployment profile in `P13-S2`.
 - Decide the threshold model for risky/stale thread health in `P13-S3`.
+- Decide whether the first shipped thread-health surface is API-only, UI-visible, or both.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -14,8 +14,8 @@ Alice is a pre-1.0 continuity platform for AI agents and agent-assisted workflow
 ## Current Repo Posture
 - Phase 13 is active.
 - `P13-S1` One-Call Continuity is shipped.
-- `P13-S2` Alice Lite is the active execution sprint.
-- `P13-S3` Memory Hygiene + Conversation Health follows after Alice Lite.
+- `P13-S2` Alice Lite is shipped.
+- `P13-S3` Memory Hygiene + Conversation Health is the active execution sprint.
 - Phase 13 is an adoption and ergonomics phase built on top of the shipped Phase 12 baseline.
 
 ## Active Phase
@@ -67,5 +67,5 @@ Phase 13 should make those gains easier to adopt:
 
 ## Control Tower Decisions Needed
 - Whether the next public release boundary should wrap the whole Phase 13 sequence or ship incrementally.
-- Whether Alice Lite in `P13-S2` should remain a deployment-profile change only or later justify an embedded mode.
-- Exact default inclusion behavior for `/v1/continuity/brief` when query, thread, and entity context all coexist.
+- Threshold model for risky/stale thread health in `P13-S3`.
+- Whether the first shipped thread-health surface should be API-only, UI-visible, or both.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,37 +4,33 @@
 PASS
 
 ## criteria met
-- Alice Lite provides a real one-command local startup path through `./scripts/alice_lite_up.sh` and a lighter Postgres-only local profile through `docker-compose.lite.yml`.
-- Alice Lite preserves the shipped continuity semantics and keeps the shipped one-call continuity surface as the default demo and integration path.
-- The quickstart and first-result path are materially simpler than before and now keep Lite prerequisites scoped to the Lite flow.
-- Lite is clearly documented as a deployment profile, not a separate product, in `README.md` and `docs/quickstart/local-setup-and-first-result.md`.
-- The sample bootstrap path works end to end and no longer prints the live `session_token` in its success output.
-- Phase 13 control docs and `ARCHITECTURE.md` now reflect the current sprint state: `P13-S1` shipped, `P13-S2` active.
-- I did not find committed local workstation paths, usernames, or other machine-specific identifiers in the reviewed changed files.
+- Memory hygiene visibility is implemented for duplicates, stale facts, unresolved contradictions, weak trust, and review queue pressure via API, web, and CLI surfaces.
+- Conversation health visibility is implemented for recent, stale, and risky threads via API, web, and CLI surfaces.
+- The thread-health weak-trust aggregation no longer relies on a global fixed-cap signal fetch; it now counts active `weak_inference` signals per continuity object, so higher-volume workspaces do not silently undercount thread risk.
+- Coverage now includes:
+  - the high-volume weak-trust aggregation case
+  - reachable-path CLI status output for the new hygiene and thread-health fields
+  - endpoint-level API tests for both new dashboard routes
+- `ARCHITECTURE.md` now matches the active Phase 13 control-doc posture.
+- I did not find local workstation identifiers, usernames, or local filesystem paths in the changed sprint files or docs.
 
 ## criteria missed
 - None.
 
 ## quality issues
-- No blocking quality issues remain for this sprint.
-- Focused regression checks now cover the bootstrap-token leak guard and the narrowed Lite quickstart prerequisites in `tests/unit/test_phase13_alice_lite_assets.py`.
+- No blocking quality issues found in the reviewed implementation after the fixes.
 
 ## regression risks
-- Normal local profile risk remains around switching between the full stack and Lite compose profiles in the same workspace, but this does not block sprint acceptance.
+- Low residual risk around future changes to thread risk scoring, because the dashboard posture depends on cross-surface shared aggregation logic. Current focused unit coverage is adequate for this sprint.
 
 ## docs issues
 - No blocking docs issues remain for this sprint.
-- `BUILD_REPORT.md` now reflects the actual sprint file set and the fixed verification story.
 
 ## should anything be added to RULES.md?
-No.
-
-The existing rules were sufficient. The earlier problems were implementation drift, not a missing policy.
+- No.
 
 ## should anything update ARCHITECTURE.md?
-No further update is required for this sprint.
-
-The architecture doc now matches the current Phase 13 execution posture closely enough for follow-on work.
+- No further update is required for this sprint.
 
 ## recommended next action
-Accept `P13-S2` as passed and move to the next queued Phase 13 sprint.
+- Accept `P13-S3` as passed.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,8 +14,8 @@ These remain baseline truth and are not future milestones.
 ## Active Planning Status
 - Phase 13 is active.
 - `P13-S1` One-Call Continuity is shipped.
-- `P13-S2` Alice Lite is the active execution sprint.
-- `P13-S3` Memory Hygiene + Conversation Health follows after Alice Lite.
+- `P13-S2` Alice Lite is shipped.
+- `P13-S3` Memory Hygiene + Conversation Health is the active execution sprint.
 
 ## Phase 13 Planned Milestones
 
@@ -34,14 +34,14 @@ Status: shipped
 - tighten quickstart and first-result path
 - keep semantics aligned with the full Alice baseline
 
-Status: active
+Status: shipped
 
 ### P13-S3: Memory Hygiene + Conversation Health
 - surface duplicates, stale facts, unresolved contradictions, and review queue pressure
 - surface recent threads, stale threads, risky threads, and thread health
 - improve operational visibility without adding new substrate work
 
-Status: queued
+Status: active
 
 ## Sequencing Rules
 - Phase 13 is an adoption layer on top of the shipped Phase 12 baseline.

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -87,6 +87,7 @@ from alicebot_api.continuity_open_loops import (
     ContinuityOpenLoopValidationError,
     compile_continuity_open_loop_dashboard,
 )
+from alicebot_api.conversation_health import get_thread_health_dashboard
 from alicebot_api.continuity_recall import (
     ContinuityRecallValidationError,
     query_continuity_recall,
@@ -103,6 +104,7 @@ from alicebot_api.continuity_review import (
     list_continuity_review_queue,
 )
 from alicebot_api.continuity_trust import list_trust_signals
+from alicebot_api.memory import get_memory_hygiene_dashboard_summary
 from alicebot_api.contracts import (
     CONTINUITY_CAPTURE_EXPLICIT_SIGNALS,
     CONTINUITY_CORRECTION_ACTIONS,
@@ -928,6 +930,12 @@ def _run_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
     status_payload: dict[str, object] = {
         "user_id": str(ctx.user_id),
         "database_status": "reachable" if database_reachable else "unreachable",
+        "memory_hygiene_posture": "unknown",
+        "memory_duplicate_groups": 0,
+        "memory_stale_facts": 0,
+        "memory_unresolved_contradictions": 0,
+        "memory_weak_trust": 0,
+        "memory_review_queue_pressure": "unknown",
         "continuity_capture_events": 0,
         "continuity_objects_total": 0,
         "continuity_objects_active": 0,
@@ -938,6 +946,11 @@ def _run_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
         "continuity_objects_non_searchable": 0,
         "continuity_objects_promotable": 0,
         "continuity_objects_non_promotable": 0,
+        "thread_health_posture": "unknown",
+        "threads_recent": 0,
+        "threads_stale": 0,
+        "threads_risky": 0,
+        "threads_watch": 0,
         "review_correction_ready": 0,
         "review_active": 0,
         "review_stale": 0,
@@ -995,9 +1008,23 @@ def _run_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
             store,
             user_id=ctx.user_id,
         )["summary"]
+        memory_hygiene = get_memory_hygiene_dashboard_summary(
+            store,
+            user_id=ctx.user_id,
+        )["dashboard"]
+        thread_health = get_thread_health_dashboard(
+            store,
+            user_id=ctx.user_id,
+        )["dashboard"]
 
         status_payload.update(
             {
+                "memory_hygiene_posture": memory_hygiene["posture"],
+                "memory_duplicate_groups": memory_hygiene["duplicate_group_count"],
+                "memory_stale_facts": memory_hygiene["stale_fact_count"],
+                "memory_unresolved_contradictions": memory_hygiene["unresolved_contradiction_count"],
+                "memory_weak_trust": memory_hygiene["weak_trust_count"],
+                "memory_review_queue_pressure": memory_hygiene["review_queue_pressure"]["posture"],
                 "continuity_capture_events": store.count_continuity_capture_events(),
                 "continuity_objects_total": len(recall_candidates),
                 "continuity_objects_active": object_status_counts["active"],
@@ -1044,6 +1071,11 @@ def _run_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
                         )
                     )
                 ),
+                "thread_health_posture": thread_health["posture"],
+                "threads_recent": thread_health["recent_thread_count"],
+                "threads_stale": thread_health["stale_thread_count"],
+                "threads_risky": thread_health["risky_thread_count"],
+                "threads_watch": thread_health["watch_thread_count"],
                 "review_correction_ready": review_counts["active"] + review_counts["stale"],
                 "review_active": review_counts["active"],
                 "review_stale": review_counts["stale"],

--- a/apps/api/src/alicebot_api/cli_formatting.py
+++ b/apps/api/src/alicebot_api/cli_formatting.py
@@ -1321,6 +1321,15 @@ def format_status_output(status: Mapping[str, object]) -> str:
         "alice-core status",
         f"user_id: {status['user_id']}",
         f"database: {status['database_status']}",
+        (
+            "memory_hygiene: "
+            f"posture={status['memory_hygiene_posture']} "
+            f"duplicate_groups={status['memory_duplicate_groups']} "
+            f"stale_facts={status['memory_stale_facts']} "
+            f"open_contradictions={status['memory_unresolved_contradictions']} "
+            f"weak_trust={status['memory_weak_trust']} "
+            f"queue_pressure={status['memory_review_queue_pressure']}"
+        ),
         f"continuity_capture_events: {status['continuity_capture_events']}",
         f"continuity_objects_total: {status['continuity_objects_total']}",
         (
@@ -1336,6 +1345,14 @@ def format_status_output(status: Mapping[str, object]) -> str:
             f"non_searchable={status['continuity_objects_non_searchable']} "
             f"promotable={status['continuity_objects_promotable']} "
             f"non_promotable={status['continuity_objects_non_promotable']}"
+        ),
+        (
+            "thread_health: "
+            f"posture={status['thread_health_posture']} "
+            f"recent={status['threads_recent']} "
+            f"stale={status['threads_stale']} "
+            f"risky={status['threads_risky']} "
+            f"watch={status['threads_watch']}"
         ),
         (
             "review_queue: "

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -1118,6 +1118,56 @@ class ThreadListResponse(TypedDict):
     summary: ThreadListSummary
 
 
+ThreadActivityPosture = Literal["recent", "current", "stale"]
+ThreadRiskPosture = Literal["normal", "watch", "risky"]
+ThreadHealthPosture = Literal["healthy", "watch", "critical"]
+
+
+class ThreadHealthThresholdsRecord(TypedDict):
+    recent_window_hours: float
+    stale_window_hours: float
+    risky_score_threshold: int
+
+
+class ThreadHealthRecord(TypedDict):
+    thread: ThreadRecord
+    health_posture: ThreadHealthPosture
+    activity_posture: ThreadActivityPosture
+    risk_posture: ThreadRiskPosture
+    risk_score: int
+    last_activity_at: str | None
+    last_conversation_at: str | None
+    hours_since_last_activity: float | None
+    conversation_event_count: int
+    operational_event_count: int
+    active_session_count: int
+    open_loop_count: int
+    stale_open_loop_count: int
+    unresolved_contradiction_count: int
+    weak_trust_signal_count: int
+    reasons: list[str]
+    recommended_action: str
+
+
+class ThreadHealthDashboardSummary(TypedDict):
+    posture: ThreadHealthPosture
+    total_thread_count: int
+    recent_thread_count: int
+    stale_thread_count: int
+    risky_thread_count: int
+    watch_thread_count: int
+    thresholds: ThreadHealthThresholdsRecord
+    recent_threads: list[ThreadHealthRecord]
+    stale_threads: list[ThreadHealthRecord]
+    risky_threads: list[ThreadHealthRecord]
+    items: list[ThreadHealthRecord]
+    sources: list[str]
+
+
+class ThreadHealthDashboardResponse(TypedDict):
+    dashboard: ThreadHealthDashboardSummary
+
+
 class ThreadDetailResponse(TypedDict):
     thread: ThreadRecord
 
@@ -4878,6 +4928,61 @@ class MemoryTrustRecommendedReview(TypedDict):
     priority_mode: MemoryReviewQueuePriorityMode
     action: MemoryQualityReviewAction
     reason: str
+
+
+MemoryHygienePosture = Literal["healthy", "watch", "critical"]
+MemoryHygieneFocusKind = Literal[
+    "duplicates",
+    "stale_facts",
+    "unresolved_contradictions",
+    "weak_trust",
+    "review_queue_pressure",
+]
+
+
+class MemoryDuplicateGroupRecord(TypedDict):
+    group_key: str
+    memory_type: str
+    normalized_value: str
+    count: int
+    memory_ids: list[str]
+    memory_keys: list[str]
+    latest_updated_at: str
+
+
+class MemoryReviewQueuePressureSummary(TypedDict):
+    posture: MemoryHygienePosture
+    total_count: int
+    stale_over_72h_count: int
+    aging_24h_to_72h_count: int
+    reason: str
+
+
+class MemoryHygieneFocusRecord(TypedDict):
+    kind: MemoryHygieneFocusKind
+    posture: MemoryHygienePosture
+    count: int
+    reason: str
+    action: str
+    sample_ids: list[str]
+
+
+class MemoryHygieneDashboardSummary(TypedDict):
+    posture: MemoryHygienePosture
+    reason: str
+    duplicate_group_count: int
+    duplicate_memory_count: int
+    stale_fact_count: int
+    unresolved_contradiction_count: int
+    weak_trust_count: int
+    review_queue_pressure: MemoryReviewQueuePressureSummary
+    duplicate_groups: list[MemoryDuplicateGroupRecord]
+    focus: list[MemoryHygieneFocusRecord]
+    sources: list[str]
+
+
+class MemoryHygieneDashboardResponse(TypedDict):
+    dashboard: MemoryHygieneDashboardSummary
 
 
 class MemoryTrustDashboardSummary(TypedDict):

--- a/apps/api/src/alicebot_api/conversation_health.py
+++ b/apps/api/src/alicebot_api/conversation_health.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+import psycopg
+
+from alicebot_api.continuity_contradictions import sync_contradiction_state_for_objects
+from alicebot_api.contracts import (
+    ThreadActivityPosture,
+    ThreadHealthDashboardResponse,
+    ThreadHealthDashboardSummary,
+    ThreadHealthPosture,
+    ThreadHealthRecord,
+    ThreadHealthThresholdsRecord,
+    ThreadRecord,
+    ThreadRiskPosture,
+)
+from alicebot_api.store import (
+    ContinuityRecallCandidateRow,
+    ContinuityStore,
+    EventRow,
+    SessionRow,
+    ThreadRow,
+)
+
+_RECENT_THREAD_WINDOW_HOURS = 24.0
+_STALE_THREAD_WINDOW_HOURS = 72.0
+_RISKY_THREAD_SCORE_THRESHOLD = 2
+_OPEN_LOOP_OBJECT_TYPES = {"WaitingFor", "Blocker", "NextAction"}
+_CONVERSATION_EVENT_KINDS = {"message.user", "message.assistant"}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _serialize_thread(thread: ThreadRow) -> ThreadRecord:
+    return {
+        "id": str(thread["id"]),
+        "title": thread["title"],
+        "agent_profile_id": thread["agent_profile_id"],
+        "created_at": thread["created_at"].isoformat(),
+        "updated_at": thread["updated_at"].isoformat(),
+    }
+
+
+def _hours_since(now: datetime, value: datetime | None) -> float | None:
+    if value is None:
+        return None
+    return round(max(0.0, (now - value).total_seconds() / 3600.0), 6)
+
+
+def _thread_id_from_provenance(row: ContinuityRecallCandidateRow) -> UUID | None:
+    provenance = row.get("provenance")
+    if not isinstance(provenance, dict):
+        return None
+    raw_thread_id = provenance.get("thread_id")
+    if isinstance(raw_thread_id, UUID):
+        return raw_thread_id
+    if isinstance(raw_thread_id, str):
+        try:
+            return UUID(raw_thread_id)
+        except ValueError:
+            return None
+    return None
+
+
+def _activity_posture(hours_since_last_activity: float | None) -> ThreadActivityPosture:
+    if hours_since_last_activity is None or hours_since_last_activity <= _RECENT_THREAD_WINDOW_HOURS:
+        return "recent"
+    if hours_since_last_activity <= _STALE_THREAD_WINDOW_HOURS:
+        return "current"
+    return "stale"
+
+
+def _risk_posture(score: int) -> ThreadRiskPosture:
+    if score >= _RISKY_THREAD_SCORE_THRESHOLD:
+        return "risky"
+    if score > 0:
+        return "watch"
+    return "normal"
+
+
+def _health_posture(
+    *,
+    activity_posture: ThreadActivityPosture,
+    risk_posture: ThreadRiskPosture,
+) -> ThreadHealthPosture:
+    if risk_posture == "risky":
+        return "critical"
+    if activity_posture == "stale" or risk_posture == "watch":
+        return "watch"
+    return "healthy"
+
+
+def _recommended_action(
+    *,
+    risk_posture: ThreadRiskPosture,
+    activity_posture: ThreadActivityPosture,
+    unresolved_contradiction_count: int,
+    stale_open_loop_count: int,
+    weak_trust_signal_count: int,
+) -> str:
+    if unresolved_contradiction_count > 0:
+        return "Resolve contradiction cases before trusting this thread for recall or briefing."
+    if stale_open_loop_count > 0:
+        return "Review stale waiting-for or blocker items linked to this thread."
+    if weak_trust_signal_count > 0:
+        return "Corroborate weakly supported continuity objects before reuse."
+    if risk_posture == "watch":
+        return "Inspect recent continuity changes before continuing the thread."
+    if activity_posture == "stale":
+        return "Refresh thread context before resuming work."
+    return "No immediate intervention required."
+
+
+def _thread_reasons(
+    *,
+    hours_since_last_activity: float | None,
+    active_session_count: int,
+    stale_open_loop_count: int,
+    unresolved_contradiction_count: int,
+    weak_trust_signal_count: int,
+) -> tuple[int, list[str]]:
+    score = 0
+    reasons: list[str] = []
+
+    if unresolved_contradiction_count > 0:
+        score += 2
+        reasons.append(f"{unresolved_contradiction_count} unresolved contradiction case(s).")
+
+    if stale_open_loop_count > 0:
+        score += 1
+        reasons.append(f"{stale_open_loop_count} stale open-loop item(s).")
+
+    if weak_trust_signal_count > 0:
+        score += 1
+        reasons.append(f"{weak_trust_signal_count} active weak-trust signal(s).")
+
+    if active_session_count > 0 and hours_since_last_activity is not None and hours_since_last_activity > _RECENT_THREAD_WINDOW_HOURS:
+        score += 1
+        reasons.append(
+            f"Active session has been quiet for {hours_since_last_activity:.1f}h."
+        )
+
+    if not reasons:
+        reasons.append("No active contradiction, stale open-loop, or weak-trust pressure is currently visible.")
+
+    return score, reasons
+
+
+def _sort_thread_item(item: ThreadHealthRecord) -> tuple[int, int, float, str]:
+    health_priority = {"critical": 2, "watch": 1, "healthy": 0}[item["health_posture"]]
+    activity_hours = item["hours_since_last_activity"]
+    return (
+        health_priority,
+        item["risk_score"],
+        0.0 if activity_hours is None else activity_hours,
+        item["thread"]["updated_at"],
+    )
+
+
+def _safe_sync_contradictions(store: ContinuityStore) -> None:
+    try:
+        sync_contradiction_state_for_objects(store, continuity_object_ids=None)
+    except psycopg.errors.UndefinedTable:
+        return
+
+
+def _weak_trust_counts_by_thread(
+    store: ContinuityStore,
+    *,
+    thread_by_object_id: dict[UUID, UUID],
+) -> dict[UUID, int]:
+    counts: dict[UUID, int] = {thread_id: 0 for thread_id in thread_by_object_id.values()}
+
+    if hasattr(store, "count_trust_signals"):
+        for object_id, thread_id in thread_by_object_id.items():
+            try:
+                counts[thread_id] += store.count_trust_signals(
+                    continuity_object_id=object_id,
+                    signal_state="active",
+                    signal_type="weak_inference",
+                )
+            except psycopg.errors.UndefinedTable:
+                return counts
+        return counts
+
+    if hasattr(store, "list_trust_signals"):
+        for object_id, thread_id in thread_by_object_id.items():
+            try:
+                signals = store.list_trust_signals(
+                    limit=10_000,
+                    continuity_object_id=object_id,
+                    signal_state="active",
+                    signal_type="weak_inference",
+                )
+            except psycopg.errors.UndefinedTable:
+                return counts
+            counts[thread_id] += len(signals)
+
+    return counts
+
+
+def get_thread_health_dashboard(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+) -> ThreadHealthDashboardResponse:
+    del user_id
+
+    now = _utcnow()
+    threads = store.list_threads()
+    thread_ids = {thread["id"] for thread in threads}
+    sessions_by_thread: dict[UUID, list[SessionRow]] = {
+        thread_id: store.list_thread_sessions(thread_id) for thread_id in thread_ids
+    }
+    events_by_thread: dict[UUID, list[EventRow]] = {
+        thread_id: store.list_thread_events(thread_id) for thread_id in thread_ids
+    }
+
+    recall_by_thread: dict[UUID, list[ContinuityRecallCandidateRow]] = {thread_id: [] for thread_id in thread_ids}
+    contradiction_counts_by_thread: dict[UUID, int] = {thread_id: 0 for thread_id in thread_ids}
+    weak_trust_counts_by_thread: dict[UUID, int] = {thread_id: 0 for thread_id in thread_ids}
+
+    recall_candidates: list[ContinuityRecallCandidateRow] = []
+    if hasattr(store, "list_continuity_recall_candidates"):
+        try:
+            recall_candidates = store.list_continuity_recall_candidates()
+        except psycopg.errors.UndefinedTable:
+            recall_candidates = []
+
+    recall_object_ids: list[UUID] = []
+    for row in recall_candidates:
+        thread_id = _thread_id_from_provenance(row)
+        if thread_id is None or thread_id not in recall_by_thread:
+            continue
+        recall_by_thread[thread_id].append(row)
+        recall_object_ids.append(row["id"])
+
+    if recall_object_ids and hasattr(store, "list_contradiction_cases_for_objects"):
+        _safe_sync_contradictions(store)
+        try:
+            cases = store.list_contradiction_cases_for_objects(
+                continuity_object_ids=recall_object_ids,
+                statuses=["open"],
+            )
+        except psycopg.errors.UndefinedTable:
+            cases = []
+        thread_by_object_id = {
+            row["id"]: thread_id
+            for thread_id, rows in recall_by_thread.items()
+            for row in rows
+        }
+        counted_case_ids: dict[UUID, set[UUID]] = {thread_id: set() for thread_id in thread_ids}
+        for case in cases:
+            for object_id in (case["continuity_object_id"], case["counterpart_object_id"]):
+                thread_id = thread_by_object_id.get(object_id)
+                if thread_id is None or case["id"] in counted_case_ids[thread_id]:
+                    continue
+                counted_case_ids[thread_id].add(case["id"])
+                contradiction_counts_by_thread[thread_id] += 1
+
+    if recall_object_ids:
+        thread_by_object_id = {
+            row["id"]: thread_id
+            for thread_id, rows in recall_by_thread.items()
+            for row in rows
+        }
+        weak_trust_counts_by_thread.update(
+            _weak_trust_counts_by_thread(
+                store,
+                thread_by_object_id=thread_by_object_id,
+            )
+        )
+
+    items: list[ThreadHealthRecord] = []
+    for thread in threads:
+        thread_id = thread["id"]
+        sessions = sessions_by_thread.get(thread_id, [])
+        events = events_by_thread.get(thread_id, [])
+        recall_rows = recall_by_thread.get(thread_id, [])
+
+        conversation_events = [event for event in events if event["kind"] in _CONVERSATION_EVENT_KINDS]
+        last_conversation_at = (
+            max((event["created_at"] for event in conversation_events), default=None)
+            if conversation_events
+            else None
+        )
+        candidate_activity_times = [thread["updated_at"]]
+        candidate_activity_times.extend(session["created_at"] for session in sessions)
+        candidate_activity_times.extend(event["created_at"] for event in events)
+        last_activity_at = max(candidate_activity_times) if candidate_activity_times else None
+        hours_since_last_activity = _hours_since(now, last_activity_at)
+
+        open_loop_rows = [
+            row
+            for row in recall_rows
+            if row["object_type"] in _OPEN_LOOP_OBJECT_TYPES and row["status"] in {"active", "stale"}
+        ]
+        stale_open_loop_count = sum(1 for row in open_loop_rows if row["status"] == "stale")
+        active_session_count = sum(1 for session in sessions if session["status"] == "active")
+        unresolved_contradiction_count = contradiction_counts_by_thread.get(thread_id, 0)
+        weak_trust_signal_count = weak_trust_counts_by_thread.get(thread_id, 0)
+        score, reasons = _thread_reasons(
+            hours_since_last_activity=hours_since_last_activity,
+            active_session_count=active_session_count,
+            stale_open_loop_count=stale_open_loop_count,
+            unresolved_contradiction_count=unresolved_contradiction_count,
+            weak_trust_signal_count=weak_trust_signal_count,
+        )
+        activity_posture = _activity_posture(hours_since_last_activity)
+        risk_posture = _risk_posture(score)
+        health_posture = _health_posture(
+            activity_posture=activity_posture,
+            risk_posture=risk_posture,
+        )
+
+        items.append(
+            {
+                "thread": _serialize_thread(thread),
+                "health_posture": health_posture,
+                "activity_posture": activity_posture,
+                "risk_posture": risk_posture,
+                "risk_score": score,
+                "last_activity_at": None if last_activity_at is None else last_activity_at.isoformat(),
+                "last_conversation_at": (
+                    None if last_conversation_at is None else last_conversation_at.isoformat()
+                ),
+                "hours_since_last_activity": hours_since_last_activity,
+                "conversation_event_count": len(conversation_events),
+                "operational_event_count": max(0, len(events) - len(conversation_events)),
+                "active_session_count": active_session_count,
+                "open_loop_count": len(open_loop_rows),
+                "stale_open_loop_count": stale_open_loop_count,
+                "unresolved_contradiction_count": unresolved_contradiction_count,
+                "weak_trust_signal_count": weak_trust_signal_count,
+                "reasons": reasons,
+                "recommended_action": _recommended_action(
+                    risk_posture=risk_posture,
+                    activity_posture=activity_posture,
+                    unresolved_contradiction_count=unresolved_contradiction_count,
+                    stale_open_loop_count=stale_open_loop_count,
+                    weak_trust_signal_count=weak_trust_signal_count,
+                ),
+            }
+        )
+
+    ordered_items = sorted(items, key=_sort_thread_item, reverse=True)
+    recent_threads = sorted(
+        [item for item in ordered_items if item["activity_posture"] == "recent"],
+        key=lambda item: (item["last_activity_at"] or "", item["thread"]["id"]),
+        reverse=True,
+    )
+    stale_threads = sorted(
+        [item for item in ordered_items if item["activity_posture"] == "stale"],
+        key=lambda item: (item["hours_since_last_activity"] or 0.0, item["thread"]["id"]),
+        reverse=True,
+    )
+    risky_threads = sorted(
+        [item for item in ordered_items if item["risk_posture"] == "risky"],
+        key=lambda item: (item["risk_score"], item["hours_since_last_activity"] or 0.0, item["thread"]["id"]),
+        reverse=True,
+    )
+    watch_thread_count = sum(1 for item in ordered_items if item["health_posture"] == "watch")
+    risky_thread_count = len(risky_threads)
+    stale_thread_count = len(stale_threads)
+
+    if risky_thread_count > 0:
+        posture: ThreadHealthPosture = "critical"
+    elif stale_thread_count > 0 or watch_thread_count > 0:
+        posture = "watch"
+    else:
+        posture = "healthy"
+
+    thresholds: ThreadHealthThresholdsRecord = {
+        "recent_window_hours": _RECENT_THREAD_WINDOW_HOURS,
+        "stale_window_hours": _STALE_THREAD_WINDOW_HOURS,
+        "risky_score_threshold": _RISKY_THREAD_SCORE_THRESHOLD,
+    }
+    dashboard: ThreadHealthDashboardSummary = {
+        "posture": posture,
+        "total_thread_count": len(ordered_items),
+        "recent_thread_count": len(recent_threads),
+        "stale_thread_count": stale_thread_count,
+        "risky_thread_count": risky_thread_count,
+        "watch_thread_count": watch_thread_count,
+        "thresholds": thresholds,
+        "recent_threads": recent_threads,
+        "stale_threads": stale_threads,
+        "risky_threads": risky_threads,
+        "items": ordered_items,
+        "sources": [
+            "threads",
+            "thread_sessions",
+            "thread_events",
+            "continuity_recall",
+            "contradiction_cases",
+            "trust_signals",
+        ],
+    }
+    return {"dashboard": dashboard}
+
+
+__all__ = ["get_thread_health_dashboard"]

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -168,10 +168,12 @@ from alicebot_api.contracts import (
     ChiefOfStaffRecommendationOutcomeCaptureResponse,
     ContinuityWeeklyReviewRequestInput,
     ContinuityWeeklyReviewResponse,
+    MemoryHygieneDashboardResponse,
     MemoryTrustDashboardResponse,
     RetrievalEvaluationResponse,
     RetrievalRunListResponse,
     RetrievalTraceResponse,
+    ThreadHealthDashboardResponse,
     TrustSignalListQueryInput,
     TrustSignalListResponse,
     EmbeddingConfigStatus,
@@ -606,6 +608,7 @@ from alicebot_api.continuity_open_loops import (
     compile_continuity_open_loop_dashboard,
     compile_continuity_weekly_review,
 )
+from alicebot_api.conversation_health import get_thread_health_dashboard
 from alicebot_api.continuity_objects import ContinuityObjectValidationError
 from alicebot_api.memory import (
     MemoryAdmissionValidationError,
@@ -617,6 +620,7 @@ from alicebot_api.memory import (
     create_memory_review_label_record,
     get_open_loop_record,
     get_memory_evaluation_summary,
+    get_memory_hygiene_dashboard_summary,
     get_memory_quality_gate_summary,
     get_memory_trust_dashboard_summary,
     get_memory_review_record,
@@ -3026,6 +3030,22 @@ def list_threads(user_id: UUID) -> JSONResponse:
         "items": items,
         "summary": summary,
     }
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/threads/health-dashboard")
+def get_threads_health_dashboard(user_id: UUID) -> JSONResponse:
+    settings = get_settings()
+
+    with user_connection(settings.database_url, user_id) as conn:
+        payload: ThreadHealthDashboardResponse = get_thread_health_dashboard(
+            ContinuityStore(conn),
+            user_id=user_id,
+        )
+
     return JSONResponse(
         status_code=200,
         content=jsonable_encoder(payload),
@@ -6487,6 +6507,22 @@ def get_memories_trust_dashboard(user_id: UUID) -> JSONResponse:
 
     with user_connection(settings.database_url, user_id) as conn:
         payload: MemoryTrustDashboardResponse = get_memory_trust_dashboard_summary(
+            ContinuityStore(conn),
+            user_id=user_id,
+        )
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(payload),
+    )
+
+
+@app.get("/v0/memories/hygiene-dashboard")
+def get_memories_hygiene_dashboard(user_id: UUID) -> JSONResponse:
+    settings = get_settings()
+
+    with user_connection(settings.database_url, user_id) as conn:
+        payload: MemoryHygieneDashboardResponse = get_memory_hygiene_dashboard_summary(
             ContinuityStore(conn),
             user_id=user_id,
         )

--- a/apps/api/src/alicebot_api/memory.py
+++ b/apps/api/src/alicebot_api/memory.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import datetime
+import json
 from uuid import UUID
 
 import psycopg
@@ -34,6 +36,12 @@ from alicebot_api.contracts import (
     MemoryCandidateInput,
     MemoryEvaluationSummary,
     MemoryEvaluationSummaryResponse,
+    MemoryDuplicateGroupRecord,
+    MemoryHygieneDashboardResponse,
+    MemoryHygieneDashboardSummary,
+    MemoryHygieneFocusKind,
+    MemoryHygieneFocusRecord,
+    MemoryHygienePosture,
     MemoryReviewLabelCounts,
     MemoryReviewLabelCreateResponse,
     MemoryReviewLabelListResponse,
@@ -52,6 +60,7 @@ from alicebot_api.contracts import (
     MemoryTrustCorrectionFreshnessSummary,
     MemoryTrustDashboardResponse,
     MemoryTrustDashboardSummary,
+    MemoryReviewQueuePressureSummary,
     MemoryTrustQueueAgingSummary,
     MemoryTrustQueuePostureSummary,
     MemoryTrustRecommendedReview,
@@ -934,6 +943,227 @@ def get_memory_trust_dashboard_summary(
             "continuity_recall",
             "continuity_correction_events",
             "retrieval_evaluation_fixtures",
+        ],
+    }
+    return {"dashboard": dashboard}
+
+
+def _normalize_duplicate_value(value: object) -> str:
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    except TypeError:
+        return repr(value)
+
+
+def _memory_duplicate_groups(active_memories: list[MemoryRow]) -> list[MemoryDuplicateGroupRecord]:
+    groups: dict[tuple[str, str], list[MemoryRow]] = defaultdict(list)
+    for memory in active_memories:
+        groups[(memory["memory_type"], _normalize_duplicate_value(memory["value"]))].append(memory)
+
+    duplicate_groups: list[MemoryDuplicateGroupRecord] = []
+    for (memory_type, normalized_value), grouped_memories in groups.items():
+        if len(grouped_memories) < 2:
+            continue
+        ordered = sorted(
+            grouped_memories,
+            key=lambda memory: (memory["updated_at"], memory["created_at"], str(memory["id"])),
+            reverse=True,
+        )
+        duplicate_groups.append(
+            {
+                "group_key": f"{memory_type}:{normalized_value}",
+                "memory_type": memory_type,
+                "normalized_value": normalized_value,
+                "count": len(ordered),
+                "memory_ids": [str(memory["id"]) for memory in ordered],
+                "memory_keys": [memory["memory_key"] for memory in ordered],
+                "latest_updated_at": ordered[0]["updated_at"].isoformat(),
+            }
+        )
+
+    return sorted(
+        duplicate_groups,
+        key=lambda group: (group["count"], group["latest_updated_at"], group["group_key"]),
+        reverse=True,
+    )
+
+
+def _memory_hygiene_focus(
+    *,
+    kind: MemoryHygieneFocusKind,
+    posture: MemoryHygienePosture,
+    count: int,
+    reason: str,
+    action: str,
+    sample_ids: list[str],
+) -> MemoryHygieneFocusRecord:
+    return {
+        "kind": kind,
+        "posture": posture,
+        "count": count,
+        "reason": reason,
+        "action": action,
+        "sample_ids": sample_ids,
+    }
+
+
+def _review_queue_pressure(queue_posture: MemoryTrustQueuePostureSummary) -> MemoryReviewQueuePressureSummary:
+    stale_over_72h_count = queue_posture["aging"]["stale_over_72h_count"]
+    aging_24h_to_72h_count = queue_posture["aging"]["aging_24h_to_72h_count"]
+    total_count = queue_posture["total_count"]
+
+    posture: MemoryHygienePosture
+    reason: str
+    if stale_over_72h_count > 0 or total_count >= 10:
+        posture = "critical"
+        reason = "Review backlog contains stale queue items or has grown beyond the bounded operating range."
+    elif total_count > 0 or aging_24h_to_72h_count > 0:
+        posture = "watch"
+        reason = "Review backlog exists and should be drained before it becomes stale."
+    else:
+        posture = "healthy"
+        reason = "Review backlog is clear."
+
+    return {
+        "posture": posture,
+        "total_count": total_count,
+        "stale_over_72h_count": stale_over_72h_count,
+        "aging_24h_to_72h_count": aging_24h_to_72h_count,
+        "reason": reason,
+    }
+
+
+def _missing_contradiction_tables(exc: psycopg.errors.UndefinedTable) -> bool:
+    message = str(exc)
+    return (
+        "continuity_objects" in message
+        or "contradiction_cases" in message
+        or "trust_signals" in message
+    )
+
+
+def get_memory_hygiene_dashboard_summary(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+) -> MemoryHygieneDashboardResponse:
+    active_memory_count = store.count_memories(status="active")
+    active_memories = (
+        []
+        if active_memory_count == 0
+        else store.list_review_memories(status="active", limit=active_memory_count)
+    )
+    duplicate_groups = _memory_duplicate_groups(active_memories)
+    duplicate_memory_count = sum(group["count"] for group in duplicate_groups)
+    stale_facts = [memory for memory in active_memories if _is_stale_truth_memory(memory)]
+    weak_trust_memories = [
+        memory
+        for memory in active_memories
+        if memory.get("promotion_eligibility") == "not_promotable"
+        or memory.get("trust_class") == "llm_single_source"
+        or memory.get("confirmation_status") != "confirmed"
+        or memory.get("confidence") is None
+        or float(memory["confidence"]) < MEMORY_QUALITY_HIGH_RISK_CONFIDENCE_THRESHOLD
+    ]
+
+    trust_dashboard = get_memory_trust_dashboard_summary(store, user_id=user_id)["dashboard"]
+    review_queue_pressure = _review_queue_pressure(trust_dashboard["queue_posture"])
+
+    unresolved_contradiction_count = 0
+    try:
+        from alicebot_api.continuity_contradictions import sync_contradiction_state_for_objects
+
+        sync_contradiction_state_for_objects(store, continuity_object_ids=None)
+        if hasattr(store, "count_contradiction_cases"):
+            unresolved_contradiction_count = store.count_contradiction_cases(statuses=["open"])
+    except psycopg.errors.UndefinedTable as exc:
+        if not _missing_contradiction_tables(exc):
+            raise
+
+    focus: list[MemoryHygieneFocusRecord] = []
+    if duplicate_groups:
+        focus.append(
+            _memory_hygiene_focus(
+                kind="duplicates",
+                posture="watch",
+                count=duplicate_memory_count,
+                reason="Multiple active memories share the same normalized value and should be reviewed for consolidation.",
+                action="Review duplicate groups and keep one canonical fact per repeated value.",
+                sample_ids=duplicate_groups[0]["memory_ids"],
+            )
+        )
+    if stale_facts:
+        focus.append(
+            _memory_hygiene_focus(
+                kind="stale_facts",
+                posture="watch",
+                count=len(stale_facts),
+                reason="Facts are marked contested or bounded by expired truth windows.",
+                action="Reconfirm or retire stale facts before they influence recall.",
+                sample_ids=[str(memory["id"]) for memory in stale_facts[:5]],
+            )
+        )
+    if unresolved_contradiction_count > 0:
+        focus.append(
+            _memory_hygiene_focus(
+                kind="unresolved_contradictions",
+                posture="critical",
+                count=unresolved_contradiction_count,
+                reason="Open contradiction cases still penalize trust and recall quality.",
+                action="Resolve contradiction cases before relying on those facts in continuity surfaces.",
+                sample_ids=[],
+            )
+        )
+    if weak_trust_memories:
+        focus.append(
+            _memory_hygiene_focus(
+                kind="weak_trust",
+                posture="watch",
+                count=len(weak_trust_memories),
+                reason="Some active memories still rely on low-confidence or non-promotable evidence.",
+                action="Add corroboration or downgrade these memories before reuse.",
+                sample_ids=[str(memory["id"]) for memory in weak_trust_memories[:5]],
+            )
+        )
+    if review_queue_pressure["total_count"] > 0:
+        focus.append(
+            _memory_hygiene_focus(
+                kind="review_queue_pressure",
+                posture=review_queue_pressure["posture"],
+                count=review_queue_pressure["total_count"],
+                reason=review_queue_pressure["reason"],
+                action="Drain the unlabeled review queue in the recommended priority mode.",
+                sample_ids=[],
+            )
+        )
+
+    if unresolved_contradiction_count > 0 or review_queue_pressure["posture"] == "critical":
+        posture: MemoryHygienePosture = "critical"
+        reason = "Contradiction or queue pressure currently blocks a healthy memory posture."
+    elif focus:
+        posture = "watch"
+        reason = "Memory hygiene issues are visible and should be handled before they accumulate."
+    else:
+        posture = "healthy"
+        reason = "No duplicate, stale, contradiction, weak-trust, or queue-pressure issue is currently visible."
+
+    dashboard: MemoryHygieneDashboardSummary = {
+        "posture": posture,
+        "reason": reason,
+        "duplicate_group_count": len(duplicate_groups),
+        "duplicate_memory_count": duplicate_memory_count,
+        "stale_fact_count": len(stale_facts),
+        "unresolved_contradiction_count": unresolved_contradiction_count,
+        "weak_trust_count": len(weak_trust_memories),
+        "review_queue_pressure": review_queue_pressure,
+        "duplicate_groups": duplicate_groups,
+        "focus": focus,
+        "sources": [
+            "memories",
+            "memory_review_labels",
+            "contradiction_cases",
+            "trust_signals",
+            "continuity_recall",
         ],
     }
     return {"dashboard": dashboard}

--- a/apps/web/app/continuity/page.test.tsx
+++ b/apps/web/app/continuity/page.test.tsx
@@ -11,6 +11,7 @@ const {
   getContinuityCaptureDetailMock,
   getContinuityReviewDetailMock,
   getContinuityResumptionBriefMock,
+  getThreadHealthDashboardMock,
   getContinuityWeeklyReviewMock,
   hasLiveApiConfigMock,
   listContinuityReviewQueueMock,
@@ -24,6 +25,7 @@ const {
   getContinuityCaptureDetailMock: vi.fn(),
   getContinuityReviewDetailMock: vi.fn(),
   getContinuityResumptionBriefMock: vi.fn(),
+  getThreadHealthDashboardMock: vi.fn(),
   getContinuityWeeklyReviewMock: vi.fn(),
   hasLiveApiConfigMock: vi.fn(),
   listContinuityReviewQueueMock: vi.fn(),
@@ -66,6 +68,7 @@ vi.mock("../../lib/api", async () => {
     getContinuityCaptureDetail: getContinuityCaptureDetailMock,
     getContinuityReviewDetail: getContinuityReviewDetailMock,
     getContinuityResumptionBrief: getContinuityResumptionBriefMock,
+    getThreadHealthDashboard: getThreadHealthDashboardMock,
     getContinuityWeeklyReview: getContinuityWeeklyReviewMock,
     hasLiveApiConfig: hasLiveApiConfigMock,
     listContinuityReviewQueue: listContinuityReviewQueueMock,
@@ -82,6 +85,7 @@ describe("ContinuityPage", () => {
     getContinuityCaptureDetailMock.mockReset();
     getContinuityReviewDetailMock.mockReset();
     getContinuityResumptionBriefMock.mockReset();
+    getThreadHealthDashboardMock.mockReset();
     getContinuityWeeklyReviewMock.mockReset();
     hasLiveApiConfigMock.mockReset();
     listContinuityReviewQueueMock.mockReset();
@@ -112,6 +116,8 @@ describe("ContinuityPage", () => {
     expect(screen.getByText("Fixture open loops")).toBeInTheDocument();
     expect(screen.getByText("Fixture daily brief")).toBeInTheDocument();
     expect(screen.getByText("Fixture weekly review")).toBeInTheDocument();
+    expect(screen.getByText("Conversation health posture")).toBeInTheDocument();
+    expect(screen.getByText("Fixture thread dashboard")).toBeInTheDocument();
     expect(screen.getByText("Fixture review queue")).toBeInTheDocument();
     expect(screen.getByText("Continuity recall")).toBeInTheDocument();
     expect(screen.getAllByText("Correction actions").length).toBeGreaterThan(0);
@@ -121,6 +127,7 @@ describe("ContinuityPage", () => {
     expect(getContinuityOpenLoopDashboardMock).not.toHaveBeenCalled();
     expect(getContinuityDailyBriefMock).not.toHaveBeenCalled();
     expect(getContinuityWeeklyReviewMock).not.toHaveBeenCalled();
+    expect(getThreadHealthDashboardMock).not.toHaveBeenCalled();
     expect(listContinuityReviewQueueMock).not.toHaveBeenCalled();
   });
 
@@ -403,6 +410,85 @@ describe("ContinuityPage", () => {
         sources: ["continuity_capture_events", "continuity_objects", "continuity_correction_events"],
       },
     });
+    getThreadHealthDashboardMock.mockResolvedValue({
+      dashboard: {
+        posture: "critical",
+        total_thread_count: 2,
+        recent_thread_count: 1,
+        stale_thread_count: 0,
+        risky_thread_count: 1,
+        watch_thread_count: 0,
+        thresholds: {
+          recent_window_hours: 24,
+          stale_window_hours: 72,
+          risky_score_threshold: 2,
+        },
+        recent_threads: [
+          {
+            thread: {
+              id: "thread-live-1",
+              title: "Launch thread",
+              agent_profile_id: "assistant_default",
+              created_at: "2026-03-29T09:00:00Z",
+              updated_at: "2026-03-29T09:20:00Z",
+            },
+            health_posture: "healthy",
+            activity_posture: "recent",
+            risk_posture: "normal",
+            risk_score: 0,
+            last_activity_at: "2026-03-29T09:20:00Z",
+            last_conversation_at: "2026-03-29T09:20:00Z",
+            hours_since_last_activity: 2,
+            conversation_event_count: 3,
+            operational_event_count: 1,
+            active_session_count: 1,
+            open_loop_count: 0,
+            stale_open_loop_count: 0,
+            unresolved_contradiction_count: 0,
+            weak_trust_signal_count: 0,
+            reasons: ["No active contradiction, stale open-loop, or weak-trust pressure is currently visible."],
+            recommended_action: "No immediate intervention required.",
+          },
+        ],
+        stale_threads: [],
+        risky_threads: [
+          {
+            thread: {
+              id: "thread-live-2",
+              title: "Conflict thread",
+              agent_profile_id: "assistant_default",
+              created_at: "2026-03-28T09:00:00Z",
+              updated_at: "2026-03-28T09:20:00Z",
+            },
+            health_posture: "critical",
+            activity_posture: "current",
+            risk_posture: "risky",
+            risk_score: 2,
+            last_activity_at: "2026-03-28T09:20:00Z",
+            last_conversation_at: "2026-03-28T09:20:00Z",
+            hours_since_last_activity: 26,
+            conversation_event_count: 2,
+            operational_event_count: 0,
+            active_session_count: 0,
+            open_loop_count: 0,
+            stale_open_loop_count: 0,
+            unresolved_contradiction_count: 1,
+            weak_trust_signal_count: 0,
+            reasons: ["1 unresolved contradiction case(s)."],
+            recommended_action: "Resolve contradiction cases before trusting this thread for recall or briefing.",
+          },
+        ],
+        items: [],
+        sources: [
+          "threads",
+          "thread_sessions",
+          "thread_events",
+          "continuity_recall",
+          "contradiction_cases",
+          "trust_signals",
+        ],
+      },
+    });
     listContinuityReviewQueueMock.mockResolvedValue({
       items: [
         {
@@ -467,7 +553,9 @@ describe("ContinuityPage", () => {
     expect(screen.getByText("Live open loops")).toBeInTheDocument();
     expect(screen.getByText("Live daily brief")).toBeInTheDocument();
     expect(screen.getByText("Live weekly review")).toBeInTheDocument();
+    expect(screen.getByText("Live thread dashboard")).toBeInTheDocument();
     expect(screen.getByText("Live review queue")).toBeInTheDocument();
+    expect(screen.getByText("Conflict thread")).toBeInTheDocument();
     expect(screen.getAllByText("Decision: Keep admission conservative").length).toBeGreaterThan(0);
 
     expect(listContinuityCapturesMock).toHaveBeenCalledWith("https://api.example.com", "user-1", {
@@ -542,5 +630,6 @@ describe("ContinuityPage", () => {
       until: "",
       limit: 5,
     });
+    expect(getThreadHealthDashboardMock).toHaveBeenCalledWith("https://api.example.com", "user-1");
   });
 });

--- a/apps/web/app/continuity/page.tsx
+++ b/apps/web/app/continuity/page.tsx
@@ -11,6 +11,7 @@ import { PageHeader } from "../../components/page-header";
 import { ResumptionBrief } from "../../components/resumption-brief";
 import { SectionCard } from "../../components/section-card";
 import { StatusBadge } from "../../components/status-badge";
+import { ThreadHealthDashboard } from "../../components/thread-health-dashboard";
 import type {
   ApiSource,
   ContinuityCaptureInboxItem,
@@ -25,6 +26,7 @@ import type {
   ContinuityReviewStatusFilter,
   ContinuityResumptionBrief,
   ContinuityWeeklyReview,
+  ThreadHealthDashboardSummary,
 } from "../../lib/api";
 import {
   getContinuityReviewDetail,
@@ -34,6 +36,7 @@ import {
   getContinuityDailyBrief,
   getContinuityOpenLoopDashboard,
   getContinuityResumptionBrief,
+  getThreadHealthDashboard,
   getContinuityWeeklyReview,
   hasLiveApiConfig,
   listContinuityReviewQueue,
@@ -539,6 +542,110 @@ const continuityReviewDetailFixture: ContinuityReviewDetail = {
   },
 };
 
+const threadHealthDashboardFixture: ThreadHealthDashboardSummary = {
+  posture: "watch",
+  total_thread_count: 3,
+  recent_thread_count: 1,
+  stale_thread_count: 1,
+  risky_thread_count: 1,
+  watch_thread_count: 1,
+  thresholds: {
+    recent_window_hours: 24,
+    stale_window_hours: 72,
+    risky_score_threshold: 2,
+  },
+  recent_threads: [
+    {
+      thread: {
+        id: "thread-fixture-1",
+        title: "Launch Project",
+        agent_profile_id: "assistant_default",
+        created_at: "2026-03-29T09:00:00Z",
+        updated_at: "2026-03-29T09:20:00Z",
+      },
+      health_posture: "healthy",
+      activity_posture: "recent",
+      risk_posture: "normal",
+      risk_score: 0,
+      last_activity_at: "2026-03-29T09:20:00Z",
+      last_conversation_at: "2026-03-29T09:20:00Z",
+      hours_since_last_activity: 4,
+      conversation_event_count: 3,
+      operational_event_count: 1,
+      active_session_count: 1,
+      open_loop_count: 1,
+      stale_open_loop_count: 0,
+      unresolved_contradiction_count: 0,
+      weak_trust_signal_count: 0,
+      reasons: ["No active contradiction, stale open-loop, or weak-trust pressure is currently visible."],
+      recommended_action: "No immediate intervention required.",
+    },
+  ],
+  stale_threads: [
+    {
+      thread: {
+        id: "thread-fixture-2",
+        title: "Vendor Follow-up",
+        agent_profile_id: "assistant_default",
+        created_at: "2026-03-20T09:00:00Z",
+        updated_at: "2026-03-21T09:00:00Z",
+      },
+      health_posture: "watch",
+      activity_posture: "stale",
+      risk_posture: "watch",
+      risk_score: 1,
+      last_activity_at: "2026-03-21T09:00:00Z",
+      last_conversation_at: "2026-03-21T09:00:00Z",
+      hours_since_last_activity: 96,
+      conversation_event_count: 1,
+      operational_event_count: 1,
+      active_session_count: 0,
+      open_loop_count: 1,
+      stale_open_loop_count: 1,
+      unresolved_contradiction_count: 0,
+      weak_trust_signal_count: 0,
+      reasons: ["1 stale open-loop item(s)."],
+      recommended_action: "Review stale waiting-for or blocker items linked to this thread.",
+    },
+  ],
+  risky_threads: [
+    {
+      thread: {
+        id: "thread-fixture-3",
+        title: "Preference conflict",
+        agent_profile_id: "assistant_default",
+        created_at: "2026-03-25T09:00:00Z",
+        updated_at: "2026-03-28T09:00:00Z",
+      },
+      health_posture: "critical",
+      activity_posture: "current",
+      risk_posture: "risky",
+      risk_score: 2,
+      last_activity_at: "2026-03-28T09:00:00Z",
+      last_conversation_at: "2026-03-28T09:00:00Z",
+      hours_since_last_activity: 28,
+      conversation_event_count: 2,
+      operational_event_count: 0,
+      active_session_count: 0,
+      open_loop_count: 0,
+      stale_open_loop_count: 0,
+      unresolved_contradiction_count: 1,
+      weak_trust_signal_count: 0,
+      reasons: ["1 unresolved contradiction case(s)."],
+      recommended_action: "Resolve contradiction cases before trusting this thread for recall or briefing.",
+    },
+  ],
+  items: [],
+  sources: [
+    "threads",
+    "thread_sessions",
+    "thread_events",
+    "continuity_recall",
+    "contradiction_cases",
+    "trust_signals",
+  ],
+};
+
 function renderDetail(item: ContinuityCaptureInboxItem | null, source: ApiSource | "unavailable" | null, unavailableReason?: string) {
   if (!item) {
     return (
@@ -841,6 +948,23 @@ export default async function ContinuityPage({
     }
   }
 
+  let threadHealthDashboard = threadHealthDashboardFixture;
+  let threadHealthSource: ApiSource = "fixture";
+  let threadHealthUnavailableReason: string | undefined;
+
+  if (liveModeReady) {
+    try {
+      const payload = await getThreadHealthDashboard(apiConfig.apiBaseUrl, apiConfig.userId);
+      threadHealthDashboard = payload.dashboard;
+      threadHealthSource = "live";
+    } catch (error) {
+      threadHealthUnavailableReason =
+        error instanceof Error
+          ? error.message
+          : "Thread health dashboard could not be loaded.";
+    }
+  }
+
   let reviewItems = continuityReviewFixtures;
   let reviewSummary = continuityReviewSummaryFixture;
   let reviewSource: ApiSource = "fixture";
@@ -897,6 +1021,7 @@ export default async function ContinuityPage({
     openLoopSource,
     dailyBriefSource,
     weeklyReviewSource,
+    threadHealthSource,
     reviewSource,
     correctionSource,
   );
@@ -970,6 +1095,12 @@ export default async function ContinuityPage({
         review={weeklyReview}
         source={weeklyReviewSource}
         unavailableReason={weeklyReviewUnavailableReason}
+      />
+
+      <ThreadHealthDashboard
+        dashboard={threadHealthDashboard}
+        source={threadHealthSource}
+        unavailableReason={threadHealthUnavailableReason}
       />
 
       <div className="grid grid--two">

--- a/apps/web/app/memories/page.test.tsx
+++ b/apps/web/app/memories/page.test.tsx
@@ -8,6 +8,7 @@ const {
   getApiConfigMock,
   getMemoryDetailMock,
   getMemoryEvaluationSummaryMock,
+  getMemoryHygieneDashboardMock,
   getMemoryTrustDashboardMock,
   getMemoryRevisionsMock,
   getOpenLoopDetailMock,
@@ -20,6 +21,7 @@ const {
   getApiConfigMock: vi.fn(),
   getMemoryDetailMock: vi.fn(),
   getMemoryEvaluationSummaryMock: vi.fn(),
+  getMemoryHygieneDashboardMock: vi.fn(),
   getMemoryTrustDashboardMock: vi.fn(),
   getMemoryRevisionsMock: vi.fn(),
   getOpenLoopDetailMock: vi.fn(),
@@ -61,6 +63,7 @@ vi.mock("../../lib/api", async () => {
     getApiConfig: getApiConfigMock,
     getMemoryDetail: getMemoryDetailMock,
     getMemoryEvaluationSummary: getMemoryEvaluationSummaryMock,
+    getMemoryHygieneDashboard: getMemoryHygieneDashboardMock,
     getMemoryTrustDashboard: getMemoryTrustDashboardMock,
     getMemoryRevisions: getMemoryRevisionsMock,
     getOpenLoopDetail: getOpenLoopDetailMock,
@@ -77,6 +80,7 @@ describe("MemoriesPage", () => {
     getApiConfigMock.mockReset();
     getMemoryDetailMock.mockReset();
     getMemoryEvaluationSummaryMock.mockReset();
+    getMemoryHygieneDashboardMock.mockReset();
     getMemoryTrustDashboardMock.mockReset();
     getMemoryRevisionsMock.mockReset();
     getOpenLoopDetailMock.mockReset();
@@ -104,8 +108,10 @@ describe("MemoriesPage", () => {
 
     expect(screen.getByText("Fixture-backed")).toBeInTheDocument();
     expect(screen.getByText("Summary Fixture")).toBeInTheDocument();
+    expect(screen.getByText("Operational hygiene posture")).toBeInTheDocument();
     expect(screen.getByText("Canonical quality posture")).toBeInTheDocument();
     expect(screen.getByText(/Fixture dashboard/)).toBeInTheDocument();
+    expect(screen.getByText(/Fixture hygiene dashboard/)).toBeInTheDocument();
     expect(screen.getByText("Queue Fixture")).toBeInTheDocument();
     expect(screen.getAllByText("Insufficient sample").length).toBeGreaterThan(0);
     expect(screen.getByText("Fixture list")).toBeInTheDocument();
@@ -116,6 +122,7 @@ describe("MemoriesPage", () => {
       ),
     ).toBeInTheDocument();
     expect(listMemoriesMock).not.toHaveBeenCalled();
+    expect(getMemoryHygieneDashboardMock).not.toHaveBeenCalled();
   });
 
   it("renders live-backed memory summary, detail, revisions, and labels when live reads succeed", async () => {
@@ -274,6 +281,47 @@ describe("MemoriesPage", () => {
         ],
       },
     });
+    getMemoryHygieneDashboardMock.mockResolvedValue({
+      dashboard: {
+        posture: "watch",
+        reason: "Live duplicate and contradiction posture remains visible.",
+        duplicate_group_count: 1,
+        duplicate_memory_count: 2,
+        stale_fact_count: 1,
+        unresolved_contradiction_count: 1,
+        weak_trust_count: 2,
+        review_queue_pressure: {
+          posture: "watch",
+          total_count: 2,
+          stale_over_72h_count: 0,
+          aging_24h_to_72h_count: 1,
+          reason: "Backlog exists and should be drained before it becomes stale.",
+        },
+        duplicate_groups: [
+          {
+            group_key: "preference:{\"merchant\":\"Live Merchant\"}",
+            memory_type: "preference",
+            normalized_value: "{\"merchant\":\"Live Merchant\"}",
+            count: 2,
+            memory_ids: ["memory-live-1", "memory-live-2"],
+            memory_keys: ["user.preference.live", "user.preference.live_backup"],
+            latest_updated_at: "2026-03-18T10:05:00Z",
+          },
+        ],
+        focus: [
+          {
+            kind: "duplicates",
+            posture: "watch",
+            count: 2,
+            reason:
+              "Multiple active memories share the same normalized value and should be reviewed for consolidation.",
+            action: "Review duplicate groups and keep one canonical fact per repeated value.",
+            sample_ids: ["memory-live-1", "memory-live-2"],
+          },
+        ],
+        sources: ["memories", "contradiction_cases", "trust_signals", "continuity_recall"],
+      },
+    });
     listOpenLoopsMock.mockResolvedValue({
       items: [
         {
@@ -389,9 +437,11 @@ describe("MemoriesPage", () => {
     expect(screen.getByText("Live API")).toBeInTheDocument();
     expect(screen.getByText("Summary Live")).toBeInTheDocument();
     expect(screen.getByText(/Live dashboard/)).toBeInTheDocument();
+    expect(screen.getByText("Live hygiene dashboard")).toBeInTheDocument();
     expect(screen.getByText("review_high_risk_queue")).toBeInTheDocument();
     expect(screen.getByText("Queue Live")).toBeInTheDocument();
     expect(screen.getByText("Healthy")).toBeInTheDocument();
+    expect(screen.getByText("Live duplicate and contradiction posture remains visible.")).toBeInTheDocument();
     expect(screen.getByText("Live list")).toBeInTheDocument();
     expect(screen.getByText("Live detail")).toBeInTheDocument();
     expect(screen.getByText("Live revisions")).toBeInTheDocument();
@@ -423,6 +473,7 @@ describe("MemoriesPage", () => {
       priorityMode: "recent_first",
     });
     expect(getMemoryTrustDashboardMock).toHaveBeenCalledWith("https://api.example.com", "user-1");
+    expect(getMemoryHygieneDashboardMock).toHaveBeenCalledWith("https://api.example.com", "user-1");
   });
 
   it("keeps fallback state explicit when live reads partially fail and shows unavailable revision/label panels", async () => {
@@ -457,6 +508,7 @@ describe("MemoriesPage", () => {
     });
     listMemoryReviewQueueMock.mockRejectedValue(new Error("queue down"));
     getMemoryEvaluationSummaryMock.mockRejectedValue(new Error("summary down"));
+    getMemoryHygieneDashboardMock.mockRejectedValue(new Error("hygiene dashboard down"));
     getMemoryTrustDashboardMock.mockRejectedValue(new Error("trust dashboard down"));
     listOpenLoopsMock.mockRejectedValue(new Error("open loops down"));
     getMemoryDetailMock.mockRejectedValue(new Error("detail down"));
@@ -472,6 +524,7 @@ describe("MemoriesPage", () => {
     );
 
     expect(screen.getByText("Summary: summary down")).toBeInTheDocument();
+    expect(screen.getByText(/hygiene dashboard down/)).toBeInTheDocument();
     expect(screen.getByText(/trust dashboard down/)).toBeInTheDocument();
     expect(screen.getByText("Queue: queue down")).toBeInTheDocument();
     expect(screen.getByText(/open loops down/)).toBeInTheDocument();

--- a/apps/web/app/memories/page.tsx
+++ b/apps/web/app/memories/page.tsx
@@ -1,4 +1,5 @@
 import { MemoryDetail } from "../../components/memory-detail";
+import { MemoryHygieneDashboard } from "../../components/memory-hygiene-dashboard";
 import { MemoryLabelForm } from "../../components/memory-label-form";
 import { MemoryLabelList } from "../../components/memory-label-list";
 import { MemoryList } from "../../components/memory-list";
@@ -7,6 +8,7 @@ import { MemorySummary } from "../../components/memory-summary";
 import { PageHeader } from "../../components/page-header";
 import type {
   ApiSource,
+  MemoryHygieneDashboardSummary,
   MemoryReviewLabelSummary,
   MemoryReviewQueuePriorityMode,
   MemoryReviewRecord,
@@ -21,6 +23,7 @@ import {
   getApiConfig,
   getMemoryDetail,
   getMemoryEvaluationSummary,
+  getMemoryHygieneDashboard,
   getMemoryTrustDashboard,
   getMemoryRevisions,
   hasLiveApiConfig,
@@ -209,6 +212,59 @@ const trustDashboardFixture: MemoryTrustDashboardSummary = {
   ],
 };
 
+const hygieneDashboardFixture: MemoryHygieneDashboardSummary = {
+  posture: "watch",
+  reason: "Fixture posture keeps duplicate, stale, contradiction, weak-trust, and queue-pressure visibility explicit.",
+  duplicate_group_count: 1,
+  duplicate_memory_count: 2,
+  stale_fact_count: 1,
+  unresolved_contradiction_count: 1,
+  weak_trust_count: 2,
+  review_queue_pressure: {
+    posture: "watch",
+    total_count: 2,
+    stale_over_72h_count: 0,
+    aging_24h_to_72h_count: 1,
+    reason: "Fixture queue backlog exists and should be drained before it becomes stale.",
+  },
+  duplicate_groups: [
+    {
+      group_key: "preference:{\"merchant\":\"Fixture Store\"}",
+      memory_type: "preference",
+      normalized_value: "{\"merchant\":\"Fixture Store\"}",
+      count: 2,
+      memory_ids: [
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1",
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3",
+      ],
+      memory_keys: ["user.preference.store", "user.preference.backup_store"],
+      latest_updated_at: "2026-03-23T09:00:00Z",
+    },
+  ],
+  focus: [
+    {
+      kind: "duplicates",
+      posture: "watch",
+      count: 2,
+      reason: "Fixture duplicate facts are visible for consolidation review.",
+      action: "Review duplicate groups and keep one canonical fact per repeated value.",
+      sample_ids: [
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1",
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3",
+      ],
+    },
+    {
+      kind: "unresolved_contradictions",
+      posture: "critical",
+      count: 1,
+      reason: "Fixture contradiction pressure is visible in the hygiene surface.",
+      action: "Resolve contradiction cases before relying on those facts in continuity surfaces.",
+      sample_ids: [],
+    },
+  ],
+  sources: ["memories", "contradiction_cases", "trust_signals", "continuity_recall"],
+};
+
 const openLoopFixtures: OpenLoopRecord[] = [
   {
     id: "loop-fixture-1",
@@ -292,13 +348,24 @@ export default async function MemoriesPage({
   let trustDashboardSource: ApiSource = "fixture";
   let trustDashboardUnavailableReason: string | undefined;
 
+  let hygieneDashboard = hygieneDashboardFixture;
+  let hygieneDashboardSource: ApiSource = "fixture";
+  let hygieneDashboardUnavailableReason: string | undefined;
+
   let openLoops = openLoopFixtures;
   let openLoopSummary = openLoopSummaryFixture;
   let openLoopSource: ApiSource = "fixture";
   let openLoopUnavailableReason: string | undefined;
 
   if (liveModeReady) {
-    const [memoryResult, queueResult, summaryResult, trustDashboardResult, openLoopResult] =
+    const [
+      memoryResult,
+      queueResult,
+      summaryResult,
+      trustDashboardResult,
+      hygieneDashboardResult,
+      openLoopResult,
+    ] =
       await Promise.allSettled([
       listMemories(apiConfig.apiBaseUrl, apiConfig.userId, { status: "active" }),
       listMemoryReviewQueue(apiConfig.apiBaseUrl, apiConfig.userId, {
@@ -306,6 +373,7 @@ export default async function MemoriesPage({
       }),
       getMemoryEvaluationSummary(apiConfig.apiBaseUrl, apiConfig.userId),
       getMemoryTrustDashboard(apiConfig.apiBaseUrl, apiConfig.userId),
+      getMemoryHygieneDashboard(apiConfig.apiBaseUrl, apiConfig.userId),
       listOpenLoops(apiConfig.apiBaseUrl, apiConfig.userId, { status: "open", limit: 20 }),
     ]);
 
@@ -349,6 +417,16 @@ export default async function MemoriesPage({
         trustDashboardResult.reason instanceof Error
           ? trustDashboardResult.reason.message
           : "Memory trust dashboard could not be loaded.";
+    }
+
+    if (hygieneDashboardResult.status === "fulfilled") {
+      hygieneDashboard = hygieneDashboardResult.value.dashboard;
+      hygieneDashboardSource = "live";
+    } else {
+      hygieneDashboardUnavailableReason =
+        hygieneDashboardResult.reason instanceof Error
+          ? hygieneDashboardResult.reason.message
+          : "Memory hygiene dashboard could not be loaded.";
     }
 
     if (openLoopResult.status === "fulfilled") {
@@ -491,6 +569,7 @@ export default async function MemoriesPage({
     reviewQueueSource,
     evaluationSummarySource,
     trustDashboardSource,
+    hygieneDashboardSource,
     openLoopSource,
     selectedMemorySource,
     selectedOpenLoopSource,
@@ -527,6 +606,12 @@ export default async function MemoriesPage({
         queueSource={reviewQueueSource}
         queueUnavailableReason={reviewQueueUnavailableReason}
         activeFilter={activeFilter}
+      />
+
+      <MemoryHygieneDashboard
+        dashboard={hygieneDashboard}
+        source={hygieneDashboardSource}
+        unavailableReason={hygieneDashboardUnavailableReason}
       />
 
       <div className="section-card">

--- a/apps/web/components/memory-hygiene-dashboard.tsx
+++ b/apps/web/components/memory-hygiene-dashboard.tsx
@@ -1,0 +1,113 @@
+import type { ApiSource, MemoryHygieneDashboardSummary } from "../lib/api";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type MemoryHygieneDashboardProps = {
+  dashboard: MemoryHygieneDashboardSummary;
+  source: ApiSource;
+  unavailableReason?: string;
+};
+
+function postureBadge(posture: MemoryHygieneDashboardSummary["posture"]) {
+  if (posture === "healthy") {
+    return { status: "ready", label: "Healthy posture" };
+  }
+  if (posture === "critical") {
+    return { status: "error", label: "Critical posture" };
+  }
+  return { status: "requires_review", label: "Watch posture" };
+}
+
+export function MemoryHygieneDashboard({
+  dashboard,
+  source,
+  unavailableReason,
+}: MemoryHygieneDashboardProps) {
+  const badge = postureBadge(dashboard.posture);
+
+  return (
+    <SectionCard
+      eyebrow="Memory hygiene"
+      title="Operational hygiene posture"
+      description="Surface duplicate facts, stale truth, contradictions, weak trust, and queue pressure before item-by-item review."
+    >
+      <div className="detail-stack">
+        <div className="cluster">
+          <StatusBadge status={badge.status} label={badge.label} />
+          <StatusBadge
+            status={source}
+            label={source === "live" ? "Live hygiene dashboard" : "Fixture hygiene dashboard"}
+          />
+        </div>
+
+        <p>{dashboard.reason}</p>
+        {unavailableReason ? (
+          <div className="execution-summary__note execution-summary__note--danger">
+            <p className="execution-summary__label">Live source note</p>
+            <p>{unavailableReason}</p>
+          </div>
+        ) : null}
+
+        <dl className="key-value-grid key-value-grid--compact">
+          <div>
+            <dt>Duplicate groups</dt>
+            <dd>{dashboard.duplicate_group_count}</dd>
+          </div>
+          <div>
+            <dt>Duplicate memories</dt>
+            <dd>{dashboard.duplicate_memory_count}</dd>
+          </div>
+          <div>
+            <dt>Stale facts</dt>
+            <dd>{dashboard.stale_fact_count}</dd>
+          </div>
+          <div>
+            <dt>Unresolved contradictions</dt>
+            <dd>{dashboard.unresolved_contradiction_count}</dd>
+          </div>
+          <div>
+            <dt>Weak trust</dt>
+            <dd>{dashboard.weak_trust_count}</dd>
+          </div>
+          <div>
+            <dt>Queue pressure</dt>
+            <dd>{dashboard.review_queue_pressure.total_count}</dd>
+          </div>
+        </dl>
+
+        <div className="detail-group detail-group--muted">
+          <span className="history-entry__label">Focus queue</span>
+          {dashboard.focus.length > 0 ? (
+            <ul className="timeline-list">
+              {dashboard.focus.map((item) => (
+                <li key={item.kind} className="timeline-item">
+                  <p className="mono">{item.kind}</p>
+                  <p>{item.reason}</p>
+                  <p>{item.action}</p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="muted-copy">No active hygiene issues are currently surfaced.</p>
+          )}
+        </div>
+
+        <div className="detail-group detail-group--muted">
+          <span className="history-entry__label">Duplicate groups</span>
+          {dashboard.duplicate_groups.length > 0 ? (
+            <ul className="timeline-list">
+              {dashboard.duplicate_groups.slice(0, 3).map((group) => (
+                <li key={group.group_key} className="timeline-item">
+                  <p className="mono">{group.memory_keys.join(", ")}</p>
+                  <p>{group.count} memories share one normalized value.</p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="muted-copy">No duplicate fact groups are currently visible.</p>
+          )}
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/components/thread-health-dashboard.tsx
+++ b/apps/web/components/thread-health-dashboard.tsx
@@ -1,0 +1,146 @@
+import type { ApiSource, ThreadHealthDashboardSummary } from "../lib/api";
+import { SectionCard } from "./section-card";
+import { StatusBadge } from "./status-badge";
+
+type ThreadHealthDashboardProps = {
+  dashboard: ThreadHealthDashboardSummary;
+  source: ApiSource;
+  unavailableReason?: string;
+};
+
+function postureBadge(posture: ThreadHealthDashboardSummary["posture"]) {
+  if (posture === "healthy") {
+    return { status: "ready", label: "Healthy posture" };
+  }
+  if (posture === "critical") {
+    return { status: "error", label: "Critical posture" };
+  }
+  return { status: "requires_review", label: "Watch posture" };
+}
+
+function formatHours(value: number | null) {
+  if (value == null) {
+    return "Not yet active";
+  }
+  return `${value.toFixed(1)}h`;
+}
+
+export function ThreadHealthDashboard({
+  dashboard,
+  source,
+  unavailableReason,
+}: ThreadHealthDashboardProps) {
+  const badge = postureBadge(dashboard.posture);
+
+  return (
+    <SectionCard
+      eyebrow="Thread health"
+      title="Conversation health posture"
+      description="Keep recent, stale, and risky threads visible before diving into recall, open loops, or review queues."
+    >
+      <div className="detail-stack">
+        <div className="cluster">
+          <StatusBadge status={badge.status} label={badge.label} />
+          <StatusBadge
+            status={source}
+            label={source === "live" ? "Live thread dashboard" : "Fixture thread dashboard"}
+          />
+          <span className="meta-pill">
+            Recent within {dashboard.thresholds.recent_window_hours}h
+          </span>
+          <span className="meta-pill">
+            Stale after {dashboard.thresholds.stale_window_hours}h
+          </span>
+        </div>
+
+        {unavailableReason ? (
+          <div className="execution-summary__note execution-summary__note--danger">
+            <p className="execution-summary__label">Live source note</p>
+            <p>{unavailableReason}</p>
+          </div>
+        ) : null}
+
+        <dl className="key-value-grid key-value-grid--compact">
+          <div>
+            <dt>Total threads</dt>
+            <dd>{dashboard.total_thread_count}</dd>
+          </div>
+          <div>
+            <dt>Recent</dt>
+            <dd>{dashboard.recent_thread_count}</dd>
+          </div>
+          <div>
+            <dt>Stale</dt>
+            <dd>{dashboard.stale_thread_count}</dd>
+          </div>
+          <div>
+            <dt>Risky</dt>
+            <dd>{dashboard.risky_thread_count}</dd>
+          </div>
+          <div>
+            <dt>Watch</dt>
+            <dd>{dashboard.watch_thread_count}</dd>
+          </div>
+          <div>
+            <dt>Risk threshold</dt>
+            <dd>{dashboard.thresholds.risky_score_threshold}</dd>
+          </div>
+        </dl>
+
+        <div className="detail-group detail-group--muted">
+          <span className="history-entry__label">Risky threads</span>
+          {dashboard.risky_threads.length > 0 ? (
+            <ul className="timeline-list">
+              {dashboard.risky_threads.slice(0, 3).map((item) => (
+                <li key={item.thread.id} className="timeline-item">
+                  <p className="mono">{item.thread.title}</p>
+                  <p>
+                    Score {item.risk_score} · {item.unresolved_contradiction_count} contradictions ·{" "}
+                    {item.stale_open_loop_count} stale loops
+                  </p>
+                  <p>{item.recommended_action}</p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="muted-copy">No risky threads are currently surfaced.</p>
+          )}
+        </div>
+
+        <div className="detail-group detail-group--muted">
+          <span className="history-entry__label">Stale threads</span>
+          {dashboard.stale_threads.length > 0 ? (
+            <ul className="timeline-list">
+              {dashboard.stale_threads.slice(0, 3).map((item) => (
+                <li key={item.thread.id} className="timeline-item">
+                  <p className="mono">{item.thread.title}</p>
+                  <p>Last activity {formatHours(item.hours_since_last_activity)} ago.</p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="muted-copy">No stale threads are currently surfaced.</p>
+          )}
+        </div>
+
+        <div className="detail-group detail-group--muted">
+          <span className="history-entry__label">Recent threads</span>
+          {dashboard.recent_threads.length > 0 ? (
+            <ul className="timeline-list">
+              {dashboard.recent_threads.slice(0, 3).map((item) => (
+                <li key={item.thread.id} className="timeline-item">
+                  <p className="mono">{item.thread.title}</p>
+                  <p>
+                    {item.conversation_event_count} conversation events · {item.operational_event_count} operational events
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="muted-copy">No recent threads are currently surfaced.</p>
+          )}
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -48,6 +48,51 @@ export type ThreadListSummary = {
   order: string[];
 };
 
+export type ThreadActivityPosture = "recent" | "current" | "stale";
+export type ThreadRiskPosture = "normal" | "watch" | "risky";
+export type ThreadHealthPosture = "healthy" | "watch" | "critical";
+
+export type ThreadHealthThresholds = {
+  recent_window_hours: number;
+  stale_window_hours: number;
+  risky_score_threshold: number;
+};
+
+export type ThreadHealthItem = {
+  thread: ThreadItem;
+  health_posture: ThreadHealthPosture;
+  activity_posture: ThreadActivityPosture;
+  risk_posture: ThreadRiskPosture;
+  risk_score: number;
+  last_activity_at: string | null;
+  last_conversation_at: string | null;
+  hours_since_last_activity: number | null;
+  conversation_event_count: number;
+  operational_event_count: number;
+  active_session_count: number;
+  open_loop_count: number;
+  stale_open_loop_count: number;
+  unresolved_contradiction_count: number;
+  weak_trust_signal_count: number;
+  reasons: string[];
+  recommended_action: string;
+};
+
+export type ThreadHealthDashboardSummary = {
+  posture: ThreadHealthPosture;
+  total_thread_count: number;
+  recent_thread_count: number;
+  stale_thread_count: number;
+  risky_thread_count: number;
+  watch_thread_count: number;
+  thresholds: ThreadHealthThresholds;
+  recent_threads: ThreadHealthItem[];
+  stale_threads: ThreadHealthItem[];
+  risky_threads: ThreadHealthItem[];
+  items: ThreadHealthItem[];
+  sources: string[];
+};
+
 export type AgentProfileItem = {
   id: string;
   name: string;
@@ -579,6 +624,55 @@ export type MemoryTrustRecommendedReview = {
   priority_mode: MemoryReviewQueuePriorityMode;
   action: MemoryQualityReviewAction;
   reason: string;
+};
+
+export type MemoryHygienePosture = "healthy" | "watch" | "critical";
+export type MemoryHygieneFocusKind =
+  | "duplicates"
+  | "stale_facts"
+  | "unresolved_contradictions"
+  | "weak_trust"
+  | "review_queue_pressure";
+
+export type MemoryDuplicateGroup = {
+  group_key: string;
+  memory_type: string;
+  normalized_value: string;
+  count: number;
+  memory_ids: string[];
+  memory_keys: string[];
+  latest_updated_at: string;
+};
+
+export type MemoryReviewQueuePressureSummary = {
+  posture: MemoryHygienePosture;
+  total_count: number;
+  stale_over_72h_count: number;
+  aging_24h_to_72h_count: number;
+  reason: string;
+};
+
+export type MemoryHygieneFocusItem = {
+  kind: MemoryHygieneFocusKind;
+  posture: MemoryHygienePosture;
+  count: number;
+  reason: string;
+  action: string;
+  sample_ids: string[];
+};
+
+export type MemoryHygieneDashboardSummary = {
+  posture: MemoryHygienePosture;
+  reason: string;
+  duplicate_group_count: number;
+  duplicate_memory_count: number;
+  stale_fact_count: number;
+  unresolved_contradiction_count: number;
+  weak_trust_count: number;
+  review_queue_pressure: MemoryReviewQueuePressureSummary;
+  duplicate_groups: MemoryDuplicateGroup[];
+  focus: MemoryHygieneFocusItem[];
+  sources: string[];
 };
 
 export type MemoryTrustDashboardSummary = {
@@ -2435,6 +2529,15 @@ export function listThreads(apiBaseUrl: string, userId: string) {
   );
 }
 
+export function getThreadHealthDashboard(apiBaseUrl: string, userId: string) {
+  return requestJson<{ dashboard: ThreadHealthDashboardSummary }>(
+    apiBaseUrl,
+    "/v0/threads/health-dashboard",
+    undefined,
+    { user_id: userId },
+  );
+}
+
 export function listAgentProfiles(apiBaseUrl: string) {
   return requestJson<{ items: AgentProfileItem[]; summary: AgentProfileListSummary }>(
     apiBaseUrl,
@@ -3426,6 +3529,15 @@ export function getMemoryTrustDashboard(apiBaseUrl: string, userId: string) {
   return requestJson<{ dashboard: MemoryTrustDashboardSummary }>(
     apiBaseUrl,
     "/v0/memories/trust-dashboard",
+    undefined,
+    { user_id: userId },
+  );
+}
+
+export function getMemoryHygieneDashboard(apiBaseUrl: string, userId: string) {
+  return requestJson<{ dashboard: MemoryHygieneDashboardSummary }>(
+    apiBaseUrl,
+    "/v0/memories/hygiene-dashboard",
     undefined,
     { user_id: userId },
   );

--- a/docs/memory/p13-s3-memory-hygiene-conversation-health.md
+++ b/docs/memory/p13-s3-memory-hygiene-conversation-health.md
@@ -1,0 +1,57 @@
+# P13-S3 Memory Hygiene + Conversation Health
+
+This sprint adds bounded visibility surfaces for memory hygiene and conversation health without changing storage shape or continuity semantics.
+
+## Shipped Surfaces
+
+- `GET /v0/memories/hygiene-dashboard`
+- `GET /v0/threads/health-dashboard`
+- web memory hygiene panel in the memory review workspace
+- web thread health panel in the continuity workspace
+- CLI `alicebot status` extensions for hygiene and thread-health posture
+
+## Memory Hygiene Coverage
+
+The hygiene dashboard makes the following states visible in one summary:
+
+- duplicate active memories grouped by normalized value and memory type
+- stale facts derived from contested memories or bounded truth windows
+- unresolved contradiction count from open contradiction cases
+- weak-trust memory count from low-confidence, unconfirmed, or non-promotable facts
+- review queue pressure derived from unlabeled queue size and queue aging
+
+Each nonzero category ships with an explicit action string so the operator can decide what to inspect next.
+
+## Conversation Health Coverage
+
+The thread-health dashboard classifies threads across three dimensions:
+
+- recent threads: last visible activity within 24 hours
+- stale threads: last visible activity older than 72 hours
+- risky threads: thread risk score at or above 2
+
+Current risk score model:
+
+- `+2` for any unresolved contradiction on a thread-scoped continuity object
+- `+1` for any stale thread-scoped open-loop item
+- `+1` for any active weak-inference trust signal on a thread-scoped continuity object
+- `+1` when an active session remains open after more than 24 hours of inactivity
+
+Overall thread posture is:
+
+- `critical` when any risky thread is visible
+- `watch` when stale or watch threads are visible without a risky thread
+- `healthy` otherwise
+
+## Scope Notes
+
+- No new connector, runtime, persistence, or retrieval substrate was introduced.
+- The dashboard builders aggregate existing thread, event, continuity, contradiction, trust-signal, and review-queue data.
+- The first shipped thread-health surface is both API-visible and UI-visible.
+
+## Verification
+
+- targeted unit coverage for memory hygiene aggregation
+- targeted unit coverage for thread-health aggregation
+- page coverage for the memory and continuity workspace panels
+- control-doc truth verification remains green

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -36,9 +36,9 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "P13-S2: Alice Lite",
+            "P13-S3: Memory Hygiene + Conversation Health",
             "`v0.3.2` is the latest published tag.",
-            "Alice Lite",
+            "Memory Hygiene + Conversation Health",
         ),
     ),
     ControlDocTruthRule(
@@ -54,7 +54,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
             "Phase 12 is shipped.",
             "`v0.3.2` is the latest published tag.",
             "Phase 13 is active.",
-            "`P13-S2` Alice Lite is the active execution sprint.",
+            "`P13-S3` Memory Hygiene + Conversation Health is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import json
 from pathlib import Path
 from uuid import UUID, uuid4
@@ -313,6 +314,121 @@ def test_status_command_surfaces_latest_maintenance_snapshot(monkeypatch, capsys
     assert "maintenance: status=warn schedule=nightly" in captured.out
     assert "last_run=2026-04-11T01:00:00Z" in captured.out
     assert "failures=0 warnings=2 stale_facts=3 reembedded_segments=5 pattern_candidates=8 benchmark=pass" in captured.out
+
+
+def test_status_command_reports_memory_hygiene_and_thread_health_when_database_is_reachable(
+    monkeypatch,
+    capsys,
+) -> None:
+    user_id = UUID("44444444-4444-4444-8444-444444444444")
+
+    class FakeStatusStore:
+        def count_continuity_review_queue(self, *, statuses: list[str]) -> int:
+            return {
+                ("active",): 2,
+                ("stale",): 1,
+                ("superseded",): 0,
+                ("deleted",): 0,
+            }[tuple(statuses)]
+
+        def list_continuity_recall_candidates(self) -> list[dict[str, object]]:
+            return [
+                {
+                    "id": uuid4(),
+                    "status": "active",
+                    "object_type": "Decision",
+                    "is_searchable": True,
+                    "is_promotable": True,
+                },
+                {
+                    "id": uuid4(),
+                    "status": "stale",
+                    "object_type": "WaitingFor",
+                    "is_searchable": True,
+                    "is_promotable": False,
+                },
+            ]
+
+        def count_continuity_capture_events(self) -> int:
+            return 7
+
+    @contextmanager
+    def fake_store_context(_ctx):
+        yield FakeStatusStore()
+
+    monkeypatch.setattr(
+        cli_module,
+        "get_settings",
+        lambda: Settings(
+            database_url="postgresql://db",
+            healthcheck_timeout_seconds=2,
+            auth_user_id=str(user_id),
+        ),
+    )
+    monkeypatch.setattr(cli_module, "ping_database", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(cli_module, "_store_context", fake_store_context)
+    monkeypatch.setattr(
+        cli_module,
+        "compile_continuity_open_loop_dashboard",
+        lambda *_args, **_kwargs: {
+            "dashboard": {
+                "summary": {"total_count": 3},
+                "waiting_for": {"summary": {"total_count": 1}},
+                "blocker": {"summary": {"total_count": 1}},
+                "stale": {"summary": {"total_count": 1}},
+                "next_action": {"summary": {"total_count": 0}},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "get_retrieval_evaluation_summary",
+        lambda *_args, **_kwargs: {
+            "summary": {
+                "status": "healthy",
+                "precision_at_k_mean": 0.875,
+                "precision_at_1_mean": 1.0,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "get_memory_hygiene_dashboard_summary",
+        lambda *_args, **_kwargs: {
+            "dashboard": {
+                "posture": "watch",
+                "duplicate_group_count": 2,
+                "stale_fact_count": 1,
+                "unresolved_contradiction_count": 1,
+                "weak_trust_count": 3,
+                "review_queue_pressure": {"posture": "critical"},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "get_thread_health_dashboard",
+        lambda *_args, **_kwargs: {
+            "dashboard": {
+                "posture": "critical",
+                "recent_thread_count": 4,
+                "stale_thread_count": 2,
+                "risky_thread_count": 1,
+                "watch_thread_count": 3,
+            }
+        },
+    )
+
+    exit_code = cli_module.main(["status"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "database: reachable" in captured.out
+    assert (
+        "memory_hygiene: posture=watch duplicate_groups=2 stale_facts=1 "
+        "open_contradictions=1 weak_trust=3 queue_pressure=critical"
+    ) in captured.out
+    assert "thread_health: posture=critical recent=4 stale=2 risky=1 watch=3" in captured.out
 
 
 def test_recall_formatting_renders_provenance_source_label_when_present() -> None:

--- a/tests/unit/test_conversation_health.py
+++ b/tests/unit/test_conversation_health.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import alicebot_api.conversation_health as conversation_health_module
+from alicebot_api.conversation_health import get_thread_health_dashboard
+
+
+class ThreadHealthStoreStub:
+    def __init__(self) -> None:
+        self.threads: list[dict[str, object]] = []
+        self.sessions: list[dict[str, object]] = []
+        self.events: list[dict[str, object]] = []
+        self.recall_candidates: list[dict[str, object]] = []
+        self.contradiction_cases: list[dict[str, object]] = []
+        self.trust_signals: list[dict[str, object]] = []
+
+    def list_threads(self) -> list[dict[str, object]]:
+        return list(self.threads)
+
+    def list_thread_sessions(self, thread_id: UUID) -> list[dict[str, object]]:
+        return [session for session in self.sessions if session["thread_id"] == thread_id]
+
+    def list_thread_events(self, thread_id: UUID) -> list[dict[str, object]]:
+        return [event for event in self.events if event["thread_id"] == thread_id]
+
+    def list_continuity_recall_candidates(self) -> list[dict[str, object]]:
+        return list(self.recall_candidates)
+
+    def list_contradiction_cases_for_objects(
+        self,
+        *,
+        continuity_object_ids: list[UUID],
+        statuses: list[str],
+    ) -> list[dict[str, object]]:
+        assert statuses == ["open"]
+        return [
+            case
+            for case in self.contradiction_cases
+            if case["status"] in statuses
+            and (
+                case["continuity_object_id"] in continuity_object_ids
+                or case["counterpart_object_id"] in continuity_object_ids
+            )
+        ]
+
+    def list_trust_signals(
+        self,
+        *,
+        limit: int,
+        continuity_object_id: UUID | None = None,
+        signal_state: str | None = None,
+        signal_type: str | None = None,
+    ) -> list[dict[str, object]]:
+        signals = list(self.trust_signals)
+        if continuity_object_id is not None:
+            signals = [signal for signal in signals if signal["continuity_object_id"] == continuity_object_id]
+        if signal_state is not None:
+            signals = [signal for signal in signals if signal["signal_state"] == signal_state]
+        if signal_type is not None:
+            signals = [signal for signal in signals if signal["signal_type"] == signal_type]
+        return signals[:limit]
+
+    def count_trust_signals(
+        self,
+        *,
+        continuity_object_id: UUID | None = None,
+        signal_state: str | None = None,
+        signal_type: str | None = None,
+    ) -> int:
+        return len(
+            self.list_trust_signals(
+                limit=10_000,
+                continuity_object_id=continuity_object_id,
+                signal_state=signal_state,
+                signal_type=signal_type,
+            )
+        )
+
+
+def test_get_thread_health_dashboard_surfaces_recent_stale_and_risky_threads(
+    monkeypatch,
+) -> None:
+    now = datetime(2026, 4, 15, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(conversation_health_module, "_utcnow", lambda: now)
+
+    store = ThreadHealthStoreStub()
+    recent_thread_id = UUID("00000000-0000-4000-8000-000000000001")
+    stale_thread_id = UUID("00000000-0000-4000-8000-000000000002")
+    risky_thread_id = UUID("00000000-0000-4000-8000-000000000003")
+    risky_object_id = UUID("10000000-0000-4000-8000-000000000001")
+    stale_object_id = UUID("10000000-0000-4000-8000-000000000002")
+
+    store.threads = [
+        {
+            "id": recent_thread_id,
+            "user_id": uuid4(),
+            "title": "Recent thread",
+            "agent_profile_id": "assistant_default",
+            "created_at": now - timedelta(hours=6),
+            "updated_at": now - timedelta(hours=2),
+        },
+        {
+            "id": stale_thread_id,
+            "user_id": uuid4(),
+            "title": "Stale thread",
+            "agent_profile_id": "assistant_default",
+            "created_at": now - timedelta(days=7),
+            "updated_at": now - timedelta(days=5),
+        },
+        {
+            "id": risky_thread_id,
+            "user_id": uuid4(),
+            "title": "Risky thread",
+            "agent_profile_id": "assistant_default",
+            "created_at": now - timedelta(days=2),
+            "updated_at": now - timedelta(hours=30),
+        },
+    ]
+    store.sessions = [
+        {
+            "id": uuid4(),
+            "thread_id": recent_thread_id,
+            "status": "active",
+            "started_at": now - timedelta(hours=3),
+            "ended_at": None,
+            "created_at": now - timedelta(hours=3),
+        }
+    ]
+    store.events = [
+        {
+            "id": uuid4(),
+            "thread_id": recent_thread_id,
+            "session_id": None,
+            "sequence_no": 1,
+            "kind": "message.user",
+            "payload": {"text": "hello"},
+            "created_at": now - timedelta(hours=2),
+        },
+        {
+            "id": uuid4(),
+            "thread_id": stale_thread_id,
+            "session_id": None,
+            "sequence_no": 1,
+            "kind": "message.assistant",
+            "payload": {"text": "later"},
+            "created_at": now - timedelta(days=5),
+        },
+        {
+            "id": uuid4(),
+            "thread_id": risky_thread_id,
+            "session_id": None,
+            "sequence_no": 1,
+            "kind": "message.user",
+            "payload": {"text": "conflict"},
+            "created_at": now - timedelta(hours=30),
+        },
+    ]
+    store.recall_candidates = [
+        {
+            "id": stale_object_id,
+            "capture_event_id": uuid4(),
+            "object_type": "WaitingFor",
+            "status": "stale",
+            "is_preserved": True,
+            "is_searchable": True,
+            "is_promotable": True,
+            "title": "Need vendor follow-up",
+            "body": {"waiting_for_text": "Vendor reply"},
+            "provenance": {"thread_id": str(stale_thread_id)},
+            "confidence": 0.9,
+            "last_confirmed_at": None,
+            "supersedes_object_id": None,
+            "superseded_by_object_id": None,
+            "object_created_at": now - timedelta(days=6),
+            "object_updated_at": now - timedelta(days=5),
+            "admission_posture": "DERIVED",
+        },
+        {
+            "id": risky_object_id,
+            "capture_event_id": uuid4(),
+            "object_type": "Decision",
+            "status": "active",
+            "is_preserved": True,
+            "is_searchable": True,
+            "is_promotable": True,
+            "title": "Conflicting preference",
+            "body": {"decision_text": "Use provider A"},
+            "provenance": {"thread_id": str(risky_thread_id)},
+            "confidence": 0.7,
+            "last_confirmed_at": None,
+            "supersedes_object_id": None,
+            "superseded_by_object_id": None,
+            "object_created_at": now - timedelta(days=2),
+            "object_updated_at": now - timedelta(hours=30),
+            "admission_posture": "DERIVED",
+        },
+    ]
+    store.contradiction_cases = [
+        {
+            "id": uuid4(),
+            "continuity_object_id": risky_object_id,
+            "counterpart_object_id": uuid4(),
+            "status": "open",
+        }
+    ]
+    store.trust_signals = [
+        {
+            "id": uuid4(),
+            "continuity_object_id": risky_object_id,
+            "signal_key": "weak_inference:risky",
+            "signal_type": "weak_inference",
+            "signal_state": "active",
+            "direction": "negative",
+            "magnitude": 0.35,
+            "reason": "Structured continuity state exists without corroborating evidence.",
+            "contradiction_case_id": None,
+            "related_continuity_object_id": None,
+            "payload": {},
+            "created_at": now - timedelta(hours=29),
+            "updated_at": now - timedelta(hours=29),
+        }
+    ]
+
+    payload = get_thread_health_dashboard(store, user_id=uuid4())  # type: ignore[arg-type]
+
+    assert payload["dashboard"]["posture"] == "critical"
+    assert payload["dashboard"]["recent_thread_count"] == 1
+    assert payload["dashboard"]["stale_thread_count"] == 1
+    assert payload["dashboard"]["risky_thread_count"] == 1
+    assert payload["dashboard"]["risky_threads"][0]["thread"]["title"] == "Risky thread"
+    assert payload["dashboard"]["risky_threads"][0]["unresolved_contradiction_count"] == 1
+    assert payload["dashboard"]["risky_threads"][0]["weak_trust_signal_count"] == 1
+    assert payload["dashboard"]["stale_threads"][0]["thread"]["title"] == "Stale thread"
+    assert payload["dashboard"]["stale_threads"][0]["stale_open_loop_count"] == 1
+    assert payload["dashboard"]["recent_threads"][0]["thread"]["title"] == "Recent thread"
+
+
+def test_get_thread_health_dashboard_counts_weak_trust_without_global_signal_truncation(
+    monkeypatch,
+) -> None:
+    now = datetime(2026, 4, 15, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(conversation_health_module, "_utcnow", lambda: now)
+
+    store = ThreadHealthStoreStub()
+    target_thread_id = UUID("00000000-0000-4000-8000-000000000111")
+    filler_thread_id = UUID("00000000-0000-4000-8000-000000000112")
+
+    store.threads = [
+        {
+            "id": target_thread_id,
+            "user_id": uuid4(),
+            "title": "Target thread",
+            "agent_profile_id": "assistant_default",
+            "created_at": now - timedelta(hours=8),
+            "updated_at": now - timedelta(hours=2),
+        },
+        {
+            "id": filler_thread_id,
+            "user_id": uuid4(),
+            "title": "Filler thread",
+            "agent_profile_id": "assistant_default",
+            "created_at": now - timedelta(hours=8),
+            "updated_at": now - timedelta(hours=2),
+        },
+    ]
+
+    filler_object_ids = [
+        UUID(f"20000000-0000-4000-8000-{index:012d}")
+        for index in range(1, 61)
+    ]
+    target_object_id = UUID("30000000-0000-4000-8000-000000000001")
+    store.recall_candidates = [
+        {
+            "id": object_id,
+            "capture_event_id": uuid4(),
+            "object_type": "Decision",
+            "status": "active",
+            "is_preserved": True,
+            "is_searchable": True,
+            "is_promotable": True,
+            "title": f"Filler object {index}",
+            "body": {"decision_text": f"Filler {index}"},
+            "provenance": {"thread_id": str(filler_thread_id)},
+            "confidence": 0.8,
+            "last_confirmed_at": None,
+            "supersedes_object_id": None,
+            "superseded_by_object_id": None,
+            "object_created_at": now - timedelta(hours=7),
+            "object_updated_at": now - timedelta(hours=6),
+            "admission_posture": "DERIVED",
+        }
+        for index, object_id in enumerate(filler_object_ids, start=1)
+    ]
+    store.recall_candidates.append(
+        {
+            "id": target_object_id,
+            "capture_event_id": uuid4(),
+            "object_type": "Decision",
+            "status": "active",
+            "is_preserved": True,
+            "is_searchable": True,
+            "is_promotable": True,
+            "title": "Target object",
+            "body": {"decision_text": "Target"},
+            "provenance": {"thread_id": str(target_thread_id)},
+            "confidence": 0.8,
+            "last_confirmed_at": None,
+            "supersedes_object_id": None,
+            "superseded_by_object_id": None,
+            "object_created_at": now - timedelta(hours=7),
+            "object_updated_at": now - timedelta(hours=6),
+            "admission_posture": "DERIVED",
+        }
+    )
+
+    for object_id in filler_object_ids:
+        for signal_index in range(5):
+            store.trust_signals.append(
+                {
+                    "id": uuid4(),
+                    "continuity_object_id": object_id,
+                    "signal_key": f"weak_inference:filler:{signal_index}",
+                    "signal_type": "weak_inference",
+                    "signal_state": "active",
+                    "direction": "negative",
+                    "magnitude": 0.1,
+                    "reason": "Filler weak inference signal.",
+                    "contradiction_case_id": None,
+                    "related_continuity_object_id": None,
+                    "payload": {},
+                    "created_at": now - timedelta(hours=5),
+                    "updated_at": now - timedelta(hours=5),
+                }
+            )
+    for signal_index in range(5):
+        store.trust_signals.append(
+            {
+                "id": uuid4(),
+                "continuity_object_id": target_object_id,
+                "signal_key": f"weak_inference:target:{signal_index}",
+                "signal_type": "weak_inference",
+                "signal_state": "active",
+                "direction": "negative",
+                "magnitude": 0.2,
+                "reason": "Target weak inference signal.",
+                "contradiction_case_id": None,
+                "related_continuity_object_id": None,
+                "payload": {},
+                "created_at": now - timedelta(hours=4),
+                "updated_at": now - timedelta(hours=4),
+            }
+        )
+
+    payload = get_thread_health_dashboard(store, user_id=uuid4())  # type: ignore[arg-type]
+
+    target_item = next(
+        item for item in payload["dashboard"]["items"] if item["thread"]["id"] == str(target_thread_id)
+    )
+    assert target_item["weak_trust_signal_count"] == 5
+    assert target_item["risk_posture"] == "watch"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -123,6 +123,7 @@ def test_healthcheck_route_is_registered() -> None:
     assert "/v0/memories" in route_paths
     assert "/v0/memories/review-queue" in route_paths
     assert "/v0/memories/quality-gate" in route_paths
+    assert "/v0/memories/hygiene-dashboard" in route_paths
     assert "/v0/memories/evaluation-summary" in route_paths
     assert "/v0/memories/semantic-retrieval" in route_paths
     assert "/v0/memories/{memory_id}" in route_paths
@@ -165,6 +166,7 @@ def test_healthcheck_route_is_registered() -> None:
     assert "/v0/tasks/{task_id}" in route_paths
     assert "/v0/tasks/{task_id}/workspace" in route_paths
     assert "/v0/tasks/{task_id}/steps" in route_paths
+    assert "/v0/threads/health-dashboard" in route_paths
     assert "/v0/threads/{thread_id}/resumption-brief" in route_paths
     assert "/v0/task-workspaces" in route_paths
     assert "/v0/task-workspaces/{task_workspace_id}" in route_paths
@@ -2641,6 +2643,310 @@ def test_get_memories_quality_gate_returns_canonical_payload(monkeypatch) -> Non
                 "outdated_label_count": 0,
                 "insufficient_evidence_label_count": 0,
             },
+        }
+    }
+    assert captured["database_url"] == "postgresql://app"
+    assert captured["current_user_id"] == user_id
+    assert captured["user_id"] == user_id
+
+
+def test_get_memories_hygiene_dashboard_returns_canonical_payload(monkeypatch) -> None:
+    user_id = uuid4()
+    settings = Settings(database_url="postgresql://app")
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def fake_user_connection(database_url: str, current_user_id):
+        captured["database_url"] = database_url
+        captured["current_user_id"] = current_user_id
+        yield object()
+
+    def fake_get_memory_hygiene_dashboard_summary(store, *, user_id):
+        captured["store_type"] = type(store).__name__
+        captured["user_id"] = user_id
+        return {
+            "dashboard": {
+                "posture": "watch",
+                "reason": "Duplicate and contradiction pressure is visible.",
+                "duplicate_group_count": 1,
+                "duplicate_memory_count": 2,
+                "stale_fact_count": 1,
+                "unresolved_contradiction_count": 1,
+                "weak_trust_count": 2,
+                "review_queue_pressure": {
+                    "posture": "watch",
+                    "total_count": 2,
+                    "stale_over_72h_count": 0,
+                    "aging_24h_to_72h_count": 1,
+                    "reason": "Backlog exists and should be drained before it becomes stale.",
+                },
+                "duplicate_groups": [
+                    {
+                        "group_key": "preference:{\"merchant\":\"Fixture\"}",
+                        "memory_type": "preference",
+                        "normalized_value": "{\"merchant\":\"Fixture\"}",
+                        "count": 2,
+                        "memory_ids": ["memory-1", "memory-2"],
+                        "memory_keys": ["user.preference.primary", "user.preference.secondary"],
+                        "latest_updated_at": "2026-03-18T10:05:00+00:00",
+                    }
+                ],
+                "focus": [
+                    {
+                        "kind": "duplicates",
+                        "posture": "watch",
+                        "count": 2,
+                        "reason": "Multiple active memories share the same normalized value.",
+                        "action": "Review duplicate groups and keep one canonical fact per repeated value.",
+                        "sample_ids": ["memory-1", "memory-2"],
+                    }
+                ],
+                "sources": ["memories", "contradiction_cases", "trust_signals", "continuity_recall"],
+            }
+        }
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(
+        main_module,
+        "get_memory_hygiene_dashboard_summary",
+        fake_get_memory_hygiene_dashboard_summary,
+    )
+
+    response = main_module.get_memories_hygiene_dashboard(user_id=user_id)
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {
+        "dashboard": {
+            "posture": "watch",
+            "reason": "Duplicate and contradiction pressure is visible.",
+            "duplicate_group_count": 1,
+            "duplicate_memory_count": 2,
+            "stale_fact_count": 1,
+            "unresolved_contradiction_count": 1,
+            "weak_trust_count": 2,
+            "review_queue_pressure": {
+                "posture": "watch",
+                "total_count": 2,
+                "stale_over_72h_count": 0,
+                "aging_24h_to_72h_count": 1,
+                "reason": "Backlog exists and should be drained before it becomes stale.",
+            },
+            "duplicate_groups": [
+                {
+                    "group_key": "preference:{\"merchant\":\"Fixture\"}",
+                    "memory_type": "preference",
+                    "normalized_value": "{\"merchant\":\"Fixture\"}",
+                    "count": 2,
+                    "memory_ids": ["memory-1", "memory-2"],
+                    "memory_keys": ["user.preference.primary", "user.preference.secondary"],
+                    "latest_updated_at": "2026-03-18T10:05:00+00:00",
+                }
+            ],
+            "focus": [
+                {
+                    "kind": "duplicates",
+                    "posture": "watch",
+                    "count": 2,
+                    "reason": "Multiple active memories share the same normalized value.",
+                    "action": "Review duplicate groups and keep one canonical fact per repeated value.",
+                    "sample_ids": ["memory-1", "memory-2"],
+                }
+            ],
+            "sources": ["memories", "contradiction_cases", "trust_signals", "continuity_recall"],
+        }
+    }
+    assert captured["database_url"] == "postgresql://app"
+    assert captured["current_user_id"] == user_id
+    assert captured["user_id"] == user_id
+
+
+def test_get_threads_health_dashboard_returns_canonical_payload(monkeypatch) -> None:
+    user_id = uuid4()
+    settings = Settings(database_url="postgresql://app")
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def fake_user_connection(database_url: str, current_user_id):
+        captured["database_url"] = database_url
+        captured["current_user_id"] = current_user_id
+        yield object()
+
+    def fake_get_thread_health_dashboard(store, *, user_id):
+        captured["store_type"] = type(store).__name__
+        captured["user_id"] = user_id
+        return {
+            "dashboard": {
+                "posture": "critical",
+                "total_thread_count": 2,
+                "recent_thread_count": 1,
+                "stale_thread_count": 0,
+                "risky_thread_count": 1,
+                "watch_thread_count": 0,
+                "thresholds": {
+                    "recent_window_hours": 24.0,
+                    "stale_window_hours": 72.0,
+                    "risky_score_threshold": 2,
+                },
+                "recent_threads": [
+                    {
+                        "thread": {
+                            "id": "thread-1",
+                            "title": "Recent thread",
+                            "agent_profile_id": "assistant_default",
+                            "created_at": "2026-03-18T09:00:00+00:00",
+                            "updated_at": "2026-03-18T10:00:00+00:00",
+                        },
+                        "health_posture": "healthy",
+                        "activity_posture": "recent",
+                        "risk_posture": "normal",
+                        "risk_score": 0,
+                        "last_activity_at": "2026-03-18T10:00:00+00:00",
+                        "last_conversation_at": "2026-03-18T10:00:00+00:00",
+                        "hours_since_last_activity": 2.0,
+                        "conversation_event_count": 3,
+                        "operational_event_count": 1,
+                        "active_session_count": 1,
+                        "open_loop_count": 0,
+                        "stale_open_loop_count": 0,
+                        "unresolved_contradiction_count": 0,
+                        "weak_trust_signal_count": 0,
+                        "reasons": [
+                            "No active contradiction, stale open-loop, or weak-trust pressure is currently visible."
+                        ],
+                        "recommended_action": "No immediate intervention required.",
+                    }
+                ],
+                "stale_threads": [],
+                "risky_threads": [
+                    {
+                        "thread": {
+                            "id": "thread-2",
+                            "title": "Risky thread",
+                            "agent_profile_id": "assistant_default",
+                            "created_at": "2026-03-18T09:00:00+00:00",
+                            "updated_at": "2026-03-18T08:00:00+00:00",
+                        },
+                        "health_posture": "critical",
+                        "activity_posture": "current",
+                        "risk_posture": "risky",
+                        "risk_score": 3,
+                        "last_activity_at": "2026-03-18T08:00:00+00:00",
+                        "last_conversation_at": "2026-03-18T08:00:00+00:00",
+                        "hours_since_last_activity": 26.0,
+                        "conversation_event_count": 2,
+                        "operational_event_count": 0,
+                        "active_session_count": 0,
+                        "open_loop_count": 1,
+                        "stale_open_loop_count": 1,
+                        "unresolved_contradiction_count": 1,
+                        "weak_trust_signal_count": 1,
+                        "reasons": ["1 unresolved contradiction case(s).", "1 stale open-loop item(s)."],
+                        "recommended_action": "Resolve contradiction cases before trusting this thread for recall or briefing.",
+                    }
+                ],
+                "items": [],
+                "sources": [
+                    "threads",
+                    "thread_sessions",
+                    "thread_events",
+                    "continuity_recall",
+                    "contradiction_cases",
+                    "trust_signals",
+                ],
+            }
+        }
+
+    monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(main_module, "user_connection", fake_user_connection)
+    monkeypatch.setattr(
+        main_module,
+        "get_thread_health_dashboard",
+        fake_get_thread_health_dashboard,
+    )
+
+    response = main_module.get_threads_health_dashboard(user_id=user_id)
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {
+        "dashboard": {
+            "posture": "critical",
+            "total_thread_count": 2,
+            "recent_thread_count": 1,
+            "stale_thread_count": 0,
+            "risky_thread_count": 1,
+            "watch_thread_count": 0,
+            "thresholds": {
+                "recent_window_hours": 24.0,
+                "stale_window_hours": 72.0,
+                "risky_score_threshold": 2,
+            },
+            "recent_threads": [
+                {
+                    "thread": {
+                        "id": "thread-1",
+                        "title": "Recent thread",
+                        "agent_profile_id": "assistant_default",
+                        "created_at": "2026-03-18T09:00:00+00:00",
+                        "updated_at": "2026-03-18T10:00:00+00:00",
+                    },
+                    "health_posture": "healthy",
+                    "activity_posture": "recent",
+                    "risk_posture": "normal",
+                    "risk_score": 0,
+                    "last_activity_at": "2026-03-18T10:00:00+00:00",
+                    "last_conversation_at": "2026-03-18T10:00:00+00:00",
+                    "hours_since_last_activity": 2.0,
+                    "conversation_event_count": 3,
+                    "operational_event_count": 1,
+                    "active_session_count": 1,
+                    "open_loop_count": 0,
+                    "stale_open_loop_count": 0,
+                    "unresolved_contradiction_count": 0,
+                    "weak_trust_signal_count": 0,
+                    "reasons": [
+                        "No active contradiction, stale open-loop, or weak-trust pressure is currently visible."
+                    ],
+                    "recommended_action": "No immediate intervention required.",
+                }
+            ],
+            "stale_threads": [],
+            "risky_threads": [
+                {
+                    "thread": {
+                        "id": "thread-2",
+                        "title": "Risky thread",
+                        "agent_profile_id": "assistant_default",
+                        "created_at": "2026-03-18T09:00:00+00:00",
+                        "updated_at": "2026-03-18T08:00:00+00:00",
+                    },
+                    "health_posture": "critical",
+                    "activity_posture": "current",
+                    "risk_posture": "risky",
+                    "risk_score": 3,
+                    "last_activity_at": "2026-03-18T08:00:00+00:00",
+                    "last_conversation_at": "2026-03-18T08:00:00+00:00",
+                    "hours_since_last_activity": 26.0,
+                    "conversation_event_count": 2,
+                    "operational_event_count": 0,
+                    "active_session_count": 0,
+                    "open_loop_count": 1,
+                    "stale_open_loop_count": 1,
+                    "unresolved_contradiction_count": 1,
+                    "weak_trust_signal_count": 1,
+                    "reasons": ["1 unresolved contradiction case(s).", "1 stale open-loop item(s)."],
+                    "recommended_action": "Resolve contradiction cases before trusting this thread for recall or briefing.",
+                }
+            ],
+            "items": [],
+            "sources": [
+                "threads",
+                "thread_sessions",
+                "thread_events",
+                "continuity_recall",
+                "contradiction_cases",
+                "trust_signals",
+            ],
         }
     }
     assert captured["database_url"] == "postgresql://app"

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -23,6 +23,7 @@ from alicebot_api.memory import (
     create_memory_review_label_record,
     get_open_loop_record,
     get_memory_evaluation_summary,
+    get_memory_hygiene_dashboard_summary,
     get_memory_quality_gate_summary,
     get_memory_trust_dashboard_summary,
     get_memory_review_record,
@@ -592,6 +593,7 @@ class MemoryReviewStoreStub:
         self.memories: list[dict[str, object]] = []
         self.revisions: dict[UUID, list[dict[str, object]]] = {}
         self.labels: dict[UUID, list[dict[str, object]]] = {}
+        self.open_contradiction_count = 0
 
     def count_memories(self, *, status: str | None = None) -> int:
         return len(self._filtered_memories(status))
@@ -696,6 +698,10 @@ class MemoryReviewStoreStub:
         del continuity_object_id
         del limit
         return []
+
+    def count_contradiction_cases(self, *, statuses: list[str]) -> int:
+        assert statuses == ["open"]
+        return self.open_contradiction_count
 
     def _filtered_memories(self, status: str | None) -> list[dict[str, object]]:
         if status is None:
@@ -1441,6 +1447,102 @@ def test_get_memory_trust_dashboard_summary_handles_missing_continuity_tables(
         "correction_recurrence_count": 0,
         "freshness_drift_count": 0,
     }
+
+
+def test_get_memory_hygiene_dashboard_summary_surfaces_duplicates_stale_and_queue_pressure() -> None:
+    store = MemoryReviewStoreStub()
+    base_time = datetime(2026, 3, 11, 12, 0, tzinfo=UTC)
+
+    duplicate_a = uuid4()
+    duplicate_b = uuid4()
+    stale_memory = uuid4()
+    weak_memory = uuid4()
+    store.memories = [
+        {
+            "id": duplicate_a,
+            "user_id": uuid4(),
+            "memory_key": "user.preference.store",
+            "value": {"merchant": "Fixture Store"},
+            "status": "active",
+            "source_event_ids": ["event-1"],
+            "memory_type": "preference",
+            "confirmation_status": "confirmed",
+            "confidence": 0.95,
+            "promotion_eligibility": "promotable",
+            "trust_class": "deterministic",
+            "valid_to": None,
+            "created_at": base_time,
+            "updated_at": base_time + timedelta(hours=1),
+            "deleted_at": None,
+        },
+        {
+            "id": duplicate_b,
+            "user_id": uuid4(),
+            "memory_key": "user.preference.backup_store",
+            "value": {"merchant": "Fixture Store"},
+            "status": "active",
+            "source_event_ids": ["event-2"],
+            "memory_type": "preference",
+            "confirmation_status": "confirmed",
+            "confidence": 0.91,
+            "promotion_eligibility": "promotable",
+            "trust_class": "deterministic",
+            "valid_to": None,
+            "created_at": base_time,
+            "updated_at": base_time + timedelta(hours=2),
+            "deleted_at": None,
+        },
+        {
+            "id": stale_memory,
+            "user_id": uuid4(),
+            "memory_key": "user.fact.trip_window",
+            "value": {"status": "expired"},
+            "status": "active",
+            "source_event_ids": ["event-3"],
+            "memory_type": "fact",
+            "confirmation_status": "contested",
+            "confidence": 0.88,
+            "promotion_eligibility": "promotable",
+            "trust_class": "deterministic",
+            "valid_to": base_time - timedelta(days=1),
+            "created_at": base_time,
+            "updated_at": base_time + timedelta(hours=3),
+            "deleted_at": None,
+        },
+        {
+            "id": weak_memory,
+            "user_id": uuid4(),
+            "memory_key": "user.fact.single_source",
+            "value": {"status": "tentative"},
+            "status": "active",
+            "source_event_ids": ["event-4"],
+            "memory_type": "fact",
+            "confirmation_status": "unconfirmed",
+            "confidence": 0.4,
+            "promotion_eligibility": "not_promotable",
+            "trust_class": "llm_single_source",
+            "valid_to": None,
+            "created_at": base_time,
+            "updated_at": base_time + timedelta(hours=4),
+            "deleted_at": None,
+        },
+    ]
+    store.open_contradiction_count = 1
+
+    payload = get_memory_hygiene_dashboard_summary(store, user_id=uuid4())  # type: ignore[arg-type]
+
+    assert payload["dashboard"]["posture"] == "critical"
+    assert payload["dashboard"]["duplicate_group_count"] == 1
+    assert payload["dashboard"]["duplicate_memory_count"] == 2
+    assert payload["dashboard"]["stale_fact_count"] == 1
+    assert payload["dashboard"]["unresolved_contradiction_count"] == 1
+    assert payload["dashboard"]["weak_trust_count"] == 2
+    assert payload["dashboard"]["review_queue_pressure"]["total_count"] == 4
+    assert payload["dashboard"]["focus"][0]["kind"] == "duplicates"
+    assert payload["dashboard"]["duplicate_groups"][0]["memory_keys"] == [
+        "user.preference.backup_store",
+        "user.preference.store",
+    ]
 
 
 def test_list_memory_revision_review_records_returns_deterministic_revision_order() -> None:


### PR DESCRIPTION
## Summary

This PR ships `P13-S3: Memory Hygiene + Conversation Health` by making memory quality and thread risk visible through bounded API, CLI, and web surfaces.

Key changes:
- adds a memory hygiene dashboard for duplicates, stale facts, unresolved contradictions, weak trust, and review pressure
- adds a thread health dashboard for recent, stale, and risky threads plus posture summaries and recommended actions
- extends CLI status output to expose the same hygiene and thread-health posture used by the dashboard builders
- adds web panels to the continuity and memory review surfaces
- documents the shipped hygiene and conversation-health model in `docs/memory/p13-s3-memory-hygiene-conversation-health.md`

## Validation

- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py tests/unit/test_memory.py tests/unit/test_conversation_health.py tests/unit/test_main.py tests/unit/test_events.py tests/unit/test_cli.py -q`
- `pnpm test app/memories/page.test.tsx app/continuity/page.test.tsx` from `apps/web`

## Upgrade Overview

### Protected Areas

- [x] memory schema
- [ ] evidence pipeline
- [x] trust rules
- [x] promotion logic
- [x] continuity APIs

### Compatibility Impact

This is additive visibility work. It introduces new hygiene and conversation-health surfaces without changing the shipped one-call continuity entrypoint or Alice Lite path. The new dashboards expose quality and risk posture over the existing memory and thread substrate rather than changing persistence or retrieval semantics.

### Migration / Rollout

No schema migration or data backfill is required. Rollout is application-only: deploy the API and web changes together so the new hygiene and thread-health summaries are available consistently across API, CLI, and web surfaces.

### Operator Action

No manual operator action is required beyond normal deploy verification. Operators can begin using the new memory hygiene and thread health views immediately after deploy to inspect stale, contradictory, duplicate, weak-trust, and risky-thread posture.

### Validation

Validated with targeted unit coverage for memory hygiene aggregation, conversation health aggregation, CLI status output, and endpoint-level route coverage, plus focused web tests for the shipped memory and continuity panels:

- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py tests/unit/test_memory.py tests/unit/test_conversation_health.py tests/unit/test_main.py tests/unit/test_events.py tests/unit/test_cli.py -q`
- `pnpm test app/memories/page.test.tsx app/continuity/page.test.tsx` from `apps/web`

### Rollback

Rollback is straightforward: revert commit `c65bfedc1ec84e5a52d592b82cf537e15683dfd3` to remove the new hygiene and conversation-health surfaces and return to the prior Phase 13 baseline. Because the change is additive and does not include a schema migration, rollback does not require compensating data work.
