### PR TITLE
[codex] P14-S3: ship model packs

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -1,7 +1,7 @@
 # Sprint Packet
 
 ## Sprint Title
-P14-S2: Ollama + llama.cpp + vLLM Adapters
+P14-S3: Model Packs
 
 ## Activation Note
 - This packet is active.
@@ -9,8 +9,8 @@ P14-S2: Ollama + llama.cpp + vLLM Adapters
 - Phase 14 is active on top of the shipped Phase 13 baseline.
 - Phase 14 sequence is fixed for now:
   - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter: shipped
-  - `P14-S2` Ollama + llama.cpp + vLLM Adapters: active
-  - `P14-S3` Model Packs
+  - `P14-S2` Ollama + llama.cpp + vLLM Adapters: shipped
+  - `P14-S3` Model Packs: active
   - `P14-S4` Reference Integrations
   - `P14-S5` Design Partner Launch
 
@@ -18,10 +18,10 @@ P14-S2: Ollama + llama.cpp + vLLM Adapters
 feature
 
 ## Sprint Reason
-`P14-S1` established the provider contract and telemetry baseline. `P14-S2` now hardens the existing local and self-hosted runtime paths against that contract so later model-pack, integration, and design-partner work sits on compatibility proof instead of assumptions.
+`P14-S1` and `P14-S2` established the provider contract, telemetry baseline, and local/self-hosted compatibility layer. `P14-S3` now turns that provider surface into usable defaults so external builders do not need to hand-tune pack behavior per workspace.
 
 ## Git Instructions
-- Branch Name: `codex/phase14-s2-local-self-hosted-adapters`
+- Branch Name: `codex/phase14-s3-model-packs`
 - Base Branch: `main`
 - PR Strategy: one implementation branch, one PR
 - Merge Policy: squash merge after review `PASS` and explicit approval
@@ -34,23 +34,23 @@ feature
 - shipped Alice Lite profile
 - shipped hygiene/thread-health visibility
 - shipped `P14-S1` provider contract, capability snapshot, and invocation telemetry baseline
+- shipped `P14-S2` local/self-hosted compatibility layer, including the dedicated `vllm` provider path and aligned runtime/pack compatibility hooks
 - no semantic fork between API, CLI, MCP, hosted, provider-runtime, and Hermes paths
 
 ## Exact Goal
-Harden Alice's existing Ollama, llama.cpp, and vLLM paths onto the stabilized provider contract and prove local/self-hosted compatibility without changing continuity semantics.
+Make common model families easy to use with sensible continuity defaults on top of the shipped provider/runtime baseline.
 
 ## In Scope
-- Ollama adapter alignment to the stabilized provider interface
-- llama.cpp / llama-server adapter alignment to the stabilized provider interface
-- vLLM adapter alignment to the stabilized provider interface
-- provider-specific capability mapping cleanup
-- consistent telemetry and continuity behavior across the three runtime classes
-- local model quickstarts and example configs
-- local compatibility smoke tests
+- model-pack schema and storage hardening where needed
+- model-pack API and workspace pack-binding workflow
+- first-party packs for Llama, Qwen, Gemma, and `gpt-oss`
+- pack-aware invocation and briefing defaults
+- compatibility matrix docs
+- pack smoke tests
 
 ## Out Of Scope
-- new provider classes beyond what is required to keep the interface stable
-- model-pack UX/polish beyond compatibility hooks
+- provider-contract redesign
+- new provider classes beyond what is required to support declared pack families
 - reference integrations
 - design-partner workflows
 - retrieval research, graph migration, new channels, marketplace work, or enterprise governance expansion
@@ -60,37 +60,35 @@ Harden Alice's existing Ollama, llama.cpp, and vLLM paths onto the stabilized pr
 - `apps/api/alembic/versions/`
 - `tests/unit/`
 - `tests/integration/`
-- `docs/` provider/runtime docs
-- local/self-hosted runtime smoke helpers
+- `docs/` model-pack and compatibility docs
 - control docs if baseline status markers need updates
 
 ## Planned Deliverables
-- Ollama adapter contract alignment
-- llama.cpp / llama-server adapter contract alignment
-- vLLM adapter contract alignment
-- normalized capability mappings and telemetry behavior for local/self-hosted runtimes
-- local model quickstarts and example configs
-- local compatibility smoke tests
+- model-pack schema and API surface
+- workspace pack binding flow
+- first-party pack definitions for Llama, Qwen, Gemma, and `gpt-oss`
+- pack-aware runtime and briefing defaults
+- compatibility matrix docs
+- pack smoke tests
 
 ## Acceptance Criteria
-- Alice works with a local Ollama deployment through the stabilized provider contract
-- Alice works with a llama.cpp-compatible server through the stabilized provider contract
-- Alice works with a self-hosted vLLM deployment through the stabilized provider contract
-- capability mapping and telemetry behavior are consistent and inspectable across all three
-- one-call continuity semantics stay stable across all three local/self-hosted paths
-- local quickstarts are reproducible
+- a workspace can bind a provider to a pack
+- pack defaults affect briefing and runtime behavior correctly
+- first-party packs are versioned and documented
+- users get good defaults without manual tuning
+- pack behavior composes the shipped provider/runtime baseline instead of reopening provider work
 
 ## Required Verification
 - `python3 scripts/check_control_doc_truth.py`
 - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-- targeted unit/integration coverage for Ollama, llama.cpp, and vLLM adapter behavior
-- smoke validation for local/self-hosted runtime paths
-- doc/quickstart validation for local runtime setup paths
+- targeted unit/integration coverage for model-pack storage, binding, and runtime/briefing defaults
+- pack smoke validation against the shipped provider/runtime surface
+- compatibility-matrix and pack-doc validation
 
 ## Control Tower Decisions Needed
-- whether Azure polish is pulled into this sprint or explicitly deferred to later integration/documentation work
-- whether any pre-Phase-14 local adapter behavior must be deprecated now instead of carried forward
-- what minimum local runtime versions are declared as supported in the Phase 14 docs
+- whether DeepSeek or Mistral stay explicitly deferred after the first-party pack set ships
+- how strict the initial pack-to-provider compatibility matrix is at launch
+- which pack quirks are allowed as declarative defaults versus requiring runtime code changes
 
 ## Exit Condition
-This sprint is complete when Alice's existing Ollama, llama.cpp, and vLLM paths are aligned to the stabilized provider contract, backed by compatibility proof and local quickstarts, and still preserve one-call continuity semantics.
+This sprint is complete when workspaces can bind documented first-party packs to the shipped provider/runtime baseline, pack-aware defaults behave correctly, and the result reduces manual tuning without creating a second continuity model.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -10,8 +10,9 @@
 - `v0.4.0` is the latest published tag.
 - Phase 14 is active.
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
-- `P14-S2` Ollama + llama.cpp + vLLM Adapters is the active execution sprint.
-- `P14-S3` through `P14-S5` are planned and scoped.
+- `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
+- `P14-S3` Model Packs is the active execution sprint.
+- `P14-S4` through `P14-S5` are planned and scoped.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
@@ -21,6 +22,7 @@
 - The shipped baseline includes the Alice Lite startup/profile path.
 - The shipped baseline includes memory hygiene and thread/conversation health visibility.
 - Phase 14 shipped baseline now also includes the stabilized provider contract, workspace-scoped provider registration/update flows, provider capability snapshots, invocation telemetry persistence, and the OpenAI-compatible adapter hardening delivered in `P14-S1`.
+- Phase 14 shipped baseline now also includes the local/self-hosted compatibility layer from `P14-S2`, including the dedicated `vllm` provider path, aligned health semantics, and pack-compatibility/runtime coverage for the shipped local/self-hosted provider surface.
 - `v0.4.0` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
@@ -28,9 +30,10 @@
 - Phase 14 starts from the shipped `v0.4.0` baseline.
 - Phase 14 is focused on compatibility, packaging, reference integrations, and design-partner proof.
 - `P14-S1` is complete and establishes the provider contract, capability snapshot, and invocation telemetry baseline for the rest of the phase.
-- `P14-S2` is intentionally not a second provider-foundation sprint; it is the contract-alignment, compatibility-proof, and documentation sprint for the already-existing local/self-hosted runtime paths.
+- `P14-S2` is complete and closed the local/self-hosted compatibility sprint without reopening provider-foundation work.
+- `P14-S3` is intentionally not another provider sprint; it is the pack-schema, binding, defaults, and compatibility-matrix sprint that turns the shipped provider surface into usable defaults.
 
 ## Immediate Control Tower Decisions Needed
 - Lock the first-party pack set for the initial Phase 14 model-pack release.
-- Decide whether Azure polish is pulled fully into `P14-S2` or held to the later integration/documentation layer.
+- Decide whether DeepSeek or Mistral stay deferred after the first-party pack launch.
 - Select the first 3 to 5 design partners and their initial pilot scopes early enough for `P14-S5`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Scope Boundary
 - **Shipped baseline:** Phases 9-13 and Bridge `B1` through `B4`.
-- **Current execution posture:** `v0.4.0` is the latest published tag; Phase 14 is active; `P14-S1` is shipped; `P14-S2` is active.
+- **Current execution posture:** `v0.4.0` is the latest published tag; Phase 14 is active; `P14-S1` and `P14-S2` are shipped; `P14-S3` is active.
 - **Phase principle:** Phase 14 is a platform-and-adoption phase, not a new substrate-research phase.
 
 ## Current System Overview
@@ -91,21 +91,23 @@ Alice is a modular continuity platform with shared continuity semantics across l
 - Shipped OpenAI-compatible adapter hardening.
 - Shipped provider invocation telemetry persistence and hosted RLS posture for the new telemetry table.
 
+### P14-S2: Ollama + llama.cpp + vLLM Adapters
+- Status: shipped
+- Hardened the local/self-hosted runtime paths onto the stabilized provider contract.
+- Added the dedicated `vllm` provider path with provider-native health semantics and registration/config support.
+- Extended provider/runtime and pack-compatibility coverage for the shipped local/self-hosted provider surface.
+- Kept the sprint scoped to compatibility proof instead of reopening provider-foundation work.
+
 ## Phase 14 Active Delta
 
-### P14-S2: Ollama + llama.cpp + vLLM Adapters
+### P14-S3: Model Packs
 - Status: active
-- Align the existing local and self-hosted runtime paths to the stabilized provider contract from `P14-S1`.
-- Normalize capability mappings and telemetry behavior across Ollama, llama.cpp / llama-server, and vLLM.
-- Add local model quickstarts, example configs, and local compatibility smoke tests.
-- This sprint is compatibility proof and contract alignment, not a second provider-foundation rewrite.
+- Add versioned first-party pack definitions and workspace pack bindings.
+- Push pack-aware defaults into runtime invocation and briefing behavior.
+- Publish the first real compatibility matrix on top of the shipped provider/runtime surface.
+- This sprint is defaults-and-packaging work, not another provider sprint.
 
 ## Planned Phase 14 Follow-On Deltas
-
-### P14-S3: Model Packs
-- Versioned first-party pack definitions
-- workspace pack bindings
-- pack-aware defaults for runtime invocation and briefing
 
 ### P14-S4: Reference Integrations
 - polished Hermes and OpenClaw integration paths
@@ -126,8 +128,7 @@ Alice is a modular continuity platform with shared continuity semantics across l
 ## Testing Strategy
 - unit/integration tests for continuity, provider runtime, and API behavior
 - provider smoke tests and provider-capability parity checks
-- model-pack smoke tests and compatibility-matrix validation
-- local/self-hosted compatibility smoke tests for `P14-S2`
+- model-pack smoke tests and compatibility-matrix validation for `P14-S3`
 - integration smoke tests for Hermes, OpenClaw, Python example, and TypeScript example paths
 - release gates remain green across Python, web, Alice Lite, Hermes smoke, and public eval harness
 - docs verification is part of sprint completion, not cleanup work

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -2,65 +2,63 @@
 
 ## sprint objective
 
-Align Ollama, llama.cpp / llama-server, and vLLM runtime paths to the stabilized provider contract, keep telemetry and continuity behavior consistent across those adapters, and document reproducible local/self-hosted quickstarts.
+Make common model families easy to use with sensible continuity defaults on top of the shipped provider/runtime baseline by shipping the `P14-S3` model-pack workflow.
 
 ## completed work
 
-- Added a first-class `vllm` provider adapter with healthcheck, model discovery, and chat-completions invocation aligned to the shared provider runtime contract.
-- Added dedicated vLLM response/model parsers so runtime errors and normalization stay provider-specific instead of inheriting llama.cpp labels.
-- Added `POST /v1/providers/vllm/register` with adapter-specific defaults for self-hosted vLLM deployments.
-- Extended workspace provider config parsing so bootstrap config can seed either `openai_compatible` or `vllm` providers with provider-specific defaults.
-- Fixed vLLM healthchecks to treat provider-native empty `200` responses as healthy instead of requiring JSON on `/health`.
-- Extended provider contract literals to include `vllm`.
-- Updated built-in model-pack compatibility hooks so built-in and custom packs can declare `vllm` in `provider_keys`.
-- Extended the local/self-hosted smoke helper script to exercise `ollama`, `llamacpp`, or `vllm`.
-- Added targeted unit coverage for the vLLM adapter and config/model-pack compatibility changes.
-- Added integration coverage for vLLM registration, capability discovery, provider test, runtime invoke, workspace-config seeding, and pack-contract acceptance.
-- Updated provider/runtime docs and quickstarts for the new vLLM adapter path, including the Phase 14 config doc note about dedicated `vllm` config entries.
+- Added provider-aware model-pack bindings by extending workspace bindings with an optional `provider_id`.
+- Kept workspace-default bindings in place so briefing defaults can still resolve without a provider id.
+- Updated model-pack resolution so runtime selection now follows request override, provider-specific binding, workspace default binding, then no pack.
+- Added runtime compatibility enforcement using declarative pack contract fields (`compatibility.provider_keys` and `compatibility.runtime_providers`).
+- Updated the bind API to accept optional `provider_id`, validate provider existence in the workspace, and reject incompatible provider-to-pack bindings with `409`.
+- Updated runtime invoke to reject incompatible pack/provider combinations with `409` instead of silently applying the wrong defaults.
+- Trimmed the built-in first-party catalog to the four `P14-S3` packs: `llama`, `qwen`, `gemma`, and `gpt-oss`.
+- Added a migration and migration unit coverage for provider-aware workspace model-pack bindings.
+- Updated targeted unit and integration coverage for provider-aware binding, first-party catalog expectations, and compatibility enforcement.
+- Added provider-surface pack smoke coverage across the shipped `ollama`, `llamacpp`, and `vllm` runtime paths.
+- Updated the model-pack contract and compatibility docs to match the shipped `P14-S3` behavior.
 
 ## incomplete work
 
-- No additional implementation items remain within this sprint scope.
-- Control Tower decisions from the sprint packet remain product decisions rather than implementation work:
-  - supported minimum runtime versions
-  - Azure polish timing
-  - any pre-Phase-14 local adapter deprecations
+- No implementation items remain within the sprint scope.
+- Deferred families such as DeepSeek, Mistral, and Kimi remain out of the first-party catalog for this sprint.
 
 ## files changed
 
-- `apps/api/src/alicebot_api/config.py`
+- `apps/api/alembic/versions/20260416_0064_phase14_provider_model_pack_bindings.py`
+- `.ai/active/SPRINT_PACKET.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `ARCHITECTURE.md`
+- `CURRENT_STATE.md`
+- `PRODUCT_BRIEF.md`
+- `ROADMAP.md`
 - `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/local_provider_helpers.py`
 - `apps/api/src/alicebot_api/main.py`
 - `apps/api/src/alicebot_api/model_packs.py`
-- `apps/api/src/alicebot_api/provider_runtime.py`
-- `docs/integrations/phase11-local-provider-adapters.md`
+- `apps/api/src/alicebot_api/store.py`
 - `docs/integrations/phase11-model-pack-compatibility.md`
 - `docs/integrations/phase11-model-packs-tier1.md`
-- `docs/integrations/phase11-setup-paths.md`
-- `docs/integrations/phase14-provider-configuration.md`
-- `scripts/run_phase11_local_provider_e2e.py`
+- `docs/phase14-model-pack-contract.md`
+- `docs/phase14-s3-control-tower-packet.md`
+- `docs/phase14-sprint-14-1-14-5-plan.md`
+- `scripts/check_control_doc_truth.py`
 - `tests/integration/test_phase11_model_packs_api.py`
-- `tests/integration/test_phase11_provider_runtime_api.py`
-- `tests/unit/test_config.py`
+- `tests/unit/test_20260416_0064_phase14_provider_model_pack_bindings.py`
 - `tests/unit/test_model_packs.py`
-- `tests/unit/test_provider_runtime.py`
 
 ## tests run
 
 - `python3 scripts/check_control_doc_truth.py`
 - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_provider_runtime.py tests/unit/test_model_packs.py tests/unit/test_config.py -q`
-- `./.venv/bin/python -m pytest tests/integration/test_phase11_provider_runtime_api.py -q`
+- `./.venv/bin/python -m pytest tests/unit/test_model_packs.py tests/unit/test_task_briefing.py tests/unit/test_20260416_0064_phase14_provider_model_pack_bindings.py -q`
 - `./.venv/bin/python -m pytest tests/integration/test_phase11_model_packs_api.py -q`
-- `./.venv/bin/python -m pytest tests/integration/test_phase11_provider_runtime_api.py tests/integration/test_phase11_model_packs_api.py -q`
-- `git diff --check`
+- `./.venv/bin/python -m pytest tests/integration/test_phase11_provider_runtime_api.py -q`
 
 ## blockers/issues
 
-- No implementation blockers encountered.
-- Real-runtime validation against live Ollama, llama.cpp, and vLLM processes was not run in this build; compatibility proof here is based on targeted unit and integration coverage plus the updated smoke helper.
+- No blocking implementation issues remain.
+- Pack smoke validation in this build is covered by focused integration smoke over the shipped provider/runtime surfaces (`ollama`, `llamacpp`, `vllm`) rather than by external provider processes.
 
 ## recommended next step
 
-Run the updated smoke flow against real local/self-hosted runtimes, then lock the supported runtime-version statement in the Phase 14 docs.
+Decide whether DeepSeek and Mistral stay deferred or become first-party packs in the next sprint, then extend the compatibility matrix only after that product decision is settled.

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -13,8 +13,9 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - `v0.4.0` is the latest published tag.
 - Phase 14 is active.
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
-- `P14-S2` Ollama + llama.cpp + vLLM Adapters is the active execution sprint.
-- `P14-S3` through `P14-S5` are planned and scoped.
+- `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
+- `P14-S3` Model Packs is the active execution sprint.
+- `P14-S4` through `P14-S5` are planned and scoped.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
@@ -24,6 +25,7 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - The shipped baseline includes the Alice Lite startup/profile path.
 - The shipped baseline includes memory hygiene and thread/conversation health visibility.
 - Phase 14 shipped baseline now also includes the stabilized provider contract, workspace-scoped provider registration/update flows, provider capability snapshots, invocation telemetry persistence, and the OpenAI-compatible adapter hardening delivered in `P14-S1`.
+- Phase 14 shipped baseline now also includes the local/self-hosted compatibility layer from `P14-S2`, including the dedicated `vllm` provider path, aligned health semantics, and pack-compatibility/runtime coverage for the shipped local/self-hosted provider surface.
 - `v0.4.0` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
@@ -31,9 +33,10 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - Phase 14 starts from the shipped `v0.4.0` baseline.
 - Phase 14 is focused on compatibility, packaging, reference integrations, and design-partner proof.
 - `P14-S1` is complete and establishes the provider contract, capability snapshot, and invocation telemetry baseline for the rest of the phase.
-- `P14-S2` is intentionally not a second provider-foundation sprint; it is the contract-alignment, compatibility-proof, and documentation sprint for the already-existing local/self-hosted runtime paths.
+- `P14-S2` is complete and closed the local/self-hosted compatibility sprint without reopening provider-foundation work.
+- `P14-S3` is intentionally not another provider sprint; it is the pack-schema, binding, defaults, and compatibility-matrix sprint that turns the shipped provider surface into usable defaults.
 
 ## Immediate Control Tower Decisions Needed
 - Lock the first-party pack set for the initial Phase 14 model-pack release.
-- Decide whether Azure polish is pulled fully into `P14-S2` or held to the later integration/documentation layer.
+- Decide whether DeepSeek or Mistral stay deferred after the first-party pack launch.
 - Select the first 3 to 5 design partners and their initial pilot scopes early enough for `P14-S5`.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -15,8 +15,9 @@ Alice is a pre-1.0 continuity platform for AI agents and agent-assisted workflow
 ## Current Repo Posture
 - Phase 14 is active.
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
-- `P14-S2` Ollama + llama.cpp + vLLM Adapters is the active execution sprint.
-- `P14-S3` through `P14-S5` are planned.
+- `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
+- `P14-S3` Model Packs is the active execution sprint.
+- `P14-S4` through `P14-S5` are planned.
 
 ## Active Phase
 ### Phase 14: Provider Adapters + Design Partner Launch
@@ -63,4 +64,5 @@ Alice now has enough depth in continuity semantics. The next constraint is compa
 ## Immediate Product Posture
 - `v0.4.0` remains the current public release boundary.
 - `P14-S1` established the provider contract and telemetry baseline.
-- `P14-S2` is deliberately focused on contract alignment, compatibility proof, and local quickstarts for existing local/self-hosted paths so the phase does not drift into redundant provider rework.
+- `P14-S2` closed the local/self-hosted compatibility sprint and added the dedicated `vllm` path to the shipped provider surface.
+- `P14-S3` is deliberately focused on model-pack schema, binding, defaults, and compatibility clarity so the phase does not drift back into provider work.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,43 +4,33 @@
 PASS
 
 ## criteria met
-- vLLM is now aligned to provider-native health semantics: empty successful `/health` responses are treated as healthy instead of failing JSON parsing.
-- Registration, capability discovery, provider test, runtime invoke, and model-pack compatibility all pass for the dedicated `vllm` adapter in the reviewed automated coverage.
-- Workspace config seeding is covered for `vllm`, including capability discovery on bootstrap.
-- Existing OpenAI-compatible behavior remains covered and passing, reducing regression risk on the prior provider seam.
-- Provider/runtime docs are aligned enough for the implemented surface, including the dedicated `vllm` config note.
-- I did not find local workstation paths, usernames, or similar local identifiers introduced in the reviewed changed files or docs.
+- A workspace can bind a provider to a pack, and bindings now support both provider-specific and workspace-default resolution. Evidence: `apps/api/src/alicebot_api/main.py`, `apps/api/src/alicebot_api/model_packs.py`, `apps/api/src/alicebot_api/store.py`.
+- Pack defaults affect briefing and runtime behavior correctly. Runtime shaping, request override precedence, workspace binding precedence, and compatibility enforcement are covered by integration and unit tests. Evidence: `tests/integration/test_phase11_model_packs_api.py`, `tests/unit/test_task_briefing.py`, `tests/unit/test_model_packs.py`.
+- First-party packs are versioned and documented for the declared `P14-S3` set: `llama`, `qwen`, `gemma`, and `gpt-oss`. Evidence: `docs/phase14-model-pack-contract.md`, `docs/integrations/phase11-model-pack-compatibility.md`.
+- Users get sensible defaults without manual tuning. Briefing defaults still resolve from workspace-default bindings, while runtime selection uses explicit override -> provider binding -> workspace default -> none.
+- Pack behavior composes the shipped provider/runtime baseline rather than reopening provider work. Compatibility remains declarative through pack contract metadata.
+- Pack smoke validation is now present over the shipped provider/runtime surface. Evidence: local-provider smoke coverage across `ollama`, `llamacpp`, and `vllm` in `tests/integration/test_phase11_model_packs_api.py`.
 
 ## criteria missed
-- none blocking
+- None.
 
 ## quality issues
-- No blocking implementation issues remain in the reviewed sprint diff.
-- Residual risk remains because the build report still notes that live runtime smoke against actual Ollama, llama.cpp, and vLLM processes was not run in this workspace. Given the corrected protocol handling and the passing targeted integration coverage, I do not treat that as a blocker for this review.
+- None blocking after the fix set.
 
 ## regression risks
-- Low to moderate residual risk around real-runtime version drift, especially for provider-specific endpoint behavior outside the covered request/response shapes.
-- The new `request_ok()` healthcheck helper should stay scoped to providers whose health endpoints are success-status based rather than JSON-contract based.
+- Low. The riskiest new seam was provider-query fallback to a workspace-default binding; that case now has direct integration coverage.
+- Low. Provider-surface pack smoke now exercises the shipped local/self-hosted adapter paths with pack binding in place.
 
 ## docs issues
-- No blocking docs issues remain.
-- It would still help to lock the minimum supported Ollama, llama.cpp, and vLLM versions in the Phase 14 docs when product decides them.
+- No remaining docs issues for this sprint scope.
+- `BUILD_REPORT.md` now matches the verification evidence more closely.
+- No local filesystem paths, workstation usernames, or similar local identifiers were found in the reviewed changed files and documentation.
 
 ## should anything be added to RULES.md?
-- Not required for this sprint to pass.
-- Optional: add a rule that provider healthchecks must follow provider-native success semantics and not assume JSON unless the provider contract guarantees it.
+- No.
 
 ## should anything update ARCHITECTURE.md?
-- Not required for this sprint to pass.
-- Optional: if `vllm` remains a long-term first-class provider key distinct from `openai_compatible`, document that boundary explicitly in `ARCHITECTURE.md`.
+- No further update is needed beyond the existing Phase 14 state changes already in this sprint.
 
 ## recommended next action
-- Merge this sprint.
-- As follow-up hardening, run the updated smoke flow against real local/self-hosted runtimes and record the supported minimum runtime versions in the Phase 14 docs.
-
-## verification reviewed
-- `python3 scripts/check_control_doc_truth.py` -> PASS
-- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q` -> 5 passed
-- `./.venv/bin/python -m pytest tests/unit/test_provider_runtime.py tests/unit/test_model_packs.py tests/unit/test_config.py -q` -> 29 passed
-- `./.venv/bin/python -m pytest tests/integration/test_phase11_provider_runtime_api.py tests/integration/test_phase11_model_packs_api.py -q` -> 19 passed
-- `git diff --check` -> PASS
+- Proceed with the normal merge/review flow for `P14-S3`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,8 +15,8 @@ These remain baseline truth and are not future milestones.
 ## Active Planning Status
 - Phase 14 is active.
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
-- `P14-S2` Ollama + llama.cpp + vLLM Adapters is the active execution sprint.
-- `P14-S3` Model Packs is planned.
+- `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
+- `P14-S3` Model Packs is the active execution sprint.
 - `P14-S4` Reference Integrations is planned.
 - `P14-S5` Design Partner Launch is planned.
 
@@ -37,7 +37,7 @@ Release target: internal provider-foundation release candidate
 - normalize capability mappings, telemetry behavior, and continuity semantics across Ollama, llama.cpp, and vLLM
 - add local model quickstarts, example configs, and local compatibility smoke tests
 
-Status: active
+Status: shipped
 Release target: `v0.5.0-rc1`
 
 ### P14-S3: Model Packs
@@ -46,7 +46,7 @@ Release target: `v0.5.0-rc1`
 - integrate pack defaults into runtime invocation and briefing
 - publish a compatibility matrix
 
-Status: planned
+Status: active
 Release target: `v0.5.0-rc2`
 
 ### P14-S4: Reference Integrations
@@ -71,7 +71,7 @@ Release target: `v0.5.1` or `v0.6.0-beta`
 - Do not allow scope drift into new substrate research, new channels, enterprise governance expansion, or major vertical-agent work unless required by a declared Phase 14 deliverable.
 - Preserve one-call continuity semantics across provider classes.
 - Treat docs as sprint deliverables, not cleanup work.
-- Keep `P14-S2` narrow: it should harden and prove the existing local/self-hosted paths, not pretend those runtimes are newly invented in Phase 14.
+- Keep `P14-S3` narrow: it should turn the shipped provider/runtime surface into usable defaults, not reopen provider compatibility work under a pack label.
 
 ## Beyond Phase 14
 - No post-Phase-14 feature plan is currently defined.

--- a/apps/api/alembic/versions/20260416_0064_phase14_provider_model_pack_bindings.py
+++ b/apps/api/alembic/versions/20260416_0064_phase14_provider_model_pack_bindings.py
@@ -1,0 +1,40 @@
+"""Add provider-aware workspace model-pack bindings for Phase 14 model packs."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260416_0064"
+down_revision = "20260415_0063"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_STATEMENTS = (
+    (
+        "ALTER TABLE workspace_model_pack_bindings "
+        "ADD COLUMN provider_id uuid NULL REFERENCES model_providers(id) ON DELETE CASCADE"
+    ),
+    (
+        "CREATE INDEX workspace_model_pack_bindings_workspace_provider_created_idx "
+        "ON workspace_model_pack_bindings (workspace_id, provider_id, created_at DESC, id DESC)"
+    ),
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP INDEX IF EXISTS workspace_model_pack_bindings_workspace_provider_created_idx",
+    "ALTER TABLE workspace_model_pack_bindings DROP COLUMN IF EXISTS provider_id",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)

--- a/apps/api/src/alicebot_api/contracts.py
+++ b/apps/api/src/alicebot_api/contracts.py
@@ -1837,6 +1837,7 @@ class ModelPackDetailResponse(TypedDict):
 class WorkspaceModelPackBindingRecord(TypedDict):
     id: str
     workspace_id: str
+    provider_id: str | None
     model_pack_id: str
     bound_by_user_account_id: str
     binding_source: ModelPackBindingSource

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -703,10 +703,12 @@ from alicebot_api.provider_runtime import (
 from alicebot_api.model_packs import (
     MODEL_PACK_BINDING_SOURCE_MANUAL,
     MODEL_PACK_STATUS_ACTIVE,
+    ModelPackCompatibilityError,
     ModelPackNotFoundError,
     ModelPackValidationError,
     append_instruction,
     apply_runtime_limit_caps,
+    assert_model_pack_runtime_compatibility,
     build_model_pack_runtime_shape,
     ensure_tier1_model_packs_for_workspace,
     is_reserved_tier1_pack_key,
@@ -1718,6 +1720,7 @@ def _serialize_workspace_model_pack_binding(
     return {
         "id": str(binding["id"]),
         "workspace_id": str(binding["workspace_id"]),
+        "provider_id": None if binding["provider_id"] is None else str(binding["provider_id"]),
         "model_pack_id": str(binding["model_pack_id"]),
         "bound_by_user_account_id": str(binding["bound_by_user_account_id"]),
         "binding_source": binding["binding_source"],
@@ -2869,6 +2872,7 @@ class CreateModelPackRequest(BaseModel):
 class BindModelPackRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    provider_id: UUID | None = None
     pack_version: str | None = Field(default=None, min_length=1, max_length=40)
     metadata: dict[str, object] = Field(default_factory=dict)
 
@@ -8482,6 +8486,17 @@ def bind_v1_model_pack(pack_id: str, request: Request, body: BindModelPackReques
                     workspace_id=workspace["id"],
                     created_by_user_account_id=resolution["user_account"]["id"],
                 )
+                provider = None
+                if body.provider_id is not None:
+                    provider = store.get_model_provider_for_workspace_optional(
+                        provider_id=body.provider_id,
+                        workspace_id=workspace["id"],
+                    )
+                    if provider is None:
+                        return JSONResponse(
+                            status_code=404,
+                            content={"detail": f"provider {body.provider_id} was not found"},
+                        )
                 pack = store.get_model_pack_for_workspace_optional(
                     workspace_id=workspace["id"],
                     pack_id=normalized_pack_id,
@@ -8492,18 +8507,33 @@ def bind_v1_model_pack(pack_id: str, request: Request, body: BindModelPackReques
                         status_code=404,
                         content={"detail": f"model pack {normalized_pack_id} was not found"},
                     )
+                if provider is not None:
+                    assert_model_pack_runtime_compatibility(
+                        pack=pack,
+                        provider_key=provider["provider_key"],
+                        runtime_provider=provider["model_provider"],
+                    )
                 store.create_workspace_model_pack_binding(
                     workspace_id=workspace["id"],
+                    provider_id=None if provider is None else provider["id"],
                     model_pack_id=pack["id"],
                     bound_by_user_account_id=resolution["user_account"]["id"],
                     binding_source=MODEL_PACK_BINDING_SOURCE_MANUAL,
                     metadata=body.metadata,
                 )
-                binding = store.get_latest_workspace_model_pack_binding_optional(
-                    workspace_id=workspace["id"],
-                )
+                if provider is None:
+                    binding = store.get_latest_workspace_model_pack_binding_optional(
+                        workspace_id=workspace["id"],
+                    )
+                else:
+                    binding = store.get_resolved_workspace_model_pack_binding_optional(
+                        workspace_id=workspace["id"],
+                        provider_id=provider["id"],
+                    )
     except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
         return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except ModelPackCompatibilityError as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
     except ModelPackValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -8516,7 +8546,11 @@ def bind_v1_model_pack(pack_id: str, request: Request, body: BindModelPackReques
 
 
 @app.get("/v1/workspaces/{workspace_id}/model-pack-binding")
-def get_v1_workspace_model_pack_binding(workspace_id: UUID, request: Request) -> JSONResponse:
+def get_v1_workspace_model_pack_binding(
+    workspace_id: UUID,
+    request: Request,
+    provider_id: Annotated[UUID | None, Query()] = None,
+) -> JSONResponse:
     settings = get_settings()
 
     try:
@@ -8533,9 +8567,21 @@ def get_v1_workspace_model_pack_binding(workspace_id: UUID, request: Request) ->
                     return JSONResponse(status_code=404, content={"detail": f"workspace {workspace_id} was not found"})
 
                 store = ContinuityStore(conn)
-                binding = store.get_latest_workspace_model_pack_binding_optional(
-                    workspace_id=workspace["id"],
-                )
+                if provider_id is None:
+                    binding = store.get_latest_workspace_model_pack_binding_optional(
+                        workspace_id=workspace["id"],
+                    )
+                else:
+                    provider = store.get_model_provider_for_workspace_optional(
+                        provider_id=provider_id,
+                        workspace_id=workspace["id"],
+                    )
+                    if provider is None:
+                        return JSONResponse(status_code=404, content={"detail": f"provider {provider_id} was not found"})
+                    binding = store.get_resolved_workspace_model_pack_binding_optional(
+                        workspace_id=workspace["id"],
+                        provider_id=provider_id,
+                    )
     except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
         return JSONResponse(status_code=401, content={"detail": str(exc)})
 
@@ -8599,11 +8645,14 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
                     workspace_id=workspace["id"],
                     requested_pack_id=body.pack_id,
                     requested_pack_version=body.pack_version,
+                    provider_id=runtime_provider.provider_id,
                 )
                 model_pack = selected_pack.pack
                 model_pack_source = selected_pack.source
     except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
         return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except ModelPackCompatibilityError as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
     except ModelPackNotFoundError as exc:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
     except ModelPackValidationError as exc:
@@ -8630,37 +8679,45 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
     runtime_system_instruction = SYSTEM_INSTRUCTION
     runtime_developer_instruction = DEVELOPER_INSTRUCTION
 
-    if model_pack is not None:
-        runtime_shape = build_model_pack_runtime_shape(model_pack["contract"])
-        (
-            max_sessions,
-            max_events,
-            max_memories,
-            max_entities,
-            max_entity_edges,
-        ) = apply_runtime_limit_caps(
-            max_sessions=runtime_limits.max_sessions,
-            max_events=runtime_limits.max_events,
-            max_memories=runtime_limits.max_memories,
-            max_entities=runtime_limits.max_entities,
-            max_entity_edges=runtime_limits.max_entity_edges,
-            shape=runtime_shape,
-        )
-        runtime_limits = ContextCompilerLimits(
-            max_sessions=max_sessions,
-            max_events=max_events,
-            max_memories=max_memories,
-            max_entities=max_entities,
-            max_entity_edges=max_entity_edges,
-        )
-        runtime_system_instruction = append_instruction(
-            SYSTEM_INSTRUCTION,
-            runtime_shape.system_instruction_append,
-        )
-        runtime_developer_instruction = append_instruction(
-            DEVELOPER_INSTRUCTION,
-            runtime_shape.developer_instruction_append,
-        )
+    try:
+        if model_pack is not None:
+            assert_model_pack_runtime_compatibility(
+                pack=model_pack,
+                provider_key=runtime_provider.provider_key,
+                runtime_provider=runtime_provider.model_provider,
+            )
+            runtime_shape = build_model_pack_runtime_shape(model_pack["contract"])
+            (
+                max_sessions,
+                max_events,
+                max_memories,
+                max_entities,
+                max_entity_edges,
+            ) = apply_runtime_limit_caps(
+                max_sessions=runtime_limits.max_sessions,
+                max_events=runtime_limits.max_events,
+                max_memories=runtime_limits.max_memories,
+                max_entities=runtime_limits.max_entities,
+                max_entity_edges=runtime_limits.max_entity_edges,
+                shape=runtime_shape,
+            )
+            runtime_limits = ContextCompilerLimits(
+                max_sessions=max_sessions,
+                max_events=max_events,
+                max_memories=max_memories,
+                max_entities=max_entities,
+                max_entity_edges=max_entity_edges,
+            )
+            runtime_system_instruction = append_instruction(
+                SYSTEM_INSTRUCTION,
+                runtime_shape.system_instruction_append,
+            )
+            runtime_developer_instruction = append_instruction(
+                DEVELOPER_INSTRUCTION,
+                runtime_shape.developer_instruction_append,
+            )
+    except ModelPackCompatibilityError as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
 
     user_account_id = user_account["id"]
     if not isinstance(user_account_id, UUID):

--- a/apps/api/src/alicebot_api/model_packs.py
+++ b/apps/api/src/alicebot_api/model_packs.py
@@ -43,6 +43,10 @@ class ModelPackNotFoundError(LookupError):
     """Raised when a model pack cannot be found in the workspace scope."""
 
 
+class ModelPackCompatibilityError(ValueError):
+    """Raised when a model pack is incompatible with the selected provider/runtime."""
+
+
 PackSelectionSource = Literal["none", "request", "workspace_binding"]
 
 
@@ -484,124 +488,36 @@ def _tier1_pack_specs() -> tuple[Tier1PackSpec, ...]:
     )
 
 
-def _tier2_pack_specs() -> tuple[Tier1PackSpec, ...]:
-    return (
-        Tier1PackSpec(
-            pack_id="deepseek",
-            pack_version="1.0.0",
-            display_name="DeepSeek Tier 2",
-            family="deepseek",
-            description="Tier-2 declarative runtime shaping for DeepSeek-family instruct models.",
-            briefing_strategy="balanced",
-            briefing_max_tokens=192,
-            contract=normalize_model_pack_contract(
-                {
-                    "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
-                    "context": {
-                        "max_sessions_cap": 3,
-                        "max_events_cap": 8,
-                        "max_memories_cap": 6,
-                        "max_entities_cap": 6,
-                        "max_entity_edges_cap": 12,
-                    },
-                    "tools": {"mode": "none"},
-                    "response": {
-                        "system_instruction_append": (
-                            "Prefer precise, concise outputs and anchor claims to explicit context."
-                        ),
-                        "developer_instruction_append": (
-                            "Keep recommendations concrete and avoid speculative branching."
-                        ),
-                    },
-                    "compatibility": {
-                        "provider_keys": ["openai_compatible", "ollama", "llamacpp", "vllm"],
-                        "runtime_providers": ["openai_responses"],
-                        "notes": "Tier-2 baseline for DeepSeek-family backends.",
-                    },
-                }
-            ),
-            seed="tier2",
-            seed_version="p11-s6",
-        ),
-        Tier1PackSpec(
-            pack_id="kimi",
-            pack_version="1.0.0",
-            display_name="Kimi Tier 2",
-            family="kimi",
-            description="Tier-2 declarative runtime shaping for Kimi-family instruct models.",
-            briefing_strategy="detailed",
-            briefing_max_tokens=224,
-            contract=normalize_model_pack_contract(
-                {
-                    "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
-                    "context": {
-                        "max_sessions_cap": 3,
-                        "max_events_cap": 8,
-                        "max_memories_cap": 5,
-                        "max_entities_cap": 6,
-                        "max_entity_edges_cap": 10,
-                    },
-                    "tools": {"mode": "none"},
-                    "response": {
-                        "system_instruction_append": (
-                            "Use direct language and preserve important continuity facts."
-                        ),
-                        "developer_instruction_append": (
-                            "Favor short, execution-ready output with explicit next actions."
-                        ),
-                    },
-                    "compatibility": {
-                        "provider_keys": ["openai_compatible", "ollama", "llamacpp", "vllm"],
-                        "runtime_providers": ["openai_responses"],
-                        "notes": "Tier-2 baseline for Kimi-family backends.",
-                    },
-                }
-            ),
-            seed="tier2",
-            seed_version="p11-s6",
-        ),
-        Tier1PackSpec(
-            pack_id="mistral",
-            pack_version="1.0.0",
-            display_name="Mistral Tier 2",
-            family="mistral",
-            description="Tier-2 declarative runtime shaping for Mistral-family instruct models.",
-            briefing_strategy="balanced",
-            briefing_max_tokens=176,
-            contract=normalize_model_pack_contract(
-                {
-                    "contract_version": MODEL_PACK_CONTRACT_VERSION_V1,
-                    "context": {
-                        "max_sessions_cap": 3,
-                        "max_events_cap": 8,
-                        "max_memories_cap": 5,
-                        "max_entities_cap": 5,
-                        "max_entity_edges_cap": 10,
-                    },
-                    "tools": {"mode": "none"},
-                    "response": {
-                        "system_instruction_append": (
-                            "Keep responses structured and grounded in available evidence."
-                        ),
-                        "developer_instruction_append": (
-                            "Prefer concise summaries and call out uncertainty when applicable."
-                        ),
-                    },
-                    "compatibility": {
-                        "provider_keys": ["openai_compatible", "ollama", "llamacpp", "vllm"],
-                        "runtime_providers": ["openai_responses"],
-                        "notes": "Tier-2 baseline for Mistral-family backends.",
-                    },
-                }
-            ),
-            seed="tier2",
-            seed_version="p11-s6",
-        ),
-    )
-
-
 def _catalog_pack_specs() -> tuple[Tier1PackSpec, ...]:
-    return _tier1_pack_specs() + _tier2_pack_specs()
+    return _tier1_pack_specs()
+
+
+def _compatibility_lists(contract: Mapping[str, object]) -> tuple[list[str], list[str]]:
+    normalized_contract = normalize_model_pack_contract(contract)
+    compatibility = normalized_contract["compatibility"]
+    assert isinstance(compatibility, dict)
+    provider_keys = compatibility.get("provider_keys", [])
+    runtime_providers = compatibility.get("runtime_providers", [])
+    assert isinstance(provider_keys, list)
+    assert isinstance(runtime_providers, list)
+    return ([str(item) for item in provider_keys], [str(item) for item in runtime_providers])
+
+
+def assert_model_pack_runtime_compatibility(
+    *,
+    pack: ModelPackRow,
+    provider_key: str,
+    runtime_provider: str,
+) -> None:
+    compatible_provider_keys, compatible_runtime_providers = _compatibility_lists(pack["contract"])
+    if provider_key not in compatible_provider_keys:
+        raise ModelPackCompatibilityError(
+            f"model pack {pack['pack_id']} is not compatible with provider key {provider_key}"
+        )
+    if runtime_provider not in compatible_runtime_providers:
+        raise ModelPackCompatibilityError(
+            f"model pack {pack['pack_id']} is not compatible with runtime provider {runtime_provider}"
+        )
 
 
 def is_reserved_tier1_pack_key(*, pack_id: str, pack_version: str) -> bool:
@@ -658,6 +574,7 @@ def resolve_workspace_model_pack_selection(
     workspace_id: UUID,
     requested_pack_id: str | None,
     requested_pack_version: str | None,
+    provider_id: UUID | None = None,
 ) -> ResolvedModelPackSelection:
     if requested_pack_id is not None:
         normalized_pack_id = normalize_pack_id(requested_pack_id)
@@ -681,7 +598,14 @@ def resolve_workspace_model_pack_selection(
             )
         return ResolvedModelPackSelection(source="request", pack=selected_pack)
 
-    binding = store.get_latest_workspace_model_pack_binding_optional(workspace_id=workspace_id)
+    binding = None
+    if provider_id is not None:
+        binding = store.get_resolved_workspace_model_pack_binding_optional(
+            workspace_id=workspace_id,
+            provider_id=provider_id,
+        )
+    else:
+        binding = store.get_latest_workspace_model_pack_binding_optional(workspace_id=workspace_id)
     if binding is None:
         return ResolvedModelPackSelection(source="none", pack=None)
 

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -487,6 +487,7 @@ class ModelPackRow(TypedDict):
 class WorkspaceModelPackBindingRow(TypedDict):
     id: UUID
     workspace_id: UUID
+    provider_id: UUID | None
     model_pack_id: UUID
     bound_by_user_account_id: UUID
     binding_source: str
@@ -497,6 +498,7 @@ class WorkspaceModelPackBindingRow(TypedDict):
 class WorkspaceModelPackBindingDetailRow(TypedDict):
     id: UUID
     workspace_id: UUID
+    provider_id: UUID | None
     model_pack_id: UUID
     bound_by_user_account_id: UUID
     binding_source: str
@@ -2768,16 +2770,18 @@ LIST_MODEL_PACKS_FOR_WORKSPACE_SQL = """
 INSERT_WORKSPACE_MODEL_PACK_BINDING_SQL = """
                 INSERT INTO workspace_model_pack_bindings (
                   workspace_id,
+                  provider_id,
                   model_pack_id,
                   bound_by_user_account_id,
                   binding_source,
                   metadata,
                   created_at
                 )
-                VALUES (%s, %s, %s, %s, %s, clock_timestamp())
+                VALUES (%s, %s, %s, %s, %s, %s, clock_timestamp())
                 RETURNING
                   id,
                   workspace_id,
+                  provider_id,
                   model_pack_id,
                   bound_by_user_account_id,
                   binding_source,
@@ -2789,6 +2793,7 @@ GET_LATEST_WORKSPACE_MODEL_PACK_BINDING_SQL = """
                 SELECT
                   b.id,
                   b.workspace_id,
+                  b.provider_id,
                   b.model_pack_id,
                   b.bound_by_user_account_id,
                   b.binding_source,
@@ -2811,7 +2816,43 @@ GET_LATEST_WORKSPACE_MODEL_PACK_BINDING_SQL = """
                 INNER JOIN model_packs AS p
                   ON p.id = b.model_pack_id
                 WHERE b.workspace_id = %s
+                  AND b.provider_id IS NULL
                 ORDER BY b.created_at DESC, b.id DESC
+                LIMIT 1
+                """
+
+GET_RESOLVED_WORKSPACE_MODEL_PACK_BINDING_SQL = """
+                SELECT
+                  b.id,
+                  b.workspace_id,
+                  b.provider_id,
+                  b.model_pack_id,
+                  b.bound_by_user_account_id,
+                  b.binding_source,
+                  b.metadata,
+                  b.created_at,
+                  p.pack_id,
+                  p.pack_version,
+                  p.display_name AS pack_display_name,
+                  p.family AS pack_family,
+                  p.description AS pack_description,
+                  p.status AS pack_status,
+                  p.briefing_strategy AS pack_briefing_strategy,
+                  p.briefing_max_tokens AS pack_briefing_max_tokens,
+                  p.contract AS pack_contract,
+                  p.metadata AS pack_metadata,
+                  p.created_by_user_account_id AS pack_created_by_user_account_id,
+                  p.created_at AS pack_created_at,
+                  p.updated_at AS pack_updated_at
+                FROM workspace_model_pack_bindings AS b
+                INNER JOIN model_packs AS p
+                  ON p.id = b.model_pack_id
+                WHERE b.workspace_id = %s
+                  AND (b.provider_id = %s OR b.provider_id IS NULL)
+                ORDER BY
+                  CASE WHEN b.provider_id = %s THEN 0 ELSE 1 END,
+                  b.created_at DESC,
+                  b.id DESC
                 LIMIT 1
                 """
 
@@ -8548,6 +8589,7 @@ class ContinuityStore:
         self,
         *,
         workspace_id: UUID,
+        provider_id: UUID | None,
         model_pack_id: UUID,
         bound_by_user_account_id: UUID,
         binding_source: str,
@@ -8558,6 +8600,7 @@ class ContinuityStore:
             INSERT_WORKSPACE_MODEL_PACK_BINDING_SQL,
             (
                 workspace_id,
+                provider_id,
                 model_pack_id,
                 bound_by_user_account_id,
                 binding_source,
@@ -8573,6 +8616,17 @@ class ContinuityStore:
         return self._fetch_optional_one(
             GET_LATEST_WORKSPACE_MODEL_PACK_BINDING_SQL,
             (workspace_id,),
+        )
+
+    def get_resolved_workspace_model_pack_binding_optional(
+        self,
+        *,
+        workspace_id: UUID,
+        provider_id: UUID,
+    ) -> WorkspaceModelPackBindingDetailRow | None:
+        return self._fetch_optional_one(
+            GET_RESOLVED_WORKSPACE_MODEL_PACK_BINDING_SQL,
+            (workspace_id, provider_id, provider_id),
         )
 
     def workspace_visible_to_user_account(

--- a/docs/integrations/phase11-model-pack-compatibility.md
+++ b/docs/integrations/phase11-model-pack-compatibility.md
@@ -1,6 +1,6 @@
-# Phase 11 Provider + Model Pack Compatibility (P11-S6)
+# Phase 14 Model Pack Compatibility Matrix (P14-S3)
 
-This reference defines the shipped provider/pack compatibility posture for Phase 11 closeout.
+This reference defines the shipped first-party pack compatibility posture for `P14-S3`.
 
 ## Built-In Catalog Packs
 
@@ -10,28 +10,32 @@ All built-in catalog packs are seeded per workspace on first model-pack API acce
 - `runtime_providers = ["openai_responses"]`
 - `tools.mode = "none"`
 
-| Pack ID | Version | Tier | Family | Provider Keys | Runtime Provider |
+| Pack ID | Version | Family | Provider Keys | Runtime Provider | Default Briefing |
 |---|---|---|---|---|---|
-| `llama` | `1.0.0` | `tier1` | `llama` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` |
-| `qwen` | `1.0.0` | `tier1` | `qwen` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` |
-| `gemma` | `1.0.0` | `tier1` | `gemma` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` |
-| `gpt-oss` | `1.0.0` | `tier1` | `gpt-oss` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` |
-| `deepseek` | `1.0.0` | `tier2` | `deepseek` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` |
-| `kimi` | `1.0.0` | `tier2` | `kimi` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` |
-| `mistral` | `1.0.0` | `tier2` | `mistral` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` |
+| `llama` | `1.0.0` | `llama` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` | `compact`, `160` |
+| `qwen` | `1.0.0` | `qwen` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` | `compact`, `144` |
+| `gemma` | `1.0.0` | `gemma` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` | `compact`, `128` |
+| `gpt-oss` | `1.0.0` | `gpt-oss` | `openai_compatible`, `ollama`, `llamacpp`, `vllm` | `openai_responses` | `balanced`, `192` |
 
-## Shipped Provider Paths
+## Binding Resolution
 
-| Path | Adapter Key | Primary APIs | Pack Posture |
-|---|---|---|---|
-| Local (Ollama) | `ollama` | `POST /v1/providers/ollama/register`, `POST /v1/providers/test`, `POST /v1/runtime/invoke` | Built-in catalog packs supported per pack `provider_keys`. |
-| Local (llama.cpp) | `llamacpp` | `POST /v1/providers/llamacpp/register`, `POST /v1/providers/test`, `POST /v1/runtime/invoke` | Built-in catalog packs supported per pack `provider_keys`. |
-| Self-hosted vLLM | `vllm` | `POST /v1/providers/vllm/register`, `POST /v1/providers/test`, `POST /v1/runtime/invoke` | Built-in catalog packs supported per pack `provider_keys`. |
-| Self-hosted OpenAI-compatible | `openai_compatible` | `POST /v1/providers`, `POST /v1/providers/test`, `POST /v1/runtime/invoke` | Built-in catalog packs supported per pack `provider_keys`. |
-| Enterprise Azure | `azure` | `POST /v1/providers/azure/register`, `POST /v1/providers/test`, `POST /v1/runtime/invoke` | Uses the same pack seam; built-in catalog contracts are not Azure-keyed. Use custom packs when Azure-specific compatibility metadata is required. |
-| External-agent orchestration (AutoGen bridge) | runtime passthrough to configured provider | `scripts/run_phase11_autogen_runtime_bridge.py` + `POST /v1/runtime/invoke` | Same pack selection rules and metadata as direct runtime invoke. |
+- request override
+- provider-specific workspace binding
+- workspace default binding
+- no pack
+
+Provider-specific bindings must satisfy both:
+- `compatibility.provider_keys`
+- `compatibility.runtime_providers`
+
+Workspace default bindings intentionally stay provider-agnostic so briefing defaults can resolve without a provider id.
+
+## Deferred Families
+
+DeepSeek, Mistral, Kimi, and other non-first-party families are not shipped as built-in catalog entries in `P14-S3`. They require custom packs until a later sprint adds first-party definitions.
 
 ## Scope Notes
 
-- Provider behavior stays in adapters; pack behavior stays declarative in pack contracts.
-- This document reflects shipped Phase 11 surfaces only; no new providers or frameworks are implied.
+- Provider behavior stays in adapters.
+- Pack behavior stays declarative in pack contracts and briefing defaults.
+- `P14-S3` does not reopen provider work or add new runtime providers.

--- a/docs/integrations/phase11-model-packs-tier1.md
+++ b/docs/integrations/phase11-model-packs-tier1.md
@@ -32,8 +32,9 @@ Each tier-1 pack uses `contract_version = model_pack_contract_v1` and keeps beha
 For `POST /v1/runtime/invoke`, model-pack selection precedence is:
 
 1. request override (`pack_id` + optional `pack_version`)
-2. current workspace binding
-3. no pack
+2. provider-specific workspace binding
+3. workspace default binding
+4. no pack
 
 This precedence affects runtime shaping only. It does not change provider adapter semantics.
 
@@ -54,10 +55,13 @@ curl -sS -X POST "http://127.0.0.1:8000/v1/model-packs/gpt-oss/bind" \
   -H "Authorization: Bearer $SESSION_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
+    "provider_id": "'$PROVIDER_ID'",
     "pack_version": "1.0.0",
-    "metadata": {"reason": "team-default"}
+    "metadata": {"reason": "provider-default"}
   }'
 ```
+
+Omit `provider_id` to set the workspace default pack used for briefing defaults.
 
 ## Invoke With Bound Pack
 
@@ -78,6 +82,13 @@ curl -sS -X POST "http://127.0.0.1:8000/v1/runtime/invoke" \
 ```
 
 The response metadata reports the resolved pack and source when a pack is applied.
+
+## Read The Current Binding
+
+```bash
+curl -sS -X GET "http://127.0.0.1:8000/v1/workspaces/$WORKSPACE_ID/model-pack-binding?provider_id=$PROVIDER_ID" \
+  -H "Authorization: Bearer $SESSION_TOKEN"
+```
 
 ## Create A Custom Pack
 

--- a/docs/phase14-model-pack-contract.md
+++ b/docs/phase14-model-pack-contract.md
@@ -1,46 +1,64 @@
 # Phase 14 Model Pack Contract
 
 ## Purpose
-Define the declarative pack profile Alice uses to make provider-backed models usable without manual tuning.
+Model packs provide declarative continuity defaults on top of the shipped provider/runtime baseline.
 
-## Rule
-Model packs are profiles, not forks.
+They shape briefing and runtime behavior without creating a second provider path or changing Alice continuity semantics.
 
-They may shape defaults for prompting, briefing, tools, token budgets, and quirks, but they must not create new continuity semantics.
+## Shipped First-Party Packs
+- `llama@1.0.0`
+- `qwen@1.0.0`
+- `gemma@1.0.0`
+- `gpt-oss@1.0.0`
 
-## Required Fields
+DeepSeek, Mistral, and other families remain deferred from the first-party catalog in `P14-S3`.
+
+## Persisted Model-Pack Fields
 - `pack_id`
-- `family`
+- `pack_version`
 - `display_name`
-- `provider_type`
-- `default_model_name`
-- `supports_tools`
-- `supports_reasoning`
-- `supports_vision`
+- `family`
+- `description`
+- `status`
 - `briefing_strategy`
-- `resume_brief_style`
-- `max_context_pack_tokens`
-- `max_brief_tokens`
-- `default_temperature`
-- `default_top_p`
-- `evidence_strategy`
-- `known_quirks`
+- `briefing_max_tokens`
+- `contract`
+- `metadata`
 
-## Initial First-Party Families
-- Llama
-- Qwen
-- Gemma
-- `gpt-oss`
+## Contract Shape
+`contract.contract_version` must equal `model_pack_contract_v1`.
 
-Optional later Phase 14 families if capacity remains:
-- DeepSeek
-- Mistral
+### `context`
+- `max_sessions_cap`
+- `max_events_cap`
+- `max_memories_cap`
+- `max_entities_cap`
+- `max_entity_edges_cap`
+
+### `tools`
+- `mode`
+
+`P14-S3` ships only `tools.mode = "none"`.
+
+### `response`
+- `system_instruction_append`
+- `developer_instruction_append`
+
+### `compatibility`
+- `provider_keys`
+- `runtime_providers`
+- `notes`
 
 ## Binding Rules
-- a workspace binds a provider to a model pack
-- packs must be versioned
-- pack bindings may allow model-name override without semantic drift
-- pack defaults must flow into runtime invocation and briefing behavior
+- a workspace may bind a default pack with no provider id
+- a workspace may bind a specific provider to a pack by `provider_id`
+- runtime selection precedence is:
+  1. explicit request override
+  2. provider-specific binding
+  3. workspace default binding
+  4. no pack
+- task-briefing defaults resolve from the workspace default binding when no explicit pack is requested
+- pack compatibility must remain declarative through `compatibility.provider_keys` and `compatibility.runtime_providers`
 
 ## Success Condition
-Users should be able to bind a supported provider to a first-party pack and get sensible continuity defaults without hand tuning or hidden behavior changes.
+Users can bind a supported provider or workspace default to a documented first-party pack and get sensible continuity defaults without manual tuning or hidden runtime behavior changes.

--- a/docs/phase14-s3-control-tower-packet.md
+++ b/docs/phase14-s3-control-tower-packet.md
@@ -4,7 +4,7 @@
 `P14-S3` Model Packs
 
 ## Goal
-Make common model families easy to use with sensible continuity defaults.
+Make common model families easy to use with sensible continuity defaults on top of the shipped Phase 14 provider/runtime surface.
 
 ## Planned Branch
 `codex/phase14-s3-model-packs`
@@ -21,6 +21,7 @@ Make common model families easy to use with sensible continuity defaults.
 ## Out Of Scope
 - provider-contract redesign
 - broad provider expansion unrelated to packs
+- reopening local/self-hosted compatibility work already closed in `P14-S2`
 - design-partner operations
 
 ## Acceptance Criteria
@@ -28,3 +29,4 @@ Make common model families easy to use with sensible continuity defaults.
 - pack defaults affect briefing and runtime behavior correctly
 - first-party packs are versioned and documented
 - users get good defaults without manual tuning
+- pack behavior composes the shipped provider/runtime baseline instead of creating a second provider path

--- a/docs/phase14-sprint-14-1-14-5-plan.md
+++ b/docs/phase14-sprint-14-1-14-5-plan.md
@@ -35,7 +35,7 @@ None
 Internal provider-foundation release candidate
 
 ### Status
-Active
+Shipped
 
 ## P14-S2: Ollama + llama.cpp + vLLM Adapters
 
@@ -57,7 +57,7 @@ Support the most important local and self-hosted inference paths without semanti
 `v0.5.0-rc1`
 
 ### Status
-Planned
+Shipped
 
 ## P14-S3: Model Packs
 
@@ -78,7 +78,7 @@ Make common model families easy to use with sensible continuity defaults.
 `v0.5.0-rc2`
 
 ### Status
-Planned
+Active
 
 ## P14-S4: Reference Integrations
 

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -30,15 +30,15 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "`v0.4.0`: released",
             "Phase 14 is active.",
-            "`P14-S2` Ollama + llama.cpp + vLLM Adapters is the active execution sprint.",
+            "`P14-S3` Model Packs is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "P14-S2: Ollama + llama.cpp + vLLM Adapters",
+            "P14-S3: Model Packs",
             "`v0.4.0` is the current public release boundary.",
-            "codex/phase14-s2-local-self-hosted-adapters",
+            "codex/phase14-s3-model-packs",
         ),
     ),
     ControlDocTruthRule(
@@ -53,7 +53,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "`v0.4.0` is the latest published tag.",
             "Phase 14 is active.",
-            "`P14-S2` Ollama + llama.cpp + vLLM Adapters is the active execution sprint.",
+            "`P14-S3` Model Packs is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(

--- a/tests/integration/test_phase11_model_packs_api.py
+++ b/tests/integration/test_phase11_model_packs_api.py
@@ -179,6 +179,93 @@ class FakeHTTPResponse:
         return self.body
 
 
+def _install_local_provider_success(monkeypatch) -> list[dict[str, object]]:
+    captured_requests: list[dict[str, object]] = []
+
+    def fake_urlopen(request, timeout):
+        url = request.full_url
+        captured_requests.append(
+            {
+                "url": url,
+                "timeout": timeout,
+                "body": None if request.data is None else json.loads(request.data.decode("utf-8")),
+            }
+        )
+        if url == "http://ollama.example:11434/api/version":
+            return FakeHTTPResponse(json.dumps({"version": "0.5.1"}).encode("utf-8"))
+        if url == "http://ollama.example:11434/api/tags":
+            return FakeHTTPResponse(
+                json.dumps({"models": [{"name": "llama3.2:latest"}]}).encode("utf-8")
+            )
+        if url == "http://ollama.example:11434/api/chat":
+            return FakeHTTPResponse(
+                json.dumps(
+                    {
+                        "message": {"role": "assistant", "content": "Ollama pack smoke response"},
+                        "done": True,
+                        "prompt_eval_count": 13,
+                        "eval_count": 4,
+                    }
+                ).encode("utf-8")
+            )
+        if url == "http://llamacpp.example:8080/health":
+            return FakeHTTPResponse(json.dumps({"status": "ok"}).encode("utf-8"))
+        if url == "http://llamacpp.example:8080/v1/models":
+            return FakeHTTPResponse(
+                json.dumps({"data": [{"id": "Meta-Llama-3.1-8B-Instruct"}]}).encode("utf-8")
+            )
+        if url == "http://llamacpp.example:8080/v1/chat/completions":
+            return FakeHTTPResponse(
+                json.dumps(
+                    {
+                        "id": "chatcmpl-llamacpp-pack-smoke",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": "llama.cpp pack smoke response"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {
+                            "prompt_tokens": 13,
+                            "completion_tokens": 4,
+                            "total_tokens": 17,
+                        },
+                    }
+                ).encode("utf-8")
+            )
+        if url == "http://vllm.example:8001/health":
+            return FakeHTTPResponse(json.dumps({"status": "ok"}).encode("utf-8"))
+        if url == "http://vllm.example:8001/v1/models":
+            return FakeHTTPResponse(
+                json.dumps({"data": [{"id": "mistral-small-instruct"}]}).encode("utf-8")
+            )
+        if url == "http://vllm.example:8001/v1/chat/completions":
+            return FakeHTTPResponse(
+                json.dumps(
+                    {
+                        "id": "chatcmpl-vllm-pack-smoke",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": "vLLM pack smoke response"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {
+                            "prompt_tokens": 13,
+                            "completion_tokens": 4,
+                            "total_tokens": 17,
+                        },
+                    }
+                ).encode("utf-8")
+            )
+        raise AssertionError(f"unexpected local provider URL: {url}")
+
+    monkeypatch.setattr("alicebot_api.local_provider_helpers.urlopen", fake_urlopen)
+    return captured_requests
+
+
 def _extract_context_payload(http_payload: dict[str, Any]) -> dict[str, Any]:
     input_items = http_payload["input"]
     context_item = next(
@@ -223,21 +310,18 @@ def test_phase11_model_pack_catalog_bind_and_runtime_shaping(migrated_database_u
         "qwen",
         "gemma",
         "gpt-oss",
-        "deepseek",
-        "kimi",
-        "mistral",
     }.issubset(listed_ids)
 
     detail_status, detail_payload = invoke_request(
         "GET",
-        "/v1/model-packs/deepseek",
+        "/v1/model-packs/gpt-oss",
         query_params={"version": "1.0.0"},
         headers=auth_header(session_token),
     )
     assert detail_status == 200
-    assert detail_payload["model_pack"]["pack_id"] == "deepseek"
+    assert detail_payload["model_pack"]["pack_id"] == "gpt-oss"
     assert detail_payload["model_pack"]["pack_version"] == "1.0.0"
-    assert detail_payload["model_pack"]["metadata"]["seed"] == "tier2"
+    assert detail_payload["model_pack"]["metadata"]["seed"] == "tier1"
     assert detail_payload["model_pack"]["briefing_strategy"] == "balanced"
     assert detail_payload["model_pack"]["briefing_max_tokens"] == 192
 
@@ -310,20 +394,27 @@ def test_phase11_model_pack_catalog_bind_and_runtime_shaping(migrated_database_u
     bind_status, bind_payload = invoke_request(
         "POST",
         "/v1/model-packs/gpt-oss/bind",
-        payload={"pack_version": "1.0.0", "metadata": {"reason": "workspace-default"}},
+        payload={
+            "provider_id": provider_id,
+            "pack_version": "1.0.0",
+            "metadata": {"reason": "provider-default"},
+        },
         headers=auth_header(session_token),
     )
     assert bind_status == 200
     assert bind_payload["binding"]["model_pack"]["pack_id"] == "gpt-oss"
+    assert bind_payload["binding"]["provider_id"] == provider_id
     assert bind_payload["binding"]["binding_source"] == "manual"
 
     binding_status, binding_payload = invoke_request(
         "GET",
         f"/v1/workspaces/{workspace_id}/model-pack-binding",
+        query_params={"provider_id": provider_id},
         headers=auth_header(session_token),
     )
     assert binding_status == 200
     assert binding_payload["binding"]["model_pack"]["pack_id"] == "gpt-oss"
+    assert binding_payload["binding"]["provider_id"] == provider_id
 
     thread_id = _seed_thread_for_user(
         admin_db_url=migrated_database_urls["admin"],
@@ -425,14 +516,61 @@ def test_phase11_model_pack_catalog_bind_and_runtime_shaping(migrated_database_u
     assert second_context["limits"]["max_entity_edges"] == 8
     assert "Keep outputs directly actionable and compact." in second_request["input"][1]["content"][0]["text"]
 
-    tier2_override_status, tier2_override_payload = invoke_request(
+    create_provider_specific_pack_status, create_provider_specific_pack_payload = invoke_request(
+        "POST",
+        "/v1/model-packs",
+        payload={
+            "pack_id": "ollama-only-pack",
+            "pack_version": "1.0.0",
+            "display_name": "Ollama Only Pack",
+            "family": "custom",
+            "description": "Pack constrained to Ollama providers.",
+            "briefing_strategy": "compact",
+            "briefing_max_tokens": 128,
+            "contract": {
+                "contract_version": "model_pack_contract_v1",
+                "context": {
+                    "max_sessions_cap": 2,
+                    "max_events_cap": 6,
+                    "max_memories_cap": 4,
+                    "max_entities_cap": 4,
+                    "max_entity_edges_cap": 8,
+                },
+                "tools": {"mode": "none"},
+                "response": {
+                    "system_instruction_append": "Keep answers tight.",
+                    "developer_instruction_append": "Prefer compact steps.",
+                },
+                "compatibility": {
+                    "provider_keys": ["ollama"],
+                    "runtime_providers": ["openai_responses"],
+                    "notes": "Intentionally provider-specific for compatibility testing.",
+                },
+            },
+            "metadata": {"owner": "tests"},
+        },
+        headers=auth_header(session_token),
+    )
+    assert create_provider_specific_pack_status == 201
+    assert create_provider_specific_pack_payload["model_pack"]["pack_id"] == "ollama-only-pack"
+
+    incompatible_bind_status, incompatible_bind_payload = invoke_request(
+        "POST",
+        "/v1/model-packs/ollama-only-pack/bind",
+        payload={"provider_id": provider_id, "pack_version": "1.0.0"},
+        headers=auth_header(session_token),
+    )
+    assert incompatible_bind_status == 409
+    assert "not compatible with provider key openai_compatible" in incompatible_bind_payload["detail"]
+
+    incompatible_override_status, incompatible_override_payload = invoke_request(
         "POST",
         "/v1/runtime/invoke",
         payload={
             "provider_id": provider_id,
             "thread_id": thread_id,
-            "message": "Summarize current status with tier-2 override.",
-            "pack_id": "deepseek",
+            "message": "Try an incompatible override.",
+            "pack_id": "ollama-only-pack",
             "pack_version": "1.0.0",
             "max_sessions": 10,
             "max_events": 40,
@@ -442,22 +580,145 @@ def test_phase11_model_pack_catalog_bind_and_runtime_shaping(migrated_database_u
         },
         headers=auth_header(session_token),
     )
-    assert tier2_override_status == 200
-    assert tier2_override_payload["metadata"]["model_pack"] == {
-        "pack_id": "deepseek",
-        "pack_version": "1.0.0",
-        "source": "request",
-    }
+    assert incompatible_override_status == 409
+    assert "not compatible with provider key openai_compatible" in incompatible_override_payload["detail"]
 
-    third_request = captured_model_requests[2]
-    third_context = _extract_context_payload(third_request)
-    assert third_context["limits"]["max_memories"] == 6
-    assert third_context["limits"]["max_entities"] == 6
-    assert third_context["limits"]["max_entity_edges"] == 12
-    assert (
-        "Keep recommendations concrete and avoid speculative branching."
-        in third_request["input"][1]["content"][0]["text"]
+
+def test_phase11_provider_query_binding_falls_back_to_workspace_default(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, workspace_id, _ = _bootstrap_workspace_session("model-pack-default@example.com")
+
+    create_provider_status, create_provider_payload = invoke_request(
+        "POST",
+        "/v1/providers",
+        payload={
+            "provider_key": "openai_compatible",
+            "display_name": "Default Fallback Provider",
+            "base_url": "https://provider.example/v1",
+            "api_key": "provider-secret-key",
+            "default_model": "gpt-5-mini",
+        },
+        headers=auth_header(session_token),
     )
+    assert create_provider_status == 201
+    provider_id = create_provider_payload["provider"]["id"]
+
+    bind_status, bind_payload = invoke_request(
+        "POST",
+        "/v1/model-packs/llama/bind",
+        payload={"pack_version": "1.0.0", "metadata": {"reason": "workspace-default"}},
+        headers=auth_header(session_token),
+    )
+    assert bind_status == 200
+    assert bind_payload["binding"]["model_pack"]["pack_id"] == "llama"
+    assert bind_payload["binding"]["provider_id"] is None
+
+    binding_status, binding_payload = invoke_request(
+        "GET",
+        f"/v1/workspaces/{workspace_id}/model-pack-binding",
+        query_params={"provider_id": provider_id},
+        headers=auth_header(session_token),
+    )
+    assert binding_status == 200
+    assert binding_payload["binding"]["model_pack"]["pack_id"] == "llama"
+    assert binding_payload["binding"]["provider_id"] is None
+
+
+def test_phase11_model_pack_smoke_covers_local_provider_paths(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, workspace_id, user_account_id = _bootstrap_workspace_session(
+        "model-pack-local-smoke@example.com"
+    )
+    captured_requests = _install_local_provider_success(monkeypatch)
+
+    providers: tuple[tuple[str, str, str, str, str], ...] = (
+        (
+            "/v1/providers/ollama/register",
+            "Ollama Pack Smoke",
+            "http://ollama.example:11434",
+            "llama3.2:latest",
+            "Ollama pack smoke response",
+        ),
+        (
+            "/v1/providers/llamacpp/register",
+            "llama.cpp Pack Smoke",
+            "http://llamacpp.example:8080",
+            "Meta-Llama-3.1-8B-Instruct",
+            "llama.cpp pack smoke response",
+        ),
+        (
+            "/v1/providers/vllm/register",
+            "vLLM Pack Smoke",
+            "http://vllm.example:8001",
+            "mistral-small-instruct",
+            "vLLM pack smoke response",
+        ),
+    )
+    provider_ids: list[str] = []
+    for path, display_name, base_url, default_model, _ in providers:
+        create_status, create_payload = invoke_request(
+            "POST",
+            path,
+            payload={
+                "display_name": display_name,
+                "base_url": base_url,
+                "default_model": default_model,
+            },
+            headers=auth_header(session_token),
+        )
+        assert create_status == 201
+        provider_ids.append(create_payload["provider"]["id"])
+
+    thread_id = _seed_thread_for_user(
+        admin_db_url=migrated_database_urls["admin"],
+        user_id=user_account_id,
+        email="model-pack-local-smoke@example.com",
+    )
+
+    for provider_id, (_, _, _, _, expected_text) in zip(provider_ids, providers, strict=True):
+        bind_status, bind_payload = invoke_request(
+            "POST",
+            "/v1/model-packs/llama/bind",
+            payload={
+                "provider_id": provider_id,
+                "pack_version": "1.0.0",
+                "metadata": {"reason": "provider-smoke"},
+            },
+            headers=auth_header(session_token),
+        )
+        assert bind_status == 200
+        assert bind_payload["binding"]["model_pack"]["pack_id"] == "llama"
+        assert bind_payload["binding"]["provider_id"] == provider_id
+
+        runtime_status, runtime_payload = invoke_request(
+            "POST",
+            "/v1/runtime/invoke",
+            payload={
+                "provider_id": provider_id,
+                "thread_id": thread_id,
+                "message": "Run the model-pack smoke.",
+            },
+            headers=auth_header(session_token),
+        )
+        assert runtime_status == 200
+        assert runtime_payload["assistant"]["provider_id"] == provider_id
+        assert runtime_payload["assistant"]["text"] == expected_text
+        assert runtime_payload["metadata"]["model_pack"] == {
+            "pack_id": "llama",
+            "pack_version": "1.0.0",
+            "source": "workspace_binding",
+        }
+
+    captured_urls = [record["url"] for record in captured_requests]
+    assert "http://ollama.example:11434/api/chat" in captured_urls
+    assert "http://llamacpp.example:8080/v1/chat/completions" in captured_urls
+    assert "http://vllm.example:8001/v1/chat/completions" in captured_urls
 
 
 def test_phase11_workspace_model_pack_binding_is_workspace_isolated(migrated_database_urls, monkeypatch) -> None:

--- a/tests/unit/test_20260416_0064_phase14_provider_model_pack_bindings.py
+++ b/tests/unit/test_20260416_0064_phase14_provider_model_pack_bindings.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260416_0064_phase14_provider_model_pack_bindings"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == list(module._UPGRADE_STATEMENTS)
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_upgrade_adds_provider_binding_column_and_index() -> None:
+    module = load_migration_module()
+    ddl = "\n".join(module._UPGRADE_STATEMENTS)
+
+    assert "ADD COLUMN provider_id uuid NULL" in ddl
+    assert "REFERENCES model_providers(id) ON DELETE CASCADE" in ddl
+    assert "workspace_model_pack_bindings_workspace_provider_created_idx" in ddl

--- a/tests/unit/test_model_packs.py
+++ b/tests/unit/test_model_packs.py
@@ -7,9 +7,11 @@ import pytest
 
 from alicebot_api.model_packs import (
     MODEL_PACK_CONTRACT_VERSION_V1,
+    ModelPackCompatibilityError,
     ModelPackNotFoundError,
     ModelPackValidationError,
     apply_runtime_limit_caps,
+    assert_model_pack_runtime_compatibility,
     build_model_pack_runtime_shape,
     ensure_tier1_model_packs_for_workspace,
     is_reserved_tier1_pack_key,
@@ -73,6 +75,7 @@ class FakeModelPackStore:
         self.packs_by_key: dict[tuple[str, str], dict[str, object]] = {}
         self.packs_by_row_id: dict[object, dict[str, object]] = {}
         self.binding: dict[str, object] | None = None
+        self.provider_bindings: dict[object, dict[str, object]] = {}
 
     def get_model_pack_for_workspace_optional(
         self,
@@ -168,6 +171,10 @@ class FakeModelPackStore:
     def get_latest_workspace_model_pack_binding_optional(self, *, workspace_id):
         del workspace_id
         return self.binding
+
+    def get_resolved_workspace_model_pack_binding_optional(self, *, workspace_id, provider_id):
+        del workspace_id
+        return self.provider_bindings.get(provider_id) or self.binding
 
     def get_model_pack_for_workspace_by_row_id_optional(self, *, workspace_id, model_pack_id):
         del workspace_id
@@ -300,25 +307,17 @@ def test_ensure_tier1_model_packs_for_workspace_seeds_once() -> None:
         created_by_user_account_id=user_account_id,
     )
 
-    assert len(first_seed) == 7
-    assert len(second_seed) == 7
-    assert len(store.packs_by_key) == 7
+    assert len(first_seed) == 4
+    assert len(second_seed) == 4
+    assert len(store.packs_by_key) == 4
     assert {row["pack_id"] for row in first_seed} == {
         "llama",
         "qwen",
         "gemma",
         "gpt-oss",
-        "deepseek",
-        "kimi",
-        "mistral",
     }
-    assert {
-        row["pack_id"]: row["metadata"]
-        for row in first_seed
-        if row["pack_id"] in {"llama", "deepseek"}
-    } == {
-        "llama": {"seed": "tier1", "seed_version": "p11-s4"},
-        "deepseek": {"seed": "tier2", "seed_version": "p11-s6"},
+    assert {row["pack_id"]: row["metadata"] for row in first_seed if row["pack_id"] == "llama"} == {
+        "llama": {"seed": "tier1", "seed_version": "p11-s4"}
     }
 
 
@@ -329,22 +328,20 @@ def test_ensure_tier1_model_packs_handles_seed_race_with_existing_row() -> None:
         workspace_id=uuid4(),
         created_by_user_account_id=uuid4(),
     )
-    assert len(seeded) == 7
+    assert len(seeded) == 4
     assert {row["pack_id"] for row in seeded} == {
         "llama",
         "qwen",
         "gemma",
         "gpt-oss",
-        "deepseek",
-        "kimi",
-        "mistral",
     }
 
 
 def test_is_reserved_tier1_pack_key() -> None:
     assert is_reserved_tier1_pack_key(pack_id="llama", pack_version="1.0.0")
-    assert is_reserved_tier1_pack_key(pack_id="deepseek", pack_version="1.0.0")
+    assert is_reserved_tier1_pack_key(pack_id="gpt-oss", pack_version="1.0.0")
     assert not is_reserved_tier1_pack_key(pack_id="llama", pack_version="1.0.1")
+    assert not is_reserved_tier1_pack_key(pack_id="deepseek", pack_version="1.0.0")
     assert not is_reserved_tier1_pack_key(pack_id="custom-brief", pack_version="1.0.0")
 
 
@@ -393,6 +390,34 @@ def test_pack_selection_uses_workspace_binding_when_request_not_supplied() -> No
     assert selected.pack is bound_pack
 
 
+def test_pack_selection_prefers_provider_binding_then_workspace_default() -> None:
+    store = FakeModelPackStore()
+    workspace_id = uuid4()
+    provider_id = uuid4()
+    provider_pack = _pack_row(pack_id="qwen")
+    default_pack = _pack_row(pack_id="llama")
+    store.packs_by_key[("qwen", "1.0.0")] = provider_pack
+    store.packs_by_key[("llama", "1.0.0")] = default_pack
+    store.packs_by_row_id[provider_pack["id"]] = provider_pack
+    store.packs_by_row_id[default_pack["id"]] = default_pack
+    store.binding = {"provider_id": None, "model_pack_id": default_pack["id"]}
+    store.provider_bindings[provider_id] = {
+        "provider_id": provider_id,
+        "model_pack_id": provider_pack["id"],
+    }
+
+    selected = resolve_workspace_model_pack_selection(
+        store=store,  # type: ignore[arg-type]
+        workspace_id=workspace_id,
+        requested_pack_id=None,
+        requested_pack_version=None,
+        provider_id=provider_id,
+    )
+
+    assert selected.source == "workspace_binding"
+    assert selected.pack is provider_pack
+
+
 def test_pack_selection_raises_when_request_pack_is_missing() -> None:
     store = FakeModelPackStore()
 
@@ -402,4 +427,15 @@ def test_pack_selection_raises_when_request_pack_is_missing() -> None:
             workspace_id=uuid4(),
             requested_pack_id="gemma",
             requested_pack_version="1.0.0",
+        )
+
+
+def test_assert_model_pack_runtime_compatibility_rejects_mismatched_provider() -> None:
+    pack = _pack_row(pack_id="llama")
+
+    with pytest.raises(ModelPackCompatibilityError, match="provider key azure"):
+        assert_model_pack_runtime_compatibility(
+            pack=pack,  # type: ignore[arg-type]
+            provider_key="azure",
+            runtime_provider="openai_responses",
         )


### PR DESCRIPTION
## Summary
- add provider-aware model-pack bindings with workspace-default fallback, compatibility enforcement, and the Phase 14 model-pack workflow
- ship the P14-S3 first-party pack set (`llama`, `qwen`, `gemma`, `gpt-oss`) plus the migration and coverage for provider-aware bindings
- update control docs, pack contract docs, and compatibility docs to match the shipped P14-S3 behavior

## Validation
- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
- `./.venv/bin/python -m pytest tests/unit/test_model_packs.py tests/unit/test_task_briefing.py tests/unit/test_20260416_0064_phase14_provider_model_pack_bindings.py -q`
- `./.venv/bin/python -m pytest tests/integration/test_phase11_model_packs_api.py -q`
- `./.venv/bin/python -m pytest tests/integration/test_phase11_provider_runtime_api.py -q`

## Upgrade Overview

### Protected Areas
- [ ] memory schema
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact
This sprint is additive at the model-pack schema and API layer. It adds provider-aware bindings, trims the first-party catalog to the declared Phase 14 set, and keeps pack compatibility declarative so the shipped provider/runtime baseline is reused rather than reopened.

### Migration / Rollout
Apply the new migration for provider-aware workspace model-pack bindings before using provider-specific bindings in upgraded environments. Existing workspace-default bindings remain valid and continue to drive briefing defaults.

### Operator Action
Use the updated model-pack contract and compatibility docs when binding workspaces to packs. After deploy, run the pack-focused smoke and integration validation if operators want explicit confirmation of provider-bound pack behavior.

### Validation
- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
- `./.venv/bin/python -m pytest tests/unit/test_model_packs.py tests/unit/test_task_briefing.py tests/unit/test_20260416_0064_phase14_provider_model_pack_bindings.py -q`
- `./.venv/bin/python -m pytest tests/integration/test_phase11_model_packs_api.py -q`
- `./.venv/bin/python -m pytest tests/integration/test_phase11_provider_runtime_api.py -q`

### Rollback
Revert the squash merge commit and roll back the provider-aware model-pack binding migration if the new binding shape must be removed. Existing workspace-default binding behavior remains the fallback path.