### PR TITLE
[codex] P14-S1: ship provider foundation and OpenAI-compatible adapter

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -1,78 +1,94 @@
 # Sprint Packet
 
 ## Sprint Title
-Phase 13 Closeout + `v0.4.0` Release
+P14-S1: Provider Abstraction Cleanup + OpenAI-Compatible Adapter
 
 ## Activation Note
-- This packet remains active until the next phase packet is accepted.
+- This packet is active.
 - `v0.4.0` is the current public release boundary.
-- Phase 13 is shipped.
-- Phase 13 sequence shipped as:
-  - `P13-S1` One-Call Continuity
-  - `P13-S2` Alice Lite
-  - `P13-S3` Memory Hygiene + Conversation Health
+- Phase 14 is active on top of the shipped Phase 13 baseline.
+- Phase 14 sequence is fixed for now:
+  - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter
+  - `P14-S2` Ollama + llama.cpp + vLLM Adapters
+  - `P14-S3` Model Packs
+  - `P14-S4` Reference Integrations
+  - `P14-S5` Design Partner Launch
 
 ## Sprint Type
-release-closeout
+feature
 
 ## Sprint Reason
-Phase 13 is complete. This packet keeps the active control slot aligned to the shipped `v0.4.0` baseline while the next phase is being defined.
+Alice already has strong continuity depth. The next constraint is compatibility and adoption. `P14-S1` creates the stable provider foundation that later local adapters, model packs, reference integrations, and design-partner workflows will depend on.
 
 ## Git Instructions
-- Branch Name: `main`
+- Branch Name: `codex/phase14-s1-provider-foundation-openai-compatible`
 - Base Branch: `main`
-- PR Strategy: none; this is a release-state packet
-- Merge Policy: replace this packet when the next phase is accepted
+- PR Strategy: one implementation branch, one PR
+- Merge Policy: squash merge after review `PASS` and explicit approval
 
 ## Baseline To Preserve
 - shipped Phases 9-13 baseline
 - shipped Bridge `B1` through `B4`
 - published `v0.4.0` baseline
-- shipped `P13-S1` one-call continuity surface
-- shipped `P13-S2` Alice Lite profile
-- shipped `P13-S3` hygiene/thread-health visibility
+- shipped one-call continuity surface
+- shipped Alice Lite profile
+- shipped hygiene/thread-health visibility
 - no semantic fork between API, CLI, MCP, hosted, provider-runtime, and Hermes paths
 
 ## Exact Goal
-Preserve a clean release-aligned control state after the completed Phase 13 sequence and before the next phase packet is created.
+Create the stable provider foundation and unlock any OpenAI-compatible runtime without changing continuity semantics.
 
 ## In Scope
-- release-aligned control-doc truth
-- release-aligned version markers
-- release evidence and closeout docs
-- preserving the shipped baseline until the next phase is accepted
+- provider abstraction cleanup
+- finalized provider interface in code
+- provider registry and workspace-scoped provider management flows
+- provider capability discovery
+- OpenAI-compatible adapter
+- normalized runtime invocation telemetry
+- provider configuration docs
+- smoke tests against a compliant endpoint
 
 ## Out Of Scope
-- new feature work
-- reopening completed Phase 13 implementation
-- speculative next-phase scope before explicit acceptance
+- Ollama, llama.cpp, and vLLM adapters beyond what is required to keep the interface general
+- model-pack UX/polish beyond foundation compatibility hooks
+- reference integrations
+- design-partner workflows
+- retrieval research, graph migration, new channels, marketplace work, or enterprise governance expansion
 
 ## Proposed Files And Modules
-- control docs
-- release docs
-- public version markers
-- evidence reports
+- `apps/api/src/alicebot_api/`
+- `apps/api/alembic/versions/`
+- `tests/unit/`
+- `tests/integration/`
+- `docs/` provider/runtime docs
+- control docs if baseline status markers need updates
 
 ## Planned Deliverables
-- Phase 13 closeout summary
-- `v0.4.0` release checklist, tag plan, and runbook
-- updated release-aligned canonical docs
-- release evidence reports
+- stable provider adapter interface
+- provider registration/update flows
+- capability check endpoint
+- OpenAI-compatible provider adapter
+- normalized runtime invocation telemetry persistence
+- provider configuration docs
+- provider-level smoke tests
 
 ## Acceptance Criteria
-- canonical docs accurately describe the shipped Phase 13 baseline
-- release evidence matches exact verification commands
-- `v0.4.0` is the active public release boundary
-- the packet is safe to leave in place until the next phase packet replaces it
+- a provider can be registered via API and config
+- Alice can call a compliant OpenAI-compatible endpoint
+- provider capabilities are stored and visible
+- runtime invocation telemetry is persisted
+- one-call continuity works cleanly through the provider abstraction
 
 ## Required Verification
 - `python3 scripts/check_control_doc_truth.py`
 - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-- full release gates recorded in `BUILD_REPORT.md`
+- targeted unit/integration coverage for provider registration, capability discovery, and runtime invocation telemetry
+- smoke tests against a compliant OpenAI-compatible endpoint
 
 ## Control Tower Decisions Needed
-- define the next phase before opening another build sprint
-- keep future work non-redundant with the shipped Phase 13 boundary
+- exact provider capability surface stored in `provider_capabilities`
+- whether provider registration remains API-first, config-first, or explicitly dual-path from the first sprint
+- how much Azure-specific capability shape is deferred while keeping the interface stable
 
 ## Exit Condition
-This packet stays valid until the next phase packet is accepted and activated.
+This sprint is complete when Alice has a stable provider abstraction, a working OpenAI-compatible adapter, visible provider capabilities, persisted invocation telemetry, and preserved one-call continuity semantics.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -8,27 +8,26 @@
 - Phase 12 is shipped.
 - Phase 13 is shipped.
 - `v0.4.0` is the latest published tag.
-- `P13-S1` One-Call Continuity is shipped.
-- `P13-S2` Alice Lite is shipped.
-- `P13-S3` Memory Hygiene + Conversation Health is shipped.
-- No post-Phase-13 build sprint is active yet.
+- Phase 14 is active.
+- `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is the active execution sprint.
+- `P14-S2` through `P14-S5` are planned and scoped.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
 - Alice exposes CLI, MCP, hosted/product, provider-runtime, and Hermes bridge surfaces.
-- The shipped baseline now includes hybrid retrieval and reranking with traces, explicit memory mutation operations, contradiction/trust handling, the public eval harness, and task-adaptive briefing.
-- The shipped baseline also now includes the one-call continuity surface across API, CLI, and MCP from `P13-S1`.
-- The shipped baseline also now includes the lighter Alice Lite startup/profile path from `P13-S2`.
-- The shipped baseline also now includes memory hygiene and thread/conversation health visibility from `P13-S3`.
+- The shipped baseline includes hybrid retrieval and reranking with traces, explicit memory mutation operations, contradiction/trust handling, the public eval harness, and task-adaptive briefing.
+- The shipped baseline includes one-call continuity across API, CLI, and MCP.
+- The shipped baseline includes the Alice Lite startup/profile path.
+- The shipped baseline includes memory hygiene and thread/conversation health visibility.
 - `v0.4.0` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
-- Phase 12 is complete and remains baseline truth.
 - Phase 13 is complete and remains baseline truth.
-- `P13-S1` is complete and established the primary one-call continuity surface across API, CLI, and MCP.
-- `P13-S2` is complete and established the lighter Alice Lite startup/profile path without semantic drift.
-- `P13-S3` is complete and made hygiene and thread/conversation health visible and operationally useful.
+- Phase 14 starts from the shipped `v0.4.0` baseline.
+- Phase 14 is focused on compatibility, packaging, reference integrations, and design-partner proof.
+- No Phase 14 deliverable is shipped yet beyond the existing provider/runtime foundation.
 
 ## Immediate Control Tower Decisions Needed
-- Define the next phase and its first sprint packet on top of the shipped `v0.4.0` baseline.
-- Avoid reopening completed Phase 13 work unless a defect or follow-up is explicitly scoped.
+- Lock the first-party pack set for the initial Phase 14 model-pack release.
+- Decide whether Azure polish is pulled fully into `P14-S2` or held to the later integration/documentation layer.
+- Select the first 3 to 5 design partners and their initial pilot scopes early enough for `P14-S5`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,11 +2,11 @@
 
 ## Scope Boundary
 - **Shipped baseline:** Phases 9-13 and Bridge `B1` through `B4`.
-- **Current repo execution posture:** `v0.4.0` is the latest published tag; Phase 13 is shipped; no post-Phase-13 execution sprint is active yet.
-- **Phase principle preserved:** Phase 13 was an adoption layer on top of Phase 12, not a new substrate phase.
+- **Current repo execution posture:** `v0.4.0` is the latest published tag; Phase 14 is active; `P14-S1` is the active execution sprint.
+- **Phase principle:** Phase 14 is a platform-and-adoption phase, not a new substrate-research phase.
 
 ## Current System Overview
-Alice is a modular continuity platform with shared continuity semantics across local, hosted, provider-runtime, MCP, and Hermes-integrated surfaces.
+Alice is a modular continuity platform with shared continuity semantics across local, hosted, provider-runtime, CLI, MCP, Hermes-integrated, and imported-workflow surfaces.
 
 ## Technical Stack
 - API/runtime: Python + FastAPI in [`apps/api/src/alicebot_api`](apps/api/src/alicebot_api)
@@ -19,38 +19,22 @@ Alice is a modular continuity platform with shared continuity semantics across l
 ## Shipped Module Boundaries
 
 ### Continuity Core
-- Capture, review, lifecycle, explainability, recall, resumption, and open-loop flows.
-- Primary modules:
-  - [`continuity_capture.py`](apps/api/src/alicebot_api/continuity_capture.py)
-  - [`continuity_review.py`](apps/api/src/alicebot_api/continuity_review.py)
-  - [`continuity_recall.py`](apps/api/src/alicebot_api/continuity_recall.py)
-  - [`continuity_resumption.py`](apps/api/src/alicebot_api/continuity_resumption.py)
-  - [`continuity_open_loops.py`](apps/api/src/alicebot_api/continuity_open_loops.py)
+- Capture, review, lifecycle, explainability, recall, resumption, open-loop workflows, and one-call continuity assembly.
 
 ### Retrieval And Evidence Foundations
-- Shipped baseline includes semantic retrieval, embeddings, entities, trusted-fact promotion, fixture-based retrieval evaluation, hybrid retrieval streams, reranking, and persisted retrieval traces.
-- Primary modules:
-  - [`semantic_retrieval.py`](apps/api/src/alicebot_api/semantic_retrieval.py)
-  - [`retrieval_evaluation.py`](apps/api/src/alicebot_api/retrieval_evaluation.py)
-  - [`entity.py`](apps/api/src/alicebot_api/entity.py)
-  - [`entity_edge.py`](apps/api/src/alicebot_api/entity_edge.py)
-  - [`trusted_fact_promotions.py`](apps/api/src/alicebot_api/trusted_fact_promotions.py)
+- Hybrid retrieval, embeddings, entity/entity-edge support, reranking, trust-aware evidence shaping, and persisted retrieval traces.
 
 ### Mutation, Trust, And Briefing Foundations
-- Shipped baseline includes explicit memory operations, contradiction cases, trust signals, public eval persistence, and task-adaptive briefing.
-- Primary modules:
-  - [`memory.py`](apps/api/src/alicebot_api/memory.py)
-  - [`task_briefing.py`](apps/api/src/alicebot_api/task_briefing.py)
-  - [`contracts.py`](apps/api/src/alicebot_api/contracts.py)
+- Explicit memory operations, contradiction cases, trust signals, public eval persistence, and task-adaptive briefing.
 
 ### Hosted/Product Layer
 - Workspace, identity, devices, preferences, telemetry, web/admin, and channel surfaces.
 
-### Provider Runtime
-- Workspace-scoped provider registration, capability snapshots, model packs, invocation, and secret handling.
+### Provider Runtime Foundation
+- Workspace-scoped provider records, capability snapshots, runtime invocation boundaries, model-pack primitives, and secret handling.
 
-### Hermes Bridge
-- Provider hook integration, prefetch, post-turn capture, review queue, explainability, and MCP fallback.
+### Integration Surfaces
+- CLI, MCP, Hermes bridge/provider flows, OpenClaw import/augmentation, and deployment profiles such as Alice Lite.
 
 ## Current Data Model Summary
 
@@ -66,12 +50,10 @@ Alice is a modular continuity platform with shared continuity semantics across l
 - `entities`, `entity_edges`
 - `retrieval_runs`, `retrieval_candidates`
 - `eval_suites`, `eval_cases`, `eval_runs`, `eval_results`
-- task-artifact chunk embeddings for artifact-scoped retrieval
 
 ### Product / Runtime
 - `workspaces`, `workspace_members`, `auth_sessions`, `devices`
-- `model_providers`, `provider_capabilities`, `model_packs`, `workspace_model_pack_bindings`
-- `task_briefs`
+- current provider/runtime tables from the shipped baseline
 - channel, task, trace, approval, and execution tables
 
 ## Current Key Flows
@@ -82,117 +64,92 @@ Alice is a modular continuity platform with shared continuity semantics across l
 3. Review/correction can confirm, edit, supersede, or delete.
 4. Explainability preserves provenance and lifecycle state.
 
-### Recall And Resumption
+### Recall, Resumption, And Briefing
 1. Recall loads continuity candidates.
 2. Ranking considers semantic similarity, lexical/entity signals, trust, freshness, provenance, and supersession.
-3. Resumption composes ranked recall into decisions, open loops, recent changes, and next action.
+3. Resumption and one-call continuity compose ranked recall into decisions, open loops, recent changes, provenance, trust posture, and next action.
 
 ### Provider / Hermes Runtime
 1. Workspace binds provider and model-pack configuration.
 2. Runtime invokes through provider adapter boundaries.
 3. Hermes can prefetch before a turn and capture after a turn while Alice remains the system of record.
 
-## Phase 12 Baseline In Force
-- Hybrid retrieval and reranking are the recall baseline.
-- Explicit mutation operations are the memory-change baseline.
-- Contradiction cases and trust signals are the conflict/trust baseline.
-- The public eval harness is the quality-evidence baseline.
-- Task-adaptive briefing is the current compiled-context baseline.
+## Phase 13 Baseline In Force
+- One-call continuity is the primary continuity integration surface.
+- Alice Lite is the lighter local deployment profile.
+- Hygiene and thread-health visibility are part of the shipped baseline.
 
-## Phase 13 Shipped Delta
+## Phase 14 Shared Delta
 
-### P13-S1: One-Call Continuity
-- Status: shipped
-- Add the primary integration surface:
-  - API: `POST /v1/continuity/brief`
-  - CLI: `alice brief`
-  - MCP: `alice_brief`
-- Input should support:
-  - `query`
-  - optional `thread_id`
-  - optional `task_id`
-  - optional `project`
-  - optional `person`
-  - optional `since`
-  - optional `until`
-  - `brief_type`
-  - `max_relevant_facts`
-  - `max_recent_changes`
-  - `max_open_loops`
-  - `max_conflicts`
-  - `max_timeline_highlights`
-  - `include_non_promotable_facts`
-- Output should include:
-  - summary
-  - relevant facts
-  - recent changes
-  - open loops
-  - conflicts
-  - timeline highlights
-  - next suggested action
-  - provenance bundle
-  - trust posture
-- This surface must compose shipped Phase 12 layers rather than reimplement them.
+### Platform Concepts
+- **Provider:** a runtime connector Alice uses to talk to a specific model-serving interface.
+- **Model pack:** a versioned profile shaping prompt/context behavior, tool strategy, briefing strategy, token budgets, and model-specific quirks.
+- **Integration kit:** a runtime-specific starter path for Hermes, OpenClaw, Python agents, and TypeScript agents.
+- **Design partner workspace:** a tracked workspace with onboarding, support, instrumentation, and pilot outcome logging.
 
-### P13-S2: Alice Lite
-- Status: shipped
-- Add a lighter local deployment profile for solo users and builders.
-- Target outcomes:
-  - one-command local startup
-  - smaller-footprint profile
-  - sample workspace bootstrap
-  - faster first useful result
-- Alice Lite must remain a deployment/profile change, not a separate product or semantics fork.
-- SQLite or another embedded mode is not in scope unless semantics remain intact.
+### P14-S1 API Additions
+- Provider management:
+  - `POST /v1/providers`
+  - `GET /v1/providers`
+  - `GET /v1/providers/{provider_id}`
+  - `PATCH /v1/providers/{provider_id}`
+  - `POST /v1/providers/test`
+- Runtime invocation:
+  - `POST /v1/runtime/invoke`
 
-### P13-S3: Memory Hygiene + Conversation Health
-- Status: shipped
-- Add visible hygiene surfaces for:
-  - duplicates
-  - stale facts
-  - unresolved contradictions
-  - weakly trusted memory
-  - review queue pressure
-- Add conversation/thread health surfaces for:
-  - recent threads
-  - stale threads
-  - risky threads
-  - thread activity / health posture
-- This work is visibility and operational legibility first, not new substrate work.
+### P14-S1 Table Additions And Refinements
+- `model_providers`
+- `provider_capabilities`
+- `provider_invocation_telemetry`
+
+### Provider Adapter Contract
+- Required methods:
+  - `healthcheck()`
+  - `list_models()`
+  - `invoke_responses()`
+  - `invoke_embeddings()`
+  - `supports_tools()`
+  - `supports_reasoning()`
+  - `supports_vision()`
+  - `normalize_response()`
+  - `normalize_usage()`
+  - `normalize_tool_schema()`
+  - `discover_capabilities()`
+  - `invoke()`
+- Design rule:
+  - providers may affect capability support, latency, token budgets, and model-specific behavior
+  - providers must not fork continuity object semantics, contradiction handling, provenance contracts, or one-call continuity behavior
+
+### P14-S1 Notes
+- Workspace bootstrap can seed OpenAI-compatible providers from `WORKSPACE_PROVIDER_CONFIGS_JSON`.
+- Invocation telemetry persists normalized provider test and runtime invoke records.
+- Later Phase 14 API/table expansions stay in roadmap and spec docs until they are implemented.
+
+## Phase 14 Sprint Sequence
+- `P14-S1` Provider abstraction cleanup + OpenAI-compatible adapter
+- `P14-S2` Ollama + llama.cpp + vLLM adapters
+- `P14-S3` Model packs
+- `P14-S4` Reference integrations
+- `P14-S5` Design partner launch
 
 ## Security And Reliability Rules
-- Keep user/workspace isolation intact for continuity, provider, and channel data.
+- Keep user/workspace isolation intact for continuity, provider, runtime, and design-partner data.
 - Keep provider credentials and secret references out of logs and outward-facing errors.
 - Preserve approval-bounded execution for consequential side effects.
-- Keep capture, mutation, and Hermes sync paths idempotent.
+- Keep capture, mutation, and provider/Hermes sync paths idempotent.
 - Preserve append-only evidence where the system depends on auditability.
-- Do not let the one-call continuity surface bypass provenance, trust, or supersession rules already enforced by the baseline.
-- Do not let Alice Lite weaken continuity semantics in exchange for easier install.
-
-## Deployment Topology
-
-### Recommended
-- Alice API + Postgres as system of record
-- Alice MCP for explicit workflows
-- Provider runtime where model abstraction is needed
-- Hermes provider-plus-MCP for always-on continuity
-
-### Phase 13 Addition
-- Alice Lite should be a lighter deployment/profile around the same core runtime, not a separate architecture.
-
-### Fallback
-- MCP-only remains supported when provider automation is unavailable
+- Do not let provider-specific behavior fork continuity semantics.
+- Do not let model packs bypass provenance, trust, or contradiction rules already enforced by the baseline.
 
 ## Testing Strategy
-- unit/integration tests for continuity, runtime, and API behavior
-- fixture-based retrieval and eval suites
-- API/CLI/MCP parity tests for `P13-S1`
-- startup/smoke coverage for Alice Lite profile work in `P13-S2`
-- hygiene/thread-health tests for `P13-S3`
-- web tests for shipped user/admin surfaces
-- Hermes provider smoke, MCP smoke, and demo flows
+- unit/integration tests for continuity, provider runtime, and API behavior
+- provider smoke tests and provider-capability parity checks
+- model-pack smoke tests and compatibility-matrix validation
+- integration smoke tests for Hermes, OpenClaw, Python example, and TypeScript example paths
+- release gates remain green across Python, web, Alice Lite, Hermes smoke, and public eval harness
+- docs verification is part of sprint completion, not cleanup work
 
 ## Current Architectural Posture
-- `POST /v1/continuity/brief`, `alice brief`, and `alice_brief` are now the primary continuity integration entrypoints.
-- Alice Lite is now a shipped deployment profile around the same runtime semantics.
-- Hygiene and thread-health visibility are shipped operational surfaces, not a separate memory subsystem.
+- `v0.4.0` remains the active public release boundary.
+- Phase 14 extends the shipped provider/runtime foundation into a more stable integration platform.
+- The continuity substrate remains the same system of record; Phase 14 is about compatibility, packaging, reference integrations, and design-partner proof.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,78 +1,71 @@
 # BUILD_REPORT
 
-- release objective
-  - Close out Phase 13 and ship `v0.4.0` as the public pre-1.0 release boundary.
-- completed work
-  - Updated the canonical control docs to treat Phase 13 as shipped baseline truth and replaced the stale active sprint packet with a release-closeout packet.
-  - Added Phase 13 closeout docs plus `v0.4.0` release checklist, tag plan, and public release runbook.
-  - Aligned Python, API, web, CLI, core-package, and Hermes plugin version markers to `0.4.0`.
-  - Updated current quickstart and integration docs to reflect the shipped Phase 13 surface.
-  - Fixed a release-gate regression exposed by the full test suite:
-    - provider registration now skips forced DNS resolution at registration time while preserving runtime-time outbound validation
-    - OpenAI-compatible capability discovery no longer hard-fails on placeholder documentation hosts
-    - the Phase 11 model-pack integration test now applies the same `.example` host fixture used by the provider-runtime suite
-- incomplete work
-  - None identified within release scope.
-- files changed
-  - canonical docs:
-    - `README.md`
-    - `PRODUCT_BRIEF.md`
-    - `ARCHITECTURE.md`
-    - `ROADMAP.md`
-    - `RULES.md`
-    - `CURRENT_STATE.md`
-    - `.ai/handoff/CURRENT_STATE.md`
-    - `.ai/active/SPRINT_PACKET.md`
-    - `CHANGELOG.md`
-  - release/closeout docs:
-    - `docs/phase13-closeout-summary.md`
-    - `docs/runbooks/phase13-closeout-packet.md`
-    - `docs/release/v0.4.0-release-checklist.md`
-    - `docs/release/v0.4.0-tag-plan.md`
-    - `docs/runbooks/v0.4.0-public-release-runbook.md`
-    - `docs/phase13-product-spec.md`
-    - `docs/phase13-sprint-13-1-13-3-plan.md`
-  - version markers:
-    - `pyproject.toml`
-    - `apps/api/src/alicebot_api/__init__.py`
-    - `apps/api/src/alicebot_api/main.py`
-    - `apps/web/package.json`
-    - `packages/alice-cli/package.json`
-    - `packages/alice-cli/bin/alice.js`
-    - `packages/alice-core/package.json`
-    - `packages/alice-core/index.js`
-    - `docs/integrations/hermes-memory-provider/plugins/memory/alice/plugin.yaml`
-  - release-gate regression fixes:
-    - `apps/api/src/alicebot_api/provider_security.py`
-    - `apps/api/src/alicebot_api/provider_runtime.py`
-    - `tests/unit/test_provider_security.py`
-    - `tests/integration/test_phase11_model_packs_api.py`
-    - `scripts/check_control_doc_truth.py`
-- tests run
-  - `python3 scripts/check_control_doc_truth.py`
-    - `PASS`
-  - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-    - `5 passed in 0.03s`
-  - `./.venv/bin/python -m pytest tests/unit/test_provider_security.py tests/integration/test_phase11_model_packs_api.py::test_phase11_model_pack_catalog_bind_and_runtime_shaping tests/integration/test_phase11_provider_runtime_api.py::test_phase11_provider_error_reflection_and_persistence_are_sanitized -q`
-    - `26 passed in 1.73s`
-  - `./.venv/bin/python -m pytest tests/unit tests/integration -q`
-    - initial run: `1 failed, 1276 passed in 258.93s`
-    - rerun after fix: `1279 passed in 249.08s`
-  - `pnpm --dir apps/web test`
-    - `200 passed`
-  - `./.venv/bin/python scripts/run_alice_lite_smoke.py`
-    - `status: ok`
-  - `./.venv/bin/python scripts/run_hermes_memory_provider_smoke.py`
-    - provider registered, single external enforced, bridge ready
-  - `./.venv/bin/python scripts/run_hermes_mcp_smoke.py`
-    - bridge flow validated
-  - `./.venv/bin/python scripts/run_hermes_bridge_demo.py`
-    - `status: pass`
-  - `./.venv/bin/python -m alicebot_api --database-url postgresql://alicebot_app:alicebot_app@localhost:5432/alicebot --user-id 00000000-0000-0000-0000-000000000001 evals run --report-path eval/baselines/public_eval_harness_v1.json`
-    - `12/12` cases passed
-    - report status: `pass`
-- blockers/issues
-  - The first full Python run exposed a Phase 11 provider-security regression in the release tree. It is fixed and the full suite now passes.
-  - Local untracked `apps/web/package-lock.json` and `packages/alice-core/package-lock.json` remain outside release scope.
-- recommended next step
-  - Create and push the `v0.4.0` tag, then publish the GitHub release.
+## sprint objective
+Create the stable provider foundation and unlock an OpenAI-compatible runtime without changing continuity semantics.
+
+## completed work
+- finalized the provider adapter code surface around health checks, model listing, normalized response handling, usage normalization, and OpenAI-compatible invoke path support
+- upgraded the OpenAI-compatible adapter to perform real capability discovery against `/models` and to honor configured invoke paths
+- added workspace-scoped config seeding through `WORKSPACE_PROVIDER_CONFIGS_JSON` during workspace bootstrap
+- added `PATCH /v1/providers/{provider_id}` for provider updates with capability refresh
+- persisted normalized provider invocation telemetry for both provider test calls and one-call runtime invoke flows
+- added the Phase 14 provider invocation telemetry migration and store helpers
+- added focused unit and integration coverage for config seeding, provider updates, OpenAI-compatible discovery, telemetry persistence, and hosted RLS on the new telemetry table
+- added provider/runtime docs for Phase 14 configuration and a reusable OpenAI-compatible smoke script
+- tightened Phase 14 architecture and contract docs back to implemented `P14-S1` truth
+- completed the live smoke flow against a real local Alice API session and a temporary compliant stub provider, then confirmed the expected `provider_invocation_telemetry` rows persisted
+
+## incomplete work
+- none for the declared `P14-S1` scope
+
+## files changed
+- `.ai/active/SPRINT_PACKET.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `ARCHITECTURE.md`
+- `CURRENT_STATE.md`
+- `PRODUCT_BRIEF.md`
+- `README.md`
+- `ROADMAP.md`
+- `RULES.md`
+- `apps/api/src/alicebot_api/config.py`
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/provider_runtime.py`
+- `apps/api/src/alicebot_api/response_generation.py`
+- `apps/api/src/alicebot_api/store.py`
+- `apps/api/alembic/versions/20260415_0063_phase14_provider_invocation_telemetry.py`
+- `scripts/check_control_doc_truth.py`
+- `tests/unit/test_config.py`
+- `tests/unit/test_provider_runtime.py`
+- `tests/unit/test_20260415_0063_phase14_provider_invocation_telemetry.py`
+- `tests/integration/test_phase11_provider_runtime_api.py`
+- `scripts/run_phase14_openai_compatible_smoke.py`
+- `docs/integrations/phase14-provider-configuration.md`
+- `docs/phase14-product-spec.md`
+- `docs/phase14-provider-adapter-contract.md`
+- `docs/phase14-s1-control-tower-packet.md`
+- `docs/phase14-s2-control-tower-packet.md`
+- `docs/phase14-s3-control-tower-packet.md`
+- `docs/phase14-s4-control-tower-packet.md`
+- `docs/phase14-s5-control-tower-packet.md`
+- `docs/phase14-sprint-14-1-14-5-plan.md`
+- `docs/phase14-model-pack-contract.md`
+- `docs/phase14-design-partner-launch.md`
+- `docs/phase14-launch-checklist.md`
+
+## tests run
+- `python3 scripts/check_control_doc_truth.py`
+- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+- `./.venv/bin/python -m pytest tests/unit/test_provider_runtime.py tests/unit/test_config.py tests/unit/test_20260415_0063_phase14_provider_invocation_telemetry.py -q`
+- `./.venv/bin/python -m pytest tests/integration/test_phase11_provider_runtime_api.py -q`
+- `python3 -m py_compile scripts/run_phase14_openai_compatible_smoke.py`
+- `python3 scripts/run_phase14_openai_compatible_smoke.py --help`
+- `./.venv/bin/python scripts/run_phase14_openai_compatible_smoke.py --api-base-url http://127.0.0.1:8017 --session-token <redacted-session-token> --thread-id <generated-thread-id> --model gpt-5-mini`
+  - `provider_test` succeeded
+  - `runtime_invoke` succeeded
+  - persisted telemetry rows: `provider_test`, `runtime_invoke`
+
+## blockers/issues
+- no blocker remains for the declared `P14-S1` scope
+
+## recommended next step
+Proceed to `P14-S2` or package this sprint for merge/review handoff with the provider telemetry RLS posture preserved as the baseline for later workspace-scoped runtime tables.

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -11,27 +11,26 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - Phase 12 is shipped.
 - Phase 13 is shipped.
 - `v0.4.0` is the latest published tag.
-- `P13-S1` One-Call Continuity is shipped.
-- `P13-S2` Alice Lite is shipped.
-- `P13-S3` Memory Hygiene + Conversation Health is shipped.
-- No post-Phase-13 build sprint is active yet.
+- Phase 14 is active.
+- `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is the active execution sprint.
+- `P14-S2` through `P14-S5` are planned and scoped.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
 - Alice exposes CLI, MCP, hosted/product, provider-runtime, and Hermes bridge surfaces.
-- The shipped baseline now includes hybrid retrieval and reranking with traces, explicit memory mutation operations, contradiction/trust handling, the public eval harness, and task-adaptive briefing.
-- The shipped baseline also now includes the one-call continuity surface across API, CLI, and MCP from `P13-S1`.
-- The shipped baseline also now includes the lighter Alice Lite startup/profile path from `P13-S2`.
-- The shipped baseline also now includes memory hygiene and thread/conversation health visibility from `P13-S3`.
+- The shipped baseline includes hybrid retrieval and reranking with traces, explicit memory mutation operations, contradiction/trust handling, the public eval harness, and task-adaptive briefing.
+- The shipped baseline includes one-call continuity across API, CLI, and MCP.
+- The shipped baseline includes the Alice Lite startup/profile path.
+- The shipped baseline includes memory hygiene and thread/conversation health visibility.
 - `v0.4.0` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
-- Phase 12 is complete and remains baseline truth.
 - Phase 13 is complete and remains baseline truth.
-- `P13-S1` is complete and established the primary one-call continuity surface across API, CLI, and MCP.
-- `P13-S2` is complete and established the lighter Alice Lite startup/profile path without semantic drift.
-- `P13-S3` is complete and made hygiene and thread/conversation health visible and operationally useful.
+- Phase 14 starts from the shipped `v0.4.0` baseline.
+- Phase 14 is focused on compatibility, packaging, reference integrations, and design-partner proof.
+- No Phase 14 deliverable is shipped yet beyond the existing provider/runtime foundation.
 
 ## Immediate Control Tower Decisions Needed
-- Define the next phase and its first sprint packet on top of the shipped `v0.4.0` baseline.
-- Avoid reopening completed Phase 13 work unless a defect or follow-up is explicitly scoped.
+- Lock the first-party pack set for the initial Phase 14 model-pack release.
+- Decide whether Azure polish is pulled fully into `P14-S2` or held to the later integration/documentation layer.
+- Select the first 3 to 5 design partners and their initial pilot scopes early enough for `P14-S5`.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -1,71 +1,68 @@
 # Product Brief
 
 ## Product Summary
-Alice is a pre-1.0 continuity platform for AI agents and agent-assisted workflows. It provides typed memory, provenance, correction-aware recall, open-loop tracking, resumable context, provider/runtime portability, and Hermes bridge integration.
+Alice is a pre-1.0 continuity platform for AI agents and agent-assisted workflows. It provides typed memory, provenance, correction-aware recall, open-loop tracking, resumable context, provider/runtime portability, and integration paths for external agent runtimes.
 
 ## Shipped Baseline
 - Phase 9 shipped the continuity core, CLI, MCP, importers, approvals, and evaluation foundation.
 - Phase 10 shipped the hosted/product layer, identity/workspace model, and channel surfaces.
-- Phase 11 shipped provider runtime abstraction, provider adapters, and model packs.
+- Phase 11 shipped provider runtime foundations, initial provider adapters, and model-pack primitives.
 - Bridge `B1` through `B4` shipped Hermes lifecycle hooks, auto-capture, review flow, explainability, packaging docs, smoke validation, and demo path.
 - Phase 12 shipped hybrid retrieval and reranking, explicit memory mutation operations, contradiction/trust handling, the public eval harness, and task-adaptive briefing.
 - Phase 13 shipped one-call continuity, Alice Lite, and memory hygiene / conversation health visibility.
 - `v0.4.0` is the latest published pre-1.0 release tag.
 
 ## Current Repo Posture
-- Phase 13 is shipped.
-- `P13-S1` One-Call Continuity is shipped.
-- `P13-S2` Alice Lite is shipped.
-- `P13-S3` Memory Hygiene + Conversation Health is shipped.
-- No post-Phase-13 execution sprint is active yet.
+- Phase 14 is active.
+- `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is the active execution sprint.
+- `P14-S2` Ollama + llama.cpp + vLLM Adapters is planned.
+- `P14-S3` Model Packs is planned.
+- `P14-S4` Reference Integrations is planned.
+- `P14-S5` Design Partner Launch is planned.
 
-## Latest Completed Phase
-### Phase 13: Alice Lite + Integration Ergonomics
-Phase 13 turned Alice from a powerful continuity system into an easier-to-adopt, easier-to-feel, and easier-to-integrate product for solo users, builders, and agent teams.
+## Active Phase
+### Phase 14: Provider Adapters + Design Partner Launch
+Turn Alice from a strong continuity system into a practical integration platform for local runtimes, self-hosted inference servers, enterprise-curious teams, and early design partners.
 
 ## Why This Phase Now
-Phase 12 improved Alice's internal quality:
-- hybrid retrieval
-- explicit memory mutation
-- contradiction and trust handling
-- public evals
-- task-adaptive briefing
-
-Phase 13 should make those gains easier to adopt:
-- simpler local install
-- a single continuity call for external runtimes
-- visible memory hygiene
-- visible conversation health
-- tighter docs and examples for real integrations
+Alice now has enough depth in continuity semantics. The next constraint is compatibility, proof, and adoption:
+- model/runtime compatibility
+- first-class provider adapters
+- plug-and-play model packs
+- reference integrations
+- design partner onboarding
+- usage proof in real environments
 
 ## Primary Users
-- Solo technical users who want fast setup, local-first usage, and useful continuity without heavy ops.
-- Agent builders who want one integration surface and less orchestration complexity.
-- Teams evaluating Alice who want obvious quality, visible hygiene, and quick demo value.
+- Builders who want to plug Alice into their own agents or workflows.
+- Self-hosters running local or private model stacks through Ollama, llama.cpp, or vLLM.
+- Enterprise-curious teams evaluating Alice with Azure or OpenAI-compatible infrastructure.
+- Design partners using Alice in production-like environments and generating adoption proof.
 
-## Phase 13 Scope That Shipped
-- One-call continuity API / CLI / MCP surface.
-- Alice Lite deployment profile and simplified local startup.
-- Memory hygiene visibility for duplicates, stale facts, unresolved contradictions, weak trust, and review backlog.
-- Conversation health visibility for recent threads, stale threads, risky threads, and thread activity.
-- Integration docs and demos for existing runtimes.
+## In Scope For Phase 14
+- Stable provider abstraction and workspace-scoped provider management.
+- First-class adapters for OpenAI-compatible, Ollama, llama.cpp, vLLM, and Azure-backed paths.
+- Declarative, versioned model packs with workspace binding and sensible defaults.
+- Reference integrations for Hermes, OpenClaw, generic Python agents, and generic TypeScript agents.
+- Design-partner onboarding, tracking, instrumentation, and structured feedback capture.
 
 ## Non-Goals
-- New channels.
-- New major connectors.
-- New vertical products.
+- New retrieval research.
 - Graph-database migration.
+- New channels.
 - Marketplace work.
-- Large enterprise/admin features.
-- New provider/runtime substrate work unless directly required to support the Phase 13 deliverables.
-- Deep new memory research.
+- Enterprise governance/compliance expansion.
+- Major vertical-agent work.
+- Deep browser/action automation.
 
 ## Success Criteria
-- A solo user can install Alice through a lightweight local path and get a useful continuity brief quickly.
-- An agent builder can call one main continuity surface instead of stitching together many tool calls.
-- Memory hygiene and conversation health become visible enough that stale/conflicting/risky states are obvious without deep system knowledge.
-- Alice feels simpler and more polished without weakening its continuity semantics.
+- Alice runs cleanly with OpenAI-compatible providers, Ollama, llama.cpp, vLLM, and Azure-backed paths.
+- Users can bind a model pack and get sensible continuity defaults without hand tuning.
+- Hermes and OpenClaw have polished, documented, and tested Alice paths.
+- Generic Python and TypeScript examples exist and are reproducible.
+- At least 3 design partners are onboarded or in active pilot, with concrete usage evidence and at least 1 strong reference workflow.
 
 ## Immediate Product Posture
-- `v0.4.0` is the current public release boundary for the completed Phase 13 surface.
-- The next product decision is Phase 14 definition on top of the shipped Phase 13 baseline.
+- `v0.4.0` remains the current public release boundary.
+- Phase 14 is a platform-and-adoption phase on top of the shipped Phase 13 baseline.
+- No Phase 14 deliverable is shipped yet; `P14-S1` is the first execution sprint.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Completed baseline included in this pre-1.0 public release:
 Historical planning/control artifacts remain available in:
 [docs/archive/planning/2026-04-08-context-compaction/README.md](docs/archive/planning/2026-04-08-context-compaction/README.md)
 
+Phase 14 planning is active on top of this released baseline.
+
 ## Why Alice exists
 
 AI assistants still fail in the same places:

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,42 +4,43 @@
 PASS
 
 ## criteria met
-- Phase 13 is fully closed out in the canonical control docs and now reads as shipped baseline truth instead of an active sprint.
-- `v0.4.0` release artifacts are in place:
-  - Phase 13 closeout summary
-  - closeout packet
-  - release checklist
-  - tag plan
-  - public release runbook
-- Current-facing docs and version metadata are aligned to the shipped Phase 13 boundary.
-- Required release gates passed on the final tree:
-  - control-doc truth
-  - unit + integration test suite
-  - web suite
-  - Alice Lite smoke
-  - Hermes provider smoke
-  - Hermes MCP smoke
-  - Hermes bridge demo
-  - public eval harness
-- The release-gate regression found during the first full Python run was fixed without weakening the intended outbound-provider security posture.
+- A provider can be registered through the API and through workspace config seeding.
+- Alice can invoke a compliant OpenAI-compatible endpoint through the provider abstraction.
+- Provider capabilities are stored and visible on registration and update flows.
+- Runtime invocation telemetry is persisted for both `provider_test` and `runtime_invoke`.
+- One-call continuity still works through the provider abstraction in the covered runtime integration tests.
+- The required live smoke flow was completed against a real local Alice API session and a temporary compliant stub provider.
+- I did not find local workstation paths, usernames, or similar local identifiers introduced in the reviewed sprint files and docs.
 
 ## criteria missed
-- None.
+- none
 
 ## quality issues
-- No blocking release-quality issues remain.
+- none blocking
 
 ## regression risks
-- Low residual risk. The only material issue found during release gating was the provider-security/test-contract drift, and the final reruns passed after a narrow fix.
+- Low residual risk in the changed area. The main earlier regression risk was the missing hosted RLS posture on `provider_invocation_telemetry`; that is now fixed and covered by tests.
 
 ## docs issues
-- No blocking docs issues remain.
+- none blocking
+- `ARCHITECTURE.md` and the Phase 14 provider contract doc were narrowed back to implemented `P14-S1` truth in this pass.
 
 ## should anything be added to RULES.md?
-- No further rule change is required for this release closeout.
+- Already addressed in this pass: `RULES.md` now requires new workspace-scoped hosted tables to ship with RLS enablement, workspace access policies, and a regression test.
 
 ## should anything update ARCHITECTURE.md?
-- No further architecture update is required before tag cut.
+- Already addressed in this pass: `ARCHITECTURE.md` now describes only implemented `P14-S1` provider/runtime additions instead of future-sprint APIs and tables.
 
 ## recommended next action
-- Tag and publish `v0.4.0`.
+1. Merge or hand off `P14-S1` as complete.
+2. Start `P14-S2` from the stabilized provider contract, telemetry baseline, and hosted RLS posture now in place.
+
+## verification reviewed
+- `python3 scripts/check_control_doc_truth.py` -> PASS
+- `./.venv/bin/pytest tests/unit/test_control_doc_truth.py -q` -> 5 passed
+- `./.venv/bin/pytest tests/unit/test_provider_runtime.py tests/unit/test_config.py tests/unit/test_20260415_0063_phase14_provider_invocation_telemetry.py -q` -> 21 passed
+- `./.venv/bin/pytest tests/integration/test_phase11_provider_runtime_api.py -q` -> 16 passed
+- `python3 -m py_compile scripts/run_phase14_openai_compatible_smoke.py` -> PASS
+- `python3 scripts/run_phase14_openai_compatible_smoke.py --help` -> PASS
+- `./.venv/bin/python scripts/run_phase14_openai_compatible_smoke.py --api-base-url http://127.0.0.1:8017 --session-token <redacted-session-token> --thread-id <generated-thread-id> --model gpt-5-mini` -> PASS
+- telemetry confirmation query -> rows for `provider_test` and `runtime_invoke` persisted

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,41 +12,66 @@
 
 These remain baseline truth and are not future milestones.
 
-## Current Planning Status
-- Phase 13 is shipped.
-- No post-Phase-13 execution sprint is active yet.
-- The next roadmap step is to define the next phase on top of the `v0.4.0` baseline.
+## Active Planning Status
+- Phase 14 is active.
+- `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is the active execution sprint.
+- `P14-S2` Ollama + llama.cpp + vLLM Adapters is planned.
+- `P14-S3` Model Packs is planned.
+- `P14-S4` Reference Integrations is planned.
+- `P14-S5` Design Partner Launch is planned.
 
-## Completed Phase 13 Sequence
+## Phase 14 Planned Milestones
 
-### P13-S1: One-Call Continuity
-- ship `POST /v1/continuity/brief`
-- ship matching CLI `alice brief`
-- ship matching MCP `alice_brief`
-- return one continuity bundle containing summary, recent changes, open loops, conflicts, next action, provenance, and trust posture
-- make this the default integration surface for external agents
+### P14-S1: Provider Abstraction Cleanup + OpenAI-Compatible Adapter
+- finalize the provider interface and provider registry
+- ship provider registration/update flows
+- ship capability discovery and provider test/healthcheck paths
+- ship OpenAI-compatible adapter normalization and invocation telemetry persistence
+- keep one-call continuity working through the provider abstraction
 
-Status: shipped
+Status: active
+Release target: internal provider-foundation release candidate
 
-### P13-S2: Alice Lite
-- add one-command local startup
-- add smaller-footprint deployment profile
-- tighten quickstart and first-result path
-- keep semantics aligned with the full Alice baseline
+### P14-S2: Ollama + llama.cpp + vLLM Adapters
+- ship adapters for the main local/self-hosted runtime classes
+- add local model quickstarts and example configs
+- add local compatibility smoke tests
 
-Status: shipped
+Status: planned
+Release target: `v0.5.0-rc1`
 
-### P13-S3: Memory Hygiene + Conversation Health
-- surface duplicates, stale facts, unresolved contradictions, and review queue pressure
-- surface recent threads, stale threads, risky threads, and thread health
-- improve operational visibility without adding new substrate work
+### P14-S3: Model Packs
+- ship versioned first-party model packs for the main OSS model families
+- add pack binding workflow
+- integrate pack defaults into runtime invocation and briefing
+- publish a compatibility matrix
 
-Status: shipped
+Status: planned
+Release target: `v0.5.0-rc2`
 
-## Next Roadmap Gate
-- Define the next phase explicitly before reactivating `.ai/active/SPRINT_PACKET.md` for new build work.
-- Preserve the shipped one-call continuity, Alice Lite, and hygiene/thread-health surfaces as baseline behavior.
+### P14-S4: Reference Integrations
+- polish Hermes and OpenClaw integration paths
+- ship generic Python and TypeScript example agents
+- add “which integration path should I use?” guidance
 
-## Beyond Phase 13
-- No post-Phase-13 feature plan is currently defined.
-- The next step after Phase 13 is to define the next phase, not to reopen Phase 13 work.
+Status: planned
+Release target: `v0.5.0`
+
+### P14-S5: Design Partner Launch
+- ship design-partner onboarding, tracking, instrumentation, and feedback workflows
+- onboard 3 to 5 design partners into active or structured pilot use
+- capture at least 1 candidate case study
+
+Status: planned
+Release target: `v0.5.1` or `v0.6.0-beta`
+
+## Sequencing Rules
+- Phase 14 is a platform-and-adoption phase.
+- Prioritize provider adapters, model packs, reference integrations, and design partner onboarding.
+- Do not allow scope drift into new substrate research, new channels, enterprise governance expansion, or major vertical-agent work unless required by a declared Phase 14 deliverable.
+- Preserve one-call continuity semantics across provider classes.
+- Treat docs as sprint deliverables, not cleanup work.
+
+## Beyond Phase 14
+- No post-Phase-14 feature plan is currently defined.
+- The next step after Phase 14 is to evaluate design-partner proof, release posture, and the next phase boundary.

--- a/RULES.md
+++ b/RULES.md
@@ -7,39 +7,41 @@
 - Keep [CURRENT_STATE.md](CURRENT_STATE.md) factual/current and [ROADMAP.md](ROADMAP.md) future-facing.
 - Keep [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURRENT_STATE.md) as the canonical handoff copy when duplicate current-state files exist.
 
-## Phase 13 Baseline Rules
-- Phase 13 shipped as an adoption layer on top of the Phase 12 baseline; preserve that narrowness in future work.
-- One-call continuity, Alice Lite, and hygiene/thread-health visibility are baseline surfaces now, not optional experiments.
-- Do not reopen Phase 13 with redundant substrate work disguised as polish.
+## Phase 14 Rule
+- Phase 14 is a platform-and-adoption phase. Prioritize provider adapters, model packs, reference integrations, and design partner onboarding. Do not allow scope drift into new substrate research, new channels, or enterprise governance work unless required by a declared Phase 14 deliverable.
 
-## Continuity Surface Rules
-- One-call continuity must compose existing retrieval, contradiction, trust, recent-change, open-loop, and briefing layers rather than fork them.
-- One-call continuity output must remain explainable, provenance-backed, and trust-aware.
-- Do not fork continuity semantics between API, CLI, MCP, hosted, provider-runtime, and Hermes paths.
+## Provider Rules
+- Continuity semantics must not fork by provider.
+- A provider may change capability support, latency, token budgets, and model-specific quirks.
+- A provider must not change the continuity object model, contradiction handling, provenance contracts, trust semantics, or one-call continuity behavior.
+- Provider capability discovery and invocation telemetry should be first-class, persisted, and inspectable.
 
-## Alice Lite Rules
-- Alice Lite is a deployment profile, not a separate product.
-- Alice Lite must preserve the same continuity semantics as the full baseline.
-- Do not move to SQLite or another embedded mode unless no semantics degrade, no retrieval features materially regress, and no explain/provenance breakage is introduced.
+## Model Pack Rules
+- Model packs are declarative, versioned profiles, not forks.
+- Packs may shape prompt/context behavior, tool strategy, briefing strategy, and runtime defaults.
+- Packs must not invent a second continuity model or bypass trust/provenance rules.
+- Ship only first-party packs for major families first; everything else waits.
 
-## Hygiene And Thread Health Rules
-- Hygiene surfaces should make duplicates, stale facts, contradictions, weak trust, and review pressure visible without inventing a second memory system.
-- Thread health should be diagnostic and operational, not a separate durable truth ontology.
-- Visibility comes before cleverness. Make risky or stale states obvious before adding more scoring complexity.
-
-## API And Integration Rules
+## Integration Rules
 - For Hermes, use provider hooks for automation and MCP for explicit deep actions.
 - Keep MCP fallback viable even when provider or bridge integrations are the recommended mode.
-- Reuse the current continuity contracts where possible; add new surfaces only when the existing contract cannot express the phase goal cleanly.
+- Reference integrations must be runnable and documented, not aspirational.
+- Generic Python and TypeScript integration examples are in-scope platform proof, not optional extras.
 
-## Security And Operations Rules
-- Preserve user/workspace isolation across retrieval, mutation, eval, briefing, hygiene, and thread-health flows.
-- Keep credentials, tokens, and secret references out of logs and error payloads.
-- Keep local filesystem paths, workstation usernames, and machine-specific identifiers out of committed docs and reports.
+## Design Partner Rules
+- Design partners are tracked product proof, not ad hoc support conversations.
+- Capture onboarding, pilot status, usage summaries, and structured feedback explicitly.
+- Choose small, opinionated pilot scopes over broad custom engagements.
+
+## Docs And Operations Rules
+- Docs are sprint deliverables, not cleanup work.
+- Provider docs, model-pack docs, integration docs, and onboarding docs must stay aligned to shipped behavior.
+- Keep credentials, tokens, and secret references out of logs, docs, and outward-facing errors.
+- Any new workspace-scoped hosted table must ship with row-level security enablement, workspace access policies, and a regression test for that access posture.
 - Keep consequential side effects approval-bounded.
 - Commit public evidence only from exact commands and stable fixtures, never from inferred pass states.
 
 ## Scope Rules
-- Do not widen future adoption/ergonomics work into retrieval research, graph migration, new channels, new provider/runtime work, marketplace work, or enterprise/admin expansion unless explicitly re-scoped.
+- Do not widen Phase 14 into retrieval research, graph migration, new channels, marketplace work, enterprise governance expansion, major vertical-agent work, or deep browser/action automation unless explicitly re-scoped.
 - Do not silently hardcode unresolved Control Tower decisions as permanent runtime behavior without recording the decision.
 - Surface underspecified decisions as Control Tower decisions instead of inventing scope.

--- a/apps/api/alembic/versions/20260415_0063_phase14_provider_invocation_telemetry.py
+++ b/apps/api/alembic/versions/20260415_0063_phase14_provider_invocation_telemetry.py
@@ -1,0 +1,103 @@
+"""Add Phase 14 provider invocation telemetry table."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260415_0063"
+down_revision = "20260415_0062"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_STATEMENTS = (
+    """
+        CREATE TABLE provider_invocation_telemetry (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          provider_id uuid NOT NULL REFERENCES model_providers(id) ON DELETE CASCADE,
+          thread_id uuid NULL REFERENCES threads(id) ON DELETE SET NULL,
+          invoked_by_user_account_id uuid NOT NULL REFERENCES user_accounts(id) ON DELETE RESTRICT,
+          invocation_kind text NOT NULL,
+          adapter_key text NOT NULL,
+          runtime_provider text NOT NULL,
+          requested_model text NOT NULL,
+          response_model text NULL,
+          response_id text NULL,
+          status text NOT NULL,
+          latency_ms integer NOT NULL,
+          usage jsonb NOT NULL DEFAULT '{}'::jsonb,
+          error_detail text NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          CONSTRAINT provider_invocation_telemetry_kind_check
+            CHECK (invocation_kind IN ('provider_test', 'runtime_invoke')),
+          CONSTRAINT provider_invocation_telemetry_adapter_key_length_check
+            CHECK (char_length(adapter_key) >= 1 AND char_length(adapter_key) <= 80),
+          CONSTRAINT provider_invocation_telemetry_runtime_provider_length_check
+            CHECK (char_length(runtime_provider) >= 1 AND char_length(runtime_provider) <= 80),
+          CONSTRAINT provider_invocation_telemetry_requested_model_length_check
+            CHECK (char_length(requested_model) >= 1 AND char_length(requested_model) <= 200),
+          CONSTRAINT provider_invocation_telemetry_response_model_length_check
+            CHECK (response_model IS NULL OR char_length(response_model) BETWEEN 1 AND 200),
+          CONSTRAINT provider_invocation_telemetry_response_id_length_check
+            CHECK (response_id IS NULL OR char_length(response_id) BETWEEN 1 AND 200),
+          CONSTRAINT provider_invocation_telemetry_status_check
+            CHECK (status IN ('succeeded', 'failed')),
+          CONSTRAINT provider_invocation_telemetry_latency_ms_check
+            CHECK (latency_ms >= 0)
+        )
+        """,
+    (
+        "CREATE INDEX provider_invocation_telemetry_workspace_created_idx "
+        "ON provider_invocation_telemetry (workspace_id, created_at DESC, id DESC)"
+    ),
+    (
+        "CREATE INDEX provider_invocation_telemetry_provider_created_idx "
+        "ON provider_invocation_telemetry (provider_id, created_at DESC, id DESC)"
+    ),
+    (
+        "CREATE INDEX provider_invocation_telemetry_thread_created_idx "
+        "ON provider_invocation_telemetry (thread_id, created_at DESC, id DESC)"
+    ),
+)
+
+_UPGRADE_GRANT_STATEMENTS = (
+    "GRANT SELECT, INSERT, UPDATE, DELETE ON provider_invocation_telemetry TO alicebot_app",
+)
+
+_UPGRADE_RLS_STATEMENTS = (
+    "ALTER TABLE provider_invocation_telemetry ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE provider_invocation_telemetry FORCE ROW LEVEL SECURITY",
+)
+
+_UPGRADE_POLICY_STATEMENTS = (
+    """
+        CREATE POLICY provider_invocation_telemetry_workspace_access ON provider_invocation_telemetry
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP POLICY IF EXISTS provider_invocation_telemetry_workspace_access ON provider_invocation_telemetry",
+    "ALTER TABLE provider_invocation_telemetry NO FORCE ROW LEVEL SECURITY",
+    "ALTER TABLE provider_invocation_telemetry DISABLE ROW LEVEL SECURITY",
+    "DROP TABLE IF EXISTS provider_invocation_telemetry",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_STATEMENTS)
+    _execute_statements(_UPGRADE_GRANT_STATEMENTS)
+    _execute_statements(_UPGRADE_RLS_STATEMENTS)
+    _execute_statements(_UPGRADE_POLICY_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/config.py
+++ b/apps/api/src/alicebot_api/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import lru_cache
+import json
 import os
 from uuid import UUID
 
@@ -33,6 +34,7 @@ DEFAULT_MODEL_API_KEY = ""
 DEFAULT_MODEL_TIMEOUT_SECONDS = 30
 DEFAULT_TASK_WORKSPACE_ROOT = "/tmp/alicebot/task-workspaces"
 DEFAULT_PROVIDER_SECRET_MANAGER_URL = ""
+DEFAULT_WORKSPACE_PROVIDER_CONFIGS_JSON = "[]"
 DEFAULT_GMAIL_SECRET_MANAGER_URL = ""
 DEFAULT_CALENDAR_SECRET_MANAGER_URL = ""
 DEFAULT_AUTH_USER_ID = ""
@@ -86,6 +88,20 @@ DEFAULT_RETRIEVAL_TRACE_RETENTION_DAYS = 14
 DEFAULT_LEGACY_V0_ENABLED_OUTSIDE_DEV = False
 
 Environment = Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class WorkspaceProviderConfig:
+    provider_key: str
+    display_name: str
+    base_url: str
+    api_key: str
+    default_model: str
+    auth_mode: str = "bearer"
+    model_list_path: str = "/models"
+    healthcheck_path: str = "/models"
+    invoke_path: str = "/responses"
+    metadata: Mapping[str, object] | None = None
 
 
 def _get_env_value(env: Environment, key: str, default: str) -> str:
@@ -148,6 +164,7 @@ class Settings:
     model_timeout_seconds: int = DEFAULT_MODEL_TIMEOUT_SECONDS
     task_workspace_root: str = DEFAULT_TASK_WORKSPACE_ROOT
     provider_secret_manager_url: str = DEFAULT_PROVIDER_SECRET_MANAGER_URL
+    workspace_provider_configs: tuple[WorkspaceProviderConfig, ...] = ()
     gmail_secret_manager_url: str = DEFAULT_GMAIL_SECRET_MANAGER_URL
     calendar_secret_manager_url: str = DEFAULT_CALENDAR_SECRET_MANAGER_URL
     auth_user_id: str = DEFAULT_AUTH_USER_ID
@@ -241,6 +258,13 @@ class Settings:
                 current_env,
                 "PROVIDER_SECRET_MANAGER_URL",
                 cls.provider_secret_manager_url,
+            ),
+            workspace_provider_configs=_parse_workspace_provider_configs(
+                _get_env_value(
+                    current_env,
+                    "WORKSPACE_PROVIDER_CONFIGS_JSON",
+                    DEFAULT_WORKSPACE_PROVIDER_CONFIGS_JSON,
+                )
             ),
             gmail_secret_manager_url=_get_env_value(
                 current_env,
@@ -437,6 +461,55 @@ class Settings:
         return _validate_settings(settings)
 
 
+def _parse_workspace_provider_configs(raw_value: str) -> tuple[WorkspaceProviderConfig, ...]:
+    normalized_raw = raw_value.strip()
+    if normalized_raw == "":
+        return ()
+
+    try:
+        payload = json.loads(normalized_raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("WORKSPACE_PROVIDER_CONFIGS_JSON must be valid JSON") from exc
+
+    if not isinstance(payload, list):
+        raise ValueError("WORKSPACE_PROVIDER_CONFIGS_JSON must decode to a list")
+
+    configs: list[WorkspaceProviderConfig] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"WORKSPACE_PROVIDER_CONFIGS_JSON[{index}] must be an object"
+            )
+
+        provider_key = str(item.get("provider_key", "openai_compatible")).strip()
+        if provider_key != "openai_compatible":
+            raise ValueError(
+                f"WORKSPACE_PROVIDER_CONFIGS_JSON[{index}].provider_key must be openai_compatible"
+            )
+
+        metadata = item.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise ValueError(
+                f"WORKSPACE_PROVIDER_CONFIGS_JSON[{index}].metadata must be an object"
+            )
+
+        config = WorkspaceProviderConfig(
+            provider_key=provider_key,
+            display_name=str(item.get("display_name", "")).strip(),
+            base_url=str(item.get("base_url", "")).strip(),
+            api_key=str(item.get("api_key", "")).strip(),
+            default_model=str(item.get("default_model", "")).strip(),
+            auth_mode=str(item.get("auth_mode", "bearer")).strip().lower(),
+            model_list_path=str(item.get("model_list_path", "/models")).strip(),
+            healthcheck_path=str(item.get("healthcheck_path", "/models")).strip(),
+            invoke_path=str(item.get("invoke_path", "/responses")).strip(),
+            metadata=metadata,
+        )
+        configs.append(config)
+
+    return tuple(configs)
+
+
 def _validate_settings(settings: Settings) -> Settings:
     if settings.auth_user_id != "":
         try:
@@ -494,6 +567,31 @@ def _validate_settings(settings: Settings) -> Settings:
         raise ValueError("RETRIEVAL_TRACE_RETENTION_DAYS must be a positive integer")
     if settings.trust_proxy_headers and len(settings.trusted_proxy_ips) == 0:
         raise ValueError("TRUSTED_PROXY_IPS must include at least one IP when TRUST_PROXY_HEADERS is enabled")
+    for index, provider_config in enumerate(settings.workspace_provider_configs):
+        if provider_config.display_name == "":
+            raise ValueError(
+                f"WORKSPACE_PROVIDER_CONFIGS_JSON[{index}].display_name is required"
+            )
+        if provider_config.base_url == "":
+            raise ValueError(
+                f"WORKSPACE_PROVIDER_CONFIGS_JSON[{index}].base_url is required"
+            )
+        if provider_config.default_model == "":
+            raise ValueError(
+                f"WORKSPACE_PROVIDER_CONFIGS_JSON[{index}].default_model is required"
+            )
+        if provider_config.auth_mode not in {"bearer", "none"}:
+            raise ValueError(
+                f"WORKSPACE_PROVIDER_CONFIGS_JSON[{index}].auth_mode must be bearer or none"
+            )
+        if provider_config.auth_mode == "bearer" and provider_config.api_key == "":
+            raise ValueError(
+                f"WORKSPACE_PROVIDER_CONFIGS_JSON[{index}].api_key is required when auth_mode is bearer"
+            )
+        if provider_config.auth_mode == "none" and provider_config.api_key != "":
+            raise ValueError(
+                f"WORKSPACE_PROVIDER_CONFIGS_JSON[{index}].api_key must be empty when auth_mode is none"
+            )
 
     if settings.app_env not in {"development", "test"}:
         if "*" in settings.cors_allowed_origins:

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -1766,6 +1766,7 @@ def _fallback_provider_capability_snapshot(
         adapter_key=adapter_key,
         runtime_provider=runtime_provider,
         supports_tool_calls=False,
+        supports_reasoning=False,
         supports_streaming=False,
         supports_store=False,
         supports_vision_input=False,
@@ -1788,21 +1789,116 @@ def _fallback_provider_capability_snapshot(
 
 def _invoke_runtime_provider_model(
     *,
+    store: ContinuityStore,
+    workspace_id: UUID,
+    invoked_by_user_account_id: UUID,
+    thread_id: UUID | None,
+    invocation_kind: str,
     adapter: ProviderAdapter,
     runtime_provider: RuntimeProviderConfig,
     settings: Settings,
     model_request: ModelInvocationRequest,
 ) -> ModelInvocationResponse:
+    started_at = time.monotonic()
     try:
-        return adapter.invoke(
+        model_response = adapter.invoke(
             config=runtime_provider,
             settings=settings,
             request=model_request,
         )
     except ValueError as exc:
-        raise ModelInvocationError(str(exc)) from exc
+        error_detail = str(exc)
+        store.record_provider_invocation_telemetry(
+            workspace_id=workspace_id,
+            provider_id=runtime_provider.provider_id,
+            thread_id=thread_id,
+            invoked_by_user_account_id=invoked_by_user_account_id,
+            invocation_kind=invocation_kind,
+            adapter_key=adapter.adapter_key,
+            runtime_provider=runtime_provider.model_provider,
+            requested_model=model_request.model,
+            response_model=None,
+            response_id=None,
+            status="failed",
+            latency_ms=max(0, int((time.monotonic() - started_at) * 1000)),
+            usage={"input_tokens": None, "output_tokens": None, "total_tokens": None},
+            error_detail=error_detail,
+        )
+        raise ModelInvocationError(error_detail) from exc
     except ModelInvocationError as exc:
-        raise ModelInvocationError(sanitize_provider_error_message(str(exc))) from exc
+        sanitized_error = sanitize_provider_error_message(str(exc))
+        store.record_provider_invocation_telemetry(
+            workspace_id=workspace_id,
+            provider_id=runtime_provider.provider_id,
+            thread_id=thread_id,
+            invoked_by_user_account_id=invoked_by_user_account_id,
+            invocation_kind=invocation_kind,
+            adapter_key=adapter.adapter_key,
+            runtime_provider=runtime_provider.model_provider,
+            requested_model=model_request.model,
+            response_model=None,
+            response_id=None,
+            status="failed",
+            latency_ms=max(0, int((time.monotonic() - started_at) * 1000)),
+            usage={"input_tokens": None, "output_tokens": None, "total_tokens": None},
+            error_detail=sanitized_error,
+        )
+        raise ModelInvocationError(sanitized_error) from exc
+
+    store.record_provider_invocation_telemetry(
+        workspace_id=workspace_id,
+        provider_id=runtime_provider.provider_id,
+        thread_id=thread_id,
+        invoked_by_user_account_id=invoked_by_user_account_id,
+        invocation_kind=invocation_kind,
+        adapter_key=adapter.adapter_key,
+        runtime_provider=runtime_provider.model_provider,
+        requested_model=model_request.model,
+        response_model=model_response.model,
+        response_id=model_response.response_id,
+        status="succeeded",
+        latency_ms=max(0, int((time.monotonic() - started_at) * 1000)),
+        usage=dict(model_response.usage),
+        error_detail=None,
+    )
+    return model_response
+
+
+def _seed_workspace_provider_configs(
+    *,
+    settings: Settings,
+    store: ContinuityStore,
+    workspace_id: UUID,
+    created_by_user_account_id: UUID,
+) -> None:
+    if len(settings.workspace_provider_configs) == 0:
+        return
+
+    existing_provider_keys = {
+        (provider["provider_key"], provider["display_name"])
+        for provider in store.list_model_providers_for_workspace(workspace_id=workspace_id)
+    }
+    for provider_config in settings.workspace_provider_configs:
+        provider_identity = (provider_config.provider_key, provider_config.display_name)
+        if provider_identity in existing_provider_keys:
+            continue
+        _register_workspace_provider(
+            settings=settings,
+            store=store,
+            workspace_id=workspace_id,
+            created_by_user_account_id=created_by_user_account_id,
+            provider_key=provider_config.provider_key,
+            display_name=provider_config.display_name,
+            base_url=provider_config.base_url,
+            api_key=provider_config.api_key,
+            auth_mode=provider_config.auth_mode,
+            default_model=provider_config.default_model,
+            model_list_path=provider_config.model_list_path,
+            healthcheck_path=provider_config.healthcheck_path,
+            invoke_path=provider_config.invoke_path,
+            metadata={} if provider_config.metadata is None else dict(provider_config.metadata),
+        )
+        existing_provider_keys.add(provider_identity)
 
 
 def _register_workspace_provider(
@@ -2038,6 +2134,166 @@ def _register_workspace_azure_provider(
         workspace_id=workspace_id,
         provider_id=provider["id"],
         discovered_by_user_account_id=created_by_user_account_id,
+        adapter_key=adapter.adapter_key,
+        discovery_status=discovery_status,
+        capability_snapshot=capability_snapshot,
+        discovery_error=discovery_error,
+    )
+    return provider, capability
+
+
+def _update_workspace_provider(
+    *,
+    settings: Settings,
+    store: ContinuityStore,
+    existing_provider: ModelProviderRow,
+    updated_by_user_account_id: UUID,
+    display_name: str | None,
+    base_url: str | None,
+    api_key: str | None,
+    ad_token: str | None,
+    auth_mode: str | None,
+    default_model: str | None,
+    model_list_path: str | None,
+    healthcheck_path: str | None,
+    invoke_path: str | None,
+    api_version: str | None,
+    metadata: dict[str, object] | None,
+) -> tuple[ModelProviderRow, ProviderCapabilityRow]:
+    provider_key = existing_provider["provider_key"]
+    normalized_display_name = (
+        existing_provider["display_name"] if display_name is None else display_name.strip()
+    )
+    normalized_base_url = existing_provider["base_url"] if base_url is None else base_url.strip()
+    normalized_default_model = (
+        existing_provider["default_model"] if default_model is None else default_model.strip()
+    )
+    normalized_model_list_path = (
+        existing_provider["model_list_path"]
+        if model_list_path is None
+        else _normalize_provider_path(field_name="model_list_path", value=model_list_path)
+    )
+    normalized_healthcheck_path = (
+        existing_provider["healthcheck_path"]
+        if healthcheck_path is None
+        else _normalize_provider_path(field_name="healthcheck_path", value=healthcheck_path)
+    )
+    normalized_invoke_path = (
+        existing_provider["invoke_path"]
+        if invoke_path is None
+        else _normalize_provider_path(field_name="invoke_path", value=invoke_path)
+    )
+    normalized_metadata = (
+        existing_provider["metadata"] if metadata is None else metadata
+    )
+
+    if normalized_display_name == "":
+        raise ValueError("display_name is required")
+    normalized_base_url = validate_provider_base_url(
+        normalized_base_url,
+        require_dns_resolution=False,
+    )
+    if normalized_default_model == "":
+        raise ValueError("default_model is required")
+
+    encoded_api_key = existing_provider["api_key"]
+    normalized_auth_mode = existing_provider["auth_mode"] if auth_mode is None else auth_mode.strip().lower()
+    normalized_api_version = existing_provider["azure_api_version"]
+    normalized_azure_secret_ref = existing_provider["azure_auth_secret_ref"]
+
+    if provider_key == AZURE_ADAPTER_KEY:
+        if normalized_auth_mode not in {AZURE_AUTH_MODE_API_KEY, AZURE_AUTH_MODE_AD_TOKEN}:
+            raise ValueError(f"unsupported auth_mode: {normalized_auth_mode}")
+        if api_version is not None:
+            normalized_api_version = _normalize_azure_api_version(api_version)
+        credential_update = api_key if normalized_auth_mode == AZURE_AUTH_MODE_API_KEY else ad_token
+        if credential_update is not None and credential_update.strip() != "":
+            secret_ref = build_provider_secret_ref(workspace_id=existing_provider["workspace_id"])
+            write_provider_api_key(
+                settings=settings,
+                secret_ref=secret_ref,
+                api_key=credential_update.strip(),
+            )
+            encoded_api_key = "auth_mode_azure_secret_ref"
+            normalized_azure_secret_ref = encode_provider_secret_ref(secret_ref=secret_ref)
+    else:
+        if normalized_auth_mode not in {"bearer", "none"}:
+            raise ValueError(f"unsupported auth_mode: {normalized_auth_mode}")
+        if normalized_auth_mode == "none":
+            if api_key is not None and api_key.strip() != "":
+                raise ValueError("api_key must be empty when auth_mode is none")
+            encoded_api_key = "auth_mode_none"
+        else:
+            if api_key is not None:
+                if api_key.strip() == "":
+                    raise ValueError("api_key is required when auth_mode is bearer")
+                secret_ref = build_provider_secret_ref(workspace_id=existing_provider["workspace_id"])
+                write_provider_api_key(
+                    settings=settings,
+                    secret_ref=secret_ref,
+                    api_key=api_key.strip(),
+                )
+                encoded_api_key = encode_provider_secret_ref(secret_ref=secret_ref)
+            elif existing_provider["auth_mode"] != "bearer":
+                raise ValueError("api_key is required when auth_mode is bearer")
+        normalized_api_version = ""
+        normalized_azure_secret_ref = ""
+
+    provider = store.update_model_provider(
+        provider_id=existing_provider["id"],
+        workspace_id=existing_provider["workspace_id"],
+        provider_key=provider_key,
+        model_provider=existing_provider["model_provider"],
+        display_name=normalized_display_name,
+        base_url=normalized_base_url,
+        api_key=encoded_api_key,
+        auth_mode=normalized_auth_mode,
+        default_model=normalized_default_model,
+        status=existing_provider["status"],
+        model_list_path=normalized_model_list_path,
+        healthcheck_path=normalized_healthcheck_path,
+        invoke_path=normalized_invoke_path,
+        azure_api_version=normalized_api_version,
+        azure_auth_secret_ref=normalized_azure_secret_ref,
+        metadata=normalized_metadata,
+    )
+
+    runtime_provider = resolve_runtime_provider_config_secrets(
+        config=RuntimeProviderConfig.from_row(provider),
+        settings=settings,
+    )
+    adapter = provider_adapter_registry.resolve(runtime_provider.provider_key)
+    discovery_status: str = "ready"
+    discovery_error: str | None = None
+    try:
+        capability_snapshot = adapter.discover_capabilities(
+            config=runtime_provider,
+            settings=settings,
+        )
+    except ModelInvocationError as exc:
+        sanitized_discovery_error = sanitize_provider_error_message(str(exc))
+        extra_snapshot_fields = None
+        if runtime_provider.provider_key == AZURE_ADAPTER_KEY:
+            extra_snapshot_fields = {
+                "azure_api_version": runtime_provider.azure_api_version.strip()
+                or DEFAULT_AZURE_API_VERSION,
+                "azure_auth_mode": runtime_provider.auth_mode,
+            }
+        capability_snapshot = _fallback_provider_capability_snapshot(
+            adapter_key=adapter.adapter_key,
+            runtime_provider=adapter.runtime_provider,
+            model_list_path=normalized_model_list_path,
+            healthcheck_path=normalized_healthcheck_path,
+            invoke_path=normalized_invoke_path,
+            extra_snapshot_fields=extra_snapshot_fields,
+        )
+        discovery_status = "failed"
+        discovery_error = sanitized_discovery_error
+
+    capability = store.upsert_provider_capability(
+        workspace_id=existing_provider["workspace_id"],
+        provider_id=provider["id"],
+        discovered_by_user_account_id=updated_by_user_account_id,
         adapter_key=adapter.adapter_key,
         discovery_status=discovery_status,
         capability_snapshot=capability_snapshot,
@@ -2563,6 +2819,22 @@ class TestProviderRequest(BaseModel):
         min_length=1,
         max_length=1000,
     )
+
+
+class UpdateProviderRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str | None = Field(default=None, min_length=1, max_length=120)
+    base_url: str | None = Field(default=None, min_length=1, max_length=500)
+    auth_mode: str | None = Field(default=None, min_length=1, max_length=40)
+    api_key: str | None = Field(default=None, max_length=8000)
+    ad_token: str | None = Field(default=None, max_length=16000)
+    api_version: str | None = Field(default=None, min_length=1, max_length=40)
+    default_model: str | None = Field(default=None, min_length=1, max_length=200)
+    model_list_path: str | None = Field(default=None, min_length=1, max_length=200)
+    healthcheck_path: str | None = Field(default=None, min_length=1, max_length=200)
+    invoke_path: str | None = Field(default=None, min_length=1, max_length=200)
+    metadata: dict[str, object] | None = None
 
 
 class CreateModelPackRequest(BaseModel):
@@ -7280,6 +7552,13 @@ def bootstrap_v1_workspace(
                     workspace_id=workspace["id"],
                     user_account_id=user_account_id,
                 )
+                store = ContinuityStore(conn)
+                _seed_workspace_provider_configs(
+                    settings=settings,
+                    store=store,
+                    workspace_id=workspace["id"],
+                    created_by_user_account_id=user_account_id,
+                )
                 preferences = ensure_user_preferences(conn, user_account_id=user_account_id)
                 status_payload = get_bootstrap_status(
                     conn,
@@ -7704,6 +7983,77 @@ def get_v1_provider(provider_id: UUID, request: Request) -> JSONResponse:
     )
 
 
+@app.patch("/v1/providers/{provider_id}")
+def update_v1_provider(
+    provider_id: UUID,
+    request: Request,
+    body: UpdateProviderRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                workspace = get_current_workspace(
+                    conn,
+                    user_account_id=resolution["user_account"]["id"],
+                    preferred_workspace_id=resolution["session"]["workspace_id"],
+                )
+                if workspace is None:
+                    return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+
+                store = ContinuityStore(conn)
+                provider = store.get_model_provider_for_workspace_optional(
+                    provider_id=provider_id,
+                    workspace_id=workspace["id"],
+                )
+                if provider is None:
+                    return JSONResponse(status_code=404, content={"detail": f"provider {provider_id} was not found"})
+
+                provider, capability = _update_workspace_provider(
+                    settings=settings,
+                    store=store,
+                    existing_provider=provider,
+                    updated_by_user_account_id=resolution["user_account"]["id"],
+                    display_name=body.display_name,
+                    base_url=body.base_url,
+                    api_key=body.api_key,
+                    ad_token=body.ad_token,
+                    auth_mode=body.auth_mode,
+                    default_model=body.default_model,
+                    model_list_path=body.model_list_path,
+                    healthcheck_path=body.healthcheck_path,
+                    invoke_path=body.invoke_path,
+                    api_version=body.api_version,
+                    metadata=body.metadata,
+                )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except psycopg.errors.UniqueViolation:
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "provider display_name must be unique within the workspace"},
+        )
+    except ProviderAdapterNotFoundError as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
+    except ProviderSecretManagerError as exc:
+        return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(
+        status_code=200,
+        content=jsonable_encoder(
+            {
+                "provider": _serialize_model_provider(provider),
+                "capabilities": _serialize_provider_capability(capability),
+            }
+        ),
+    )
+
+
 @app.post("/v1/providers/test")
 def test_v1_provider(request: Request, body: TestProviderRequest) -> JSONResponse:
     settings = get_settings()
@@ -7788,10 +8138,16 @@ def test_v1_provider(request: Request, body: TestProviderRequest) -> JSONRespons
                 )
 
                 try:
-                    model_response = adapter.invoke(
-                        config=runtime_provider,
+                    model_response = _invoke_runtime_provider_model(
+                        store=store,
+                        workspace_id=workspace["id"],
+                        invoked_by_user_account_id=resolution["user_account"]["id"],
+                        thread_id=None,
+                        invocation_kind="provider_test",
+                        adapter=adapter,
+                        runtime_provider=runtime_provider,
                         settings=settings,
-                        request=model_request,
+                        model_request=model_request,
                     )
                 except ModelInvocationError as exc:
                     sanitized_invoke_error = sanitize_provider_error_message(str(exc))
@@ -8240,6 +8596,7 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
 
     try:
         with user_connection(settings.database_url, user_account_id) as conn:
+            set_current_user_account(conn, user_account_id)
             store = ContinuityStore(conn)
             result = generate_response(
                 store=store,
@@ -8250,6 +8607,11 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
                 limits=runtime_limits,
                 runtime_override=(runtime_provider.model_provider, selected_model),
                 model_invoker=lambda model_request: _invoke_runtime_provider_model(
+                    store=store,
+                    workspace_id=workspace_id,
+                    invoked_by_user_account_id=user_account_id,
+                    thread_id=body.thread_id,
+                    invocation_kind="runtime_invoke",
                     adapter=adapter,
                     runtime_provider=runtime_provider,
                     settings=settings,

--- a/apps/api/src/alicebot_api/provider_runtime.py
+++ b/apps/api/src/alicebot_api/provider_runtime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 import json
-from typing import NotRequired, Protocol, TypedDict
+from typing import Any, NotRequired, Protocol, TypedDict
 from uuid import UUID
 
 from alicebot_api.azure_provider_helpers import (
@@ -62,6 +62,7 @@ class ProviderCapabilitySnapshot(TypedDict):
     supports_text_input: bool
     supports_text_output: bool
     supports_tool_calls: bool
+    supports_reasoning: bool
     supports_streaming: bool
     supports_store: bool
     supports_vision_input: bool
@@ -119,9 +120,66 @@ class RuntimeProviderConfig:
         )
 
 
+class ProviderHealthcheckResult(TypedDict):
+    status: str
+    endpoint: str
+
+
+class ProviderModelCatalogResult(TypedDict):
+    endpoint: str
+    models: list[str]
+
+
 class ProviderAdapter(Protocol):
     adapter_key: str
     runtime_provider: str
+
+    def healthcheck(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderHealthcheckResult: ...
+
+    def list_models(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderModelCatalogResult: ...
+
+    def invoke_responses(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+        request: ModelInvocationRequest,
+    ) -> ModelInvocationResponse: ...
+
+    def invoke_embeddings(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+        payload: dict[str, object],
+    ) -> dict[str, object]: ...
+
+    def supports_tools(self) -> bool: ...
+
+    def supports_reasoning(self) -> bool: ...
+
+    def supports_vision(self) -> bool: ...
+
+    def normalize_response(
+        self,
+        *,
+        request: ModelInvocationRequest,
+        payload: Any,
+    ) -> ModelInvocationResponse: ...
+
+    def normalize_usage(self, *, payload: Any) -> JsonObject: ...
+
+    def normalize_tool_schema(self, *, tool_schema: dict[str, object]) -> dict[str, object]: ...
 
     def discover_capabilities(
         self,
@@ -137,6 +195,98 @@ class ProviderAdapter(Protocol):
         settings: Settings,
         request: ModelInvocationRequest,
     ) -> ModelInvocationResponse: ...
+
+
+class BaseProviderAdapter:
+    adapter_key: str
+    runtime_provider: str
+
+    def supports_tools(self) -> bool:
+        return False
+
+    def supports_reasoning(self) -> bool:
+        return False
+
+    def supports_vision(self) -> bool:
+        return False
+
+    def normalize_response(
+        self,
+        *,
+        request: ModelInvocationRequest,
+        payload: Any,
+    ) -> ModelInvocationResponse:
+        if not isinstance(payload, ModelInvocationResponse):
+            raise ModelInvocationError("provider adapter returned invalid normalized response")
+        return payload
+
+    def normalize_usage(self, *, payload: Any) -> JsonObject:
+        if isinstance(payload, ModelInvocationResponse):
+            return dict(payload.usage)
+        if isinstance(payload, dict):
+            return payload
+        raise ModelInvocationError("provider adapter returned invalid usage payload")
+
+    def normalize_tool_schema(self, *, tool_schema: dict[str, object]) -> dict[str, object]:
+        return tool_schema
+
+    def invoke_embeddings(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+        payload: dict[str, object],
+    ) -> dict[str, object]:
+        del config, settings, payload
+        raise ModelInvocationError(f"{self.adapter_key} does not support embeddings")
+
+    def discover_capabilities(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderCapabilitySnapshot:
+        health = self.healthcheck(config=config, settings=settings)
+        model_catalog = self.list_models(config=config, settings=settings)
+        snapshot = normalized_capability_snapshot(
+            adapter_key=self.adapter_key,
+            runtime_provider=self.runtime_provider,
+            supports_tool_calls=self.supports_tools(),
+            supports_reasoning=self.supports_reasoning(),
+            supports_streaming=False,
+            supports_store=False,
+            supports_vision_input=self.supports_vision(),
+            supports_audio_input=False,
+        )
+        snapshot.update(
+            {
+                "health_status": health["status"],
+                "health_endpoint": health["endpoint"],
+                "models_endpoint": model_catalog["endpoint"],
+                "invoke_endpoint": config.invoke_path,
+                "model_count": len(model_catalog["models"]),
+                "models": model_catalog["models"],
+            }
+        )
+        return snapshot
+
+    def invoke(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+        request: ModelInvocationRequest,
+    ) -> ModelInvocationResponse:
+        if request.provider != self.runtime_provider:
+            raise ModelInvocationError(f"unsupported model provider: {request.provider}")
+        return self.normalize_response(
+            request=request,
+            payload=self.invoke_responses(
+                config=config,
+                settings=settings,
+                request=request,
+            ),
+        )
 
 
 class ProviderAdapterRegistry:
@@ -167,6 +317,7 @@ def normalized_capability_snapshot(
     adapter_key: str,
     runtime_provider: str,
     supports_tool_calls: bool,
+    supports_reasoning: bool,
     supports_streaming: bool,
     supports_store: bool,
     supports_vision_input: bool,
@@ -179,6 +330,7 @@ def normalized_capability_snapshot(
         "supports_text_input": True,
         "supports_text_output": True,
         "supports_tool_calls": supports_tool_calls,
+        "supports_reasoning": supports_reasoning,
         "supports_streaming": supports_streaming,
         "supports_store": supports_store,
         "supports_vision_input": supports_vision_input,
@@ -186,29 +338,53 @@ def normalized_capability_snapshot(
     }
 
 
-class OpenAICompatibleAdapter:
+class OpenAICompatibleAdapter(BaseProviderAdapter):
     adapter_key = OPENAI_COMPATIBLE_ADAPTER_KEY
     runtime_provider = OPENAI_RESPONSES_PROVIDER
+    default_healthcheck_path = "/models"
+    default_model_list_path = "/models"
+    default_invoke_path = "/responses"
 
-    def discover_capabilities(
+    def healthcheck(
         self,
         *,
         config: RuntimeProviderConfig,
         settings: Settings,
-    ) -> ProviderCapabilitySnapshot:
-        validate_provider_base_url(config.base_url, require_dns_resolution=False)
-        del settings
-        return normalized_capability_snapshot(
-            adapter_key=self.adapter_key,
-            runtime_provider=self.runtime_provider,
-            supports_tool_calls=False,
-            supports_streaming=False,
-            supports_store=False,
-            supports_vision_input=False,
-            supports_audio_input=False,
+    ) -> ProviderHealthcheckResult:
+        validated_base_url = validate_provider_base_url(config.base_url)
+        headers = build_auth_headers(auth_mode=config.auth_mode, api_key=config.api_key)
+        healthcheck_path = config.healthcheck_path or self.default_healthcheck_path
+        request_json(
+            method="GET",
+            base_url=validated_base_url,
+            path=healthcheck_path,
+            timeout_seconds=settings.healthcheck_timeout_seconds,
+            headers=headers,
         )
+        return {"status": "ok", "endpoint": healthcheck_path}
 
-    def invoke(
+    def list_models(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderModelCatalogResult:
+        validated_base_url = validate_provider_base_url(config.base_url)
+        headers = build_auth_headers(auth_mode=config.auth_mode, api_key=config.api_key)
+        model_list_path = config.model_list_path or self.default_model_list_path
+        payload = request_json(
+            method="GET",
+            base_url=validated_base_url,
+            path=model_list_path,
+            timeout_seconds=settings.healthcheck_timeout_seconds,
+            headers=headers,
+        )
+        return {
+            "endpoint": model_list_path,
+            "models": parse_azure_models(payload),
+        }
+
+    def invoke_responses(
         self,
         *,
         config: RuntimeProviderConfig,
@@ -224,29 +400,29 @@ class OpenAICompatibleAdapter:
                 base_url=validated_base_url,
                 api_key=config.api_key,
                 timeout_seconds=settings.model_timeout_seconds,
+                invoke_path=config.invoke_path or self.default_invoke_path,
             ),
             request=request,
         )
 
 
-class AzureAdapter:
+class AzureAdapter(BaseProviderAdapter):
     adapter_key = AZURE_ADAPTER_KEY
     runtime_provider = OPENAI_RESPONSES_PROVIDER
     default_healthcheck_path = "/openai/models"
     default_model_list_path = "/openai/models"
     default_invoke_path = "/openai/responses"
 
-    def discover_capabilities(
+    def healthcheck(
         self,
         *,
         config: RuntimeProviderConfig,
         settings: Settings,
-    ) -> ProviderCapabilitySnapshot:
+    ) -> ProviderHealthcheckResult:
         validated_base_url = validate_provider_base_url(config.base_url)
         api_version = config.azure_api_version.strip() or DEFAULT_AZURE_API_VERSION
         headers = build_azure_auth_headers(auth_mode=config.auth_mode, credential=config.api_key)
         healthcheck_path = config.healthcheck_path or self.default_healthcheck_path
-        model_list_path = config.model_list_path or self.default_model_list_path
         request_azure_json(
             method="GET",
             base_url=validated_base_url,
@@ -255,6 +431,18 @@ class AzureAdapter:
             timeout_seconds=settings.healthcheck_timeout_seconds,
             headers=headers,
         )
+        return {"status": "ok", "endpoint": healthcheck_path}
+
+    def list_models(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderModelCatalogResult:
+        validated_base_url = validate_provider_base_url(config.base_url)
+        api_version = config.azure_api_version.strip() or DEFAULT_AZURE_API_VERSION
+        headers = build_azure_auth_headers(auth_mode=config.auth_mode, credential=config.api_key)
+        model_list_path = config.model_list_path or self.default_model_list_path
         model_payload = request_azure_json(
             method="GET",
             base_url=validated_base_url,
@@ -263,31 +451,25 @@ class AzureAdapter:
             timeout_seconds=settings.healthcheck_timeout_seconds,
             headers=headers,
         )
-        models = parse_azure_models(model_payload)
-        snapshot = normalized_capability_snapshot(
-            adapter_key=self.adapter_key,
-            runtime_provider=self.runtime_provider,
-            supports_tool_calls=False,
-            supports_streaming=False,
-            supports_store=False,
-            supports_vision_input=False,
-            supports_audio_input=False,
-        )
+        return {"endpoint": model_list_path, "models": parse_azure_models(model_payload)}
+
+    def discover_capabilities(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderCapabilitySnapshot:
+        snapshot = super().discover_capabilities(config=config, settings=settings)
+        api_version = config.azure_api_version.strip() or DEFAULT_AZURE_API_VERSION
         snapshot.update(
             {
-                "health_status": "ok",
-                "health_endpoint": healthcheck_path,
-                "models_endpoint": model_list_path,
-                "invoke_endpoint": config.invoke_path or self.default_invoke_path,
-                "model_count": len(models),
-                "models": models,
                 "azure_api_version": api_version,
                 "azure_auth_mode": config.auth_mode,
             }
         )
         return snapshot
 
-    def invoke(
+    def invoke_responses(
         self,
         *,
         config: RuntimeProviderConfig,
@@ -308,23 +490,22 @@ class AzureAdapter:
         )
 
 
-class OllamaAdapter:
+class OllamaAdapter(BaseProviderAdapter):
     adapter_key = OLLAMA_ADAPTER_KEY
     runtime_provider = OPENAI_RESPONSES_PROVIDER
     default_healthcheck_path = "/api/version"
     default_model_list_path = "/api/tags"
     default_invoke_path = "/api/chat"
 
-    def discover_capabilities(
+    def healthcheck(
         self,
         *,
         config: RuntimeProviderConfig,
         settings: Settings,
-    ) -> ProviderCapabilitySnapshot:
+    ) -> ProviderHealthcheckResult:
         validated_base_url = validate_provider_base_url(config.base_url)
         headers = build_auth_headers(auth_mode=config.auth_mode, api_key=config.api_key)
         healthcheck_path = config.healthcheck_path or self.default_healthcheck_path
-        model_list_path = config.model_list_path or self.default_model_list_path
         request_json(
             method="GET",
             base_url=validated_base_url,
@@ -332,6 +513,17 @@ class OllamaAdapter:
             timeout_seconds=settings.healthcheck_timeout_seconds,
             headers=headers,
         )
+        return {"status": "ok", "endpoint": healthcheck_path}
+
+    def list_models(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderModelCatalogResult:
+        validated_base_url = validate_provider_base_url(config.base_url)
+        headers = build_auth_headers(auth_mode=config.auth_mode, api_key=config.api_key)
+        model_list_path = config.model_list_path or self.default_model_list_path
         model_payload = request_json(
             method="GET",
             base_url=validated_base_url,
@@ -339,29 +531,9 @@ class OllamaAdapter:
             timeout_seconds=settings.healthcheck_timeout_seconds,
             headers=headers,
         )
-        models = parse_ollama_models(model_payload)
-        snapshot = normalized_capability_snapshot(
-            adapter_key=self.adapter_key,
-            runtime_provider=self.runtime_provider,
-            supports_tool_calls=False,
-            supports_streaming=False,
-            supports_store=False,
-            supports_vision_input=False,
-            supports_audio_input=False,
-        )
-        snapshot.update(
-            {
-                "health_status": "ok",
-                "health_endpoint": healthcheck_path,
-                "models_endpoint": model_list_path,
-                "invoke_endpoint": config.invoke_path or self.default_invoke_path,
-                "model_count": len(models),
-                "models": models,
-            }
-        )
-        return snapshot
+        return {"endpoint": model_list_path, "models": parse_ollama_models(model_payload)}
 
-    def invoke(
+    def invoke_responses(
         self,
         *,
         config: RuntimeProviderConfig,
@@ -387,23 +559,22 @@ class OllamaAdapter:
         return parse_ollama_invoke_response(request=request, payload=payload)
 
 
-class LlamaCppAdapter:
+class LlamaCppAdapter(BaseProviderAdapter):
     adapter_key = LLAMACPP_ADAPTER_KEY
     runtime_provider = OPENAI_RESPONSES_PROVIDER
     default_healthcheck_path = "/health"
     default_model_list_path = "/v1/models"
     default_invoke_path = "/v1/chat/completions"
 
-    def discover_capabilities(
+    def healthcheck(
         self,
         *,
         config: RuntimeProviderConfig,
         settings: Settings,
-    ) -> ProviderCapabilitySnapshot:
+    ) -> ProviderHealthcheckResult:
         validated_base_url = validate_provider_base_url(config.base_url)
         headers = build_auth_headers(auth_mode=config.auth_mode, api_key=config.api_key)
         healthcheck_path = config.healthcheck_path or self.default_healthcheck_path
-        model_list_path = config.model_list_path or self.default_model_list_path
         request_json(
             method="GET",
             base_url=validated_base_url,
@@ -411,6 +582,17 @@ class LlamaCppAdapter:
             timeout_seconds=settings.healthcheck_timeout_seconds,
             headers=headers,
         )
+        return {"status": "ok", "endpoint": healthcheck_path}
+
+    def list_models(
+        self,
+        *,
+        config: RuntimeProviderConfig,
+        settings: Settings,
+    ) -> ProviderModelCatalogResult:
+        validated_base_url = validate_provider_base_url(config.base_url)
+        headers = build_auth_headers(auth_mode=config.auth_mode, api_key=config.api_key)
+        model_list_path = config.model_list_path or self.default_model_list_path
         model_payload = request_json(
             method="GET",
             base_url=validated_base_url,
@@ -418,29 +600,9 @@ class LlamaCppAdapter:
             timeout_seconds=settings.healthcheck_timeout_seconds,
             headers=headers,
         )
-        models = parse_llamacpp_models(model_payload)
-        snapshot = normalized_capability_snapshot(
-            adapter_key=self.adapter_key,
-            runtime_provider=self.runtime_provider,
-            supports_tool_calls=False,
-            supports_streaming=False,
-            supports_store=False,
-            supports_vision_input=False,
-            supports_audio_input=False,
-        )
-        snapshot.update(
-            {
-                "health_status": "ok",
-                "health_endpoint": healthcheck_path,
-                "models_endpoint": model_list_path,
-                "invoke_endpoint": config.invoke_path or self.default_invoke_path,
-                "model_count": len(models),
-                "models": models,
-            }
-        )
-        return snapshot
+        return {"endpoint": model_list_path, "models": parse_llamacpp_models(model_payload)}
 
-    def invoke(
+    def invoke_responses(
         self,
         *,
         config: RuntimeProviderConfig,

--- a/apps/api/src/alicebot_api/response_generation.py
+++ b/apps/api/src/alicebot_api/response_generation.py
@@ -60,6 +60,7 @@ class OpenAICompatibleTransportConfig:
     base_url: str
     api_key: str
     timeout_seconds: int
+    invoke_path: str = "/responses"
 
 
 class _OpenAIResponseContentItem(TypedDict, total=False):
@@ -246,8 +247,15 @@ def _extract_http_error_detail(exc: HTTPError) -> str | None:
     return None
 
 
-def _build_model_http_request(*, base_url: str, api_key: str, payload: JsonObject) -> Request:
-    endpoint = base_url.rstrip("/") + "/responses"
+def _build_model_http_request(
+    *,
+    base_url: str,
+    api_key: str,
+    invoke_path: str,
+    payload: JsonObject,
+) -> Request:
+    normalized_invoke_path = invoke_path if invoke_path.startswith("/") else f"/{invoke_path}"
+    endpoint = base_url.rstrip("/") + normalized_invoke_path
     return Request(
         endpoint,
         data=json.dumps(payload).encode("utf-8"),
@@ -319,6 +327,7 @@ def invoke_openai_compatible_model(
     http_request = _build_model_http_request(
         base_url=transport.base_url,
         api_key=transport.api_key,
+        invoke_path=transport.invoke_path,
         payload=payload,
     )
 

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -447,6 +447,25 @@ class ProviderCapabilityRow(TypedDict):
     updated_at: datetime
 
 
+class ProviderInvocationTelemetryRow(TypedDict):
+    id: UUID
+    workspace_id: UUID
+    provider_id: UUID
+    thread_id: UUID | None
+    invoked_by_user_account_id: UUID
+    invocation_kind: str
+    adapter_key: str
+    runtime_provider: str
+    requested_model: str
+    response_model: str | None
+    response_id: str | None
+    status: str
+    latency_ms: int
+    usage: JsonObject
+    error_detail: str | None
+    created_at: datetime
+
+
 class ModelPackRow(TypedDict):
     id: UUID
     workspace_id: UUID
@@ -2402,6 +2421,47 @@ LIST_MODEL_PROVIDERS_FOR_WORKSPACE_SQL = """
                 ORDER BY created_at ASC, id ASC
                 """
 
+UPDATE_MODEL_PROVIDER_SQL = """
+                UPDATE model_providers
+                SET provider_key = %s,
+                    model_provider = %s,
+                    display_name = %s,
+                    base_url = %s,
+                    api_key = %s,
+                    auth_mode = %s,
+                    default_model = %s,
+                    status = %s,
+                    model_list_path = %s,
+                    healthcheck_path = %s,
+                    invoke_path = %s,
+                    azure_api_version = %s,
+                    azure_auth_secret_ref = %s,
+                    metadata = %s,
+                    updated_at = clock_timestamp()
+                WHERE id = %s
+                  AND workspace_id = %s
+                RETURNING
+                  id,
+                  workspace_id,
+                  created_by_user_account_id,
+                  provider_key,
+                  model_provider,
+                  display_name,
+                  base_url,
+                  api_key,
+                  auth_mode,
+                  default_model,
+                  status,
+                  model_list_path,
+                  healthcheck_path,
+                  invoke_path,
+                  azure_api_version,
+                  azure_auth_secret_ref,
+                  metadata,
+                  created_at,
+                  updated_at
+                """
+
 UPSERT_PROVIDER_CAPABILITY_SQL = """
                 INSERT INTO provider_capabilities (
                   workspace_id,
@@ -2455,6 +2515,60 @@ GET_PROVIDER_CAPABILITY_FOR_PROVIDER_SQL = """
                 FROM provider_capabilities
                 WHERE provider_id = %s
                   AND workspace_id = %s
+                """
+
+INSERT_PROVIDER_INVOCATION_TELEMETRY_SQL = """
+                INSERT INTO provider_invocation_telemetry (
+                  workspace_id,
+                  provider_id,
+                  thread_id,
+                  invoked_by_user_account_id,
+                  invocation_kind,
+                  adapter_key,
+                  runtime_provider,
+                  requested_model,
+                  response_model,
+                  response_id,
+                  status,
+                  latency_ms,
+                  usage,
+                  error_detail,
+                  created_at
+                )
+                VALUES (
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  clock_timestamp()
+                )
+                RETURNING
+                  id,
+                  workspace_id,
+                  provider_id,
+                  thread_id,
+                  invoked_by_user_account_id,
+                  invocation_kind,
+                  adapter_key,
+                  runtime_provider,
+                  requested_model,
+                  response_model,
+                  response_id,
+                  status,
+                  latency_ms,
+                  usage,
+                  error_detail,
+                  created_at
                 """
 
 INSERT_MODEL_PACK_SQL = """
@@ -8209,6 +8323,49 @@ class ContinuityStore:
             (workspace_id,),
         )
 
+    def update_model_provider(
+        self,
+        *,
+        provider_id: UUID,
+        workspace_id: UUID,
+        provider_key: str,
+        model_provider: str,
+        display_name: str,
+        base_url: str,
+        api_key: str,
+        auth_mode: str,
+        default_model: str,
+        status: str,
+        model_list_path: str,
+        healthcheck_path: str,
+        invoke_path: str,
+        azure_api_version: str,
+        azure_auth_secret_ref: str,
+        metadata: JsonObject,
+    ) -> ModelProviderRow:
+        return self._fetch_one(
+            "update_model_provider",
+            UPDATE_MODEL_PROVIDER_SQL,
+            (
+                provider_key,
+                model_provider,
+                display_name,
+                base_url,
+                api_key,
+                auth_mode,
+                default_model,
+                status,
+                model_list_path,
+                healthcheck_path,
+                invoke_path,
+                azure_api_version,
+                azure_auth_secret_ref,
+                Jsonb(metadata),
+                provider_id,
+                workspace_id,
+            ),
+        )
+
     def upsert_provider_capability(
         self,
         *,
@@ -8243,6 +8400,45 @@ class ContinuityStore:
         return self._fetch_optional_one(
             GET_PROVIDER_CAPABILITY_FOR_PROVIDER_SQL,
             (provider_id, workspace_id),
+        )
+
+    def record_provider_invocation_telemetry(
+        self,
+        *,
+        workspace_id: UUID,
+        provider_id: UUID,
+        thread_id: UUID | None,
+        invoked_by_user_account_id: UUID,
+        invocation_kind: str,
+        adapter_key: str,
+        runtime_provider: str,
+        requested_model: str,
+        response_model: str | None,
+        response_id: str | None,
+        status: str,
+        latency_ms: int,
+        usage: JsonObject,
+        error_detail: str | None,
+    ) -> ProviderInvocationTelemetryRow:
+        return self._fetch_one(
+            "record_provider_invocation_telemetry",
+            INSERT_PROVIDER_INVOCATION_TELEMETRY_SQL,
+            (
+                workspace_id,
+                provider_id,
+                thread_id,
+                invoked_by_user_account_id,
+                invocation_kind,
+                adapter_key,
+                runtime_provider,
+                requested_model,
+                response_model,
+                response_id,
+                status,
+                latency_ms,
+                Jsonb(usage),
+                error_detail,
+            ),
         )
 
     def create_model_pack(

--- a/docs/integrations/phase14-provider-configuration.md
+++ b/docs/integrations/phase14-provider-configuration.md
@@ -1,0 +1,144 @@
+# Phase 14 Provider Configuration (P14-S1)
+
+This guide covers the Phase 14 provider foundation paths:
+
+- `POST /v1/providers`
+- `PATCH /v1/providers/{provider_id}`
+- `POST /v1/providers/test`
+- `POST /v1/runtime/invoke`
+- workspace bootstrap seeding through `WORKSPACE_PROVIDER_CONFIGS_JSON`
+- `scripts/run_phase14_openai_compatible_smoke.py`
+
+Scope note: this page documents the OpenAI-compatible foundation path owned by `P14-S1`.
+
+## API Registration
+
+Register an OpenAI-compatible provider in the current workspace:
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_key": "openai_compatible",
+    "display_name": "Primary OpenAI-Compatible",
+    "base_url": "https://provider.example/v1",
+    "api_key": "'"$PROVIDER_API_KEY"'",
+    "default_model": "gpt-5-mini"
+  }'
+```
+
+Capability discovery runs during registration and stores:
+
+- `health_status`
+- `health_endpoint`
+- `models_endpoint`
+- `invoke_endpoint`
+- `model_count`
+- `models`
+- `supports_reasoning`
+
+## Config Registration
+
+Workspace bootstrap can seed OpenAI-compatible providers from config with `WORKSPACE_PROVIDER_CONFIGS_JSON`.
+
+Example:
+
+```bash
+export WORKSPACE_PROVIDER_CONFIGS_JSON='[
+  {
+    "provider_key": "openai_compatible",
+    "display_name": "Configured OpenAI-Compatible",
+    "base_url": "https://provider.example/v1",
+    "api_key": "provider-secret-key",
+    "default_model": "gpt-5-mini",
+    "model_list_path": "/models",
+    "healthcheck_path": "/models",
+    "invoke_path": "/responses",
+    "metadata": {
+      "source": "workspace_bootstrap"
+    }
+  }
+]'
+```
+
+Then bootstrap the workspace normally:
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/workspaces/bootstrap" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"workspace_id": "'"$WORKSPACE_ID"'"}'
+```
+
+Providers from config are seeded once per workspace when bootstrap completes. Existing providers with the same `provider_key` and `display_name` are left in place.
+
+## Provider Updates
+
+Update provider configuration and refresh capability discovery:
+
+```bash
+curl -sS -X PATCH "http://127.0.0.1:8000/v1/providers/$PROVIDER_ID" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "Updated OpenAI-Compatible",
+    "base_url": "https://provider.example/v1",
+    "default_model": "gpt-4.1-mini",
+    "model_list_path": "/models",
+    "healthcheck_path": "/models",
+    "invoke_path": "/responses"
+  }'
+```
+
+For bearer-auth OpenAI-compatible providers, send `api_key` when rotating credentials.
+
+## Provider Test
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/providers/test" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_id": "'"$PROVIDER_ID"'",
+    "prompt": "Reply with one sentence confirming connectivity."
+  }'
+```
+
+The provider-test flow persists normalized invocation telemetry with status, latency, response ID, usage, and error detail.
+
+## Runtime Invoke
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8000/v1/runtime/invoke" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_id": "'"$PROVIDER_ID"'",
+    "thread_id": "'"$THREAD_ID"'",
+    "message": "Summarize runtime status in one sentence."
+  }'
+```
+
+One-call continuity still runs through the normal continuity compiler and response trace path. The provider layer adds capability discovery plus invocation telemetry without changing continuity semantics.
+
+## Smoke Script
+
+Run the Phase 14 smoke flow against a real endpoint:
+
+```bash
+./scripts/run_phase14_openai_compatible_smoke.py \
+  --session-token "$SESSION_TOKEN" \
+  --thread-id "$THREAD_ID" \
+  --provider-base-url "https://provider.example/v1" \
+  --model "gpt-5-mini"
+```
+
+Or let the script start a local compliant stub endpoint for the smoke run:
+
+```bash
+./scripts/run_phase14_openai_compatible_smoke.py \
+  --session-token "$SESSION_TOKEN" \
+  --thread-id "$THREAD_ID" \
+  --model "gpt-5-mini"
+```

--- a/docs/phase14-design-partner-launch.md
+++ b/docs/phase14-design-partner-launch.md
@@ -1,0 +1,32 @@
+# Phase 14 Design Partner Launch
+
+## Objective
+Turn Phase 14 technical readiness into real usage proof with a small number of close, high-signal partner pilots.
+
+## Design Partner Scope
+- 3 to 5 design partners
+- production-like or pilot environments
+- tracked onboarding, support, instrumentation, and feedback
+- at least 1 candidate case study underway by phase closeout
+
+## Core Objects
+- `design_partners`
+- `design_partner_workspaces`
+- `design_partner_feedback`
+
+## Operational Needs
+- partner onboarding workflow
+- workspace linkage
+- support and feedback logging
+- usage summaries
+- partner success dashboard
+- case-study template
+
+## Success Criteria
+- at least 3 partners are active or in structured pilot
+- usage summaries are visible
+- feedback is captured in a structured way
+- partner scopes stay opinionated and small enough to get fast value
+
+## Phase Rule
+Do not treat design-partner work as generic enterprise expansion. The goal is usage proof, feedback quality, and credible launch readiness rather than broad admin or governance buildout.

--- a/docs/phase14-launch-checklist.md
+++ b/docs/phase14-launch-checklist.md
@@ -1,0 +1,35 @@
+# Phase 14 Launch Checklist
+
+## Product Readiness
+- provider abstraction is stable
+- one-call continuity behavior is unchanged semantically
+- first-party model packs are usable
+- integrations are documented
+- local and hosted setup paths are both documented
+
+## Engineering Readiness
+- provider smoke tests pass
+- pack smoke tests pass
+- integration smoke tests pass
+- release gates remain green
+- migration and upgrade notes are complete
+
+## Documentation Readiness
+- quickstarts are current
+- compatibility matrix is published
+- provider docs are linked from the main README
+- integration docs are linked from the main README
+
+## Design Partner Readiness
+- onboarding doc is ready
+- support path is defined
+- instrumentation is ready
+- success checklist is ready
+- case-study template is ready
+
+## Demo Readiness
+- Alice + Ollama + one-call continuity demo
+- Alice + vLLM + model pack + generic agent demo
+- Hermes + Alice provider + MCP + continuity brief demo
+- OpenClaw + Alice import/augmentation + one-call continuity demo
+- optional Azure-backed enterprise continuity demo if capacity remains

--- a/docs/phase14-model-pack-contract.md
+++ b/docs/phase14-model-pack-contract.md
@@ -1,0 +1,46 @@
+# Phase 14 Model Pack Contract
+
+## Purpose
+Define the declarative pack profile Alice uses to make provider-backed models usable without manual tuning.
+
+## Rule
+Model packs are profiles, not forks.
+
+They may shape defaults for prompting, briefing, tools, token budgets, and quirks, but they must not create new continuity semantics.
+
+## Required Fields
+- `pack_id`
+- `family`
+- `display_name`
+- `provider_type`
+- `default_model_name`
+- `supports_tools`
+- `supports_reasoning`
+- `supports_vision`
+- `briefing_strategy`
+- `resume_brief_style`
+- `max_context_pack_tokens`
+- `max_brief_tokens`
+- `default_temperature`
+- `default_top_p`
+- `evidence_strategy`
+- `known_quirks`
+
+## Initial First-Party Families
+- Llama
+- Qwen
+- Gemma
+- `gpt-oss`
+
+Optional later Phase 14 families if capacity remains:
+- DeepSeek
+- Mistral
+
+## Binding Rules
+- a workspace binds a provider to a model pack
+- packs must be versioned
+- pack bindings may allow model-name override without semantic drift
+- pack defaults must flow into runtime invocation and briefing behavior
+
+## Success Condition
+Users should be able to bind a supported provider to a first-party pack and get sensible continuity defaults without hand tuning or hidden behavior changes.

--- a/docs/phase14-product-spec.md
+++ b/docs/phase14-product-spec.md
@@ -1,0 +1,50 @@
+# Phase 14 Product Spec
+
+## Phase Theme
+Provider Adapters + Design Partner Launch
+
+## Baseline
+Phase 13 closed in `v0.4.0` with:
+- one-call continuity across API, CLI, and MCP
+- Alice Lite local deployment profile
+- memory hygiene visibility
+- conversation health visibility
+- passing release gates and public eval coverage
+
+## Objective
+Make Alice the easiest continuity layer to plug into local model runtimes, self-hosted inference servers, hosted enterprise providers, external agent runtimes, and early design-partner workflows.
+
+## Phase Thesis
+Alice now has enough continuity depth. Phase 14 should optimize for compatibility, proof, and adoption rather than more memory-substrate research.
+
+## Primary Users
+- builders integrating Alice into their own agents or workflows
+- self-hosters running Ollama, llama.cpp, or vLLM
+- enterprise-curious teams evaluating Azure or OpenAI-compatible infrastructure
+- design partners using Alice in production-like conditions
+
+## In Scope
+- provider abstraction cleanup and first-class adapters
+- model packs with sensible continuity defaults
+- polished reference integrations
+- design-partner onboarding and usage proof
+
+## Out Of Scope
+- new retrieval research
+- graph-database migration
+- new channels
+- marketplace work
+- enterprise governance/compliance expansion
+- major vertical-agent expansion
+- deep browser or action-automation work
+
+## Success Criteria
+- Alice runs cleanly with OpenAI-compatible providers, Ollama, llama.cpp, vLLM, and Azure-backed provider paths
+- users can bind a model pack and get good continuity defaults without hand tuning
+- Hermes and OpenClaw have polished, documented, tested Alice paths
+- generic Python and TypeScript examples exist
+- at least 3 design partners are active or in structured pilot
+- external builders can quickly understand what Alice is, which runtimes it supports, how to integrate it, and how to get first value
+
+## Definition Of Done
+Phase 14 is done when Alice works cleanly across major provider/runtime classes, first-party model packs exist for major OSS model families, reference integrations are polished, design partners are live and producing feedback, and Alice is credibly operating as a continuity platform rather than just a repo.

--- a/docs/phase14-provider-adapter-contract.md
+++ b/docs/phase14-provider-adapter-contract.md
@@ -1,0 +1,55 @@
+# Phase 14 Provider Adapter Contract
+
+## Purpose
+Define the stable provider interface that every Alice runtime connector must implement in Phase 14.
+
+## Required Methods
+- `healthcheck()`
+- `list_models()`
+- `invoke_responses()`
+- `invoke_embeddings()`
+- `supports_tools()`
+- `supports_reasoning()`
+- `supports_vision()`
+- `normalize_response()`
+- `normalize_usage()`
+- `normalize_tool_schema()`
+- `discover_capabilities()`
+- `invoke()`
+
+## Extension Note
+Phase `P14-S1` standardizes the methods above. Streaming and provider-specific JSON-mode helpers can be added later if a future sprint needs them, but they are not part of the current stable contract.
+
+## Provider Responsibilities
+- translate provider-specific request/response details into Alice runtime semantics
+- expose capabilities without changing continuity behavior
+- normalize usage, latency, and error reporting
+- persist capability checks and invocation telemetry through the shared store
+
+## Continuity Invariants
+A provider adapter may affect:
+- capability support
+- latency
+- token budgets
+- model-specific behavior
+
+A provider adapter must not change:
+- the continuity object model
+- memory and trust semantics
+- contradiction handling
+- provenance contracts
+- one-call continuity behavior
+
+## Shared Surface
+`P14-S1` provider work supports:
+- provider registration and update
+- workspace bootstrap config seeding
+- provider test and capability persistence
+- runtime invocation through the shared continuity path
+
+## Initial Phase 14 Target Adapters
+- OpenAI-compatible for this sprint
+- Azure-backed path and local/self-hosted adapters remain follow-on Phase 14 work
+
+## Verification Expectation
+Every adapter must have parity-focused smoke coverage proving that continuity semantics remain stable while provider capabilities and operational behavior vary.

--- a/docs/phase14-s1-control-tower-packet.md
+++ b/docs/phase14-s1-control-tower-packet.md
@@ -1,0 +1,38 @@
+# P14-S1 Control Tower Packet
+
+## Sprint
+`P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter
+
+## Goal
+Create the stable provider foundation and unlock any OpenAI-compatible runtime without changing continuity semantics.
+
+## Branch
+`codex/phase14-s1-provider-foundation-openai-compatible`
+
+## In Scope
+- define the stable provider adapter interface in code
+- build provider registration and update flows
+- implement provider capability discovery
+- implement the OpenAI-compatible adapter
+- normalize usage, latency, and error telemetry
+- document provider configuration
+- add provider-level smoke tests
+
+## Out Of Scope
+- local adapter delivery beyond keeping the interface general
+- model-pack UX
+- reference integrations
+- design-partner operations
+
+## Acceptance Criteria
+- a provider can be registered via API and config
+- Alice can invoke a compliant OpenAI-compatible endpoint
+- provider capabilities are stored and visible
+- invocation telemetry is persisted
+- one-call continuity works through the provider abstraction
+
+## Verification
+- `python3 scripts/check_control_doc_truth.py`
+- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+- targeted provider runtime tests
+- compliant-endpoint smoke coverage

--- a/docs/phase14-s2-control-tower-packet.md
+++ b/docs/phase14-s2-control-tower-packet.md
@@ -1,0 +1,32 @@
+# P14-S2 Control Tower Packet
+
+## Sprint
+`P14-S2` Ollama + llama.cpp + vLLM Adapters
+
+## Goal
+Support the highest-value local and self-hosted inference paths on top of the Phase 14 provider contract.
+
+## Planned Branch
+`codex/phase14-s2-local-self-hosted-adapters`
+
+## In Scope
+- Ollama adapter
+- llama.cpp / llama-server adapter
+- vLLM adapter
+- provider-specific capability mappings
+- local model quickstarts
+- example configs
+- local compatibility smoke tests
+
+## Out Of Scope
+- model-pack UX beyond compatibility hooks
+- reference integrations
+- design-partner workflows
+- unrelated provider expansion
+
+## Acceptance Criteria
+- Alice works with local Ollama
+- Alice works with llama.cpp-compatible servers
+- Alice works with self-hosted vLLM
+- continuity semantics stay stable across all three
+- local quickstarts are reproducible

--- a/docs/phase14-s3-control-tower-packet.md
+++ b/docs/phase14-s3-control-tower-packet.md
@@ -1,0 +1,30 @@
+# P14-S3 Control Tower Packet
+
+## Sprint
+`P14-S3` Model Packs
+
+## Goal
+Make common model families easy to use with sensible continuity defaults.
+
+## Planned Branch
+`codex/phase14-s3-model-packs`
+
+## In Scope
+- model-pack schema and storage
+- model-pack API
+- workspace pack binding workflow
+- first-party packs for Llama, Qwen, Gemma, and `gpt-oss`
+- pack-aware invocation and briefing defaults
+- compatibility matrix docs
+- pack smoke tests
+
+## Out Of Scope
+- provider-contract redesign
+- broad provider expansion unrelated to packs
+- design-partner operations
+
+## Acceptance Criteria
+- a workspace can bind a provider to a pack
+- pack defaults affect briefing and runtime behavior correctly
+- first-party packs are versioned and documented
+- users get good defaults without manual tuning

--- a/docs/phase14-s4-control-tower-packet.md
+++ b/docs/phase14-s4-control-tower-packet.md
@@ -1,0 +1,29 @@
+# P14-S4 Control Tower Packet
+
+## Sprint
+`P14-S4` Reference Integrations
+
+## Goal
+Make Alice clearly adoptable by external agent builders.
+
+## Planned Branch
+`codex/phase14-s4-reference-integrations`
+
+## In Scope
+- Hermes integration docs refresh
+- OpenClaw integration docs refresh
+- generic Python agent example
+- generic TypeScript agent example
+- integration-path guidance
+- reproducible demos for major integration paths
+
+## Out Of Scope
+- new runtime substrate work unless strictly required
+- design-partner onboarding
+- marketplace or new-channel work
+
+## Acceptance Criteria
+- external builders can integrate Alice into Hermes from docs
+- external builders can integrate Alice into OpenClaw from docs
+- generic Python and TypeScript examples run successfully
+- at least one reproducible demo exists per major integration path

--- a/docs/phase14-s5-control-tower-packet.md
+++ b/docs/phase14-s5-control-tower-packet.md
@@ -1,0 +1,30 @@
+# P14-S5 Control Tower Packet
+
+## Sprint
+`P14-S5` Design Partner Launch
+
+## Goal
+Turn platform readiness into real-world usage proof and structured launch feedback.
+
+## Planned Branch
+`codex/phase14-s5-design-partner-launch`
+
+## In Scope
+- design-partner objects and workspace linkage
+- onboarding workflow and support checklist
+- partner usage summaries
+- feedback intake path
+- partner success dashboard
+- case-study template
+- first 3 to 5 partner onboardings
+
+## Out Of Scope
+- general enterprise governance expansion
+- unrelated channel work
+- broad marketing-site work beyond what partner launch requires
+
+## Acceptance Criteria
+- at least 3 design partners are active or in structured pilot
+- usage summaries are visible
+- feedback is captured in a structured way
+- at least one candidate case study is underway

--- a/docs/phase14-sprint-14-1-14-5-plan.md
+++ b/docs/phase14-sprint-14-1-14-5-plan.md
@@ -1,0 +1,126 @@
+# Phase 14 Sprint Plan
+
+## Sequence
+- `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter
+- `P14-S2` Ollama + llama.cpp + vLLM Adapters
+- `P14-S3` Model Packs
+- `P14-S4` Reference Integrations
+- `P14-S5` Design Partner Launch
+
+This sequence is intentionally non-redundant:
+- `P14-S1` stabilizes the provider contract and telemetry baseline
+- `P14-S2` proves local and self-hosted compatibility on top of that contract
+- `P14-S3` turns raw provider support into usable defaults
+- `P14-S4` makes adoption concrete for external builders
+- `P14-S5` turns technical readiness into real usage proof
+
+## P14-S1: Provider Abstraction Cleanup + OpenAI-Compatible Adapter
+
+### Objective
+Create the stable provider foundation and unlock any OpenAI-compatible runtime.
+
+### Deliverables
+- finalized provider interface
+- provider registry
+- provider capability discovery
+- OpenAI-compatible adapter
+- invocation telemetry normalization
+- provider configuration docs
+- provider smoke tests
+
+### Dependencies
+None
+
+### Release Target
+Internal provider-foundation release candidate
+
+### Status
+Active
+
+## P14-S2: Ollama + llama.cpp + vLLM Adapters
+
+### Objective
+Support the most important local and self-hosted inference paths without semantic drift.
+
+### Deliverables
+- Ollama adapter
+- llama.cpp-compatible adapter
+- vLLM adapter
+- local model quickstart docs
+- example configs
+- local compatibility smoke tests
+
+### Dependencies
+`P14-S1`
+
+### Release Target
+`v0.5.0-rc1`
+
+### Status
+Planned
+
+## P14-S3: Model Packs
+
+### Objective
+Make common model families easy to use with sensible continuity defaults.
+
+### Deliverables
+- model-pack schema and API
+- workspace pack binding workflow
+- first-party packs for Llama, Qwen, Gemma, and `gpt-oss`
+- pack compatibility matrix
+- pack smoke tests
+
+### Dependencies
+`P14-S1`, `P14-S2`
+
+### Release Target
+`v0.5.0-rc2`
+
+### Status
+Planned
+
+## P14-S4: Reference Integrations
+
+### Objective
+Make Alice clearly adoptable by external agent builders.
+
+### Deliverables
+- polished Hermes integration docs
+- polished OpenClaw integration docs
+- generic Python agent example
+- generic TypeScript agent example
+- integration-path guidance
+- reproducible demos for major paths
+
+### Dependencies
+`P14-S1` through `P14-S3`
+
+### Release Target
+`v0.5.0`
+
+### Status
+Planned
+
+## P14-S5: Design Partner Launch
+
+### Objective
+Move from platform readiness to real-world usage proof.
+
+### Deliverables
+- design-partner onboarding workflow
+- pilot support checklist
+- usage instrumentation
+- partner feedback path
+- partner success dashboard
+- case-study template
+- first 3 to 5 structured onboardings
+
+### Dependencies
+`P14-S1` through `P14-S4`
+
+### Release Target
+`v0.5.1` or `v0.6.0-beta`
+
+### Status
+Planned

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -22,38 +22,38 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
             "## Release Boundary (`v0.4.0`)",
             "Phase 13 adoption surfaces:",
             "Historical planning/control artifacts remain available in:",
+            "Phase 14 planning is active on top of this released baseline.",
         ),
     ),
     ControlDocTruthRule(
         relative_path="ROADMAP.md",
         required_markers=(
             "`v0.4.0`: released",
-            "Phase 13 is shipped.",
-            "No post-Phase-13 execution sprint is active yet.",
+            "Phase 14 is active.",
+            "`P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Phase 13 Closeout + `v0.4.0` Release",
+            "P14-S1: Provider Abstraction Cleanup + OpenAI-Compatible Adapter",
             "`v0.4.0` is the current public release boundary.",
-            "release-closeout",
+            "codex/phase14-s1-provider-foundation-openai-compatible",
         ),
     ),
     ControlDocTruthRule(
         relative_path="RULES.md",
         required_markers=(
-            "Treat Phases 9-13 and Bridge `B1` through `B4` as shipped baseline truth.",
-            "Alice Lite is a deployment profile, not a separate product.",
+            "Phase 14 is a platform-and-adoption phase.",
+            "Continuity semantics must not fork by provider.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/handoff/CURRENT_STATE.md",
         required_markers=(
-            "Phase 12 is shipped.",
             "`v0.4.0` is the latest published tag.",
-            "Phase 13 is shipped.",
-            "No post-Phase-13 build sprint is active yet.",
+            "Phase 14 is active.",
+            "`P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(

--- a/scripts/run_phase14_openai_compatible_smoke.py
+++ b/scripts/run_phase14_openai_compatible_smoke.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Run an OpenAI-compatible provider smoke flow for P14-S1.
+
+Flow:
+1) Register an OpenAI-compatible provider through `/v1/providers`
+2) Run `/v1/providers/test`
+3) Run `/v1/runtime/invoke`
+
+If `--provider-base-url` is omitted, the script starts a temporary local
+OpenAI-compatible stub endpoint for the smoke run.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+import json
+from typing import Any, Iterator
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import threading
+
+
+def _request_json(
+    *,
+    method: str,
+    url: str,
+    bearer_token: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = Request(
+        url=url,
+        method=method,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {bearer_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            raw_payload = response.read()
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed with HTTP {exc.code}: {error_body}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"{method} {url} failed: {exc.reason}") from exc
+
+    try:
+        parsed = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{method} {url} returned invalid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"{method} {url} returned invalid payload shape")
+    return parsed
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    model_name = "gpt-5-mini"
+
+    def _write_json(self, status_code: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path != "/v1/models":
+            self._write_json(404, {"error": {"message": "not found"}})
+            return
+        self._write_json(200, {"data": [{"id": self.model_name}]})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/v1/responses":
+            self._write_json(404, {"error": {"message": "not found"}})
+            return
+
+        content_length = int(self.headers.get("Content-Length", "0"))
+        raw_body = self.rfile.read(content_length)
+        try:
+            payload = json.loads(raw_body.decode("utf-8"))
+        except json.JSONDecodeError:
+            self._write_json(400, {"error": {"message": "invalid json"}})
+            return
+
+        model_name = payload.get("model")
+        if not isinstance(model_name, str) or model_name.strip() == "":
+            self._write_json(400, {"error": {"message": "model is required"}})
+            return
+
+        self._write_json(
+            200,
+            {
+                "id": "resp_phase14_smoke",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "OpenAI-compatible smoke OK"}],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 12,
+                    "output_tokens": 4,
+                    "total_tokens": 16,
+                },
+            },
+        )
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        del format, args
+
+
+@contextmanager
+def _temporary_stub_server(*, model_name: str) -> Iterator[str]:
+    handler = type(
+        "OpenAICompatibleSmokeHandler",
+        (_StubHandler,),
+        {"model_name": model_name},
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}/v1"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _run_flow(
+    *,
+    api_base_url: str,
+    session_token: str,
+    thread_id: str,
+    provider_base_url: str,
+    display_name: str,
+    model: str,
+    test_prompt: str,
+    message: str,
+) -> dict[str, object]:
+    register_response = _request_json(
+        method="POST",
+        url=f"{api_base_url.rstrip('/')}/v1/providers",
+        bearer_token=session_token,
+        payload={
+            "provider_key": "openai_compatible",
+            "display_name": display_name,
+            "base_url": provider_base_url,
+            "api_key": "phase14-smoke-key",
+            "default_model": model,
+            "metadata": {"source": "phase14_openai_compatible_smoke"},
+        },
+    )
+    provider_id = register_response["provider"]["id"]
+
+    test_response = _request_json(
+        method="POST",
+        url=f"{api_base_url.rstrip('/')}/v1/providers/test",
+        bearer_token=session_token,
+        payload={
+            "provider_id": provider_id,
+            "model": model,
+            "prompt": test_prompt,
+        },
+    )
+
+    invoke_response = _request_json(
+        method="POST",
+        url=f"{api_base_url.rstrip('/')}/v1/runtime/invoke",
+        bearer_token=session_token,
+        payload={
+            "provider_id": provider_id,
+            "thread_id": thread_id,
+            "message": message,
+            "model": model,
+        },
+    )
+
+    return {
+        "provider": register_response["provider"],
+        "capabilities": register_response["capabilities"],
+        "test_result": test_response["result"],
+        "runtime_assistant": invoke_response["assistant"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="run_phase14_openai_compatible_smoke.py",
+        description="Register and invoke an OpenAI-compatible provider through the P14-S1 runtime paths.",
+    )
+    parser.add_argument(
+        "--api-base-url",
+        default="http://127.0.0.1:8000",
+        help="Alice API base URL (default: http://127.0.0.1:8000).",
+    )
+    parser.add_argument(
+        "--session-token",
+        required=True,
+        help="Hosted session bearer token.",
+    )
+    parser.add_argument(
+        "--thread-id",
+        required=True,
+        help="Thread ID to use for /v1/runtime/invoke.",
+    )
+    parser.add_argument(
+        "--provider-base-url",
+        default=None,
+        help="OpenAI-compatible provider base URL. If omitted, a local compliant stub is started.",
+    )
+    parser.add_argument(
+        "--display-name",
+        default="OpenAI-Compatible Smoke",
+        help="Provider display name.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gpt-5-mini",
+        help="Model name to register/test/invoke.",
+    )
+    parser.add_argument(
+        "--test-prompt",
+        default="Reply with one sentence confirming OpenAI-compatible connectivity.",
+        help="Prompt used for /v1/providers/test.",
+    )
+    parser.add_argument(
+        "--message",
+        default="Give a concise runtime confirmation.",
+        help="Message used for /v1/runtime/invoke.",
+    )
+    args = parser.parse_args()
+
+    if args.provider_base_url is not None:
+        result = _run_flow(
+            api_base_url=args.api_base_url,
+            session_token=args.session_token,
+            thread_id=args.thread_id,
+            provider_base_url=args.provider_base_url.strip(),
+            display_name=args.display_name,
+            model=args.model,
+            test_prompt=args.test_prompt,
+            message=args.message,
+        )
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
+    with _temporary_stub_server(model_name=args.model) as stub_provider_base_url:
+        result = _run_flow(
+            api_base_url=args.api_base_url,
+            session_token=args.session_token,
+            thread_id=args.thread_id,
+            provider_base_url=stub_provider_base_url,
+            display_name=args.display_name,
+            model=args.model,
+            test_prompt=args.test_prompt,
+            message=args.message,
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_phase11_provider_runtime_api.py
+++ b/tests/integration/test_phase11_provider_runtime_api.py
@@ -13,7 +13,7 @@ import psycopg
 import pytest
 
 import apps.api.src.alicebot_api.main as main_module
-from apps.api.src.alicebot_api.config import Settings
+from apps.api.src.alicebot_api.config import Settings, WorkspaceProviderConfig
 
 
 def invoke_request(
@@ -179,6 +179,67 @@ class FakeHTTPResponse:
 
     def read(self) -> bytes:
         return self.body
+
+
+def install_openai_compatible_success(
+    monkeypatch,
+    *,
+    models: list[str] | None = None,
+    response_text: str = "OpenAI runtime response",
+    response_id: str = "resp_openai_1",
+    usage: dict[str, int] | None = None,
+) -> list[dict[str, object]]:
+    captured_requests: list[dict[str, object]] = []
+    resolved_models = ["gpt-5-mini"] if models is None else models
+    resolved_usage = (
+        {"input_tokens": 12, "output_tokens": 5, "total_tokens": 17}
+        if usage is None
+        else usage
+    )
+
+    def fake_discovery_urlopen(request, timeout):
+        captured_requests.append(
+            {
+                "url": request.full_url,
+                "timeout": timeout,
+                "headers": dict(request.header_items()),
+                "body": None if request.data is None else json.loads(request.data.decode("utf-8")),
+            }
+        )
+        if request.full_url.endswith("/models"):
+            return FakeHTTPResponse(
+                json.dumps({"data": [{"id": model_name} for model_name in resolved_models]}).encode("utf-8")
+            )
+        raise AssertionError(f"unexpected openai-compatible discovery URL: {request.full_url}")
+
+    def fake_invoke_urlopen(request, timeout):
+        captured_requests.append(
+            {
+                "url": request.full_url,
+                "timeout": timeout,
+                "headers": dict(request.header_items()),
+                "body": None if request.data is None else json.loads(request.data.decode("utf-8")),
+            }
+        )
+        return FakeHTTPResponse(
+            json.dumps(
+                {
+                    "id": response_id,
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "content": [{"type": "output_text", "text": response_text}],
+                        }
+                    ],
+                    "usage": resolved_usage,
+                }
+            ).encode("utf-8")
+        )
+
+    monkeypatch.setattr("alicebot_api.local_provider_helpers.urlopen", fake_discovery_urlopen)
+    monkeypatch.setattr("alicebot_api.response_generation.urlopen", fake_invoke_urlopen)
+    return captured_requests
 
 
 def test_phase11_local_provider_registration_list_and_detail(migrated_database_urls, monkeypatch) -> None:
@@ -471,6 +532,7 @@ def test_phase13_hosted_provider_rows_respect_workspace_rls(
     monkeypatch,
 ) -> None:
     _configure_settings(migrated_database_urls, monkeypatch)
+    install_openai_compatible_success(monkeypatch)
     owner_session_token, owner_workspace_id, owner_user_account_id = _bootstrap_workspace_session(
         "provider-rls-owner@example.com"
     )
@@ -617,6 +679,10 @@ def test_phase13_hosted_rls_blocks_cross_workspace_channel_identity_forgery(
 
 def test_phase11_openai_compatible_registration_still_works(migrated_database_urls, monkeypatch) -> None:
     _configure_settings(migrated_database_urls, monkeypatch)
+    captured_requests = install_openai_compatible_success(
+        monkeypatch,
+        models=["gpt-4.1-mini", "gpt-5-mini"],
+    )
     session_token, workspace_id, _ = _bootstrap_workspace_session("provider-openai-reg@example.com")
 
     create_status, create_payload = invoke_request(
@@ -637,6 +703,8 @@ def test_phase11_openai_compatible_registration_still_works(migrated_database_ur
     assert create_payload["provider"]["auth_mode"] == "bearer"
     assert create_payload["capabilities"]["discovery_status"] == "ready"
     assert create_payload["capabilities"]["snapshot"]["runtime_provider"] == "openai_responses"
+    assert create_payload["capabilities"]["snapshot"]["models"] == ["gpt-4.1-mini", "gpt-5-mini"]
+    assert any(record["url"] == "https://provider.example/v1/models" for record in captured_requests)
 
     with psycopg.connect(migrated_database_urls["admin"]) as conn:
         with conn.cursor() as cur:
@@ -655,6 +723,245 @@ def test_phase11_openai_compatible_registration_still_works(migrated_database_ur
     assert stored_auth_mode == "bearer"
     assert stored_api_key != "provider-secret-key"
     assert stored_api_key.startswith("provider_secret_ref:")
+
+
+def test_phase14_workspace_bootstrap_config_seed_and_provider_update_refresh_capabilities(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    captured_requests: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            database_url=migrated_database_urls["app"],
+            magic_link_ttl_seconds=600,
+            auth_session_ttl_seconds=3600,
+            device_link_ttl_seconds=600,
+            model_timeout_seconds=30,
+            workspace_provider_configs=(
+                WorkspaceProviderConfig(
+                    provider_key="openai_compatible",
+                    display_name="Configured OpenAI",
+                    base_url="https://provider.example/v1",
+                    api_key="provider-secret-key",
+                    default_model="gpt-5-mini",
+                ),
+            ),
+        ),
+    )
+
+    def fake_discovery_urlopen(request, timeout):
+        captured_requests.append(
+            {
+                "url": request.full_url,
+                "timeout": timeout,
+                "headers": dict(request.header_items()),
+                "body": None if request.data is None else json.loads(request.data.decode("utf-8")),
+            }
+        )
+        if request.full_url == "https://provider.example/v1/models":
+            return FakeHTTPResponse(json.dumps({"data": [{"id": "gpt-5-mini"}]}).encode("utf-8"))
+        if request.full_url == "https://updated-provider.example/v1/custom-models":
+            return FakeHTTPResponse(
+                json.dumps({"data": [{"id": "gpt-4.1-mini"}, {"id": "gpt-5-mini"}]}).encode("utf-8")
+            )
+        raise AssertionError(f"unexpected openai-compatible discovery URL: {request.full_url}")
+
+    monkeypatch.setattr("alicebot_api.local_provider_helpers.urlopen", fake_discovery_urlopen)
+
+    session_token, _, _ = _bootstrap_workspace_session("provider-bootstrap-config@example.com")
+
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v1/providers",
+        headers=auth_header(session_token),
+    )
+    assert list_status == 200
+    assert list_payload["summary"]["total_count"] == 1
+    provider_id = list_payload["items"][0]["id"]
+    assert list_payload["items"][0]["display_name"] == "Configured OpenAI"
+
+    update_status, update_payload = invoke_request(
+        "PATCH",
+        f"/v1/providers/{provider_id}",
+        payload={
+            "display_name": "Updated OpenAI",
+            "base_url": "https://updated-provider.example/v1",
+            "default_model": "gpt-4.1-mini",
+            "model_list_path": "/custom-models",
+            "healthcheck_path": "/custom-models",
+            "invoke_path": "/custom-responses",
+            "metadata": {"managed_by": "config"},
+        },
+        headers=auth_header(session_token),
+    )
+    assert update_status == 200
+    assert update_payload["provider"]["display_name"] == "Updated OpenAI"
+    assert update_payload["provider"]["invoke_path"] == "/custom-responses"
+    assert update_payload["capabilities"]["snapshot"]["models"] == ["gpt-4.1-mini", "gpt-5-mini"]
+    assert update_payload["capabilities"]["snapshot"]["models_endpoint"] == "/custom-models"
+    assert any(record["url"] == "https://provider.example/v1/models" for record in captured_requests)
+    assert any(
+        record["url"] == "https://updated-provider.example/v1/custom-models"
+        for record in captured_requests
+    )
+
+
+def test_phase14_provider_invocation_telemetry_persists_for_test_and_runtime(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    install_openai_compatible_success(
+        monkeypatch,
+        models=["gpt-5-mini"],
+        response_text="Telemetry runtime response",
+        response_id="resp_telemetry_1",
+        usage={"input_tokens": 14, "output_tokens": 3, "total_tokens": 17},
+    )
+    session_token, workspace_id, user_account_id = _bootstrap_workspace_session(
+        "provider-telemetry@example.com"
+    )
+
+    create_status, create_payload = invoke_request(
+        "POST",
+        "/v1/providers",
+        payload={
+            "provider_key": "openai_compatible",
+            "display_name": "Telemetry OpenAI",
+            "base_url": "https://provider.example/v1",
+            "api_key": "provider-secret-key",
+            "default_model": "gpt-5-mini",
+        },
+        headers=auth_header(session_token),
+    )
+    assert create_status == 201
+    provider_id = create_payload["provider"]["id"]
+
+    thread_id = _seed_thread_for_user(
+        admin_db_url=migrated_database_urls["admin"],
+        user_id=user_account_id,
+        email="provider-telemetry@example.com",
+    )
+
+    provider_test_status, provider_test_payload = invoke_request(
+        "POST",
+        "/v1/providers/test",
+        payload={"provider_id": provider_id},
+        headers=auth_header(session_token),
+    )
+    assert provider_test_status == 200
+    assert provider_test_payload["result"]["response_id"] == "resp_telemetry_1"
+
+    runtime_status, runtime_payload = invoke_request(
+        "POST",
+        "/v1/runtime/invoke",
+        payload={
+            "provider_id": provider_id,
+            "thread_id": thread_id,
+            "message": "Persist provider invocation telemetry.",
+        },
+        headers=auth_header(session_token),
+    )
+    assert runtime_status == 200
+    assert runtime_payload["assistant"]["response_id"] == "resp_telemetry_1"
+
+    with psycopg.connect(migrated_database_urls["admin"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT invocation_kind,
+                       status,
+                       thread_id,
+                       response_id,
+                       usage->>'total_tokens' AS total_tokens,
+                       runtime_provider
+                FROM provider_invocation_telemetry
+                WHERE workspace_id = %s
+                  AND provider_id = %s
+                ORDER BY created_at ASC, id ASC
+                """,
+                (workspace_id, provider_id),
+            )
+            telemetry_rows = cur.fetchall()
+
+    assert len(telemetry_rows) == 2
+    assert telemetry_rows[0][0] == "provider_test"
+    assert telemetry_rows[0][1] == "succeeded"
+    assert telemetry_rows[0][2] is None
+    assert telemetry_rows[0][3] == "resp_telemetry_1"
+    assert telemetry_rows[0][4] == "17"
+    assert telemetry_rows[0][5] == "openai_responses"
+    assert telemetry_rows[1][0] == "runtime_invoke"
+    assert telemetry_rows[1][1] == "succeeded"
+    assert str(telemetry_rows[1][2]) == thread_id
+    assert telemetry_rows[1][3] == "resp_telemetry_1"
+    assert telemetry_rows[1][4] == "17"
+    assert telemetry_rows[1][5] == "openai_responses"
+
+
+def test_phase14_provider_invocation_telemetry_respects_workspace_rls(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    install_openai_compatible_success(monkeypatch)
+    owner_session_token, _, owner_user_account_id = _bootstrap_workspace_session(
+        "provider-telemetry-rls-owner@example.com"
+    )
+    _, _, other_user_account_id = _bootstrap_workspace_session(
+        "provider-telemetry-rls-other@example.com"
+    )
+
+    create_status, create_payload = invoke_request(
+        "POST",
+        "/v1/providers",
+        payload={
+            "provider_key": "openai_compatible",
+            "display_name": "Telemetry RLS Provider",
+            "base_url": "https://provider.example/v1",
+            "api_key": "provider-secret-key",
+            "default_model": "gpt-5-mini",
+        },
+        headers=auth_header(owner_session_token),
+    )
+    assert create_status == 201
+    provider_id = create_payload["provider"]["id"]
+
+    provider_test_status, _ = invoke_request(
+        "POST",
+        "/v1/providers/test",
+        payload={"provider_id": provider_id},
+        headers=auth_header(owner_session_token),
+    )
+    assert provider_test_status == 200
+
+    with psycopg.connect(migrated_database_urls["app"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT set_config('app.current_user_account_id', %s, true)",
+                (other_user_account_id,),
+            )
+            cur.execute(
+                "SELECT count(*) FROM provider_invocation_telemetry WHERE provider_id = %s",
+                (provider_id,),
+            )
+            other_visible_count = cur.fetchone()[0]
+
+            cur.execute(
+                "SELECT set_config('app.current_user_account_id', %s, true)",
+                (owner_user_account_id,),
+            )
+            cur.execute(
+                "SELECT count(*) FROM provider_invocation_telemetry WHERE provider_id = %s",
+                (provider_id,),
+            )
+            owner_visible_count = cur.fetchone()[0]
+
+    assert other_visible_count == 0
+    assert owner_visible_count == 1
 
 
 def test_phase11_local_provider_rejects_api_key_when_auth_mode_none(
@@ -962,6 +1269,7 @@ def test_phase11_provider_test_and_runtime_reject_disallowed_target_without_outb
     monkeypatch,
 ) -> None:
     _configure_settings(migrated_database_urls, monkeypatch)
+    install_openai_compatible_success(monkeypatch)
     session_token, workspace_id, user_account_id = _bootstrap_workspace_session(
         "provider-security-blocked-runtime@example.com"
     )
@@ -1125,6 +1433,7 @@ def test_phase11_provider_error_reflection_and_persistence_are_sanitized(
     monkeypatch,
 ) -> None:
     _configure_settings(migrated_database_urls, monkeypatch)
+    install_openai_compatible_success(monkeypatch)
     session_token, _, user_account_id = _bootstrap_workspace_session(
         "provider-security-sanitized-errors@example.com"
     )

--- a/tests/unit/test_20260415_0063_phase14_provider_invocation_telemetry.py
+++ b/tests/unit/test_20260415_0063_phase14_provider_invocation_telemetry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260415_0063_phase14_provider_invocation_telemetry"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == [
+        *module._UPGRADE_STATEMENTS,
+        *module._UPGRADE_GRANT_STATEMENTS,
+        *module._UPGRADE_RLS_STATEMENTS,
+        *module._UPGRADE_POLICY_STATEMENTS,
+    ]
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_upgrade_defines_workspace_access_policy() -> None:
+    module = load_migration_module()
+    policy_sql = "\n".join(module._UPGRADE_POLICY_STATEMENTS)
+
+    assert "CREATE POLICY provider_invocation_telemetry_workspace_access" in policy_sql
+    assert "app.hosted_workspace_access_allowed(workspace_id)" in policy_sql

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -73,6 +73,7 @@ def test_settings_defaults(monkeypatch):
     assert settings.model_name == "gpt-5-mini"
     assert settings.model_timeout_seconds == 30
     assert settings.task_workspace_root == "/tmp/alicebot/task-workspaces"
+    assert settings.workspace_provider_configs == ()
     assert settings.gmail_secret_manager_url == ""
     assert settings.calendar_secret_manager_url == ""
     assert settings.auth_user_id == ""
@@ -171,6 +172,7 @@ def test_settings_honor_environment_overrides(monkeypatch):
     assert settings.model_name == "gpt-5"
     assert settings.model_timeout_seconds == 45
     assert settings.task_workspace_root == "/tmp/custom-workspaces"
+    assert settings.workspace_provider_configs == ()
     assert settings.gmail_secret_manager_url == "file:///tmp/custom-gmail-secrets"
     assert settings.calendar_secret_manager_url == "file:///tmp/custom-calendar-secrets"
     assert settings.auth_user_id == "00000000-0000-0000-0000-000000000001"
@@ -216,6 +218,12 @@ def test_settings_can_be_loaded_from_an_explicit_environment_mapping() -> None:
             "MODEL_PROVIDER": "openai_responses",
             "MODEL_NAME": "gpt-5-mini",
             "TASK_WORKSPACE_ROOT": "/tmp/mapped-workspaces",
+            "WORKSPACE_PROVIDER_CONFIGS_JSON": (
+                '[{"display_name":"Configured OpenAI",'
+                '"base_url":"https://provider.example/v1",'
+                '"api_key":"provider-secret-key",'
+                '"default_model":"gpt-5-mini"}]'
+            ),
             "GMAIL_SECRET_MANAGER_URL": "file:///tmp/mapped-gmail-secrets",
             "CALENDAR_SECRET_MANAGER_URL": "file:///tmp/mapped-calendar-secrets",
             "ALICEBOT_AUTH_USER_ID": "00000000-0000-0000-0000-000000000001",
@@ -259,6 +267,9 @@ def test_settings_can_be_loaded_from_an_explicit_environment_mapping() -> None:
     assert settings.model_provider == "openai_responses"
     assert settings.model_name == "gpt-5-mini"
     assert settings.task_workspace_root == "/tmp/mapped-workspaces"
+    assert len(settings.workspace_provider_configs) == 1
+    assert settings.workspace_provider_configs[0].display_name == "Configured OpenAI"
+    assert settings.workspace_provider_configs[0].provider_key == "openai_compatible"
     assert settings.gmail_secret_manager_url == "file:///tmp/mapped-gmail-secrets"
     assert settings.calendar_secret_manager_url == "file:///tmp/mapped-calendar-secrets"
     assert settings.auth_user_id == "00000000-0000-0000-0000-000000000001"
@@ -309,6 +320,25 @@ def test_settings_raise_clear_error_for_invalid_integer_values() -> None:
 def test_settings_reject_invalid_auth_user_id() -> None:
     with pytest.raises(ValueError, match="ALICEBOT_AUTH_USER_ID must be a valid UUID"):
         Settings.from_env({"ALICEBOT_AUTH_USER_ID": "not-a-uuid"})
+
+
+def test_settings_reject_invalid_workspace_provider_configs_json() -> None:
+    with pytest.raises(ValueError, match="WORKSPACE_PROVIDER_CONFIGS_JSON must be valid JSON"):
+        Settings.from_env({"WORKSPACE_PROVIDER_CONFIGS_JSON": "not-json"})
+
+    with pytest.raises(
+        ValueError,
+        match="WORKSPACE_PROVIDER_CONFIGS_JSON\\[0\\]\\.api_key is required when auth_mode is bearer",
+    ):
+        Settings.from_env(
+            {
+                "WORKSPACE_PROVIDER_CONFIGS_JSON": (
+                    '[{"display_name":"Configured OpenAI",'
+                    '"base_url":"https://provider.example/v1",'
+                    '"default_model":"gpt-5-mini"}]'
+                )
+            }
+        )
 
 
 def test_settings_reject_non_positive_rate_limit_values() -> None:

--- a/tests/unit/test_provider_runtime.py
+++ b/tests/unit/test_provider_runtime.py
@@ -142,13 +142,17 @@ def test_openai_compatible_adapter_invokes_registered_transport(monkeypatch) -> 
     captured: dict[str, object] = {}
     registry = make_provider_adapter_registry()
     adapter = registry.resolve(OPENAI_COMPATIBLE_ADAPTER_KEY)
-    runtime_provider = make_runtime_provider_config()
+    runtime_provider = make_runtime_provider_config(invoke_path="/responses-alt")
 
     def fake_urlopen(request, timeout):
         captured["url"] = request.full_url
         captured["timeout"] = timeout
         captured["headers"] = dict(request.header_items())
-        captured["body"] = json.loads(request.data.decode("utf-8"))
+        captured["body"] = None if request.data is None else json.loads(request.data.decode("utf-8"))
+        if request.full_url.endswith("/models"):
+            return FakeHTTPResponse(
+                json.dumps({"data": [{"id": "gpt-4.1-mini"}, {"id": "gpt-5-mini"}]}).encode("utf-8")
+            )
         return FakeHTTPResponse(
             json.dumps(
                 {
@@ -169,8 +173,13 @@ def test_openai_compatible_adapter_invokes_registered_transport(monkeypatch) -> 
             ).encode("utf-8")
         )
 
+    monkeypatch.setattr("alicebot_api.local_provider_helpers.urlopen", fake_urlopen)
     monkeypatch.setattr("alicebot_api.response_generation.urlopen", fake_urlopen)
 
+    capabilities = adapter.discover_capabilities(
+        config=runtime_provider,
+        settings=Settings(healthcheck_timeout_seconds=9),
+    )
     response = adapter.invoke(
         config=runtime_provider,
         settings=Settings(model_timeout_seconds=27),
@@ -181,7 +190,12 @@ def test_openai_compatible_adapter_invokes_registered_transport(monkeypatch) -> 
         ),
     )
 
-    assert captured["url"] == "https://provider.example/v1/responses"
+    assert capabilities["health_status"] == "ok"
+    assert capabilities["models"] == ["gpt-4.1-mini", "gpt-5-mini"]
+    assert capabilities["models_endpoint"] == "/models"
+    assert capabilities["invoke_endpoint"] == "/responses-alt"
+    assert capabilities["supports_reasoning"] is False
+    assert captured["url"] == "https://provider.example/v1/responses-alt"
     assert captured["timeout"] == 27
     assert captured["headers"]["Authorization"] == "Bearer provider-secret-key"
     assert response.provider == OPENAI_RESPONSES_PROVIDER


### PR DESCRIPTION
## Summary
- finalize the Phase 14 provider foundation and OpenAI-compatible adapter implementation for P14-S1
- add provider registration and update flows, capability discovery, normalized invocation telemetry persistence, migration coverage, and the reusable smoke script
- update control and architecture docs to reflect implemented P14-S1 scope and preserve hosted RLS expectations for workspace-scoped tables

## Validation
- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/pytest tests/unit/test_control_doc_truth.py -q`
- `./.venv/bin/pytest tests/unit/test_provider_runtime.py tests/unit/test_config.py tests/unit/test_20260415_0063_phase14_provider_invocation_telemetry.py -q`
- `./.venv/bin/pytest tests/integration/test_phase11_provider_runtime_api.py -q`
- `python3 -m py_compile scripts/run_phase14_openai_compatible_smoke.py`
- `python3 scripts/run_phase14_openai_compatible_smoke.py --help`

## Upgrade Overview

### Protected Areas
- [x] memory schema
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact
Additive schema and API work for provider registration, capability discovery, and runtime telemetry. Existing continuity behavior remains on the same public surface, but provider-runtime internals now persist normalized invocation telemetry and support OpenAI-compatible capability discovery.

### Migration / Rollout
Apply the new Alembic migration for `provider_invocation_telemetry` before relying on persisted provider test and runtime invoke telemetry in upgraded environments. No feature flag or backfill is required for the declared sprint scope.

### Operator Action
Run the migration as part of the normal deploy path. If operators want end-to-end confidence against a compatible endpoint, run `scripts/run_phase14_openai_compatible_smoke.py` with a hosted session token and thread id after deploy.

### Validation
- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/pytest tests/unit/test_control_doc_truth.py -q`
- `./.venv/bin/pytest tests/unit/test_provider_runtime.py tests/unit/test_config.py tests/unit/test_20260415_0063_phase14_provider_invocation_telemetry.py -q`
- `./.venv/bin/pytest tests/integration/test_phase11_provider_runtime_api.py -q`
- `python3 -m py_compile scripts/run_phase14_openai_compatible_smoke.py`
- `python3 scripts/run_phase14_openai_compatible_smoke.py --help`

### Rollback
Revert the squash merge commit and roll back the Phase 14 telemetry migration if the new table must be removed from an environment. Containment is straightforward because the sprint adds a new telemetry table and additive provider-runtime behavior rather than rewriting existing continuity data.