### PR TITLE
[codex] Phase 13 pentest sprint fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
     directory: /packages/alice-cli
     schedule:
       interval: weekly
+
+  - package-ecosystem: npm
+    directory: /apps/web
+    schedule:
+      interval: weekly

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -70,7 +70,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
           - javascript
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/apps/api/alembic/versions/20260415_0062_phase13_hosted_rls_backstops.py
+++ b/apps/api/alembic/versions/20260415_0062_phase13_hosted_rls_backstops.py
@@ -1,0 +1,394 @@
+"""Add hosted control-plane row-level-security backstops."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260415_0062"
+down_revision = "20260414_0061"
+branch_labels = None
+depends_on = None
+
+_RLS_TABLES = (
+    "workspaces",
+    "workspace_members",
+    "user_preferences",
+    "channel_identities",
+    "channel_link_challenges",
+    "channel_threads",
+    "channel_messages",
+    "chat_intents",
+    "channel_delivery_receipts",
+    "notification_subscriptions",
+    "continuity_briefs",
+    "daily_brief_jobs",
+    "approval_challenges",
+    "open_loop_reviews",
+    "chat_telemetry",
+    "model_providers",
+    "provider_capabilities",
+    "model_packs",
+    "workspace_model_pack_bindings",
+)
+
+_UPGRADE_FUNCTION_STATEMENTS = (
+    """
+        CREATE OR REPLACE FUNCTION app.current_user_account_id()
+        RETURNS uuid
+        LANGUAGE sql
+        STABLE
+        AS $$
+          SELECT NULLIF(current_setting('app.current_user_account_id', true), '')::uuid
+        $$;
+        """,
+    """
+        CREATE OR REPLACE FUNCTION app.hosted_admin_bypass()
+        RETURNS boolean
+        LANGUAGE sql
+        STABLE
+        AS $$
+          SELECT COALESCE(NULLIF(current_setting('app.hosted_admin_bypass', true), ''), 'false')::boolean
+        $$;
+        """,
+    """
+        CREATE OR REPLACE FUNCTION app.hosted_service_bypass()
+        RETURNS boolean
+        LANGUAGE sql
+        STABLE
+        AS $$
+          SELECT COALESCE(NULLIF(current_setting('app.hosted_service_bypass', true), ''), 'false')::boolean
+        $$;
+        """,
+    """
+        CREATE OR REPLACE FUNCTION app.hosted_access_bypass()
+        RETURNS boolean
+        LANGUAGE sql
+        STABLE
+        AS $$
+          SELECT app.hosted_admin_bypass() OR app.hosted_service_bypass()
+        $$;
+        """,
+    """
+        CREATE OR REPLACE FUNCTION app.hosted_workspace_access_allowed(target_workspace_id uuid)
+        RETURNS boolean
+        LANGUAGE sql
+        STABLE
+        AS $$
+          SELECT
+            app.hosted_access_bypass()
+            OR (
+              target_workspace_id IS NOT NULL
+              AND app.current_user_account_id() IS NOT NULL
+              AND EXISTS (
+                SELECT 1
+                FROM workspace_members AS wm
+                WHERE wm.workspace_id = target_workspace_id
+                  AND wm.user_account_id = app.current_user_account_id()
+              )
+            )
+        $$;
+        """,
+    """
+        CREATE OR REPLACE FUNCTION app.hosted_workspace_owner_allowed(target_workspace_id uuid)
+        RETURNS boolean
+        LANGUAGE sql
+        STABLE
+        SECURITY DEFINER
+        SET search_path = pg_catalog, public
+        AS $$
+          SELECT
+            app.hosted_access_bypass()
+            OR (
+              target_workspace_id IS NOT NULL
+              AND app.current_user_account_id() IS NOT NULL
+              AND EXISTS (
+                SELECT 1
+                FROM workspaces AS w
+                WHERE w.id = target_workspace_id
+                  AND w.owner_user_account_id = app.current_user_account_id()
+              )
+            )
+        $$;
+        """,
+)
+
+_UPGRADE_POLICY_STATEMENTS = (
+    """
+        CREATE POLICY workspaces_select_access ON workspaces
+          FOR SELECT
+          USING (
+            app.hosted_access_bypass()
+            OR owner_user_account_id = app.current_user_account_id()
+            OR app.hosted_workspace_access_allowed(id)
+          );
+        """,
+    """
+        CREATE POLICY workspaces_insert_access ON workspaces
+          FOR INSERT
+          WITH CHECK (
+            app.hosted_access_bypass()
+            OR owner_user_account_id = app.current_user_account_id()
+          );
+        """,
+    """
+        CREATE POLICY workspaces_update_access ON workspaces
+          FOR UPDATE
+          USING (
+            app.hosted_access_bypass()
+            OR owner_user_account_id = app.current_user_account_id()
+          )
+          WITH CHECK (
+            app.hosted_access_bypass()
+            OR owner_user_account_id = app.current_user_account_id()
+          );
+        """,
+    """
+        CREATE POLICY workspaces_delete_access ON workspaces
+          FOR DELETE
+          USING (
+            app.hosted_access_bypass()
+            OR owner_user_account_id = app.current_user_account_id()
+          );
+        """,
+    """
+        CREATE POLICY workspace_members_select_access ON workspace_members
+          FOR SELECT
+          USING (
+            app.hosted_access_bypass()
+            OR user_account_id = app.current_user_account_id()
+          );
+        """,
+    """
+        CREATE POLICY workspace_members_insert_access ON workspace_members
+          FOR INSERT
+          WITH CHECK (
+            app.hosted_access_bypass()
+            OR (
+              user_account_id = app.current_user_account_id()
+              AND app.hosted_workspace_owner_allowed(workspace_id)
+            )
+          );
+        """,
+    """
+        CREATE POLICY workspace_members_update_access ON workspace_members
+          FOR UPDATE
+          USING (
+            app.hosted_access_bypass()
+            OR user_account_id = app.current_user_account_id()
+          )
+          WITH CHECK (
+            app.hosted_access_bypass()
+            OR (
+              user_account_id = app.current_user_account_id()
+              AND app.hosted_workspace_owner_allowed(workspace_id)
+            )
+          );
+        """,
+    """
+        CREATE POLICY workspace_members_delete_access ON workspace_members
+          FOR DELETE
+          USING (
+            app.hosted_access_bypass()
+            OR user_account_id = app.current_user_account_id()
+          );
+        """,
+    """
+        CREATE POLICY user_preferences_access ON user_preferences
+          FOR ALL
+          USING (
+            app.hosted_access_bypass()
+            OR user_account_id = app.current_user_account_id()
+          )
+          WITH CHECK (
+            app.hosted_access_bypass()
+            OR user_account_id = app.current_user_account_id()
+          );
+        """,
+    """
+        CREATE POLICY channel_identities_access ON channel_identities
+          FOR ALL
+          USING (
+            app.hosted_access_bypass()
+            OR (
+              user_account_id = app.current_user_account_id()
+              AND app.hosted_workspace_access_allowed(workspace_id)
+            )
+          )
+          WITH CHECK (
+            app.hosted_access_bypass()
+            OR (
+              user_account_id = app.current_user_account_id()
+              AND app.hosted_workspace_access_allowed(workspace_id)
+            )
+          );
+        """,
+    """
+        CREATE POLICY channel_link_challenges_access ON channel_link_challenges
+          FOR ALL
+          USING (
+            app.hosted_access_bypass()
+            OR (
+              user_account_id = app.current_user_account_id()
+              AND app.hosted_workspace_access_allowed(workspace_id)
+            )
+          )
+          WITH CHECK (
+            app.hosted_access_bypass()
+            OR (
+              user_account_id = app.current_user_account_id()
+              AND app.hosted_workspace_access_allowed(workspace_id)
+            )
+          );
+        """,
+    """
+        CREATE POLICY channel_threads_workspace_access ON channel_threads
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY channel_messages_workspace_access ON channel_messages
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY chat_intents_workspace_access ON chat_intents
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY channel_delivery_receipts_workspace_access ON channel_delivery_receipts
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY notification_subscriptions_workspace_access ON notification_subscriptions
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY continuity_briefs_workspace_access ON continuity_briefs
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY daily_brief_jobs_workspace_access ON daily_brief_jobs
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY approval_challenges_workspace_access ON approval_challenges
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY open_loop_reviews_workspace_access ON open_loop_reviews
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY chat_telemetry_workspace_access ON chat_telemetry
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY model_providers_workspace_access ON model_providers
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY provider_capabilities_workspace_access ON provider_capabilities
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY model_packs_workspace_access ON model_packs
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY workspace_model_pack_bindings_workspace_access ON workspace_model_pack_bindings
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+)
+
+_DOWNGRADE_POLICY_STATEMENTS = (
+    "DROP POLICY IF EXISTS workspace_model_pack_bindings_workspace_access ON workspace_model_pack_bindings",
+    "DROP POLICY IF EXISTS model_packs_workspace_access ON model_packs",
+    "DROP POLICY IF EXISTS provider_capabilities_workspace_access ON provider_capabilities",
+    "DROP POLICY IF EXISTS model_providers_workspace_access ON model_providers",
+    "DROP POLICY IF EXISTS chat_telemetry_workspace_access ON chat_telemetry",
+    "DROP POLICY IF EXISTS open_loop_reviews_workspace_access ON open_loop_reviews",
+    "DROP POLICY IF EXISTS approval_challenges_workspace_access ON approval_challenges",
+    "DROP POLICY IF EXISTS daily_brief_jobs_workspace_access ON daily_brief_jobs",
+    "DROP POLICY IF EXISTS continuity_briefs_workspace_access ON continuity_briefs",
+    "DROP POLICY IF EXISTS notification_subscriptions_workspace_access ON notification_subscriptions",
+    "DROP POLICY IF EXISTS channel_delivery_receipts_workspace_access ON channel_delivery_receipts",
+    "DROP POLICY IF EXISTS chat_intents_workspace_access ON chat_intents",
+    "DROP POLICY IF EXISTS channel_messages_workspace_access ON channel_messages",
+    "DROP POLICY IF EXISTS channel_threads_workspace_access ON channel_threads",
+    "DROP POLICY IF EXISTS channel_link_challenges_access ON channel_link_challenges",
+    "DROP POLICY IF EXISTS channel_identities_access ON channel_identities",
+    "DROP POLICY IF EXISTS user_preferences_access ON user_preferences",
+    "DROP POLICY IF EXISTS workspace_members_delete_access ON workspace_members",
+    "DROP POLICY IF EXISTS workspace_members_update_access ON workspace_members",
+    "DROP POLICY IF EXISTS workspace_members_insert_access ON workspace_members",
+    "DROP POLICY IF EXISTS workspace_members_select_access ON workspace_members",
+    "DROP POLICY IF EXISTS workspaces_delete_access ON workspaces",
+    "DROP POLICY IF EXISTS workspaces_update_access ON workspaces",
+    "DROP POLICY IF EXISTS workspaces_insert_access ON workspaces",
+    "DROP POLICY IF EXISTS workspaces_select_access ON workspaces",
+)
+
+_DOWNGRADE_FUNCTION_STATEMENTS = (
+    "DROP FUNCTION IF EXISTS app.hosted_workspace_owner_allowed(uuid)",
+    "DROP FUNCTION IF EXISTS app.hosted_workspace_access_allowed(uuid)",
+    "DROP FUNCTION IF EXISTS app.hosted_access_bypass()",
+    "DROP FUNCTION IF EXISTS app.hosted_service_bypass()",
+    "DROP FUNCTION IF EXISTS app.hosted_admin_bypass()",
+    "DROP FUNCTION IF EXISTS app.current_user_account_id()",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def _enable_row_level_security() -> None:
+    for table_name in _RLS_TABLES:
+        op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+
+
+def _disable_row_level_security() -> None:
+    for table_name in reversed(_RLS_TABLES):
+        op.execute(f"ALTER TABLE {table_name} NO FORCE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table_name} DISABLE ROW LEVEL SECURITY")
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_FUNCTION_STATEMENTS)
+    _enable_row_level_security()
+    _execute_statements(_UPGRADE_POLICY_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_POLICY_STATEMENTS)
+    _disable_row_level_security()
+    _execute_statements(_DOWNGRADE_FUNCTION_STATEMENTS)

--- a/apps/api/src/alicebot_api/config.py
+++ b/apps/api/src/alicebot_api/config.py
@@ -83,6 +83,7 @@ DEFAULT_TRUST_PROXY_HEADERS = False
 DEFAULT_TRUSTED_PROXY_IPS: tuple[str, ...] = ()
 DEFAULT_ENTRYPOINT_RATE_LIMIT_BACKEND = "redis"
 DEFAULT_RETRIEVAL_TRACE_RETENTION_DAYS = 14
+DEFAULT_LEGACY_V0_ENABLED_OUTSIDE_DEV = False
 
 Environment = Mapping[str, str]
 
@@ -193,6 +194,7 @@ class Settings:
     trusted_proxy_ips: tuple[str, ...] = DEFAULT_TRUSTED_PROXY_IPS
     entrypoint_rate_limit_backend: str = DEFAULT_ENTRYPOINT_RATE_LIMIT_BACKEND
     retrieval_trace_retention_days: int = DEFAULT_RETRIEVAL_TRACE_RETENTION_DAYS
+    legacy_v0_enabled_outside_dev: bool = DEFAULT_LEGACY_V0_ENABLED_OUTSIDE_DEV
 
     @classmethod
     def from_env(cls, env: Environment | None = None) -> "Settings":
@@ -425,6 +427,12 @@ class Settings:
                 "RETRIEVAL_TRACE_RETENTION_DAYS",
                 cls.retrieval_trace_retention_days,
             ),
+            legacy_v0_enabled_outside_dev=_get_env_value(
+                current_env,
+                "LEGACY_V0_ENABLED_OUTSIDE_DEV",
+                "true" if cls.legacy_v0_enabled_outside_dev else "false",
+            ).strip().lower()
+            in {"1", "true", "yes", "on"},
         )
         return _validate_settings(settings)
 

--- a/apps/api/src/alicebot_api/db.py
+++ b/apps/api/src/alicebot_api/db.py
@@ -9,6 +9,9 @@ from psycopg.rows import dict_row
 
 PING_DATABASE_SQL = "SELECT 1"
 SET_CURRENT_USER_SQL = "SELECT set_config('app.current_user_id', %s, true)"
+SET_CURRENT_USER_ACCOUNT_SQL = "SELECT set_config('app.current_user_account_id', %s, true)"
+SET_HOSTED_ADMIN_BYPASS_SQL = "SELECT set_config('app.hosted_admin_bypass', %s, true)"
+SET_HOSTED_SERVICE_BYPASS_SQL = "SELECT set_config('app.hosted_service_bypass', %s, true)"
 ConnectionRow = dict[str, object]
 UserConnection = psycopg.Connection[ConnectionRow]
 
@@ -27,6 +30,21 @@ def ping_database(database_url: str, timeout_seconds: int) -> bool:
 def set_current_user(conn: psycopg.Connection, user_id: UUID) -> None:
     with conn.cursor() as cur:
         cur.execute(SET_CURRENT_USER_SQL, (str(user_id),))
+
+
+def set_current_user_account(conn: psycopg.Connection, user_account_id: UUID) -> None:
+    with conn.cursor() as cur:
+        cur.execute(SET_CURRENT_USER_ACCOUNT_SQL, (str(user_account_id),))
+
+
+def set_hosted_admin_bypass(conn: psycopg.Connection, enabled: bool) -> None:
+    with conn.cursor() as cur:
+        cur.execute(SET_HOSTED_ADMIN_BYPASS_SQL, ("true" if enabled else "false",))
+
+
+def set_hosted_service_bypass(conn: psycopg.Connection, enabled: bool) -> None:
+    with conn.cursor() as cur:
+        cur.execute(SET_HOSTED_SERVICE_BYPASS_SQL, ("true" if enabled else "false",))
 
 
 @contextmanager

--- a/apps/api/src/alicebot_api/hosted_auth.py
+++ b/apps/api/src/alicebot_api/hosted_auth.py
@@ -9,6 +9,8 @@ from uuid import UUID
 
 from psycopg.types.json import Jsonb
 
+from alicebot_api.db import set_current_user_account
+
 
 EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
@@ -291,6 +293,7 @@ def verify_magic_link_challenge(
         raise MagicLinkTokenExpiredError("magic-link token has expired")
 
     user_account = get_or_create_user_account_by_email(conn, email=challenge["email"])
+    set_current_user_account(conn, user_account["id"])
     workspace_id = _get_current_workspace_id(conn, user_account_id=user_account["id"])
     normalized_device_label = device_label.strip() or "Primary device"
     resolved_device_key = (device_key or "").strip() or _derive_device_key(
@@ -451,6 +454,7 @@ def resolve_auth_session(conn, *, session_token: str) -> SessionResolution:
         "beta_cohort_key": row["user_beta_cohort_key"],
         "created_at": row["user_created_at"],
     }
+    set_current_user_account(conn, user_account["id"])
     return {
         "session": session,
         "user_account": user_account,

--- a/apps/api/src/alicebot_api/hosted_workspace.py
+++ b/apps/api/src/alicebot_api/hosted_workspace.py
@@ -5,6 +5,8 @@ import re
 from typing import TypedDict
 from uuid import UUID
 
+import psycopg
+
 
 SLUG_SANITIZE_PATTERN = re.compile(r"[^a-z0-9-]+")
 SLUG_COLLAPSE_PATTERN = re.compile(r"-+")
@@ -38,16 +40,10 @@ def slugify_workspace_name(value: str) -> str:
     return normalized[:120]
 
 
-def _next_available_slug(conn, *, preferred_slug: str) -> str:
+def _iter_candidate_slugs(*, preferred_slug: str):
     base_slug = slugify_workspace_name(preferred_slug)
-    with conn.cursor() as cur:
-        for suffix in range(1, 201):
-            candidate = base_slug if suffix == 1 else f"{base_slug}-{suffix}"
-            cur.execute("SELECT 1 FROM workspaces WHERE slug = %s", (candidate,))
-            if cur.fetchone() is None:
-                return candidate
-
-    raise RuntimeError("unable to allocate unique workspace slug")
+    for suffix in range(1, 201):
+        yield base_slug if suffix == 1 else f"{base_slug}-{suffix}"
 
 
 def create_workspace(
@@ -62,35 +58,39 @@ def create_workspace(
         raise ValueError("workspace name is required")
 
     preferred_slug = slug if slug is not None and slug.strip() != "" else workspace_name
-    workspace_slug = _next_available_slug(conn, preferred_slug=preferred_slug)
+    for workspace_slug in _iter_candidate_slugs(preferred_slug=preferred_slug):
+        try:
+            with conn.transaction():
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO workspaces (owner_user_account_id, slug, name, bootstrap_status)
+                        VALUES (%s, %s, %s, 'pending')
+                        RETURNING id, owner_user_account_id, slug, name, bootstrap_status, bootstrapped_at,
+                                  created_at, updated_at
+                        """,
+                        (user_account_id, workspace_slug, workspace_name),
+                    )
+                    workspace = cur.fetchone()
 
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            INSERT INTO workspaces (owner_user_account_id, slug, name, bootstrap_status)
-            VALUES (%s, %s, %s, 'pending')
-            RETURNING id, owner_user_account_id, slug, name, bootstrap_status, bootstrapped_at,
-                      created_at, updated_at
-            """,
-            (user_account_id, workspace_slug, workspace_name),
-        )
-        workspace = cur.fetchone()
+                    if workspace is None:
+                        raise RuntimeError("failed to create workspace")
 
-    if workspace is None:
-        raise RuntimeError("failed to create workspace")
+                    cur.execute(
+                        """
+                        INSERT INTO workspace_members (workspace_id, user_account_id, role)
+                        VALUES (%s, %s, 'owner')
+                        ON CONFLICT (workspace_id, user_account_id) DO UPDATE
+                        SET role = EXCLUDED.role
+                        """,
+                        (workspace["id"], user_account_id),
+                    )
+                return workspace
+        except psycopg.errors.UniqueViolation as exc:
+            if exc.diag.constraint_name != "workspaces_slug_key":
+                raise
 
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            INSERT INTO workspace_members (workspace_id, user_account_id, role)
-            VALUES (%s, %s, 'owner')
-            ON CONFLICT (workspace_id, user_account_id) DO UPDATE
-            SET role = EXCLUDED.role
-            """,
-            (workspace["id"], user_account_id),
-        )
-
-    return workspace
+    raise RuntimeError("unable to allocate unique workspace slug")
 
 
 def get_workspace_for_member(

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -4,6 +4,7 @@ from collections import defaultdict, deque
 from datetime import datetime
 import hmac
 import hashlib
+import ipaddress
 import json
 import logging
 import threading
@@ -284,7 +285,13 @@ from alicebot_api.approvals import (
     reject_approval_record,
     submit_approval_request,
 )
-from alicebot_api.db import ping_database, user_connection
+from alicebot_api.db import (
+    ping_database,
+    set_current_user_account,
+    set_hosted_admin_bypass,
+    set_hosted_service_bypass,
+    user_connection,
+)
 from alicebot_api.executions import (
     ToolExecutionNotFoundError,
     get_tool_execution_record,
@@ -2131,6 +2138,15 @@ def _request_client_identifier(request: Request, settings: Settings) -> str:
     return peer_host
 
 
+def _request_client_is_loopback(request: Request, settings: Settings) -> bool:
+    client_identifier = _request_client_identifier(request, settings)
+    try:
+        client_ip = ipaddress.ip_address(client_identifier)
+    except ValueError:
+        return client_identifier in {"localhost", "localhost.localdomain"}
+    return client_ip.is_loopback
+
+
 def _entrypoint_rate_limit_error(
     *,
     detail_code: str,
@@ -2299,6 +2315,18 @@ async def enforce_authenticated_user_identity(
         return await call_next(request)
 
     settings = get_settings()
+
+    if settings.app_env not in {"development", "test"}:
+        if not settings.legacy_v0_enabled_outside_dev:
+            return JSONResponse(
+                status_code=404,
+                content={"detail": "legacy v0 API is disabled outside development and test"},
+            )
+        if not _request_client_is_loopback(request, settings):
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "legacy v0 API is restricted to loopback clients"},
+            )
 
     try:
         authenticated_user_id = _resolve_authenticated_user_id(settings, request)
@@ -2690,6 +2718,7 @@ def _ensure_hosted_admin_access(conn, *, user_account_id: UUID) -> None:
         raise PermissionError(
             "hosted admin access requires hosted_admin_read and hosted_admin_operator flags"
         )
+    set_hosted_admin_bypass(conn, True)
 
 
 def _allow_raw_evidence_debug_access(settings: Settings) -> bool:
@@ -7054,6 +7083,7 @@ def verify_v1_magic_link(http_request: Request, request: MagicLinkVerifyRequest)
                     device_label=request.device_label,
                     device_key=request.device_key,
                 )
+                set_current_user_account(conn, user_account["id"])
                 ensure_user_preferences_row(conn, user_account_id=user_account["id"])
                 preferences = ensure_user_preferences(conn, user_account_id=user_account["id"])
                 workspace = None
@@ -7204,6 +7234,7 @@ def bootstrap_v1_workspace(
 ) -> JSONResponse:
     settings = get_settings()
     resolved_workspace_id: UUID | None = None
+    user_account_id: UUID | None = None
 
     try:
         session_token = _extract_bearer_token(request)
@@ -7253,9 +7284,10 @@ def bootstrap_v1_workspace(
     except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
         return JSONResponse(status_code=401, content={"detail": str(exc)})
     except HostedWorkspaceNotFoundError as exc:
-        if resolved_workspace_id is not None:
+        if resolved_workspace_id is not None and user_account_id is not None:
             with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
                 with conn.transaction():
+                    set_current_user_account(conn, user_account_id)
                     _record_workspace_onboarding_failure(
                         conn,
                         workspace_id=resolved_workspace_id,
@@ -7264,9 +7296,10 @@ def bootstrap_v1_workspace(
                     )
         return JSONResponse(status_code=404, content={"detail": str(exc)})
     except HostedWorkspaceBootstrapConflictError as exc:
-        if resolved_workspace_id is not None:
+        if resolved_workspace_id is not None and user_account_id is not None:
             with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
                 with conn.transaction():
+                    set_current_user_account(conn, user_account_id)
                     _record_workspace_onboarding_failure(
                         conn,
                         workspace_id=resolved_workspace_id,
@@ -8941,6 +8974,7 @@ async def ingest_v1_telegram_webhook(request: Request) -> JSONResponse:
     try:
         with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
             with conn.transaction():
+                set_hosted_service_bypass(conn, True)
                 ingest_result = ingest_telegram_webhook(
                     conn,
                     payload=payload,

--- a/apps/api/src/alicebot_api/provider_security.py
+++ b/apps/api/src/alicebot_api/provider_security.py
@@ -37,6 +37,10 @@ def validate_provider_base_url(base_url: str) -> str:
     ip_literal = _parse_ip_literal(hostname)
     if ip_literal is not None and _is_disallowed_ip(ip_literal):
         raise ProviderURLValidationError("base_url host is not allowed by outbound policy")
+    if ip_literal is None:
+        resolved_addresses = _resolve_hostname_ips(hostname)
+        if any(_is_disallowed_ip(address) for address in resolved_addresses):
+            raise ProviderURLValidationError("base_url host is not allowed by outbound policy")
 
     return normalized
 
@@ -82,6 +86,35 @@ def _parse_ip_literal(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Ad
         return ipaddress.IPv4Address(packed_v4)
     except ipaddress.AddressValueError:
         return None
+
+
+def _resolve_hostname_ips(hostname: str) -> tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, ...]:
+    try:
+        addrinfo = socket.getaddrinfo(
+            hostname,
+            None,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as exc:
+        raise ProviderURLValidationError("base_url host could not be resolved") from exc
+
+    resolved: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for family, _socktype, _proto, _canonname, sockaddr in addrinfo:
+        if family == socket.AF_INET:
+            candidate = sockaddr[0]
+        elif family == socket.AF_INET6:
+            candidate = sockaddr[0]
+        else:
+            continue
+        resolved_ip = _parse_ip_literal(candidate)
+        if resolved_ip is not None and resolved_ip not in resolved:
+            resolved.append(resolved_ip)
+
+    if not resolved:
+        raise ProviderURLValidationError("base_url host could not be resolved")
+    return tuple(resolved)
+
 
 def _is_disallowed_ip(ip_address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     if ip_address.is_multicast:

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -63,6 +63,8 @@ import {
   listTraces,
   queryContinuityRecall,
   getContinuityRetrievalEvaluation,
+  hasLiveApiConfig,
+  isLocalApiBaseUrl,
   pageModeLabel,
   resolveApproval,
   shouldExpectThreadExecutionReview,
@@ -90,6 +92,23 @@ describe("api helpers", () => {
   it("combines live and fixture sources into a mixed page mode", () => {
     expect(combinePageModes("live", "fixture")).toBe("mixed");
     expect(pageModeLabel("mixed")).toBe("Mixed fallback");
+  });
+
+  it("only enables generic live API mode for loopback legacy v0 targets", () => {
+    expect(isLocalApiBaseUrl("http://127.0.0.1:8000")).toBe(true);
+    expect(isLocalApiBaseUrl("https://api.example.com")).toBe(false);
+    expect(
+      hasLiveApiConfig({
+        apiBaseUrl: "http://localhost:8000",
+        userId: "user-1",
+      }),
+    ).toBe(true);
+    expect(
+      hasLiveApiConfig({
+        apiBaseUrl: "https://api.example.com",
+        userId: "user-1",
+      }),
+    ).toBe(false);
   });
 
   it("does not borrow an older unrelated execution from the same thread", () => {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -2335,8 +2335,22 @@ export function getApiConfig(): ApiConfig {
   };
 }
 
+export function isLocalApiBaseUrl(apiBaseUrl: string) {
+  const normalized = apiBaseUrl.trim();
+  if (normalized === "") {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    return ["localhost", "127.0.0.1", "::1"].includes(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
 export function hasLiveApiConfig(config: Pick<ApiConfig, "apiBaseUrl" | "userId">) {
-  return Boolean(config.apiBaseUrl && config.userId);
+  return Boolean(config.userId && isLocalApiBaseUrl(config.apiBaseUrl));
 }
 
 export function combinePageModes(...modes: Array<ApiSource | null | undefined>): PageDataMode {

--- a/tests/integration/test_phase10_beta_hardening_launch_api.py
+++ b/tests/integration/test_phase10_beta_hardening_launch_api.py
@@ -259,7 +259,7 @@ def _promote_session_to_operator(migrated_database_urls, *, session_token: str) 
 
 
 def _workspace_support_snapshot(migrated_database_urls, *, workspace_id: str) -> dict[str, Any]:
-    with psycopg.connect(migrated_database_urls["app"], row_factory=dict_row) as conn:
+    with psycopg.connect(migrated_database_urls["admin"], row_factory=dict_row) as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """

--- a/tests/integration/test_phase11_provider_runtime_api.py
+++ b/tests/integration/test_phase11_provider_runtime_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from io import BytesIO
 import json
+import socket
 from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import urlencode
@@ -9,6 +10,7 @@ from uuid import UUID, uuid4
 
 import anyio
 import psycopg
+import pytest
 
 import apps.api.src.alicebot_api.main as main_module
 from apps.api.src.alicebot_api.config import Settings
@@ -70,6 +72,19 @@ def invoke_request(
 
 def auth_header(session_token: str) -> dict[str, str]:
     return {"authorization": f"Bearer {session_token}"}
+
+
+@pytest.fixture(autouse=True)
+def allow_documentation_provider_hosts(monkeypatch) -> None:
+    original_getaddrinfo = socket.getaddrinfo
+
+    def fake_getaddrinfo(hostname: str, port, type=0, proto=0):
+        if hostname.endswith(".example"):
+            sockaddr = ("93.184.216.34", 0)
+            return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)]
+        return original_getaddrinfo(hostname, port, type=type, proto=proto)
+
+    monkeypatch.setattr("alicebot_api.provider_security.socket.getaddrinfo", fake_getaddrinfo)
 
 
 def _configure_settings(migrated_database_urls, monkeypatch) -> None:
@@ -449,6 +464,155 @@ def test_phase11_local_provider_test_runtime_invoke_and_workspace_isolation(
     captured_urls = [record["url"] for record in captured_requests]
     assert "http://ollama.example:11434/api/chat" in captured_urls
     assert "http://llamacpp.example:8080/v1/chat/completions" in captured_urls
+
+
+def test_phase13_hosted_provider_rows_respect_workspace_rls(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    owner_session_token, owner_workspace_id, owner_user_account_id = _bootstrap_workspace_session(
+        "provider-rls-owner@example.com"
+    )
+    _, _, other_user_account_id = _bootstrap_workspace_session("provider-rls-other@example.com")
+
+    create_status, create_payload = invoke_request(
+        "POST",
+        "/v1/providers",
+        payload={
+            "provider_key": "openai_compatible",
+            "display_name": "RLS Scoped Provider",
+            "base_url": "https://provider.example/v1",
+            "api_key": "provider-secret-key",
+            "default_model": "gpt-5-mini",
+        },
+        headers=auth_header(owner_session_token),
+    )
+    assert create_status == 201
+    provider_id = create_payload["provider"]["id"]
+
+    with psycopg.connect(migrated_database_urls["app"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT set_config('app.current_user_account_id', %s, true)",
+                (other_user_account_id,),
+            )
+            cur.execute("SELECT count(*) FROM model_providers WHERE id = %s", (provider_id,))
+            other_visible_count = cur.fetchone()[0]
+            cur.execute("SELECT count(*) FROM workspaces WHERE id = %s", (owner_workspace_id,))
+            other_workspace_count = cur.fetchone()[0]
+
+            cur.execute(
+                "SELECT set_config('app.current_user_account_id', %s, true)",
+                (owner_user_account_id,),
+            )
+            cur.execute("SELECT count(*) FROM model_providers WHERE id = %s", (provider_id,))
+            owner_visible_count = cur.fetchone()[0]
+
+    assert other_visible_count == 0
+    assert other_workspace_count == 0
+    assert owner_visible_count == 1
+
+
+def test_phase13_hosted_rls_blocks_cross_workspace_membership_forgery(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    _, owner_workspace_id, _ = _bootstrap_workspace_session("provider-rls-owner-forgery@example.com")
+    _, _, other_user_account_id = _bootstrap_workspace_session("provider-rls-other-forgery@example.com")
+
+    with psycopg.connect(migrated_database_urls["app"]) as conn:
+        with pytest.raises(psycopg.errors.InsufficientPrivilege):
+            with conn.transaction():
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT set_config('app.current_user_account_id', %s, true)",
+                        (other_user_account_id,),
+                    )
+                    cur.execute(
+                        """
+                        INSERT INTO workspace_members (workspace_id, user_account_id, role)
+                        VALUES (%s, %s, 'member')
+                        """,
+                        (owner_workspace_id, other_user_account_id),
+                    )
+
+    with psycopg.connect(migrated_database_urls["app"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT set_config('app.current_user_account_id', %s, true)",
+                (other_user_account_id,),
+            )
+            cur.execute(
+                """
+                SELECT count(*)
+                FROM workspace_members
+                WHERE workspace_id = %s
+                  AND user_account_id = %s
+                """,
+                (owner_workspace_id, other_user_account_id),
+            )
+            member_count = cur.fetchone()[0]
+
+    assert member_count == 0
+
+
+def test_phase13_hosted_rls_blocks_cross_workspace_channel_identity_forgery(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    _, owner_workspace_id, _ = _bootstrap_workspace_session("provider-rls-owner-channel@example.com")
+    _, _, other_user_account_id = _bootstrap_workspace_session("provider-rls-other-channel@example.com")
+
+    with psycopg.connect(migrated_database_urls["app"]) as conn:
+        with pytest.raises(psycopg.errors.InsufficientPrivilege):
+            with conn.transaction():
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT set_config('app.current_user_account_id', %s, true)",
+                        (other_user_account_id,),
+                    )
+                    cur.execute(
+                        """
+                        INSERT INTO channel_identities (
+                          user_account_id,
+                          workspace_id,
+                          channel_type,
+                          external_user_id,
+                          external_chat_id,
+                          external_username
+                        )
+                        VALUES (%s, %s, 'telegram', %s, %s, %s)
+                        """,
+                        (
+                            other_user_account_id,
+                            owner_workspace_id,
+                            "telegram-user-1",
+                            "telegram-chat-1",
+                            "other-user",
+                        ),
+                    )
+
+    with psycopg.connect(migrated_database_urls["app"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT set_config('app.current_user_account_id', %s, true)",
+                (other_user_account_id,),
+            )
+            cur.execute(
+                """
+                SELECT count(*)
+                FROM channel_identities
+                WHERE workspace_id = %s
+                  AND user_account_id = %s
+                """,
+                (owner_workspace_id, other_user_account_id),
+            )
+            identity_count = cur.fetchone()[0]
+
+    assert identity_count == 0
 
 
 def test_phase11_openai_compatible_registration_still_works(migrated_database_urls, monkeypatch) -> None:

--- a/tests/unit/test_20260415_0062_phase13_hosted_rls_backstops.py
+++ b/tests/unit/test_20260415_0062_phase13_hosted_rls_backstops.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260415_0062_phase13_hosted_rls_backstops"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    expected = [
+        *module._UPGRADE_FUNCTION_STATEMENTS,
+    ]
+    for table_name in module._RLS_TABLES:
+        expected.append(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+        expected.append(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+    expected.extend(module._UPGRADE_POLICY_STATEMENTS)
+
+    assert executed == expected
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    expected = list(module._DOWNGRADE_POLICY_STATEMENTS)
+    for table_name in reversed(module._RLS_TABLES):
+        expected.append(f"ALTER TABLE {table_name} NO FORCE ROW LEVEL SECURITY")
+        expected.append(f"ALTER TABLE {table_name} DISABLE ROW LEVEL SECURITY")
+    expected.extend(module._DOWNGRADE_FUNCTION_STATEMENTS)
+
+    assert executed == expected
+
+
+def test_upgrade_defines_workspace_backstop_functions_and_policies() -> None:
+    module = load_migration_module()
+    function_sql = "\n".join(module._UPGRADE_FUNCTION_STATEMENTS)
+    policy_sql = "\n".join(module._UPGRADE_POLICY_STATEMENTS)
+
+    assert "app.current_user_account_id()" in function_sql
+    assert "app.hosted_workspace_access_allowed(target_workspace_id uuid)" in function_sql
+    assert "app.hosted_workspace_owner_allowed(target_workspace_id uuid)" in function_sql
+    assert "FROM workspace_members AS wm" in function_sql
+    assert "CREATE POLICY model_providers_workspace_access" in policy_sql
+    assert "CREATE POLICY workspaces_update_access" in policy_sql
+    assert "CREATE POLICY workspace_members_insert_access" in policy_sql
+    assert "app.hosted_workspace_owner_allowed(workspace_id)" in policy_sql
+    assert "CREATE POLICY channel_identities_access" in policy_sql
+    assert "app.hosted_workspace_access_allowed(workspace_id)" in policy_sql

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -94,6 +94,37 @@ def test_set_current_user_sets_database_context() -> None:
     ]
 
 
+def test_set_current_user_account_sets_database_context() -> None:
+    connection = RecordingConnection()
+    user_account_id = uuid4()
+
+    db.set_current_user_account(connection, user_account_id)
+
+    assert connection.cursor_instance.executed == [
+        ("SELECT set_config('app.current_user_account_id', %s, true)", (str(user_account_id),)),
+    ]
+
+
+def test_set_hosted_admin_bypass_sets_database_context() -> None:
+    connection = RecordingConnection()
+
+    db.set_hosted_admin_bypass(connection, True)
+
+    assert connection.cursor_instance.executed == [
+        ("SELECT set_config('app.hosted_admin_bypass', %s, true)", ("true",)),
+    ]
+
+
+def test_set_hosted_service_bypass_sets_database_context() -> None:
+    connection = RecordingConnection()
+
+    db.set_hosted_service_bypass(connection, True)
+
+    assert connection.cursor_instance.executed == [
+        ("SELECT set_config('app.hosted_service_bypass', %s, true)", ("true",)),
+    ]
+
+
 def test_user_connection_sets_current_user_inside_transaction(monkeypatch) -> None:
     connection = RecordingConnection()
     user_id = uuid4()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import Request
+from fastapi.responses import Response
 import apps.api.src.alicebot_api.main as main_module
 from apps.api.src.alicebot_api.config import Settings
 from alicebot_api.artifacts import TaskArtifactNotFoundError
@@ -227,6 +228,7 @@ def _build_request(
     query_string: str = "",
     body: bytes = b"",
     headers: dict[str, str] | None = None,
+    client_host: str = "127.0.0.1",
 ) -> Request:
     encoded_headers = [
         (key.lower().encode("utf-8"), value.encode("utf-8"))
@@ -247,7 +249,7 @@ def _build_request(
             "raw_path": path.encode("utf-8"),
             "query_string": query_string.encode("utf-8"),
             "headers": encoded_headers,
-            "client": ("127.0.0.1", 12345),
+            "client": (client_host, 12345),
             "server": ("testserver", 80),
         },
         receive,
@@ -279,6 +281,62 @@ def test_resolve_authenticated_user_id_allows_dev_without_header() -> None:
     )
 
     assert resolved is None
+
+
+def test_request_client_is_loopback_accepts_localhost() -> None:
+    request = _build_request(method="GET", path="/v0/threads")
+
+    assert main_module._request_client_is_loopback(request, Settings()) is True
+
+
+def test_request_client_is_loopback_rejects_remote_clients() -> None:
+    request = _build_request(
+        method="GET",
+        path="/v0/threads",
+        client_host="203.0.113.10",
+    )
+
+    assert main_module._request_client_is_loopback(request, Settings()) is False
+
+
+def test_v0_middleware_blocks_non_dev_when_legacy_api_disabled(monkeypatch) -> None:
+    request = _build_request(method="GET", path="/v0/threads")
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(app_env="production", auth_user_id=str(uuid4())),
+    )
+
+    async def call_next(_: Request) -> Response:
+        return Response(status_code=204)
+
+    response = asyncio.run(main_module.enforce_authenticated_user_identity(request, call_next))
+
+    assert response.status_code == 404
+
+
+def test_v0_middleware_blocks_remote_clients_outside_dev(monkeypatch) -> None:
+    request = _build_request(
+        method="GET",
+        path="/v0/threads",
+        client_host="203.0.113.10",
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            app_env="production",
+            auth_user_id=str(uuid4()),
+            legacy_v0_enabled_outside_dev=True,
+        ),
+    )
+
+    async def call_next(_: Request) -> Response:
+        return Response(status_code=204)
+
+    response = asyncio.run(main_module.enforce_authenticated_user_identity(request, call_next))
+
+    assert response.status_code == 403
 
 
 def test_rewrite_user_id_query_param_rejects_mismatch() -> None:

--- a/tests/unit/test_provider_runtime.py
+++ b/tests/unit/test_provider_runtime.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import socket
 from uuid import uuid4
+
+import pytest
 
 from apps.api.src.alicebot_api.config import Settings
 from alicebot_api.provider_runtime import (
@@ -36,6 +39,19 @@ class FakeHTTPResponse:
 
     def read(self) -> bytes:
         return self.body
+
+
+@pytest.fixture(autouse=True)
+def allow_documentation_provider_hosts(monkeypatch) -> None:
+    original_getaddrinfo = socket.getaddrinfo
+
+    def fake_getaddrinfo(hostname: str, port, type=0, proto=0):
+        if hostname.endswith(".example"):
+            sockaddr = ("93.184.216.34", 0)
+            return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)]
+        return original_getaddrinfo(hostname, port, type=type, proto=proto)
+
+    monkeypatch.setattr("alicebot_api.provider_security.socket.getaddrinfo", fake_getaddrinfo)
 
 
 def make_runtime_provider_config(

--- a/tests/unit/test_provider_security.py
+++ b/tests/unit/test_provider_security.py
@@ -1,11 +1,31 @@
 from __future__ import annotations
 
+import socket
+
 import pytest
 
 from alicebot_api.provider_security import sanitize_provider_error_message, validate_provider_base_url
 
 
-def test_validate_provider_base_url_accepts_public_targets() -> None:
+def _fake_getaddrinfo_factory(*addresses: str):
+    def fake_getaddrinfo(hostname: str, port, type=0, proto=0):
+        del hostname, port, type, proto
+        resolved = []
+        for address in addresses:
+            family = socket.AF_INET6 if ":" in address else socket.AF_INET
+            sockaddr = (address, 0) if family == socket.AF_INET else (address, 0, 0, 0)
+            resolved.append((family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr))
+        return resolved
+
+    return fake_getaddrinfo
+
+
+def test_validate_provider_base_url_accepts_public_targets(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "alicebot_api.provider_security.socket.getaddrinfo",
+        _fake_getaddrinfo_factory("93.184.216.34"),
+    )
+
     assert validate_provider_base_url("https://provider.example/v1") == "https://provider.example/v1"
     assert validate_provider_base_url("http://provider.example:8080/api") == "http://provider.example:8080/api"
 
@@ -46,6 +66,34 @@ def test_validate_provider_base_url_rejects_userinfo(url: str) -> None:
 def test_validate_provider_base_url_rejects_disallowed_targets(url: str) -> None:
     with pytest.raises(ValueError, match="not allowed by outbound policy"):
         validate_provider_base_url(url)
+
+
+def test_validate_provider_base_url_rejects_hostname_resolving_to_private_ip(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "alicebot_api.provider_security.socket.getaddrinfo",
+        _fake_getaddrinfo_factory("10.0.0.8"),
+    )
+
+    with pytest.raises(ValueError, match="not allowed by outbound policy"):
+        validate_provider_base_url("https://internal-resolver.example/v1")
+
+
+def test_validate_provider_base_url_rechecks_hostname_resolution(monkeypatch) -> None:
+    responses = iter(
+        [
+            _fake_getaddrinfo_factory("93.184.216.34"),
+            _fake_getaddrinfo_factory("10.0.0.8"),
+        ]
+    )
+
+    def fake_getaddrinfo(hostname: str, port, type=0, proto=0):
+        return next(responses)(hostname, port, type=type, proto=proto)
+
+    monkeypatch.setattr("alicebot_api.provider_security.socket.getaddrinfo", fake_getaddrinfo)
+
+    assert validate_provider_base_url("https://rebind.example/v1") == "https://rebind.example/v1"
+    with pytest.raises(ValueError, match="not allowed by outbound policy"):
+        validate_provider_base_url("https://rebind.example/v1")
 
 
 def test_sanitize_provider_error_message_removes_upstream_detail() -> None:


### PR DESCRIPTION
## Summary

This PR ships the Phase 13 pentest hardening fixes across hosted access control, legacy v0 exposure, provider runtime security, and security maintenance automation.

Included changes:
- adds hosted control-plane row-level security backstops through Alembic migration `20260415_0062`
- sets and uses hosted user-account and bypass session variables in DB-backed hosted flows
- hardens legacy v0 access outside dev/test so it is disabled or loopback-only
- tightens hosted workspace slug allocation under concurrent creation
- narrows generic live API mode in the web client to loopback legacy v0 targets
- updates CI and Dependabot coverage for security maintenance

## Validation

- `./.venv/bin/pytest tests/integration/test_phase10_beta_hardening_launch_api.py tests/integration/test_phase11_provider_runtime_api.py tests/unit/test_db.py tests/unit/test_main.py tests/unit/test_provider_runtime.py tests/unit/test_provider_security.py tests/unit/test_task_briefing.py tests/unit/test_20260415_0062_phase13_hosted_rls_backstops.py -q`
- Result: `131 passed`
- `pnpm test` in `apps/web`
- Result: `200 passed`
- `pnpm lint` in `apps/web`
- Result: passed
- `pnpm build` in `apps/web`
- Result: passed
- `pnpm test` in `packages/alice-cli`
- Result: `2 passed`

## Upgrade Overview

### Protected Areas

- [x] memory schema
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact

This is security-hardening work. The most visible compatibility change is that legacy `v0` API access outside development and test is now disabled or restricted to loopback clients, and hosted access relies on stricter row-level security backstops. Hosted and web clients that follow the intended flows continue to work, but direct or loosely scoped access patterns are narrowed.

### Migration / Rollout

Apply Alembic migration `20260415_0062_phase13_hosted_rls_backstops` before or alongside application deploy. Roll out the API and web changes together so hosted access variables, web live-mode gating, and the tightened legacy-v0 behavior are aligned with the database backstops.

### Operator Action

Operators should run the migration as part of deploy, then verify hosted admin and hosted workspace flows still work with the stricter access controls. If any non-loopback workflows still depend on legacy `v0` endpoints outside development or test, they need to be moved to supported surfaces before relying on this hardened behavior.

### Validation

Validated with the reviewed Python security slice, the new RLS migration unit test, the full web test/lint/build loop, and the alice-cli test suite:

- `./.venv/bin/pytest tests/integration/test_phase10_beta_hardening_launch_api.py tests/integration/test_phase11_provider_runtime_api.py tests/unit/test_db.py tests/unit/test_main.py tests/unit/test_provider_runtime.py tests/unit/test_provider_security.py tests/unit/test_task_briefing.py tests/unit/test_20260415_0062_phase13_hosted_rls_backstops.py -q`
- `pnpm test` in `apps/web`
- `pnpm lint` in `apps/web`
- `pnpm build` in `apps/web`
- `pnpm test` in `packages/alice-cli`

### Rollback

Rollback is straightforward: revert commit `4fdc497` and downgrade Alembic revision `20260415_0062` if the hosted backstops need to be removed. Because this is security hardening, rollback should be treated as exceptional and followed by a corrected forward fix.
