### PR TITLE
[codex] Phase 13 refactor sprint fixes

### DIFF
--- a/apps/api/src/alicebot_api/task_briefing.py
+++ b/apps/api/src/alicebot_api/task_briefing.py
@@ -64,6 +64,17 @@ class _ModeConfig:
     default_model_pack_strategy: str
 
 
+@dataclass(frozen=True, slots=True)
+class _SectionPlan:
+    section_key: str
+    title: str
+    intent: str
+    selection_rule: str
+    candidates: list[ContinuityRecallResultRecord]
+    token_budget: int
+    max_items: int
+
+
 _MODE_CONFIGS: dict[str, _ModeConfig] = {
     "user_recall": _ModeConfig(token_budget=320, default_model_pack_strategy="balanced"),
     "resume": _ModeConfig(token_budget=220, default_model_pack_strategy="balanced"),
@@ -144,6 +155,10 @@ def _empty_state(message: str, *, is_empty: bool) -> TaskBriefEmptyState:
 
 def _recent_sort_key(item: ContinuityRecallResultRecord) -> tuple[str, str]:
     return (item["created_at"], item["id"])
+
+
+def _recent_items(items: list[ContinuityRecallResultRecord]) -> list[ContinuityRecallResultRecord]:
+    return sorted(items, key=_recent_sort_key, reverse=True)
 
 
 def _is_active_truth(item: ContinuityRecallResultRecord) -> bool:
@@ -237,6 +252,27 @@ def _build_section(
             is_empty=len(selected) == 0,
         ),
     }
+
+
+def _build_sections(plans: list[_SectionPlan]) -> list[TaskBriefSectionRecord]:
+    return [
+        _build_section(
+            section_key=plan.section_key,
+            title=plan.title,
+            intent=plan.intent,
+            selection_rule=plan.selection_rule,
+            candidates=plan.candidates,
+            token_budget=plan.token_budget,
+            max_items=plan.max_items,
+        )
+        for plan in plans
+    ]
+
+
+def _single_item_candidates(
+    item: ContinuityRecallResultRecord | None,
+) -> list[ContinuityRecallResultRecord]:
+    return [] if item is None else [item]
 
 
 def _resolve_model_pack_defaults(
@@ -337,17 +373,19 @@ def _compile_user_recall_sections(
     *,
     token_budget: int,
 ) -> list[TaskBriefSectionRecord]:
-    return [
-        _build_section(
-            section_key="top_recall",
-            title="Top Recall",
-            intent="Provide the highest-ranked continuity recall items for direct user recall.",
-            selection_rule="Hybrid recall rank order with token-budget truncation.",
-            candidates=items,
-            token_budget=token_budget,
-            max_items=8,
-        )
-    ]
+    return _build_sections(
+        [
+            _SectionPlan(
+                section_key="top_recall",
+                title="Top Recall",
+                intent="Provide the highest-ranked continuity recall items for direct user recall.",
+                selection_rule="Hybrid recall rank order with token-budget truncation.",
+                candidates=items,
+                token_budget=token_budget,
+                max_items=8,
+            )
+        ]
+    )
 
 
 def _compile_worker_sections(
@@ -356,7 +394,7 @@ def _compile_worker_sections(
     token_budget: int,
     include_non_promotable_facts: bool,
 ) -> list[TaskBriefSectionRecord]:
-    recent_items = sorted(items, key=_recent_sort_key, reverse=True)
+    recent_items = _recent_items(items)
     latest_decision = next(
         (item for item in recent_items if item["object_type"] == "Decision" and _is_active_truth(item)),
         None,
@@ -387,35 +425,37 @@ def _compile_worker_sections(
     objective_budget = max(1, int(token_budget * 0.4))
     constraints_budget = max(1, int(token_budget * 0.35))
     facts_budget = max(1, token_budget - objective_budget - constraints_budget)
-    return [
-        _build_section(
-            section_key="current_objective",
-            title="Current Objective",
-            intent="Give the worker the active decision and next action first.",
-            selection_rule="Most recent active decision and next action only.",
-            candidates=objective_candidates,
-            token_budget=objective_budget,
-            max_items=2,
-        ),
-        _build_section(
-            section_key="active_constraints",
-            title="Active Constraints",
-            intent="Expose blockers, commitments, and waiting-for items that can stall execution.",
-            selection_rule="Newest active blocker, commitment, and waiting-for items under a compact budget.",
-            candidates=constraint_candidates,
-            token_budget=constraints_budget,
-            max_items=3,
-        ),
-        _build_section(
-            section_key="critical_context",
-            title="Critical Context",
-            intent="Keep only the smallest set of facts that materially change task execution.",
-            selection_rule="Newest active facts and notes that remain promotable unless explicitly overridden.",
-            candidates=fact_candidates,
-            token_budget=facts_budget,
-            max_items=2,
-        ),
-    ]
+    return _build_sections(
+        [
+            _SectionPlan(
+                section_key="current_objective",
+                title="Current Objective",
+                intent="Give the worker the active decision and next action first.",
+                selection_rule="Most recent active decision and next action only.",
+                candidates=objective_candidates,
+                token_budget=objective_budget,
+                max_items=2,
+            ),
+            _SectionPlan(
+                section_key="active_constraints",
+                title="Active Constraints",
+                intent="Expose blockers, commitments, and waiting-for items that can stall execution.",
+                selection_rule="Newest active blocker, commitment, and waiting-for items under a compact budget.",
+                candidates=constraint_candidates,
+                token_budget=constraints_budget,
+                max_items=3,
+            ),
+            _SectionPlan(
+                section_key="critical_context",
+                title="Critical Context",
+                intent="Keep only the smallest set of facts that materially change task execution.",
+                selection_rule="Newest active facts and notes that remain promotable unless explicitly overridden.",
+                candidates=fact_candidates,
+                token_budget=facts_budget,
+                max_items=2,
+            ),
+        ]
+    )
 
 
 def _compile_handoff_sections(
@@ -424,7 +464,7 @@ def _compile_handoff_sections(
     token_budget: int,
     include_non_promotable_facts: bool,
 ) -> list[TaskBriefSectionRecord]:
-    recent_items = sorted(items, key=_recent_sort_key, reverse=True)
+    recent_items = _recent_items(items)
     focus_candidates = [
         item
         for item in recent_items
@@ -447,35 +487,37 @@ def _compile_handoff_sections(
     focus_budget = max(1, int(token_budget * 0.35))
     loop_budget = max(1, int(token_budget * 0.3))
     change_budget = max(1, token_budget - focus_budget - loop_budget)
-    return [
-        _build_section(
-            section_key="handoff_focus",
-            title="Handoff Focus",
-            intent="Summarize the active decision and next action for the receiving agent.",
-            selection_rule="Newest active decision and next action first.",
-            candidates=focus_candidates,
-            token_budget=focus_budget,
-            max_items=3,
-        ),
-        _build_section(
-            section_key="handoff_open_loops",
-            title="Open Loops",
-            intent="Carry unresolved dependencies and blockers into the handoff.",
-            selection_rule="Newest active commitments, waiting-for items, and blockers.",
-            candidates=open_loop_candidates,
-            token_budget=loop_budget,
-            max_items=3,
-        ),
-        _build_section(
-            section_key="handoff_recent_changes",
-            title="Recent Changes",
-            intent="Show the most recent materially relevant changes before handoff.",
-            selection_rule="Newest change candidates, including superseded history, under token budget.",
-            candidates=recent_change_candidates,
-            token_budget=change_budget,
-            max_items=4,
-        ),
-    ]
+    return _build_sections(
+        [
+            _SectionPlan(
+                section_key="handoff_focus",
+                title="Handoff Focus",
+                intent="Summarize the active decision and next action for the receiving agent.",
+                selection_rule="Newest active decision and next action first.",
+                candidates=focus_candidates,
+                token_budget=focus_budget,
+                max_items=3,
+            ),
+            _SectionPlan(
+                section_key="handoff_open_loops",
+                title="Open Loops",
+                intent="Carry unresolved dependencies and blockers into the handoff.",
+                selection_rule="Newest active commitments, waiting-for items, and blockers.",
+                candidates=open_loop_candidates,
+                token_budget=loop_budget,
+                max_items=3,
+            ),
+            _SectionPlan(
+                section_key="handoff_recent_changes",
+                title="Recent Changes",
+                intent="Show the most recent materially relevant changes before handoff.",
+                selection_rule="Newest change candidates, including superseded history, under token budget.",
+                candidates=recent_change_candidates,
+                token_budget=change_budget,
+                max_items=4,
+            ),
+        ]
+    )
 
 
 def _compile_resume_sections(
@@ -508,126 +550,115 @@ def _compile_resume_sections(
     open_loops_budget = max(1, int(token_budget * 0.3))
     single_budget = max(1, int((token_budget - recent_changes_budget - open_loops_budget) / 2))
     return (
-        [
-            _build_section(
-                section_key="last_decision",
-                title="Last Decision",
-                intent="Keep the latest decision visible for resumption quality.",
-                selection_rule="Legacy continuity resumption latest active decision selection.",
-                candidates=[]
-                if brief["last_decision"]["item"] is None
-                else [brief["last_decision"]["item"]],
-                token_budget=single_budget,
-                max_items=1,
-            ),
-            _build_section(
-                section_key="open_loops",
-                title="Open Loops",
-                intent="Show unresolved commitments, waiting-for items, and blockers.",
-                selection_rule="Legacy continuity resumption open-loop ordering and limits.",
-                candidates=list(brief["open_loops"]["items"]),
-                token_budget=open_loops_budget,
-                max_items=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
-            ),
-            _build_section(
-                section_key="recent_changes",
-                title="Recent Changes",
-                intent="Surface recent relevant changes without reopening retrieval logic.",
-                selection_rule="Legacy continuity resumption recent-change ordering and limits.",
-                candidates=list(brief["recent_changes"]["items"]),
-                token_budget=recent_changes_budget,
-                max_items=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
-            ),
-            _build_section(
-                section_key="next_action",
-                title="Next Action",
-                intent="Keep the next action prominent for restart quality.",
-                selection_rule="Legacy continuity resumption latest active next action selection.",
-                candidates=[]
-                if brief["next_action"]["item"] is None
-                else [brief["next_action"]["item"]],
-                token_budget=single_budget,
-                max_items=1,
-            ),
-        ],
+        _build_sections(
+            [
+                _SectionPlan(
+                    section_key="last_decision",
+                    title="Last Decision",
+                    intent="Keep the latest decision visible for resumption quality.",
+                    selection_rule="Legacy continuity resumption latest active decision selection.",
+                    candidates=_single_item_candidates(brief["last_decision"]["item"]),
+                    token_budget=single_budget,
+                    max_items=1,
+                ),
+                _SectionPlan(
+                    section_key="open_loops",
+                    title="Open Loops",
+                    intent="Show unresolved commitments, waiting-for items, and blockers.",
+                    selection_rule="Legacy continuity resumption open-loop ordering and limits.",
+                    candidates=list(brief["open_loops"]["items"]),
+                    token_budget=open_loops_budget,
+                    max_items=DEFAULT_CONTINUITY_RESUMPTION_OPEN_LOOP_LIMIT,
+                ),
+                _SectionPlan(
+                    section_key="recent_changes",
+                    title="Recent Changes",
+                    intent="Surface recent relevant changes without reopening retrieval logic.",
+                    selection_rule="Legacy continuity resumption recent-change ordering and limits.",
+                    candidates=list(brief["recent_changes"]["items"]),
+                    token_budget=recent_changes_budget,
+                    max_items=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+                ),
+                _SectionPlan(
+                    section_key="next_action",
+                    title="Next Action",
+                    intent="Keep the next action prominent for restart quality.",
+                    selection_rule="Legacy continuity resumption latest active next action selection.",
+                    candidates=_single_item_candidates(brief["next_action"]["item"]),
+                    token_budget=single_budget,
+                    max_items=1,
+                ),
+            ]
+        ),
         scope,
     )
 
 
-def compile_task_brief_record(
+def _compile_sections_for_request(
     store: ContinuityStore,
     *,
     user_id: UUID,
     request: TaskBriefCompileRequestInput,
-) -> TaskBriefRecord:
-    _validate_request(request)
-    strategy = _resolve_strategy(
-        store,
-        user_id=user_id,
-        request=request,
-    )
-
+    token_budget: int,
+) -> tuple[list[TaskBriefSectionRecord], ContinuityRecallScopeFilters, int]:
     if request.mode == "resume":
         sections, scope = _compile_resume_sections(
             store,
             user_id=user_id,
             request=request,
-            token_budget=strategy["token_budget"],
+            token_budget=token_budget,
         )
         candidate_count = sum(section["summary"]["candidate_count"] for section in sections)
-    else:
-        items, scope = _compile_recall_payload(
-            store,
-            user_id=user_id,
-            request=request,
-            source_surface=f"task_brief.{request.mode}",
-        )
-        candidate_count = len(items)
-        if request.mode == "user_recall":
-            sections = _compile_user_recall_sections(
-                items,
-                token_budget=strategy["token_budget"],
-            )
-        elif request.mode == "worker_subtask":
-            sections = _compile_worker_sections(
-                items,
-                token_budget=strategy["token_budget"],
-                include_non_promotable_facts=request.include_non_promotable_facts,
-            )
-        else:
-            sections = _compile_handoff_sections(
-                items,
-                token_budget=strategy["token_budget"],
-                include_non_promotable_facts=request.include_non_promotable_facts,
-            )
+        return sections, scope, candidate_count
 
-    selected_items = [
-        item
-        for section in sections
-        for item in section["items"]
-    ]
+    items, scope = _compile_recall_payload(
+        store,
+        user_id=user_id,
+        request=request,
+        source_surface=f"task_brief.{request.mode}",
+    )
+    if request.mode == "user_recall":
+        sections = _compile_user_recall_sections(
+            items,
+            token_budget=token_budget,
+        )
+    elif request.mode == "worker_subtask":
+        sections = _compile_worker_sections(
+            items,
+            token_budget=token_budget,
+            include_non_promotable_facts=request.include_non_promotable_facts,
+        )
+    else:
+        sections = _compile_handoff_sections(
+            items,
+            token_budget=token_budget,
+            include_non_promotable_facts=request.include_non_promotable_facts,
+        )
+    return sections, scope, len(items)
+
+
+def _build_task_brief_summary(
+    *,
+    mode: str,
+    sections: list[TaskBriefSectionRecord],
+    candidate_count: int,
+    token_budget: int,
+) -> TaskBriefSummary:
+    selected_item_count = sum(len(section["items"]) for section in sections)
     base_estimated_tokens = sum(section["summary"]["estimated_tokens"] for section in sections)
-    summary: TaskBriefSummary = {
+    return {
         "candidate_count": candidate_count,
-        "selected_item_count": len(selected_items),
-        "estimated_tokens": int(
-            round(base_estimated_tokens * _MODE_TOKEN_ESTIMATE_MULTIPLIER[request.mode])
-        ),
-        "token_budget": strategy["token_budget"],
+        "selected_item_count": selected_item_count,
+        "estimated_tokens": int(round(base_estimated_tokens * _MODE_TOKEN_ESTIMATE_MULTIPLIER[mode])),
+        "token_budget": token_budget,
         "truncated": any(section["summary"]["truncated_count"] > 0 for section in sections),
         "deterministic_key": "",
         "section_order": [section["section_key"] for section in sections],
         "mode_order": list(TASK_BRIEF_MODE_ORDER),
     }
-    brief: TaskBriefRecord = {
-        "assembly_version": TASK_BRIEF_ASSEMBLY_VERSION_V0,
-        "mode": request.mode,
-        "scope": scope,
-        "strategy": strategy,
-        "summary": summary,
-        "sections": sections,
-        "sources": ["continuity_capture_events", "continuity_objects", "retrieval_runs"],
-    }
+
+
+def _task_brief_deterministic_key(brief: TaskBriefRecord) -> str:
     deterministic_payload = {
         "assembly_version": brief["assembly_version"],
         "mode": brief["mode"],
@@ -645,9 +676,45 @@ def compile_task_brief_record(
             "mode_order": brief["summary"]["mode_order"],
         },
     }
-    brief["summary"]["deterministic_key"] = sha256(
+    return sha256(
         json.dumps(deterministic_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
+
+
+def compile_task_brief_record(
+    store: ContinuityStore,
+    *,
+    user_id: UUID,
+    request: TaskBriefCompileRequestInput,
+) -> TaskBriefRecord:
+    _validate_request(request)
+    strategy = _resolve_strategy(
+        store,
+        user_id=user_id,
+        request=request,
+    )
+    sections, scope, candidate_count = _compile_sections_for_request(
+        store,
+        user_id=user_id,
+        request=request,
+        token_budget=strategy["token_budget"],
+    )
+    summary = _build_task_brief_summary(
+        mode=request.mode,
+        sections=sections,
+        candidate_count=candidate_count,
+        token_budget=strategy["token_budget"],
+    )
+    brief: TaskBriefRecord = {
+        "assembly_version": TASK_BRIEF_ASSEMBLY_VERSION_V0,
+        "mode": request.mode,
+        "scope": scope,
+        "strategy": strategy,
+        "summary": summary,
+        "sections": sections,
+        "sources": ["continuity_capture_events", "continuity_objects", "retrieval_runs"],
+    }
+    brief["summary"]["deterministic_key"] = _task_brief_deterministic_key(brief)
     return brief
 
 

--- a/apps/web/app/continuity/page.tsx
+++ b/apps/web/app/continuity/page.tsx
@@ -1015,7 +1015,7 @@ export default async function ContinuityPage({
 
   const pageMode = combinePageModes(
     listSource,
-    selectedSource,
+    selectedSource === "unavailable" ? null : selectedSource,
     recallSource,
     resumptionSource,
     openLoopSource,
@@ -1023,7 +1023,7 @@ export default async function ContinuityPage({
     weeklyReviewSource,
     threadHealthSource,
     reviewSource,
-    correctionSource,
+    correctionSource === "unavailable" ? null : correctionSource,
   );
 
   return (

--- a/apps/web/app/memories/page.tsx
+++ b/apps/web/app/memories/page.tsx
@@ -11,6 +11,7 @@ import type {
   MemoryHygieneDashboardSummary,
   MemoryReviewLabelSummary,
   MemoryReviewQueuePriorityMode,
+  MemoryReviewQueueItem,
   MemoryReviewRecord,
   MemoryTrustDashboardSummary,
   MemoryRevisionReviewListSummary,
@@ -90,22 +91,7 @@ function resolveSelectedMemoryId(requestedMemoryId: string, items: MemoryReviewR
   return items[0]?.id ?? "";
 }
 
-function queueItemAsMemory(item: {
-  id: string;
-  memory_key: string;
-  value: unknown;
-  status: "active";
-  source_event_ids: string[];
-  memory_type: MemoryReviewRecord["memory_type"];
-  confidence: MemoryReviewRecord["confidence"];
-  salience: MemoryReviewRecord["salience"];
-  confirmation_status: MemoryReviewRecord["confirmation_status"];
-  valid_from: MemoryReviewRecord["valid_from"];
-  valid_to: MemoryReviewRecord["valid_to"];
-  last_confirmed_at: MemoryReviewRecord["last_confirmed_at"];
-  created_at: string;
-  updated_at: string;
-}): MemoryReviewRecord {
+function queueItemAsMemory(item: MemoryReviewQueueItem): MemoryReviewRecord {
   return {
     ...item,
     deleted_at: null,
@@ -709,14 +695,14 @@ export default async function MemoriesPage({
                 const selected = selectedOpenLoop?.id === openLoop.id;
                 const hrefParts = [
                   `/memories?open_loop=${encodeURIComponent(openLoop.id)}`,
-                  selectedMemory?.id
-                    ? `memory=${encodeURIComponent(selectedMemory.id)}`
-                    : null,
-                  activeFilter === "queue" ? "filter=queue" : null,
-                  activeFilter === "queue"
-                    ? `priority_mode=${encodeURIComponent(queuePriorityMode)}`
-                    : null,
-                ].filter(Boolean);
+                  ...(selectedMemory?.id
+                    ? [`memory=${encodeURIComponent(selectedMemory.id)}`]
+                    : []),
+                  ...(activeFilter === "queue" ? ["filter=queue"] : []),
+                  ...(activeFilter === "queue"
+                    ? [`priority_mode=${encodeURIComponent(queuePriorityMode)}`]
+                    : []),
+                ];
                 const href = hrefParts.length > 1 ? `${hrefParts[0]}&${hrefParts.slice(1).join("&")}` : hrefParts[0];
                 return (
                   <li key={openLoop.id}>

--- a/apps/web/components/hosted-admin-panel.tsx
+++ b/apps/web/components/hosted-admin-panel.tsx
@@ -32,6 +32,8 @@ type HostedOverview = {
   };
 };
 
+type HostedOverviewPayload = HostedOverview | { overview?: HostedOverview | null };
+
 type RolloutFlag = {
   flag_key: string;
   enabled: boolean;
@@ -125,7 +127,7 @@ export function HostedAdminPanel({ apiBaseUrl }: HostedAdminPanelProps) {
     await runOperation(async () => {
       const [overviewPayload, workspacesPayload, deliveryPayload, incidentsPayload, rolloutPayload, analyticsPayload, rateLimitsPayload] =
         await Promise.all([
-          requestAdminJson<{ overview?: HostedOverview } | HostedOverview>("/v1/admin/hosted/overview"),
+          requestAdminJson<HostedOverviewPayload>("/v1/admin/hosted/overview"),
           requestAdminJson<{ items: unknown[] }>("/v1/admin/hosted/workspaces"),
           requestAdminJson<{ items: unknown[] }>("/v1/admin/hosted/delivery-receipts"),
           requestAdminJson<{ items: unknown[] }>("/v1/admin/hosted/incidents?status=open"),
@@ -134,7 +136,8 @@ export function HostedAdminPanel({ apiBaseUrl }: HostedAdminPanelProps) {
           requestAdminJson<{ items: unknown[] }>("/v1/admin/hosted/rate-limits"),
         ]);
 
-      const resolvedOverview = "overview" in overviewPayload ? overviewPayload.overview ?? null : overviewPayload;
+      const resolvedOverview: HostedOverview | null =
+        "workspaces" in overviewPayload ? overviewPayload : overviewPayload.overview ?? null;
       setOverview(resolvedOverview);
       setWorkspacesCount(workspacesPayload.items.length);
       setDeliveryCount(deliveryPayload.items.length);

--- a/apps/web/components/thread-create.tsx
+++ b/apps/web/components/thread-create.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FormEvent } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { createThread, DEFAULT_AGENT_PROFILE_ID, type AgentProfileItem } from "../lib/api";
@@ -45,15 +45,19 @@ export function ThreadCreate({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const liveModeReady = Boolean(apiBaseUrl && userId);
-  const profileOptions = agentProfiles && agentProfiles.length > 0
-    ? agentProfiles
-    : [
-        {
-          id: DEFAULT_AGENT_PROFILE_ID,
-          name: "Assistant Default",
-          description: "General-purpose assistant profile for baseline conversations.",
-        },
-      ];
+  const profileOptions = useMemo(
+    () =>
+      agentProfiles && agentProfiles.length > 0
+        ? agentProfiles
+        : [
+            {
+              id: DEFAULT_AGENT_PROFILE_ID,
+              name: "Assistant Default",
+              description: "General-purpose assistant profile for baseline conversations.",
+            },
+          ],
+    [agentProfiles],
+  );
 
   useEffect(() => {
     if (profileOptions.some((profile) => profile.id === selectedProfileId)) {

--- a/apps/web/lib/fixtures.ts
+++ b/apps/web/lib/fixtures.ts
@@ -1262,6 +1262,7 @@ export const approvalFixtures: ApprovalItem[] = [
     id: "44444444-4444-4444-8444-444444444444",
     thread_id: THREAD_MAGNESIUM,
     task_step_id: "77777777-7777-4777-8777-777777777777",
+    task_run_id: null,
     status: "pending",
     request: {
       thread_id: THREAD_MAGNESIUM,
@@ -1310,6 +1311,7 @@ export const approvalFixtures: ApprovalItem[] = [
     id: "44444444-4444-4444-8444-444444444445",
     thread_id: THREAD_VITAMIN_D,
     task_step_id: "77777777-7777-4777-8777-777777777778",
+    task_run_id: null,
     status: "approved",
     request: {
       thread_id: THREAD_VITAMIN_D,
@@ -1405,6 +1407,7 @@ export const executionFixtures: ToolExecutionItem[] = [
   {
     id: "99999999-1111-4111-8111-111111111111",
     approval_id: "44444444-4444-4444-8444-444444444445",
+    task_run_id: null,
     task_step_id: "77777777-7777-4777-8777-777777777778",
     thread_id: THREAD_VITAMIN_D,
     tool_id: PURCHASE_TOOL.id,
@@ -1413,6 +1416,7 @@ export const executionFixtures: ToolExecutionItem[] = [
     result_event_id: "event-result-311",
     status: "completed",
     handler_key: "proxy.echo",
+    idempotency_key: null,
     request: {
       thread_id: THREAD_VITAMIN_D,
       tool_id: PURCHASE_TOOL.id,

--- a/tests/unit/test_task_briefing.py
+++ b/tests/unit/test_task_briefing.py
@@ -255,6 +255,65 @@ def test_task_brief_compare_and_persistence_round_trip() -> None:
     ]
 
 
+def test_worker_subtask_filters_non_promotable_facts_by_default() -> None:
+    thread_id = UUID("12121212-1212-4212-8212-121212121212")
+    rows = [
+        _candidate(
+            title="Decision: Keep the existing contract",
+            object_type="Decision",
+            created_at=datetime(2026, 4, 14, 9, 0, tzinfo=UTC),
+            thread_id=thread_id,
+        ),
+        _candidate(
+            title="Memory Fact: Draft summary is stale",
+            object_type="MemoryFact",
+            created_at=datetime(2026, 4, 14, 9, 5, tzinfo=UTC),
+            thread_id=thread_id,
+            is_promotable=False,
+        ),
+        _candidate(
+            title="Note: Keep the rollout note short",
+            object_type="Note",
+            created_at=datetime(2026, 4, 14, 9, 10, tzinfo=UTC),
+            thread_id=thread_id,
+        ),
+    ]
+    store = TaskBriefStoreStub(rows)
+    user_id = UUID("11111111-1111-4111-8111-111111111111")
+
+    default_brief = compile_task_brief_record(
+        store,  # type: ignore[arg-type]
+        user_id=user_id,
+        request=TaskBriefCompileRequestInput(
+            mode="worker_subtask",
+            thread_id=thread_id,
+            token_budget=1024,
+        ),
+    )
+    override_brief = compile_task_brief_record(
+        store,  # type: ignore[arg-type]
+        user_id=user_id,
+        request=TaskBriefCompileRequestInput(
+            mode="worker_subtask",
+            thread_id=thread_id,
+            token_budget=1024,
+            include_non_promotable_facts=True,
+        ),
+    )
+
+    default_context_titles = [
+        item["title"]
+        for item in default_brief["sections"][2]["items"]
+    ]
+    override_context_titles = [
+        item["title"]
+        for item in override_brief["sections"][2]["items"]
+    ]
+
+    assert "Memory Fact: Draft summary is stale" not in default_context_titles
+    assert "Memory Fact: Draft summary is stale" in override_context_titles
+
+
 def test_task_brief_uses_workspace_selected_model_pack_defaults() -> None:
     thread_id = UUID("cccccccc-cccc-4ccc-8ccc-cccccccccccc")
     workspace_id = UUID("dddddddd-dddd-4ddd-8ddd-dddddddddddd")


### PR DESCRIPTION
## Summary

This PR collects the post-Phase-13 refactor fixes that were reviewed outside the sprint packet flow.

Included fixes:
- memoizes `profileOptions` in `thread-create.tsx` so lint stops flagging a recreated render-time object
- normalizes `unavailable` page-mode values to `null` on the continuity page so production build typing is satisfied
- fixes memories page typing around queue adaptation and nullable open-loop href generation
- narrows hosted admin payload handling before state assignment
- updates shared web fixtures to match the current contracts
- keeps the existing `task_briefing` refactor edits and their unit coverage on the same branch

## Validation

Per review verification:

- `./.venv/bin/pytest ...` on the Phase 13 and local `task_briefing` slice: `112 passed`
- `pnpm test` in `apps/web`: `199 passed`
- `pnpm lint` in `apps/web`: passed
- `pnpm build` in `apps/web`: passed
- `pnpm test` in `packages/alice-cli`: `2 passed`
