### PR TITLE
[codex] Phase 14 refactor 01: deduplicate continuity helpers

### DIFF
--- a/apps/api/src/alicebot_api/chief_of_staff.py
+++ b/apps/api/src/alicebot_api/chief_of_staff.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Container
 from dataclasses import dataclass
 from datetime import datetime
 import hashlib
@@ -1174,42 +1175,104 @@ def _build_resumption_supervision(
     }
 
 
-def _parse_recommendation_outcome_record(
+def _note_body_for_kind(
     item: ContinuityRecallResultRecord,
-) -> ChiefOfStaffRecommendationOutcomeRecord | None:
+    *,
+    kind: str,
+) -> dict[str, object] | None:
     if item["object_type"] != "Note":
         return None
-
     body = item["body"]
     if not isinstance(body, dict):
         return None
+    if body.get("kind") != kind:
+        return None
+    return body
 
-    kind = body.get("kind")
-    if kind != _OUTCOME_BODY_KIND:
+
+def _required_body_string(
+    body: dict[str, object],
+    key: str,
+    *,
+    strip: bool = False,
+) -> str | None:
+    value = body.get(key)
+    if not isinstance(value, str):
+        return None
+    if strip:
+        value = value.strip()
+        if not value:
+            return None
+    return value
+
+
+def _required_body_choice(
+    body: dict[str, object],
+    key: str,
+    *,
+    allowed: Container[str],
+) -> str | None:
+    value = _required_body_string(body, key)
+    if value is None or value not in allowed:
+        return None
+    return value
+
+
+def _optional_body_choice(
+    body: dict[str, object],
+    key: str,
+    *,
+    allowed: Container[str],
+) -> tuple[bool, str | None]:
+    value = body.get(key)
+    if value is None:
+        return True, None
+    if isinstance(value, str) and value in allowed:
+        return True, value
+    return False, None
+
+
+def _defaulted_body_reason(
+    body: dict[str, object],
+    *,
+    default: str,
+) -> str:
+    reason = _required_body_string(body, "reason", strip=True)
+    return default if reason is None else reason
+
+
+def _optional_body_note(body: dict[str, object]) -> str | None:
+    return _required_body_string(body, "note", strip=True)
+
+
+def _parse_recommendation_outcome_record(
+    item: ContinuityRecallResultRecord,
+) -> ChiefOfStaffRecommendationOutcomeRecord | None:
+    body = _note_body_for_kind(item, kind=_OUTCOME_BODY_KIND)
+    if body is None:
         return None
 
-    raw_outcome = body.get("outcome")
-    if not isinstance(raw_outcome, str) or raw_outcome not in CHIEF_OF_STAFF_RECOMMENDATION_OUTCOMES:
+    raw_outcome = _required_body_choice(
+        body,
+        "outcome",
+        allowed=CHIEF_OF_STAFF_RECOMMENDATION_OUTCOMES,
+    )
+    if raw_outcome is None:
         return None
     outcome: ChiefOfStaffRecommendationOutcome = raw_outcome  # type: ignore[assignment]
 
-    raw_action_type = body.get("recommendation_action_type")
-    if not isinstance(raw_action_type, str) or raw_action_type not in CHIEF_OF_STAFF_RECOMMENDED_ACTION_TYPES:
+    raw_action_type = _required_body_choice(
+        body,
+        "recommendation_action_type",
+        allowed=CHIEF_OF_STAFF_RECOMMENDED_ACTION_TYPES,
+    )
+    if raw_action_type is None:
         return None
     recommendation_action_type: ChiefOfStaffRecommendedActionType = raw_action_type  # type: ignore[assignment]
 
-    recommendation_title = body.get("recommendation_title")
-    if not isinstance(recommendation_title, str):
+    recommendation_title = _required_body_string(body, "recommendation_title")
+    if recommendation_title is None:
         return None
-
-    rewritten_title = body.get("rewritten_title")
-    rewritten_title_value = rewritten_title if isinstance(rewritten_title, str) else None
-
-    target_priority_id = body.get("target_priority_id")
-    target_priority_id_value = target_priority_id if isinstance(target_priority_id, str) else None
-
-    rationale = body.get("rationale")
-    rationale_value = rationale if isinstance(rationale, str) else None
 
     return {
         "id": item["id"],
@@ -1217,9 +1280,9 @@ def _parse_recommendation_outcome_record(
         "outcome": outcome,
         "recommendation_action_type": recommendation_action_type,
         "recommendation_title": recommendation_title,
-        "rewritten_title": rewritten_title_value,
-        "target_priority_id": target_priority_id_value,
-        "rationale": rationale_value,
+        "rewritten_title": _required_body_string(body, "rewritten_title"),
+        "target_priority_id": _required_body_string(body, "target_priority_id"),
+        "rationale": _required_body_string(body, "rationale"),
         "provenance_references": item["provenance_references"],
         "created_at": item["created_at"],
         "updated_at": item["updated_at"],
@@ -2005,67 +2068,53 @@ def _infer_handoff_queue_state(
 def _parse_handoff_review_action_record(
     item: ContinuityRecallResultRecord,
 ) -> ChiefOfStaffHandoffReviewActionRecord | None:
-    if item["object_type"] != "Note":
+    body = _note_body_for_kind(item, kind=_HANDOFF_REVIEW_ACTION_BODY_KIND)
+    if body is None:
         return None
 
-    body = item["body"]
-    if not isinstance(body, dict):
+    handoff_item_id = _required_body_string(body, "handoff_item_id", strip=True)
+    if handoff_item_id is None:
         return None
 
-    if body.get("kind") != _HANDOFF_REVIEW_ACTION_BODY_KIND:
-        return None
-
-    handoff_item_id = body.get("handoff_item_id")
-    if not isinstance(handoff_item_id, str) or not handoff_item_id.strip():
-        return None
-
-    raw_review_action = body.get("review_action")
-    if (
-        not isinstance(raw_review_action, str)
-        or raw_review_action not in CHIEF_OF_STAFF_HANDOFF_REVIEW_ACTIONS
-    ):
+    raw_review_action = _required_body_choice(
+        body,
+        "review_action",
+        allowed=CHIEF_OF_STAFF_HANDOFF_REVIEW_ACTIONS,
+    )
+    if raw_review_action is None:
         return None
     review_action: ChiefOfStaffHandoffReviewAction = raw_review_action  # type: ignore[assignment]
 
-    raw_next_state = body.get("next_lifecycle_state")
-    if (
-        not isinstance(raw_next_state, str)
-        or raw_next_state not in CHIEF_OF_STAFF_HANDOFF_QUEUE_STATE_ORDER
-    ):
+    raw_next_state = _required_body_choice(
+        body,
+        "next_lifecycle_state",
+        allowed=CHIEF_OF_STAFF_HANDOFF_QUEUE_STATE_ORDER,
+    )
+    if raw_next_state is None:
         return None
     next_lifecycle_state: ChiefOfStaffHandoffQueueLifecycleState = raw_next_state  # type: ignore[assignment]
 
-    raw_previous_state = body.get("previous_lifecycle_state")
-    previous_lifecycle_state: ChiefOfStaffHandoffQueueLifecycleState | None
-    if raw_previous_state is None:
-        previous_lifecycle_state = None
-    elif (
-        isinstance(raw_previous_state, str)
-        and raw_previous_state in CHIEF_OF_STAFF_HANDOFF_QUEUE_STATE_ORDER
-    ):
-        previous_lifecycle_state = raw_previous_state  # type: ignore[assignment]
-    else:
-        return None
-
-    raw_reason = body.get("reason")
-    reason = (
-        raw_reason
-        if isinstance(raw_reason, str) and raw_reason.strip()
-        else "Lifecycle transition captured from explicit operator review action."
+    valid_previous_state, raw_previous_state = _optional_body_choice(
+        body,
+        "previous_lifecycle_state",
+        allowed=CHIEF_OF_STAFF_HANDOFF_QUEUE_STATE_ORDER,
     )
-
-    raw_note = body.get("note")
-    note = raw_note if isinstance(raw_note, str) and raw_note.strip() else None
+    if not valid_previous_state:
+        return None
+    previous_lifecycle_state: ChiefOfStaffHandoffQueueLifecycleState | None = raw_previous_state  # type: ignore[assignment]
 
     return {
         "id": item["id"],
         "capture_event_id": item["capture_event_id"],
-        "handoff_item_id": handoff_item_id.strip(),
+        "handoff_item_id": handoff_item_id,
         "review_action": review_action,
         "previous_lifecycle_state": previous_lifecycle_state,
         "next_lifecycle_state": next_lifecycle_state,
-        "reason": reason,
-        "note": note,
+        "reason": _defaulted_body_reason(
+            body,
+            default="Lifecycle transition captured from explicit operator review action.",
+        ),
+        "note": _optional_body_note(body),
         "provenance_references": item["provenance_references"],
         "created_at": item["created_at"],
         "updated_at": item["updated_at"],
@@ -2108,59 +2157,44 @@ def _empty_handoff_outcome_counts() -> dict[ChiefOfStaffHandoffOutcomeStatus, in
 def _parse_handoff_outcome_record(
     item: ContinuityRecallResultRecord,
 ) -> ChiefOfStaffHandoffOutcomeRecord | None:
-    if item["object_type"] != "Note":
+    body = _note_body_for_kind(item, kind=_HANDOFF_OUTCOME_BODY_KIND)
+    if body is None:
         return None
 
-    body = item["body"]
-    if not isinstance(body, dict):
+    handoff_item_id = _required_body_string(body, "handoff_item_id", strip=True)
+    if handoff_item_id is None:
         return None
 
-    if body.get("kind") != _HANDOFF_OUTCOME_BODY_KIND:
-        return None
-
-    handoff_item_id = body.get("handoff_item_id")
-    if not isinstance(handoff_item_id, str) or not handoff_item_id.strip():
-        return None
-
-    raw_outcome_status = body.get("outcome_status")
-    if (
-        not isinstance(raw_outcome_status, str)
-        or raw_outcome_status not in CHIEF_OF_STAFF_HANDOFF_OUTCOME_STATUSES
-    ):
+    raw_outcome_status = _required_body_choice(
+        body,
+        "outcome_status",
+        allowed=CHIEF_OF_STAFF_HANDOFF_OUTCOME_STATUSES,
+    )
+    if raw_outcome_status is None:
         return None
     outcome_status: ChiefOfStaffHandoffOutcomeStatus = raw_outcome_status  # type: ignore[assignment]
 
-    raw_previous_outcome_status = body.get("previous_outcome_status")
-    previous_outcome_status: ChiefOfStaffHandoffOutcomeStatus | None
-    if raw_previous_outcome_status is None:
-        previous_outcome_status = None
-    elif (
-        isinstance(raw_previous_outcome_status, str)
-        and raw_previous_outcome_status in CHIEF_OF_STAFF_HANDOFF_OUTCOME_STATUSES
-    ):
-        previous_outcome_status = raw_previous_outcome_status  # type: ignore[assignment]
-    else:
-        return None
-
-    raw_reason = body.get("reason")
-    reason = (
-        raw_reason
-        if isinstance(raw_reason, str) and raw_reason.strip()
-        else "Routed handoff outcome captured as an explicit operator-authored immutable event."
+    valid_previous_status, raw_previous_outcome_status = _optional_body_choice(
+        body,
+        "previous_outcome_status",
+        allowed=CHIEF_OF_STAFF_HANDOFF_OUTCOME_STATUSES,
     )
-
-    raw_note = body.get("note")
-    note = raw_note if isinstance(raw_note, str) and raw_note.strip() else None
+    if not valid_previous_status:
+        return None
+    previous_outcome_status: ChiefOfStaffHandoffOutcomeStatus | None = raw_previous_outcome_status  # type: ignore[assignment]
 
     return {
         "id": item["id"],
         "capture_event_id": item["capture_event_id"],
-        "handoff_item_id": handoff_item_id.strip(),
+        "handoff_item_id": handoff_item_id,
         "outcome_status": outcome_status,
         "previous_outcome_status": previous_outcome_status,
         "is_latest_outcome": False,
-        "reason": reason,
-        "note": note,
+        "reason": _defaulted_body_reason(
+            body,
+            default="Routed handoff outcome captured as an explicit operator-authored immutable event.",
+        ),
+        "note": _optional_body_note(body),
         "provenance_references": item["provenance_references"],
         "created_at": item["created_at"],
         "updated_at": item["updated_at"],
@@ -2378,58 +2412,48 @@ def _build_stale_ignored_escalation_posture(
 def _parse_execution_routing_audit_record(
     item: ContinuityRecallResultRecord,
 ) -> ChiefOfStaffExecutionRoutingAuditRecord | None:
-    if item["object_type"] != "Note":
+    body = _note_body_for_kind(item, kind=_EXECUTION_ROUTING_ACTION_BODY_KIND)
+    if body is None:
         return None
 
-    body = item["body"]
-    if not isinstance(body, dict):
+    handoff_item_id = _required_body_string(body, "handoff_item_id", strip=True)
+    if handoff_item_id is None:
         return None
 
-    if body.get("kind") != _EXECUTION_ROUTING_ACTION_BODY_KIND:
-        return None
-
-    handoff_item_id = body.get("handoff_item_id")
-    if not isinstance(handoff_item_id, str) or not handoff_item_id.strip():
-        return None
-
-    raw_route_target = body.get("route_target")
-    if (
-        not isinstance(raw_route_target, str)
-        or raw_route_target not in CHIEF_OF_STAFF_EXECUTION_ROUTE_TARGET_ORDER
-    ):
+    raw_route_target = _required_body_choice(
+        body,
+        "route_target",
+        allowed=CHIEF_OF_STAFF_EXECUTION_ROUTE_TARGET_ORDER,
+    )
+    if raw_route_target is None:
         return None
     route_target: ChiefOfStaffExecutionRouteTarget = raw_route_target  # type: ignore[assignment]
 
-    raw_transition = body.get("transition")
-    if (
-        not isinstance(raw_transition, str)
-        or raw_transition not in CHIEF_OF_STAFF_EXECUTION_ROUTING_TRANSITIONS
-    ):
+    raw_transition = _required_body_choice(
+        body,
+        "transition",
+        allowed=CHIEF_OF_STAFF_EXECUTION_ROUTING_TRANSITIONS,
+    )
+    if raw_transition is None:
         return None
     transition: ChiefOfStaffExecutionRoutingTransition = raw_transition  # type: ignore[assignment]
 
     previously_routed = bool(body.get("previously_routed", False))
     route_state = bool(body.get("route_state", True))
 
-    raw_reason = body.get("reason")
-    reason = (
-        raw_reason
-        if isinstance(raw_reason, str) and raw_reason.strip()
-        else "Governed execution routing transition captured with draft-only posture."
-    )
-    raw_note = body.get("note")
-    note = raw_note if isinstance(raw_note, str) and raw_note.strip() else None
-
     return {
         "id": item["id"],
         "capture_event_id": item["capture_event_id"],
-        "handoff_item_id": handoff_item_id.strip(),
+        "handoff_item_id": handoff_item_id,
         "route_target": route_target,
         "transition": transition,
         "previously_routed": previously_routed,
         "route_state": route_state,
-        "reason": reason,
-        "note": note,
+        "reason": _defaulted_body_reason(
+            body,
+            default="Governed execution routing transition captured with draft-only posture.",
+        ),
+        "note": _optional_body_note(body),
         "provenance_references": item["provenance_references"],
         "created_at": item["created_at"],
         "updated_at": item["updated_at"],

--- a/apps/api/src/alicebot_api/continuity_recall.py
+++ b/apps/api/src/alicebot_api/continuity_recall.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 import math
 import re
 from dataclasses import dataclass
@@ -253,67 +254,51 @@ def _normalize_uuid_string(value: UUID | str | None) -> str | None:
     return str(value).strip().lower()
 
 
+def _iter_keyed_payload_values(payload: object, *, keys: set[str]) -> Iterator[object]:
+    if isinstance(payload, dict):
+        for key, child in payload.items():
+            if key.strip().casefold() in keys:
+                yield child
+            yield from _iter_keyed_payload_values(child, keys=keys)
+        return
+
+    if isinstance(payload, list):
+        for child in payload:
+            yield from _iter_keyed_payload_values(child, keys=keys)
+
+
+def _iter_normalized_string_values(value: object) -> Iterator[str]:
+    if isinstance(value, str):
+        normalized = _normalize_optional_text(value)
+        if normalized is not None:
+            yield normalized
+        return
+
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, str):
+                normalized = _normalize_optional_text(item)
+                if normalized is not None:
+                    yield normalized
+
+
 def _collect_strings(payload: object, *, keys: set[str]) -> set[str]:
-    values: set[str] = set()
-
-    def visit(value: object) -> None:
-        if isinstance(value, dict):
-            for key, child in value.items():
-                normalized_key = key.strip().casefold()
-                if normalized_key in keys:
-                    if isinstance(child, str):
-                        normalized = _normalize_optional_text(child)
-                        if normalized is not None:
-                            values.add(normalized)
-                    elif isinstance(child, list):
-                        for item in child:
-                            if isinstance(item, str):
-                                normalized = _normalize_optional_text(item)
-                                if normalized is not None:
-                                    values.add(normalized)
-                visit(child)
-            return
-
-        if isinstance(value, list):
-            for child in value:
-                visit(child)
-
-    visit(payload)
-    return values
+    return {
+        value
+        for child in _iter_keyed_payload_values(payload, keys=keys)
+        for value in _iter_normalized_string_values(child)
+    }
 
 
 def _collect_strings_in_order(payload: object, *, keys: set[str]) -> list[str]:
     values: list[str] = []
     seen: set[str] = set()
-
-    def add_value(value: str) -> None:
-        normalized = _normalize_optional_text(value)
-        if normalized is None:
-            return
-        if normalized in seen:
-            return
-        seen.add(normalized)
-        values.append(normalized)
-
-    def visit(value: object) -> None:
-        if isinstance(value, dict):
-            for key, child in value.items():
-                normalized_key = key.strip().casefold()
-                if normalized_key in keys:
-                    if isinstance(child, str):
-                        add_value(child)
-                    elif isinstance(child, list):
-                        for item in child:
-                            if isinstance(item, str):
-                                add_value(item)
-                visit(child)
-            return
-
-        if isinstance(value, list):
-            for child in value:
-                visit(child)
-
-    visit(payload)
+    for child in _iter_keyed_payload_values(payload, keys=keys):
+        for normalized in _iter_normalized_string_values(child):
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            values.append(normalized)
     return values
 
 
@@ -356,11 +341,13 @@ def _flatten_text(payload: object) -> str:
 
 def _extract_confirmation_status(row: ContinuityRecallCandidateRow) -> MemoryConfirmationStatus:
     for source in (row["provenance"], row["body"]):
-        values = _collect_strings_in_order(
-            source,
-            keys={"confirmation_status", "memory_confirmation_status"},
+        ranked_value = _select_ranked_value(
+            _collect_strings_in_order(
+                source,
+                keys={"confirmation_status", "memory_confirmation_status"},
+            ),
+            rank_map=_CONFIRMATION_RANK,
         )
-        ranked_value = _select_ranked_value(values, rank_map=_CONFIRMATION_RANK)
         if ranked_value is not None:
             return cast(MemoryConfirmationStatus, ranked_value)
 
@@ -376,11 +363,13 @@ def _extract_freshness_posture(
     confirmation_status: MemoryConfirmationStatus,
 ) -> ContinuityRecallFreshnessPosture:
     for source in (row["provenance"], row["body"]):
-        explicit_values = _collect_strings_in_order(
-            source,
-            keys={"freshness_posture", "freshness_status"},
+        ranked_value = _select_ranked_value(
+            _collect_strings_in_order(
+                source,
+                keys={"freshness_posture", "freshness_status"},
+            ),
+            rank_map=_FRESHNESS_RANK,
         )
-        ranked_value = _select_ranked_value(explicit_values, rank_map=_FRESHNESS_RANK)
         if ranked_value is not None:
             return cast(ContinuityRecallFreshnessPosture, ranked_value)
 
@@ -425,12 +414,7 @@ def _extract_provenance_posture(
     has_scope_context = len(scope_matches) > 0 or bool(
         _collect_strings(
             row["provenance"],
-            keys=(
-                _SCOPE_FILTER_KEYS["thread"]
-                | _SCOPE_FILTER_KEYS["task"]
-                | _SCOPE_FILTER_KEYS["project"]
-                | _SCOPE_FILTER_KEYS["person"]
-            ),
+            keys=_ENTITY_KEYS,
         )
     )
     if has_source_events and has_scope_context:
@@ -451,66 +435,24 @@ def _compute_scope_matches(
     person_filter: str | None,
 ) -> list[ContinuityRecallScopeMatch]:
     scope_matches: list[ContinuityRecallScopeMatch] = []
-
-    if thread_filter is not None:
+    filters_by_kind: tuple[tuple[ContinuityRecallScopeKind, str | None], ...] = (
+        ("thread", thread_filter),
+        ("task", task_filter),
+        ("project", project_filter),
+        ("person", person_filter),
+    )
+    for kind, filter_value in filters_by_kind:
+        if filter_value is None:
+            continue
         candidate_values = {
             value.casefold()
-            for value in _collect_strings(
-                row["provenance"],
-                keys=_SCOPE_FILTER_KEYS["thread"],
-            )
-            | _collect_strings(
-                row["body"],
-                keys=_SCOPE_FILTER_KEYS["thread"],
+            for value in (
+                _collect_strings(row["provenance"], keys=_SCOPE_FILTER_KEYS[kind])
+                | _collect_strings(row["body"], keys=_SCOPE_FILTER_KEYS[kind])
             )
         }
-        if thread_filter in candidate_values:
-            scope_matches.append({"kind": "thread", "value": thread_filter})
-
-    if task_filter is not None:
-        candidate_values = {
-            value.casefold()
-            for value in _collect_strings(
-                row["provenance"],
-                keys=_SCOPE_FILTER_KEYS["task"],
-            )
-            | _collect_strings(
-                row["body"],
-                keys=_SCOPE_FILTER_KEYS["task"],
-            )
-        }
-        if task_filter in candidate_values:
-            scope_matches.append({"kind": "task", "value": task_filter})
-
-    if project_filter is not None:
-        candidate_values = {
-            value.casefold()
-            for value in _collect_strings(
-                row["provenance"],
-                keys=_SCOPE_FILTER_KEYS["project"],
-            )
-            | _collect_strings(
-                row["body"],
-                keys=_SCOPE_FILTER_KEYS["project"],
-            )
-        }
-        if project_filter in candidate_values:
-            scope_matches.append({"kind": "project", "value": project_filter})
-
-    if person_filter is not None:
-        candidate_values = {
-            value.casefold()
-            for value in _collect_strings(
-                row["provenance"],
-                keys=_SCOPE_FILTER_KEYS["person"],
-            )
-            | _collect_strings(
-                row["body"],
-                keys=_SCOPE_FILTER_KEYS["person"],
-            )
-        }
-        if person_filter in candidate_values:
-            scope_matches.append({"kind": "person", "value": person_filter})
+        if filter_value in candidate_values:
+            scope_matches.append({"kind": kind, "value": filter_value})
 
     return scope_matches
 

--- a/apps/api/src/alicebot_api/execution_budgets.py
+++ b/apps/api/src/alicebot_api/execution_budgets.py
@@ -288,6 +288,71 @@ def _record_lifecycle_trace(
     return _trace_summary(trace["id"], trace_events)
 
 
+def _get_execution_budget_or_raise(
+    store: ContinuityStore,
+    *,
+    execution_budget_id: UUID,
+) -> ExecutionBudgetRow:
+    row = store.get_execution_budget_optional(execution_budget_id)
+    if row is None:
+        raise ExecutionBudgetNotFoundError(f"execution budget {execution_budget_id} was not found")
+    return row
+
+
+def _lifecycle_request_payload(
+    *,
+    thread_id: UUID,
+    execution_budget_id: UUID,
+    requested_action: ExecutionBudgetLifecycleAction,
+    replacement_max_completed_executions: int | None,
+) -> ExecutionBudgetLifecycleRequestTracePayload:
+    return {
+        "thread_id": str(thread_id),
+        "execution_budget_id": str(execution_budget_id),
+        "requested_action": requested_action,
+        "replacement_max_completed_executions": replacement_max_completed_executions,
+    }
+
+
+def _record_rejected_lifecycle_action(
+    store: ContinuityStore,
+    *,
+    thread: dict[str, object],
+    request_payload: ExecutionBudgetLifecycleRequestTracePayload,
+    row: ExecutionBudgetRow,
+    requested_action: ExecutionBudgetLifecycleAction,
+    previous_status: str,
+    replacement_max_completed_executions: int | None,
+    replacement_rolling_window_seconds: int | None,
+    rejection_reason: str,
+    active_budget_id: UUID | None,
+) -> None:
+    trace = _record_lifecycle_trace(
+        store,
+        thread=thread,
+        request_payload=request_payload,
+        state_payload=_lifecycle_state_payload(
+            row=row,
+            requested_action=requested_action,
+            previous_status=previous_status,
+            replacement_budget=None,
+            replacement_max_completed_executions=replacement_max_completed_executions,
+            replacement_rolling_window_seconds=replacement_rolling_window_seconds,
+            rejection_reason=rejection_reason,
+        ),
+        summary_payload=_lifecycle_summary_payload(
+            execution_budget_id=cast(UUID, row["id"]),
+            requested_action=requested_action,
+            outcome="rejected",
+            replacement_budget_id=None,
+            active_budget_id=active_budget_id,
+        ),
+        requested_action=requested_action,
+        outcome="rejected",
+    )
+    del trace
+
+
 def create_execution_budget_record(
     store: ContinuityStore,
     *,
@@ -359,9 +424,7 @@ def get_execution_budget_record(
 ) -> ExecutionBudgetDetailResponse:
     del user_id
 
-    row = store.get_execution_budget_optional(execution_budget_id)
-    if row is None:
-        raise ExecutionBudgetNotFoundError(f"execution budget {execution_budget_id} was not found")
+    row = _get_execution_budget_or_raise(store, execution_budget_id=execution_budget_id)
     return {"execution_budget": serialize_execution_budget_row(row)}
 
 
@@ -374,45 +437,28 @@ def deactivate_execution_budget_record(
     del user_id
 
     thread = _validate_lifecycle_thread(store, thread_id=request.thread_id)
-    row = store.get_execution_budget_optional(request.execution_budget_id)
-    if row is None:
-        raise ExecutionBudgetNotFoundError(
-            f"execution budget {request.execution_budget_id} was not found"
-        )
-
-    request_payload: ExecutionBudgetLifecycleRequestTracePayload = {
-        "thread_id": str(request.thread_id),
-        "execution_budget_id": str(request.execution_budget_id),
-        "requested_action": "deactivate",
-        "replacement_max_completed_executions": None,
-    }
+    row = _get_execution_budget_or_raise(store, execution_budget_id=request.execution_budget_id)
+    request_payload = _lifecycle_request_payload(
+        thread_id=request.thread_id,
+        execution_budget_id=request.execution_budget_id,
+        requested_action="deactivate",
+        replacement_max_completed_executions=None,
+    )
 
     if cast(str, row["status"]) != "active":
         error = _invalid_transition_error(row=row, requested_action="deactivate")
-        trace = _record_lifecycle_trace(
+        _record_rejected_lifecycle_action(
             store,
             thread=thread,
             request_payload=request_payload,
-            state_payload=_lifecycle_state_payload(
-                row=row,
-                requested_action="deactivate",
-                previous_status=cast(str, row["status"]),
-                replacement_budget=None,
-                replacement_max_completed_executions=None,
-                replacement_rolling_window_seconds=None,
-                rejection_reason=str(error),
-            ),
-            summary_payload=_lifecycle_summary_payload(
-                execution_budget_id=cast(UUID, row["id"]),
-                requested_action="deactivate",
-                outcome="rejected",
-                replacement_budget_id=None,
-                active_budget_id=None,
-            ),
             requested_action="deactivate",
-            outcome="rejected",
+            row=row,
+            previous_status=cast(str, row["status"]),
+            replacement_max_completed_executions=None,
+            replacement_rolling_window_seconds=None,
+            rejection_reason=str(error),
+            active_budget_id=None,
         )
-        del trace
         raise error
 
     updated = store.deactivate_execution_budget_optional(request.execution_budget_id)
@@ -459,45 +505,28 @@ def supersede_execution_budget_record(
     del user_id
 
     thread = _validate_lifecycle_thread(store, thread_id=request.thread_id)
-    current = store.get_execution_budget_optional(request.execution_budget_id)
-    if current is None:
-        raise ExecutionBudgetNotFoundError(
-            f"execution budget {request.execution_budget_id} was not found"
-        )
-
-    request_payload: ExecutionBudgetLifecycleRequestTracePayload = {
-        "thread_id": str(request.thread_id),
-        "execution_budget_id": str(request.execution_budget_id),
-        "requested_action": "supersede",
-        "replacement_max_completed_executions": request.max_completed_executions,
-    }
+    current = _get_execution_budget_or_raise(store, execution_budget_id=request.execution_budget_id)
+    request_payload = _lifecycle_request_payload(
+        thread_id=request.thread_id,
+        execution_budget_id=request.execution_budget_id,
+        requested_action="supersede",
+        replacement_max_completed_executions=request.max_completed_executions,
+    )
 
     if cast(str, current["status"]) != "active":
         error = _invalid_transition_error(row=current, requested_action="supersede")
-        trace = _record_lifecycle_trace(
+        _record_rejected_lifecycle_action(
             store,
             thread=thread,
             request_payload=request_payload,
-            state_payload=_lifecycle_state_payload(
-                row=current,
-                requested_action="supersede",
-                previous_status=cast(str, current["status"]),
-                replacement_budget=None,
-                replacement_max_completed_executions=request.max_completed_executions,
-                replacement_rolling_window_seconds=current["rolling_window_seconds"],
-                rejection_reason=str(error),
-            ),
-            summary_payload=_lifecycle_summary_payload(
-                execution_budget_id=cast(UUID, current["id"]),
-                requested_action="supersede",
-                outcome="rejected",
-                replacement_budget_id=None,
-                active_budget_id=cast(UUID, current["id"]) if cast(str, current["status"]) == "active" else None,
-            ),
             requested_action="supersede",
-            outcome="rejected",
+            row=current,
+            previous_status=cast(str, current["status"]),
+            replacement_max_completed_executions=request.max_completed_executions,
+            replacement_rolling_window_seconds=current["rolling_window_seconds"],
+            rejection_reason=str(error),
+            active_budget_id=cast(UUID, current["id"]) if cast(str, current["status"]) == "active" else None,
         )
-        del trace
         raise error
 
     active_scope_rows = _active_budget_rows_for_scope(
@@ -511,30 +540,18 @@ def supersede_execution_budget_record(
             "execution budget selector scope must have exactly one active budget to supersede: "
             f"{_scope_label(agent_profile_id=cast(str | None, current['agent_profile_id']), tool_key=current['tool_key'], domain_hint=current['domain_hint'])}"
         )
-        trace = _record_lifecycle_trace(
+        _record_rejected_lifecycle_action(
             store,
             thread=thread,
             request_payload=request_payload,
-            state_payload=_lifecycle_state_payload(
-                row=current,
-                requested_action="supersede",
-                previous_status="active",
-                replacement_budget=None,
-                replacement_max_completed_executions=request.max_completed_executions,
-                replacement_rolling_window_seconds=current["rolling_window_seconds"],
-                rejection_reason=str(error),
-            ),
-            summary_payload=_lifecycle_summary_payload(
-                execution_budget_id=cast(UUID, current["id"]),
-                requested_action="supersede",
-                outcome="rejected",
-                replacement_budget_id=None,
-                active_budget_id=cast(UUID, current["id"]),
-            ),
             requested_action="supersede",
-            outcome="rejected",
+            row=current,
+            previous_status="active",
+            replacement_max_completed_executions=request.max_completed_executions,
+            replacement_rolling_window_seconds=current["rolling_window_seconds"],
+            rejection_reason=str(error),
+            active_budget_id=cast(UUID, current["id"]),
         )
-        del trace
         raise error
 
     replacement_budget_id = uuid4()
@@ -574,39 +591,26 @@ def supersede_execution_budget_record(
         error = None
 
     if error is not None:
-        current_state = store.get_execution_budget_optional(request.execution_budget_id)
-        if current_state is None:
-            raise ExecutionBudgetNotFoundError(
-                f"execution budget {request.execution_budget_id} was not found"
-            )
-        trace = _record_lifecycle_trace(
+        current_state = _get_execution_budget_or_raise(
+            store,
+            execution_budget_id=request.execution_budget_id,
+        )
+        _record_rejected_lifecycle_action(
             store,
             thread=thread,
             request_payload=request_payload,
-            state_payload=_lifecycle_state_payload(
-                row=current_state,
-                requested_action="supersede",
-                previous_status=cast(str, current["status"]),
-                replacement_budget=None,
-                replacement_max_completed_executions=request.max_completed_executions,
-                replacement_rolling_window_seconds=current["rolling_window_seconds"],
-                rejection_reason=str(error),
-            ),
-            summary_payload=_lifecycle_summary_payload(
-                execution_budget_id=cast(UUID, current_state["id"]),
-                requested_action="supersede",
-                outcome="rejected",
-                replacement_budget_id=None,
-                active_budget_id=(
-                    cast(UUID, current_state["id"])
-                    if cast(str, current_state["status"]) == "active"
-                    else None
-                ),
-            ),
             requested_action="supersede",
-            outcome="rejected",
+            row=current_state,
+            previous_status=cast(str, current["status"]),
+            replacement_max_completed_executions=request.max_completed_executions,
+            replacement_rolling_window_seconds=current["rolling_window_seconds"],
+            rejection_reason=str(error),
+            active_budget_id=(
+                cast(UUID, current_state["id"])
+                if cast(str, current_state["status"]) == "active"
+                else None
+            ),
         )
-        del trace
         raise error
 
     trace = _record_lifecycle_trace(


### PR DESCRIPTION
## Summary
- deduplicate note-body parsing and validation helpers in `chief_of_staff.py`
- simplify keyed payload traversal and ordered string collection in `continuity_recall.py`
- consolidate repeated execution-budget lookup and rejected-lifecycle trace logic in `execution_budgets.py`

## Validation
- `./.venv/bin/pytest tests/unit/test_chief_of_staff.py tests/unit/test_continuity_recall.py tests/unit/test_execution_budgets.py -q` -> `44 passed`

## Notes
- intentionally outside the active sprint packet
- left unrelated untracked lockfiles untouched