### PR TITLE
[codex] P14-S4: ship reference integrations

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -1,7 +1,7 @@
 # Sprint Packet
 
 ## Sprint Title
-P14-S3: Model Packs
+P14-S4: Reference Integrations
 
 ## Activation Note
 - This packet is active.
@@ -10,18 +10,18 @@ P14-S3: Model Packs
 - Phase 14 sequence is fixed for now:
   - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter: shipped
   - `P14-S2` Ollama + llama.cpp + vLLM Adapters: shipped
-  - `P14-S3` Model Packs: active
-  - `P14-S4` Reference Integrations
+  - `P14-S3` Model Packs: shipped
+  - `P14-S4` Reference Integrations: active
   - `P14-S5` Design Partner Launch
 
 ## Sprint Type
 feature
 
 ## Sprint Reason
-`P14-S1` and `P14-S2` established the provider contract, telemetry baseline, and local/self-hosted compatibility layer. `P14-S3` now turns that provider surface into usable defaults so external builders do not need to hand-tune pack behavior per workspace.
+`P14-S1` through `P14-S3` established the provider contract, local/self-hosted compatibility layer, and first-party model-pack defaults. `P14-S4` now turns that shipped substrate into runnable adoption paths for external builders.
 
 ## Git Instructions
-- Branch Name: `codex/phase14-s3-model-packs`
+- Branch Name: `codex/phase14-s4-reference-integrations`
 - Base Branch: `main`
 - PR Strategy: one implementation branch, one PR
 - Merge Policy: squash merge after review `PASS` and explicit approval
@@ -35,60 +35,59 @@ feature
 - shipped hygiene/thread-health visibility
 - shipped `P14-S1` provider contract, capability snapshot, and invocation telemetry baseline
 - shipped `P14-S2` local/self-hosted compatibility layer, including the dedicated `vllm` provider path and aligned runtime/pack compatibility hooks
+- shipped `P14-S3` provider-aware model-pack bindings, first-party pack catalog, and pack-aware runtime/briefing defaults
 - no semantic fork between API, CLI, MCP, hosted, provider-runtime, and Hermes paths
 
 ## Exact Goal
-Make common model families easy to use with sensible continuity defaults on top of the shipped provider/runtime baseline.
+Make Alice clearly adoptable by external agent builders without reopening provider or model-pack substrate work.
 
 ## In Scope
-- model-pack schema and storage hardening where needed
-- model-pack API and workspace pack-binding workflow
-- first-party packs for Llama, Qwen, Gemma, and `gpt-oss`
-- pack-aware invocation and briefing defaults
-- compatibility matrix docs
-- pack smoke tests
+- Hermes integration docs refresh around the shipped one-call continuity and pack/provider surface
+- OpenClaw integration docs refresh around import/augmentation plus one-call continuity
+- generic Python agent example
+- generic TypeScript agent example
+- integration-path guidance
+- reproducible demos for major integration paths
 
 ## Out Of Scope
-- provider-contract redesign
-- new provider classes beyond what is required to support declared pack families
-- reference integrations
+- new provider/runtime substrate work unless strictly required to support the shipped integration contract
+- new pack families or pack-schema redesign unless strictly required to document the shipped surface
 - design-partner workflows
 - retrieval research, graph migration, new channels, marketplace work, or enterprise governance expansion
 
 ## Proposed Files And Modules
-- `apps/api/src/alicebot_api/`
-- `apps/api/alembic/versions/`
-- `tests/unit/`
-- `tests/integration/`
-- `docs/` model-pack and compatibility docs
+- `docs/integrations/`
+- `docs/examples/`
+- `scripts/` demo or smoke helpers where needed
+- targeted example/runtime test coverage
 - control docs if baseline status markers need updates
 
 ## Planned Deliverables
-- model-pack schema and API surface
-- workspace pack binding flow
-- first-party pack definitions for Llama, Qwen, Gemma, and `gpt-oss`
-- pack-aware runtime and briefing defaults
-- compatibility matrix docs
-- pack smoke tests
+- polished Hermes integration docs
+- polished OpenClaw integration docs
+- generic Python agent example
+- generic TypeScript agent example
+- integration-path guidance
+- reproducible demos for major integration paths
 
 ## Acceptance Criteria
-- a workspace can bind a provider to a pack
-- pack defaults affect briefing and runtime behavior correctly
-- first-party packs are versioned and documented
-- users get good defaults without manual tuning
-- pack behavior composes the shipped provider/runtime baseline instead of reopening provider work
+- external builders can integrate Alice into Hermes from docs
+- external builders can integrate Alice into OpenClaw from docs
+- generic Python and TypeScript examples run successfully
+- at least one reproducible demo exists per major integration path
+- the sprint packages the shipped provider/pack/continuity surface instead of adding a new runtime substrate
 
 ## Required Verification
 - `python3 scripts/check_control_doc_truth.py`
 - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-- targeted unit/integration coverage for model-pack storage, binding, and runtime/briefing defaults
-- pack smoke validation against the shipped provider/runtime surface
-- compatibility-matrix and pack-doc validation
+- targeted coverage for new integration examples and demo helpers
+- integration-doc validation for Hermes and OpenClaw paths
+- reproducible demo validation for the declared major integration paths
 
 ## Control Tower Decisions Needed
-- whether DeepSeek or Mistral stay explicitly deferred after the first-party pack set ships
-- how strict the initial pack-to-provider compatibility matrix is at launch
-- which pack quirks are allowed as declarative defaults versus requiring runtime code changes
+- whether AutoGen stays deferred or becomes an extra reference example if capacity remains
+- which integration path is the default recommendation for each user profile
+- how much demo/video artifact work is required in-sprint versus follow-up packaging
 
 ## Exit Condition
-This sprint is complete when workspaces can bind documented first-party packs to the shipped provider/runtime baseline, pack-aware defaults behave correctly, and the result reduces manual tuning without creating a second continuity model.
+This sprint is complete when the shipped provider/pack/continuity baseline is exposed through polished Hermes and OpenClaw docs, runnable Python and TypeScript examples, and reproducible integration demos without creating new substrate scope.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -11,8 +11,9 @@
 - Phase 14 is active.
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
 - `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
-- `P14-S3` Model Packs is the active execution sprint.
-- `P14-S4` through `P14-S5` are planned and scoped.
+- `P14-S3` Model Packs is shipped.
+- `P14-S4` Reference Integrations is the active execution sprint.
+- `P14-S5` is planned and scoped.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
@@ -23,6 +24,7 @@
 - The shipped baseline includes memory hygiene and thread/conversation health visibility.
 - Phase 14 shipped baseline now also includes the stabilized provider contract, workspace-scoped provider registration/update flows, provider capability snapshots, invocation telemetry persistence, and the OpenAI-compatible adapter hardening delivered in `P14-S1`.
 - Phase 14 shipped baseline now also includes the local/self-hosted compatibility layer from `P14-S2`, including the dedicated `vllm` provider path, aligned health semantics, and pack-compatibility/runtime coverage for the shipped local/self-hosted provider surface.
+- Phase 14 shipped baseline now also includes provider-aware model-pack bindings, the first-party `llama` / `qwen` / `gemma` / `gpt-oss` catalog, and pack-aware runtime/briefing defaults delivered in `P14-S3`.
 - `v0.4.0` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
@@ -31,9 +33,10 @@
 - Phase 14 is focused on compatibility, packaging, reference integrations, and design-partner proof.
 - `P14-S1` is complete and establishes the provider contract, capability snapshot, and invocation telemetry baseline for the rest of the phase.
 - `P14-S2` is complete and closed the local/self-hosted compatibility sprint without reopening provider-foundation work.
-- `P14-S3` is intentionally not another provider sprint; it is the pack-schema, binding, defaults, and compatibility-matrix sprint that turns the shipped provider surface into usable defaults.
+- `P14-S3` is complete and turned the shipped provider surface into usable pack defaults without reopening provider work.
+- `P14-S4` is intentionally not another provider or pack sprint; it is the reference-integrations sprint that turns the shipped surface into runnable adoption paths.
 
 ## Immediate Control Tower Decisions Needed
-- Lock the first-party pack set for the initial Phase 14 model-pack release.
-- Decide whether DeepSeek or Mistral stay deferred after the first-party pack launch.
+- Decide whether AutoGen remains deferred or becomes an optional extra reference integration.
+- Decide which integration path is the default recommendation for each external builder profile.
 - Select the first 3 to 5 design partners and their initial pilot scopes early enough for `P14-S5`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Scope Boundary
 - **Shipped baseline:** Phases 9-13 and Bridge `B1` through `B4`.
-- **Current execution posture:** `v0.4.0` is the latest published tag; Phase 14 is active; `P14-S1` and `P14-S2` are shipped; `P14-S3` is active.
+- **Current execution posture:** `v0.4.0` is the latest published tag; Phase 14 is active; `P14-S1` through `P14-S3` are shipped; `P14-S4` is active.
 - **Phase principle:** Phase 14 is a platform-and-adoption phase, not a new substrate-research phase.
 
 ## Current System Overview
@@ -98,20 +98,23 @@ Alice is a modular continuity platform with shared continuity semantics across l
 - Extended provider/runtime and pack-compatibility coverage for the shipped local/self-hosted provider surface.
 - Kept the sprint scoped to compatibility proof instead of reopening provider-foundation work.
 
+### P14-S3: Model Packs
+- Status: shipped
+- Added provider-aware workspace model-pack bindings on top of the shipped provider surface.
+- Shipped the first-party `llama`, `qwen`, `gemma`, and `gpt-oss` pack catalog.
+- Added pack-aware runtime and briefing defaults plus declarative compatibility enforcement.
+- Kept the sprint scoped to pack packaging/defaults instead of reopening provider work.
+
 ## Phase 14 Active Delta
 
-### P14-S3: Model Packs
+### P14-S4: Reference Integrations
 - Status: active
-- Add versioned first-party pack definitions and workspace pack bindings.
-- Push pack-aware defaults into runtime invocation and briefing behavior.
-- Publish the first real compatibility matrix on top of the shipped provider/runtime surface.
-- This sprint is defaults-and-packaging work, not another provider sprint.
+- Package the shipped continuity, provider, and pack surface into polished external-builder paths.
+- Refresh Hermes and OpenClaw documentation around the shipped one-call continuity and provider/pack baseline.
+- Add generic Python and TypeScript reference agent examples plus reproducible demos.
+- This sprint is adoption packaging work, not another backend substrate sprint.
 
 ## Planned Phase 14 Follow-On Deltas
-
-### P14-S4: Reference Integrations
-- polished Hermes and OpenClaw integration paths
-- generic Python and TypeScript examples
 
 ### P14-S5: Design Partner Launch
 - design-partner onboarding, support, instrumentation, and usage proof
@@ -128,8 +131,8 @@ Alice is a modular continuity platform with shared continuity semantics across l
 ## Testing Strategy
 - unit/integration tests for continuity, provider runtime, and API behavior
 - provider smoke tests and provider-capability parity checks
-- model-pack smoke tests and compatibility-matrix validation for `P14-S3`
-- integration smoke tests for Hermes, OpenClaw, Python example, and TypeScript example paths
+- model-pack smoke tests and compatibility-matrix validation from `P14-S3`
+- integration smoke tests for Hermes, OpenClaw, Python example, and TypeScript example paths in `P14-S4`
 - release gates remain green across Python, web, Alice Lite, Hermes smoke, and public eval harness
 - docs verification is part of sprint completion, not cleanup work
 

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,64 +1,65 @@
 # BUILD_REPORT
 
-## sprint objective
+## Sprint Objective
 
-Make common model families easy to use with sensible continuity defaults on top of the shipped provider/runtime baseline by shipping the `P14-S3` model-pack workflow.
+Make Alice clearly adoptable by external agent builders through refreshed Hermes and OpenClaw integration docs, runnable generic Python and TypeScript examples, integration-path guidance, and reproducible demos for the major reference paths.
 
-## completed work
+## Completed Work
 
-- Added provider-aware model-pack bindings by extending workspace bindings with an optional `provider_id`.
-- Kept workspace-default bindings in place so briefing defaults can still resolve without a provider id.
-- Updated model-pack resolution so runtime selection now follows request override, provider-specific binding, workspace default binding, then no pack.
-- Added runtime compatibility enforcement using declarative pack contract fields (`compatibility.provider_keys` and `compatibility.runtime_providers`).
-- Updated the bind API to accept optional `provider_id`, validate provider existence in the workspace, and reject incompatible provider-to-pack bindings with `409`.
-- Updated runtime invoke to reject incompatible pack/provider combinations with `409` instead of silently applying the wrong defaults.
-- Trimmed the built-in first-party catalog to the four `P14-S3` packs: `llama`, `qwen`, `gemma`, and `gpt-oss`.
-- Added a migration and migration unit coverage for provider-aware workspace model-pack bindings.
-- Updated targeted unit and integration coverage for provider-aware binding, first-party catalog expectations, and compatibility enforcement.
-- Added provider-surface pack smoke coverage across the shipped `ollama`, `llamacpp`, and `vllm` runtime paths.
-- Updated the model-pack contract and compatibility docs to match the shipped `P14-S3` behavior.
+- refreshed `docs/integrations/hermes.md` into a reference-integration guide centered on the shipped provider-plus-MCP recommendation, one-call continuity, and Alice-side provider/model-pack controls
+- refreshed `docs/integrations/openclaw.md` around import-plus-augmentation, one-call continuity reuse, replay/dedupe behavior, and generic agent pairing
+- added `docs/integrations/reference-paths.md` to guide builders toward the right adoption path for generic agents, Hermes, OpenClaw, and provider/model-pack controls
+- added `docs/examples/reference-agent-examples.md` documenting the generic reference examples and the reproducible demo command
+- added runnable generic examples:
+  - `docs/examples/generic_python_agent.py`
+  - `docs/examples/generic_typescript_agent.ts`
+- added `scripts/run_reference_agent_examples_demo.py` to run both generic examples against a deterministic local `/v1/continuity/brief` canonical fixture demo
+- added `fixtures/reference_integrations/continuity_brief_agent_handoff_v1.json` as the checked-in contract fixture for the generic reference demo
+- refreshed control-doc markers and phase-status docs so `P14-S4` is the active sprint across the planning and handoff surface
+- added targeted validation:
+  - `tests/unit/test_phase14_reference_integrations.py`
+  - `tests/integration/test_reference_agent_examples.py`
+  - `tests/unit/test_reference_agent_examples_contract.py`
 
-## incomplete work
+## Incomplete Work
 
-- No implementation items remain within the sprint scope.
-- Deferred families such as DeepSeek, Mistral, and Kimi remain out of the first-party catalog for this sprint.
+- none within the sprint scope implemented here
 
-## files changed
+## Files Changed
 
-- `apps/api/alembic/versions/20260416_0064_phase14_provider_model_pack_bindings.py`
+- `docs/integrations/hermes.md`
+- `docs/integrations/openclaw.md`
+- `docs/integrations/reference-paths.md`
+- `docs/examples/reference-agent-examples.md`
+- `docs/examples/generic_python_agent.py`
+- `docs/examples/generic_typescript_agent.ts`
+- `fixtures/reference_integrations/continuity_brief_agent_handoff_v1.json`
+- `scripts/run_reference_agent_examples_demo.py`
+- `scripts/check_control_doc_truth.py`
+- `tests/unit/test_phase14_reference_integrations.py`
+- `tests/unit/test_reference_agent_examples_contract.py`
+- `tests/integration/test_reference_agent_examples.py`
 - `.ai/active/SPRINT_PACKET.md`
 - `.ai/handoff/CURRENT_STATE.md`
-- `ARCHITECTURE.md`
 - `CURRENT_STATE.md`
 - `PRODUCT_BRIEF.md`
 - `ROADMAP.md`
-- `apps/api/src/alicebot_api/contracts.py`
-- `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/model_packs.py`
-- `apps/api/src/alicebot_api/store.py`
-- `docs/integrations/phase11-model-pack-compatibility.md`
-- `docs/integrations/phase11-model-packs-tier1.md`
-- `docs/phase14-model-pack-contract.md`
-- `docs/phase14-s3-control-tower-packet.md`
+- `ARCHITECTURE.md`
+- `docs/phase14-s4-control-tower-packet.md`
 - `docs/phase14-sprint-14-1-14-5-plan.md`
-- `scripts/check_control_doc_truth.py`
-- `tests/integration/test_phase11_model_packs_api.py`
-- `tests/unit/test_20260416_0064_phase14_provider_model_pack_bindings.py`
-- `tests/unit/test_model_packs.py`
+- `BUILD_REPORT.md`
 
-## tests run
+## Tests Run
 
 - `python3 scripts/check_control_doc_truth.py`
-- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_model_packs.py tests/unit/test_task_briefing.py tests/unit/test_20260416_0064_phase14_provider_model_pack_bindings.py -q`
-- `./.venv/bin/python -m pytest tests/integration/test_phase11_model_packs_api.py -q`
-- `./.venv/bin/python -m pytest tests/integration/test_phase11_provider_runtime_api.py -q`
+- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py tests/unit/test_phase14_reference_integrations.py tests/unit/test_reference_agent_examples_contract.py -q`
+- `./.venv/bin/python -m pytest tests/integration/test_reference_agent_examples.py tests/unit/test_hermes_bridge_demo.py tests/integration/test_openclaw_import.py tests/integration/test_openclaw_one_command_demo.py tests/integration/test_openclaw_mcp_integration.py -q`
 
-## blockers/issues
+## Blockers/Issues
 
-- No blocking implementation issues remain.
-- Pack smoke validation in this build is covered by focused integration smoke over the shipped provider/runtime surfaces (`ollama`, `llamacpp`, `vllm`) rather than by external provider processes.
+- no implementation blockers encountered
+- the worktree already contained unrelated user-owned changes outside this sprint slice; they were left untouched
 
-## recommended next step
+## Recommended Next Step
 
-Decide whether DeepSeek and Mistral stay deferred or become first-party packs in the next sprint, then extend the compatibility matrix only after that product decision is settled.
+Use the new generic examples and path guide as the handoff baseline for `P14-S5`, then decide whether any additional reference example beyond Hermes/OpenClaw is worth adding without expanding the provider or model-pack substrate.

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -14,8 +14,9 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - Phase 14 is active.
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
 - `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
-- `P14-S3` Model Packs is the active execution sprint.
-- `P14-S4` through `P14-S5` are planned and scoped.
+- `P14-S3` Model Packs is shipped.
+- `P14-S4` Reference Integrations is the active execution sprint.
+- `P14-S5` is planned and scoped.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
@@ -26,6 +27,7 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - The shipped baseline includes memory hygiene and thread/conversation health visibility.
 - Phase 14 shipped baseline now also includes the stabilized provider contract, workspace-scoped provider registration/update flows, provider capability snapshots, invocation telemetry persistence, and the OpenAI-compatible adapter hardening delivered in `P14-S1`.
 - Phase 14 shipped baseline now also includes the local/self-hosted compatibility layer from `P14-S2`, including the dedicated `vllm` provider path, aligned health semantics, and pack-compatibility/runtime coverage for the shipped local/self-hosted provider surface.
+- Phase 14 shipped baseline now also includes provider-aware model-pack bindings, the first-party `llama` / `qwen` / `gemma` / `gpt-oss` catalog, and pack-aware runtime/briefing defaults delivered in `P14-S3`.
 - `v0.4.0` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
@@ -34,9 +36,10 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - Phase 14 is focused on compatibility, packaging, reference integrations, and design-partner proof.
 - `P14-S1` is complete and establishes the provider contract, capability snapshot, and invocation telemetry baseline for the rest of the phase.
 - `P14-S2` is complete and closed the local/self-hosted compatibility sprint without reopening provider-foundation work.
-- `P14-S3` is intentionally not another provider sprint; it is the pack-schema, binding, defaults, and compatibility-matrix sprint that turns the shipped provider surface into usable defaults.
+- `P14-S3` is complete and turned the shipped provider surface into usable pack defaults without reopening provider work.
+- `P14-S4` is intentionally not another provider or pack sprint; it is the reference-integrations sprint that turns the shipped surface into runnable adoption paths.
 
 ## Immediate Control Tower Decisions Needed
-- Lock the first-party pack set for the initial Phase 14 model-pack release.
-- Decide whether DeepSeek or Mistral stay deferred after the first-party pack launch.
+- Decide whether AutoGen remains deferred or becomes an optional extra reference integration.
+- Decide which integration path is the default recommendation for each external builder profile.
 - Select the first 3 to 5 design partners and their initial pilot scopes early enough for `P14-S5`.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -16,8 +16,9 @@ Alice is a pre-1.0 continuity platform for AI agents and agent-assisted workflow
 - Phase 14 is active.
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
 - `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
-- `P14-S3` Model Packs is the active execution sprint.
-- `P14-S4` through `P14-S5` are planned.
+- `P14-S3` Model Packs is shipped.
+- `P14-S4` Reference Integrations is the active execution sprint.
+- `P14-S5` is planned.
 
 ## Active Phase
 ### Phase 14: Provider Adapters + Design Partner Launch
@@ -65,4 +66,5 @@ Alice now has enough depth in continuity semantics. The next constraint is compa
 - `v0.4.0` remains the current public release boundary.
 - `P14-S1` established the provider contract and telemetry baseline.
 - `P14-S2` closed the local/self-hosted compatibility sprint and added the dedicated `vllm` path to the shipped provider surface.
-- `P14-S3` is deliberately focused on model-pack schema, binding, defaults, and compatibility clarity so the phase does not drift back into provider work.
+- `P14-S3` shipped the first-party pack baseline and provider-aware pack binding behavior.
+- `P14-S4` is deliberately focused on reference integrations and runnable adoption paths so the phase does not drift back into provider or pack work.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,33 +4,41 @@
 PASS
 
 ## criteria met
-- A workspace can bind a provider to a pack, and bindings now support both provider-specific and workspace-default resolution. Evidence: `apps/api/src/alicebot_api/main.py`, `apps/api/src/alicebot_api/model_packs.py`, `apps/api/src/alicebot_api/store.py`.
-- Pack defaults affect briefing and runtime behavior correctly. Runtime shaping, request override precedence, workspace binding precedence, and compatibility enforcement are covered by integration and unit tests. Evidence: `tests/integration/test_phase11_model_packs_api.py`, `tests/unit/test_task_briefing.py`, `tests/unit/test_model_packs.py`.
-- First-party packs are versioned and documented for the declared `P14-S3` set: `llama`, `qwen`, `gemma`, and `gpt-oss`. Evidence: `docs/phase14-model-pack-contract.md`, `docs/integrations/phase11-model-pack-compatibility.md`.
-- Users get sensible defaults without manual tuning. Briefing defaults still resolve from workspace-default bindings, while runtime selection uses explicit override -> provider binding -> workspace default -> none.
-- Pack behavior composes the shipped provider/runtime baseline rather than reopening provider work. Compatibility remains declarative through pack contract metadata.
-- Pack smoke validation is now present over the shipped provider/runtime surface. Evidence: local-provider smoke coverage across `ollama`, `llamacpp`, and `vllm` in `tests/integration/test_phase11_model_packs_api.py`.
+- Hermes integration documentation is refreshed and now clearly steers builders to the shipped `provider_plus_mcp` recommendation, fallback mode, and bridge demo.
+- OpenClaw integration documentation is refreshed around import-plus-augmentation, one-call continuity reuse, replay/dedupe behavior, and the existing demo path.
+- Runnable generic Python and TypeScript examples are present and pass focused integration coverage.
+- Reproducible demos exist for the three major adoption paths in this sprint:
+  - generic agent: `scripts/run_reference_agent_examples_demo.py`
+  - Hermes: `scripts/run_hermes_bridge_demo.py`
+  - OpenClaw: `scripts/use_alice_with_openclaw.sh`
+- The generic example demo now serves a checked-in canonical continuity-brief fixture instead of an ad hoc inline payload, and the fixture is validated against the live `ContinuityBriefRecord` top-level contract.
+- The docs now clarify that provider/model-pack controls are supporting configuration for the three major adoption paths, not a fourth standalone demo path.
+- The TypeScript example docs now state the `--experimental-strip-types` runtime expectation.
+- `BUILD_REPORT.md` now reflects the actual sprint file set more accurately.
+- I did not find leaked local machine identifiers, usernames, or local absolute paths in the touched sprint files.
 
 ## criteria missed
-- None.
+- none
 
 ## quality issues
-- None blocking after the fix set.
+- none blocking for this sprint
 
 ## regression risks
-- Low. The riskiest new seam was provider-query fallback to a workspace-default binding; that case now has direct integration coverage.
-- Low. Provider-surface pack smoke now exercises the shipped local/self-hosted adapter paths with pack binding in place.
+- low residual risk: the generic example demo is still fixture-backed rather than API-backed, but the added contract test materially lowers drift risk for this sprint’s documentation/examples scope.
 
 ## docs issues
-- No remaining docs issues for this sprint scope.
-- `BUILD_REPORT.md` now matches the verification evidence more closely.
-- No local filesystem paths, workstation usernames, or similar local identifiers were found in the reviewed changed files and documentation.
+- none blocking
 
 ## should anything be added to RULES.md?
-- No.
+- Yes. Add a rule that runnable documentation examples and demo helpers should use a shared canonical fixture or the real contract surface, not a one-off inline mock payload.
 
 ## should anything update ARCHITECTURE.md?
-- No further update is needed beyond the existing Phase 14 state changes already in this sprint.
+- No additional architecture change is needed beyond the existing Phase 14 status update already present in this sprint.
 
 ## recommended next action
-- Proceed with the normal merge/review flow for `P14-S3`.
+- Mark the sprint review as passed and proceed with the normal merge/approval flow.
+
+## verification performed
+- `python3 scripts/check_control_doc_truth.py`
+- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py tests/unit/test_phase14_reference_integrations.py tests/unit/test_reference_agent_examples_contract.py -q`
+- `./.venv/bin/python -m pytest tests/integration/test_reference_agent_examples.py tests/unit/test_hermes_bridge_demo.py tests/integration/test_openclaw_import.py tests/integration/test_openclaw_one_command_demo.py tests/integration/test_openclaw_mcp_integration.py -q`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,8 +16,8 @@ These remain baseline truth and are not future milestones.
 - Phase 14 is active.
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
 - `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
-- `P14-S3` Model Packs is the active execution sprint.
-- `P14-S4` Reference Integrations is planned.
+- `P14-S3` Model Packs is shipped.
+- `P14-S4` Reference Integrations is the active execution sprint.
 - `P14-S5` Design Partner Launch is planned.
 
 ## Phase 14 Planned Milestones
@@ -46,7 +46,7 @@ Release target: `v0.5.0-rc1`
 - integrate pack defaults into runtime invocation and briefing
 - publish a compatibility matrix
 
-Status: active
+Status: shipped
 Release target: `v0.5.0-rc2`
 
 ### P14-S4: Reference Integrations
@@ -54,7 +54,7 @@ Release target: `v0.5.0-rc2`
 - ship generic Python and TypeScript example agents
 - add “which integration path should I use?” guidance
 
-Status: planned
+Status: active
 Release target: `v0.5.0`
 
 ### P14-S5: Design Partner Launch
@@ -71,7 +71,7 @@ Release target: `v0.5.1` or `v0.6.0-beta`
 - Do not allow scope drift into new substrate research, new channels, enterprise governance expansion, or major vertical-agent work unless required by a declared Phase 14 deliverable.
 - Preserve one-call continuity semantics across provider classes.
 - Treat docs as sprint deliverables, not cleanup work.
-- Keep `P14-S3` narrow: it should turn the shipped provider/runtime surface into usable defaults, not reopen provider compatibility work under a pack label.
+- Keep `P14-S4` narrow: it should package the shipped continuity/provider/pack surface into runnable integrations, not reopen provider or pack work under a docs label.
 
 ## Beyond Phase 14
 - No post-Phase-14 feature plan is currently defined.

--- a/docs/examples/generic_python_agent.py
+++ b/docs/examples/generic_python_agent.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Minimal generic Python agent example for Alice one-call continuity.",
+    )
+    parser.add_argument(
+        "--api-base-url",
+        default=os.getenv("ALICE_API_BASE_URL", "http://127.0.0.1:8000"),
+        help="Alice API base URL.",
+    )
+    parser.add_argument(
+        "--session-token",
+        default=os.getenv("ALICE_SESSION_TOKEN"),
+        help="Alice session token used as a Bearer token.",
+    )
+    parser.add_argument(
+        "--brief-type",
+        default=os.getenv("ALICE_BRIEF_TYPE", "agent_handoff"),
+        help="Alice brief type.",
+    )
+    parser.add_argument(
+        "--thread-id",
+        default=os.getenv("ALICE_THREAD_ID"),
+        help="Optional thread UUID.",
+    )
+    parser.add_argument(
+        "--query",
+        default=os.getenv("ALICE_QUERY", "release handoff"),
+        help="Optional query string.",
+    )
+    return parser
+
+
+def _compact_agent_view(payload: dict[str, Any]) -> dict[str, Any]:
+    brief = payload["brief"]
+    next_action = brief.get("next_suggested_action") or {}
+    open_loops = brief.get("open_loops") or {}
+    open_loop_summary = open_loops.get("summary") or {}
+    trust_posture = brief.get("trust_posture") or {}
+    return {
+        "brief_type": brief.get("brief_type"),
+        "summary": brief.get("summary"),
+        "next_suggested_action": next_action.get("title"),
+        "open_loop_count": open_loop_summary.get("total_count"),
+        "source_kinds": brief.get("sources", []),
+        "open_conflict_count": trust_posture.get("open_conflict_count"),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if not args.session_token:
+        print("Missing Alice session token. Set ALICE_SESSION_TOKEN or pass --session-token.", file=sys.stderr)
+        return 1
+
+    request_body: dict[str, Any] = {
+        "brief_type": args.brief_type,
+        "query": args.query,
+        "max_relevant_facts": 6,
+        "max_recent_changes": 5,
+        "max_open_loops": 5,
+        "max_conflicts": 3,
+        "max_timeline_highlights": 5,
+    }
+    if args.thread_id:
+        request_body["thread_id"] = args.thread_id
+
+    encoded_body = json.dumps(request_body).encode("utf-8")
+    request = Request(
+        url=f"{args.api_base_url.rstrip('/')}/v1/continuity/brief",
+        data=encoded_body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {args.session_token}",
+            "Content-Type": "application/json",
+        },
+    )
+
+    try:
+        with urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        print(f"Alice returned HTTP {exc.code}: {detail}", file=sys.stderr)
+        return 1
+    except URLError as exc:
+        print(f"Failed to reach Alice: {exc.reason}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(_compact_agent_view(payload), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/examples/generic_typescript_agent.ts
+++ b/docs/examples/generic_typescript_agent.ts
@@ -1,0 +1,96 @@
+type AgentView = {
+  brief_type: string | null;
+  summary: string | null;
+  next_suggested_action: string | null;
+  open_loop_count: number | null;
+  source_kinds: string[];
+  open_conflict_count: number | null;
+};
+
+function envOrDefault(name: string, fallback: string): string {
+  const value = process.env[name];
+  return value && value.trim() !== "" ? value : fallback;
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function compactAgentView(payload: Record<string, any>): AgentView {
+  const brief = (payload.brief ?? {}) as Record<string, any>;
+  const nextAction = (brief.next_suggested_action ?? {}) as Record<string, any>;
+  const openLoops = (brief.open_loops ?? {}) as Record<string, any>;
+  const openLoopSummary = (openLoops.summary ?? {}) as Record<string, any>;
+  const trustPosture = (brief.trust_posture ?? {}) as Record<string, any>;
+  const sourceKinds = Array.isArray(brief.sources)
+    ? brief.sources.filter((value): value is string => typeof value === "string")
+    : [];
+
+  return {
+    brief_type: typeof brief.brief_type === "string" ? brief.brief_type : null,
+    summary: typeof brief.summary === "string" ? brief.summary : null,
+    next_suggested_action:
+      typeof nextAction.title === "string" ? nextAction.title : null,
+    open_loop_count:
+      typeof openLoopSummary.total_count === "number" ? openLoopSummary.total_count : null,
+    source_kinds: sourceKinds,
+    open_conflict_count:
+      typeof trustPosture.open_conflict_count === "number"
+        ? trustPosture.open_conflict_count
+        : null,
+  };
+}
+
+async function main(): Promise<number> {
+  const apiBaseUrl = envOrDefault("ALICE_API_BASE_URL", "http://127.0.0.1:8000");
+  const sessionToken = requiredEnv("ALICE_SESSION_TOKEN");
+  const briefType = envOrDefault("ALICE_BRIEF_TYPE", "agent_handoff");
+  const threadId = process.env.ALICE_THREAD_ID;
+  const query = envOrDefault("ALICE_QUERY", "release handoff");
+
+  const body: Record<string, unknown> = {
+    brief_type: briefType,
+    query,
+    max_relevant_facts: 6,
+    max_recent_changes: 5,
+    max_open_loops: 5,
+    max_conflicts: 3,
+    max_timeline_highlights: 5,
+  };
+  if (threadId && threadId.trim() !== "") {
+    body.thread_id = threadId;
+  }
+
+  const response = await fetch(`${apiBaseUrl.replace(/\/$/, "")}/v1/continuity/brief`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${sessionToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Alice returned HTTP ${response.status}: ${detail}`);
+  }
+
+  const payload = (await response.json()) as Record<string, any>;
+  const result = compactAgentView(payload);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  return 0;
+}
+
+main()
+  .then((exitCode) => {
+    process.exitCode = exitCode;
+  })
+  .catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });

--- a/docs/examples/reference-agent-examples.md
+++ b/docs/examples/reference-agent-examples.md
@@ -1,0 +1,59 @@
+# Reference Agent Examples
+
+These examples show the narrow default adoption path for a generic external agent: call Alice one time through `POST /v1/continuity/brief`, then use the returned bundle inside your runtime.
+
+## Files
+
+- Python: `docs/examples/generic_python_agent.py`
+- TypeScript: `docs/examples/generic_typescript_agent.ts`
+
+Both examples:
+
+- call `POST /v1/continuity/brief`
+- accept `ALICE_API_BASE_URL` and `ALICE_SESSION_TOKEN`
+- optionally accept `ALICE_THREAD_ID`, `ALICE_QUERY`, and `ALICE_BRIEF_TYPE`
+- print a compact JSON summary that a host runtime can consume directly
+
+## Runtime Notes
+
+- the Python example runs with the repository virtualenv shown below
+- the TypeScript example assumes a Node runtime that supports `--experimental-strip-types`
+
+## Run The Python Example
+
+```bash
+ALICE_API_BASE_URL="http://127.0.0.1:8000" \
+ALICE_SESSION_TOKEN="<session-token>" \
+./.venv/bin/python docs/examples/generic_python_agent.py
+```
+
+## Run The TypeScript Example
+
+```bash
+ALICE_API_BASE_URL="http://127.0.0.1:8000" \
+ALICE_SESSION_TOKEN="<session-token>" \
+node --experimental-strip-types docs/examples/generic_typescript_agent.ts
+```
+
+## Reproducible Demo
+
+Run both examples against the shipped response contract demo server:
+
+```bash
+./.venv/bin/python scripts/run_reference_agent_examples_demo.py
+```
+
+The demo serves a shared canonical continuity-brief fixture from `fixtures/reference_integrations/continuity_brief_agent_handoff_v1.json` so the example output stays tied to a checked-in contract shape instead of an ad hoc inline payload.
+
+Expected JSON output:
+
+- `status` = `pass`
+- `python_example.returncode` = `0`
+- `typescript_example.returncode` = `0`
+- both example outputs include the same `brief_type`, `summary`, and `next_suggested_action`
+
+## When To Use Something Else
+
+- use `alice_brief` instead of HTTP when your host runtime is already speaking MCP
+- use `docs/integrations/hermes.md` when Hermes owns orchestration
+- use `docs/integrations/openclaw.md` when imported OpenClaw memory is part of the adoption path

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -1,135 +1,115 @@
-# Hermes MCP Integration (Fallback Path)
+# Hermes Reference Integration
 
-This document covers **MCP-only fallback** setup for Hermes.
+Hermes is the reference path when another agent runtime owns orchestration and Alice supplies continuity, recall, resumption, and review workflows.
 
-For the recommended deployment shape (provider plus MCP), use:
+Recommended deployment shape: `provider_plus_mcp`.
 
-- `docs/integrations/hermes-bridge-operator-guide.md`
+- Provider gives Hermes always-on prefetch plus post-turn capture hooks.
+- MCP gives Hermes the deeper Alice tool surface, including `alice_brief`, targeted recall, review, and correction flows.
+- MCP-only remains available when provider install is blocked.
 
-## When To Use This Path
+## What Stays Stable
 
-Use MCP-only when the Alice provider plugin cannot be installed yet.
+Hermes does not create a second Alice runtime contract.
 
-- Keep `memory.provider: builtin`.
-- Attach Alice through `mcp_servers`.
-- Migrate to provider plus MCP when possible.
+- one-call continuity stays `POST /v1/continuity/brief`, `alice brief`, and `alice_brief`
+- provider registration and runtime shaping stay on the shipped Alice provider surface
+- model packs stay Alice-side defaults layered on top of the shipped provider/runtime baseline
 
-## Prerequisites
+Use these docs when you need the underlying Alice runtime controls:
 
-- Hermes Agent with MCP support (`hermes mcp --help` works).
-- Alice local runtime is available (`./.venv/bin/python -m alicebot_api.mcp_server --help` works).
-- Postgres is reachable from the machine where Hermes runs.
+- `docs/integrations/one-call-continuity.md`
+- `docs/integrations/phase14-provider-configuration.md`
+- `docs/integrations/phase11-model-pack-compatibility.md`
 
-## Config (`~/.hermes/config.yaml`)
+## Choose A Mode
 
-### Option A: local command (direct Python)
+| Mode | Use it when | What you get |
+|---|---|---|
+| Provider + MCP | default Hermes deployment | prefetch, post-turn lifecycle hooks, plus full Alice tool access |
+| MCP-only | provider plugin install is blocked | explicit Alice tools with no provider lifecycle hooks |
+| Provider + MCP + skill pack | you want stronger prompting and workflow policy | recommended runtime shape plus Hermes-side policy guidance |
 
-```yaml
-memory:
-  provider: builtin
+## Recommended Setup
 
-mcp_servers:
-  alice_core:
-    command: "/path/to/alicebot/.venv/bin/python"
-    args: ["-m", "alicebot_api.mcp_server"]
-    env:
-      DATABASE_URL: "postgresql://alicebot_app:alicebot_app@localhost:5432/alicebot"
-      ALICEBOT_AUTH_USER_ID: "00000000-0000-0000-0000-000000000001"
-      PYTHONPATH: "/path/to/alicebot/apps/api/src:/path/to/alicebot/workers"
-    tools:
-      include:
-        - alice_recall
-        - alice_resume
-        - alice_open_loops
-        - alice_capture_candidates
-        - alice_commit_captures
-        - alice_review_queue
-        - alice_review_apply
-      resources: false
-      prompts: false
-```
-
-### Option B: `npx` command (via `alice-cli` package)
-
-```yaml
-memory:
-  provider: builtin
-
-mcp_servers:
-  alice_core:
-    command: "npx"
-    args: ["-y", "--package", "/path/to/alicebot/packages/alice-cli", "alice", "mcp"]
-    env:
-      NPM_CONFIG_CACHE: "/tmp/alice-npm-cache"
-      ALICEBOT_PYTHON: "/path/to/alicebot/.venv/bin/python"
-      DATABASE_URL: "postgresql://alicebot_app:alicebot_app@localhost:5432/alicebot"
-      ALICEBOT_AUTH_USER_ID: "00000000-0000-0000-0000-000000000001"
-      PYTHONPATH: "/path/to/alicebot/apps/api/src:/path/to/alicebot/workers"
-    tools:
-      include:
-        - alice_recall
-        - alice_resume
-        - alice_open_loops
-        - alice_capture_candidates
-        - alice_commit_captures
-        - alice_review_queue
-        - alice_review_apply
-      resources: false
-      prompts: false
-```
-
-If you use a published CLI package with `mcp` support, replace args with:
-
-```yaml
-args: ["-y", "@aliceos/alice-cli", "mcp"]
-```
-
-## Verify Connection
+1. Install the Alice Hermes memory provider:
 
 ```bash
-hermes mcp test alice_core
+./scripts/install_hermes_alice_memory_provider.py
 ```
 
-Expected:
+2. Configure Hermes memory for `alice` and keep Alice attached through `mcp_servers`.
 
-- `Connected`
-- `Tools discovered`
-- includes `alice_recall`, `alice_resume`, `alice_open_loops`
-
-## Verify Runtime Tool Calls
-
-```bash
-./.venv/bin/python scripts/run_hermes_mcp_smoke.py
-```
-
-Expected JSON output includes:
-
-- registered MCP tool names for recall/resume/open-loops and B2/B3 capture/review tools
-- non-zero `recall_items`
-- non-zero `capture_candidate_count`
-- non-zero `capture_review_queued_count`
-- `review_apply_resolved_action` = `confirm`
-
-## One-Command Demo
-
-For the full bridge demo command (provider smoke + MCP smoke):
+3. Validate the full bridge path:
 
 ```bash
 ./.venv/bin/python scripts/run_hermes_bridge_demo.py
 ```
 
-## Migrate To Recommended Path
+Expected JSON output:
 
-When provider install is available, move from MCP-only to provider plus MCP:
+- `status` = `pass`
+- `recommended_path` = `provider_plus_mcp`
+- provider smoke returns `structural.bridge_status.ready = true`
+- MCP smoke validates recall, open-loop, capture, and review flows
 
-1. Install provider plugin: `./scripts/install_hermes_alice_memory_provider.py`
-2. Run `hermes memory setup` and select `alice`
-3. Set `memory.provider: alice`
-4. Keep MCP server configured for deep workflows
-5. Re-run `./.venv/bin/python scripts/run_hermes_bridge_demo.py`
+## Minimal Config Shape
+
+```yaml
+memory:
+  provider: alice
+
+mcp_servers:
+  alice_core:
+    command: "/path/to/alice/.venv/bin/python"
+    args: ["-m", "alicebot_api.mcp_server"]
+    env:
+      DATABASE_URL: "postgresql://alicebot_app:alicebot_app@localhost:5432/alicebot"
+      ALICEBOT_AUTH_USER_ID: "00000000-0000-0000-0000-000000000001"
+      PYTHONPATH: "/path/to/alice/apps/api/src:/path/to/alice/workers"
+```
+
+Use the full operator examples for production config details:
+
+- `docs/integrations/examples/hermes-config.provider-plus-mcp.yaml`
+- `docs/integrations/examples/hermes-config.mcp-only.yaml`
+
+## One-Call Continuity Inside Hermes
+
+For generic continuity lookups, start with `alice_brief`.
+
+That keeps Hermes on the shipped one-call continuity surface instead of manually choreographing recall plus resumption plus conflict checks. Reach for narrower tools only when Hermes explicitly needs them:
+
+- `alice_recall` for ranked facts only
+- `alice_resume` for the legacy resume layout
+- `alice_review_queue` and `alice_review_apply` for explicit review workflows
+
+## Provider And Pack Guidance
+
+Hermes should treat Alice provider and model-pack decisions as Alice runtime configuration, not Hermes configuration.
+
+- register or update provider connections through the Alice provider endpoints documented in `docs/integrations/phase14-provider-configuration.md`
+- bind model packs in Alice when you want provider-aware defaults without changing Hermes orchestration
+- keep Hermes focused on when to call Alice, not on reproducing Alice runtime policy
+
+## Fallback Path
+
+If provider install is not available yet, keep:
+
+- `memory.provider: builtin`
+- the Alice `mcp_servers` block
+- the same `alice_brief` / `alice_recall` / review tool usage
+
+Then validate with:
+
+```bash
+hermes mcp test alice_core
+./.venv/bin/python scripts/run_hermes_mcp_smoke.py
+```
 
 ## Related Docs
 
 - `docs/integrations/hermes-bridge-operator-guide.md`
 - `docs/integrations/hermes-memory-provider.md`
 - `docs/integrations/hermes-skill-pack.md`
+- `docs/integrations/reference-paths.md`

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -1,30 +1,50 @@
-# Use Alice with OpenClaw
+# OpenClaw Reference Integration
 
-This guide is the canonical OpenClaw integration path for Alice.
+Use OpenClaw when you need to import existing workspace memory into Alice and then consume that imported state through the normal Alice continuity surfaces.
+
+This path is import plus augmentation, not a second runtime.
+
+- OpenClaw data is imported once into Alice continuity objects.
+- Imported items keep explicit `OpenClaw` provenance.
+- After import, use the same Alice brief, recall, resume, CLI, and MCP surfaces you already use for native Alice data.
 
 ## One-Command Demo
 
-Run the full import + recall + resume + idempotent replay demo:
+Run the end-to-end import, replay, recall, and resume demo:
 
 ```bash
 ./scripts/use_alice_with_openclaw.sh
 ```
 
-The command prints a JSON report.
+Expected JSON output:
 
-Key fields:
+- `status` = `pass`
+- `before.recall_returned_count` = `0` for the generated demo user
+- `import.first.status` = `ok`
+- `import.second.status` = `noop`
+- `after.recall_source_labels` includes `OpenClaw`
+- `after.resume_last_decision_source_label` = `OpenClaw`
+- `after.resume_next_action_source_label` = `OpenClaw`
+- `checks` values are all `true`
 
-- `before.recall_returned_count`: expected to be `0` for the generated demo user
-- `import.first.status`: expected `ok`
-- `import.second.status`: expected `noop` (idempotent replay)
-- `after.recall_source_labels`: expected to include `OpenClaw`
-- `after.resume_last_decision_source_label`: expected `OpenClaw`
-- `after.resume_next_action_source_label`: expected `OpenClaw`
-- `checks`: all values expected `true`
+## What Import Changes
 
-## Import-Only Commands
+Import augments Alice continuity retrieval. It does not replace:
 
-Import the primary OpenClaw fixture:
+- one-call continuity
+- provider registration
+- model-pack bindings
+
+After import, these surfaces will include OpenClaw-backed continuity when it is relevant to the request:
+
+- API: `POST /v1/continuity/brief`
+- CLI: `alice brief`
+- MCP: `alice_brief`
+- targeted lookups: `alice_recall`, `alice_resume`
+
+## Import Commands
+
+Import the file-contract fixture:
 
 ```bash
 ./scripts/load_openclaw_sample_data.sh --source fixtures/openclaw/workspace_v1.json
@@ -36,22 +56,45 @@ Import the directory-contract fixture:
 ./scripts/load_openclaw_sample_data.sh --source fixtures/openclaw/workspace_dir_v1
 ```
 
-## Before/After Value
+## Before And After
 
-Before import, recall/resume on the scoped thread usually return no imported continuity signals.
+Before import, scoped recall and resume usually return no OpenClaw-backed continuity for that user.
+
 After import:
 
-- recall returns OpenClaw-backed continuity objects
-- resume returns last-decision and next-action objects sourced from OpenClaw
-- provenance labels show `OpenClaw` with `source_kind=openclaw_import`
+- recall returns imported continuity objects with `source_kind=openclaw_import`
+- resume returns last-decision and next-action items with `source_label=OpenClaw`
+- one-call continuity can include those imported objects in the same response bundle as native Alice continuity
 
-## Determinism and Idempotency Contract
+## Replay And Dedupe Contract
 
-- importer dedupe keys are deterministic for stable payloads
+- dedupe keys are deterministic for stable payloads
 - replaying the same source for the same user does not create duplicates
-- repeated replay returns `status=noop` with duplicates counted in `skipped_duplicates`
+- repeated replay returns `status=noop`
+- duplicate skips are counted in `skipped_duplicates`
+
+## Pairing With Generic Agents
+
+OpenClaw is usually paired with the generic API or MCP integration path.
+
+Typical flow:
+
+1. Import OpenClaw data into Alice.
+2. Query Alice through `POST /v1/continuity/brief` or `alice_brief`.
+3. Let the agent act on Alice output while preserving OpenClaw provenance in the response.
+
+Generic starter examples:
+
+- `docs/examples/generic_python_agent.py`
+- `docs/examples/generic_typescript_agent.ts`
 
 ## Fixture Sources
 
 - file fixture: `fixtures/openclaw/workspace_v1.json`
 - directory fixture: `fixtures/openclaw/workspace_dir_v1/`
+
+## Related Docs
+
+- `docs/integrations/importers.md`
+- `docs/integrations/one-call-continuity.md`
+- `docs/integrations/reference-paths.md`

--- a/docs/integrations/reference-paths.md
+++ b/docs/integrations/reference-paths.md
@@ -1,0 +1,58 @@
+# Reference Integration Paths
+
+This page is the path-selection guide for external builders adopting Alice on top of the shipped `v0.4.0` continuity, provider, and model-pack baseline.
+
+## Default Recommendation
+
+Start with the narrowest path that solves the integration need:
+
+| Need | Default path | Demo or example |
+|---|---|---|
+| Generic external agent needs continuity in one call | `POST /v1/continuity/brief` or `alice_brief` | `docs/examples/reference-agent-examples.md` |
+| Hermes owns orchestration and Alice supplies continuity workflows | provider plus MCP | `./.venv/bin/python scripts/run_hermes_bridge_demo.py` |
+| Existing OpenClaw workspace data must become queryable in Alice | import, then use normal brief/recall/resume surfaces | `./scripts/use_alice_with_openclaw.sh` |
+| Alice must target a non-default runtime provider or provider-aware pack | supporting Alice-side configuration for the paths above | `docs/integrations/phase14-provider-configuration.md` |
+
+The three major adoption paths in this sprint are Generic Agent, Hermes, and OpenClaw. Provider and model-pack controls support those paths; they are not presented as a fourth standalone demo path.
+
+## Path Details
+
+### Generic Agent
+
+Use this when you are integrating Alice into a Python or TypeScript agent without adopting a framework-specific bridge.
+
+- prefer one-call continuity first
+- use `alice_recall` or `alice_resume` only when your agent truly needs narrower output
+- examples: `docs/examples/generic_python_agent.py` and `docs/examples/generic_typescript_agent.ts`
+- reproducible demo: `./.venv/bin/python scripts/run_reference_agent_examples_demo.py`
+
+### Hermes
+
+Use Hermes when another runtime owns planning and execution, and Alice should stay focused on continuity plus review workflows.
+
+- default recommendation: provider plus MCP
+- fallback: MCP-only
+- docs: `docs/integrations/hermes.md`
+- reproducible demo: `./.venv/bin/python scripts/run_hermes_bridge_demo.py`
+
+### OpenClaw
+
+Use OpenClaw when the main requirement is importing existing workspace memory into Alice and then querying it through the normal Alice surfaces.
+
+- imported data augments Alice continuity objects with explicit `OpenClaw` provenance
+- after import, keep using the same brief, recall, resume, CLI, and MCP paths
+- docs: `docs/integrations/openclaw.md`
+- reproducible demo: `./scripts/use_alice_with_openclaw.sh`
+
+### Provider And Pack Controls
+
+Use the provider and model-pack docs when Alice itself owns runtime selection and prompting defaults.
+
+- provider registration and capability discovery: `docs/integrations/phase14-provider-configuration.md`
+- pack compatibility and binding posture: `docs/integrations/phase11-model-pack-compatibility.md`
+- keep these controls in Alice rather than cloning them into Hermes or importer flows
+- treat these controls as supporting configuration for the three major adoption paths above, not as a separate reference integration path
+
+## Scope Guard
+
+These paths package the shipped Alice surface. They do not introduce a second continuity contract, a second provider substrate, or a new pack system.

--- a/docs/phase14-s4-control-tower-packet.md
+++ b/docs/phase14-s4-control-tower-packet.md
@@ -4,7 +4,7 @@
 `P14-S4` Reference Integrations
 
 ## Goal
-Make Alice clearly adoptable by external agent builders.
+Make Alice clearly adoptable by external agent builders on top of the shipped continuity, provider, and model-pack baseline.
 
 ## Planned Branch
 `codex/phase14-s4-reference-integrations`
@@ -19,6 +19,7 @@ Make Alice clearly adoptable by external agent builders.
 
 ## Out Of Scope
 - new runtime substrate work unless strictly required
+- new provider or model-pack substrate work unless strictly required to document or demonstrate the shipped surface
 - design-partner onboarding
 - marketplace or new-channel work
 
@@ -27,3 +28,4 @@ Make Alice clearly adoptable by external agent builders.
 - external builders can integrate Alice into OpenClaw from docs
 - generic Python and TypeScript examples run successfully
 - at least one reproducible demo exists per major integration path
+- the sprint packages the shipped provider/pack/continuity surface instead of adding a new runtime substrate

--- a/docs/phase14-sprint-14-1-14-5-plan.md
+++ b/docs/phase14-sprint-14-1-14-5-plan.md
@@ -78,7 +78,7 @@ Make common model families easy to use with sensible continuity defaults.
 `v0.5.0-rc2`
 
 ### Status
-Active
+Shipped
 
 ## P14-S4: Reference Integrations
 
@@ -100,7 +100,7 @@ Make Alice clearly adoptable by external agent builders.
 `v0.5.0`
 
 ### Status
-Planned
+Active
 
 ## P14-S5: Design Partner Launch
 

--- a/fixtures/reference_integrations/continuity_brief_agent_handoff_v1.json
+++ b/fixtures/reference_integrations/continuity_brief_agent_handoff_v1.json
@@ -1,0 +1,129 @@
+{
+  "brief": {
+    "assembly_version": "continuity_brief_v0",
+    "brief_type": "agent_handoff",
+    "scope": {
+      "thread_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "task_id": null,
+      "project": null,
+      "person": null,
+      "since": null,
+      "until": null
+    },
+    "summary": "agent handoff brief. Release work is ready for the next deterministic step.",
+    "selection_strategy": {
+      "task_brief_mode": "agent_handoff",
+      "provider_strategy": "continuity_brief.agent_handoff",
+      "model_pack_strategy": null,
+      "token_budget": 1200,
+      "budget_source": "default"
+    },
+    "relevant_facts": {
+      "items": [],
+      "summary": {
+        "limit": 6,
+        "returned_count": 0,
+        "total_count": 0,
+        "order": [],
+        "task_brief_mode": "agent_handoff"
+      },
+      "empty_state": {
+        "is_empty": true,
+        "message": "No relevant facts found in the requested scope."
+      }
+    },
+    "recent_changes": {
+      "items": [],
+      "summary": {
+        "limit": 5,
+        "returned_count": 0,
+        "total_count": 0,
+        "order": []
+      },
+      "empty_state": {
+        "is_empty": true,
+        "message": "No recent changes were available for the requested scope."
+      }
+    },
+    "open_loops": {
+      "items": [],
+      "summary": {
+        "limit": 5,
+        "returned_count": 0,
+        "total_count": 1,
+        "order": []
+      },
+      "empty_state": {
+        "is_empty": true,
+        "message": "No open loops were available for the requested scope."
+      }
+    },
+    "conflicts": {
+      "items": [],
+      "summary": {
+        "limit": 3,
+        "returned_count": 0,
+        "total_count": 0,
+        "order": []
+      },
+      "empty_state": {
+        "is_empty": true,
+        "message": "No open conflicts found in the requested scope."
+      }
+    },
+    "timeline_highlights": {
+      "items": [],
+      "summary": {
+        "limit": 5,
+        "returned_count": 0,
+        "total_count": 0,
+        "order": []
+      },
+      "empty_state": {
+        "is_empty": true,
+        "message": "No timeline highlights were available for the requested scope."
+      }
+    },
+    "next_suggested_action": {
+      "title": "Next Action: Run release smoke",
+      "rationale": "The handoff bundle already isolates the next deterministic step."
+    },
+    "provenance_bundle": {
+      "source_object_ids": [
+        "obj-1",
+        "obj-2"
+      ],
+      "references": [
+        {
+          "source_kind": "openclaw_import",
+          "source_id": "openclaw-event-1"
+        },
+        {
+          "source_kind": "runtime_capture",
+          "source_id": "capture-event-1"
+        }
+      ],
+      "summary": {
+        "source_object_count": 2,
+        "reference_count": 2,
+        "reference_kind_count": 2
+      }
+    },
+    "trust_posture": {
+      "confidence_posture": "high",
+      "positive_signal_count": 2,
+      "negative_signal_count": 0,
+      "neutral_signal_count": 0,
+      "open_conflict_count": 0,
+      "rationale": "No open conflicts are present in the canonical handoff fixture."
+    },
+    "sources": [
+      "continuity_capture_events",
+      "continuity_objects",
+      "retrieval_runs",
+      "contradiction_cases",
+      "trust_signals",
+      "task_briefs"
+    ]
+  }
+}

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -30,15 +30,15 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "`v0.4.0`: released",
             "Phase 14 is active.",
-            "`P14-S3` Model Packs is the active execution sprint.",
+            "`P14-S4` Reference Integrations is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "P14-S3: Model Packs",
+            "P14-S4: Reference Integrations",
             "`v0.4.0` is the current public release boundary.",
-            "codex/phase14-s3-model-packs",
+            "codex/phase14-s4-reference-integrations",
         ),
     ),
     ControlDocTruthRule(
@@ -53,7 +53,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "`v0.4.0` is the latest published tag.",
             "Phase 14 is active.",
-            "`P14-S3` Model Packs is the active execution sprint.",
+            "`P14-S4` Reference Integrations is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(

--- a/scripts/run_reference_agent_examples_demo.py
+++ b/scripts/run_reference_agent_examples_demo.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import threading
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_EXAMPLE = REPO_ROOT / "docs" / "examples" / "generic_python_agent.py"
+TYPESCRIPT_EXAMPLE = REPO_ROOT / "docs" / "examples" / "generic_typescript_agent.ts"
+CANONICAL_BRIEF_FIXTURE = (
+    REPO_ROOT / "fixtures" / "reference_integrations" / "continuity_brief_agent_handoff_v1.json"
+)
+
+
+def _brief_payload() -> dict[str, Any]:
+    return json.loads(CANONICAL_BRIEF_FIXTURE.read_text(encoding="utf-8"))
+
+
+class _DemoHandler(BaseHTTPRequestHandler):
+    server_version = "AliceReferenceDemo/1.0"
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/v1/continuity/brief":
+            self.send_error(404)
+            return
+
+        authorization = self.headers.get("Authorization")
+        if authorization != "Bearer demo-session-token":
+            self._write_json(401, {"detail": "invalid session token"})
+            return
+
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length)
+        request_payload = json.loads(body.decode("utf-8"))
+        requested_brief_type = request_payload.get("brief_type")
+        payload = _brief_payload()
+        if isinstance(requested_brief_type, str) and requested_brief_type != "":
+            payload["brief"]["brief_type"] = requested_brief_type
+        self._write_json(200, payload)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        del format, args
+
+    def _write_json(self, status_code: int, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _start_demo_server() -> tuple[ThreadingHTTPServer, threading.Thread, str]:
+    port = _find_free_port()
+    server = ThreadingHTTPServer(("127.0.0.1", port), _DemoHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread, f"http://127.0.0.1:{port}"
+
+
+def _run_step(*, name: str, command: list[str], env: dict[str, str]) -> dict[str, Any]:
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    parsed_stdout: dict[str, Any] | None = None
+    stripped_stdout = completed.stdout.strip()
+    if stripped_stdout:
+        try:
+            candidate = json.loads(stripped_stdout)
+        except json.JSONDecodeError:
+            candidate = None
+        if isinstance(candidate, dict):
+            parsed_stdout = candidate
+
+    return {
+        "name": name,
+        "command": command,
+        "returncode": completed.returncode,
+        "stdout": parsed_stdout,
+        "stderr": completed.stderr.strip(),
+    }
+
+
+def main() -> int:
+    server, thread, base_url = _start_demo_server()
+    env = os.environ.copy()
+    env.update(
+        {
+            "ALICE_API_BASE_URL": base_url,
+            "ALICE_SESSION_TOKEN": "demo-session-token",
+            "ALICE_BRIEF_TYPE": "agent_handoff",
+            "ALICE_QUERY": "release handoff",
+        }
+    )
+
+    try:
+        python_step = _run_step(
+            name="python_example",
+            command=[sys.executable, str(PYTHON_EXAMPLE)],
+            env=env,
+        )
+        typescript_step = _run_step(
+            name="typescript_example",
+            command=["node", "--experimental-strip-types", str(TYPESCRIPT_EXAMPLE)],
+            env=env,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    python_stdout = python_step["stdout"]
+    typescript_stdout = typescript_step["stdout"]
+    outputs_match = (
+        isinstance(python_stdout, dict)
+        and isinstance(typescript_stdout, dict)
+        and python_stdout == typescript_stdout
+    )
+
+    ok = (
+        python_step["returncode"] == 0
+        and typescript_step["returncode"] == 0
+        and outputs_match
+    )
+
+    payload = {
+        "status": "pass" if ok else "fail",
+        "demo_base_path": "/v1/continuity/brief",
+        "contract_fixture": str(CANONICAL_BRIEF_FIXTURE.relative_to(REPO_ROOT)),
+        "python_example": {
+            "returncode": python_step["returncode"],
+            "stdout": python_stdout,
+            "stderr": python_step["stderr"],
+        },
+        "typescript_example": {
+            "returncode": typescript_step["returncode"],
+            "stdout": typescript_stdout,
+            "stderr": typescript_step["stderr"],
+        },
+        "outputs_match": outputs_match,
+    }
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_reference_agent_examples.py
+++ b/tests/integration/test_reference_agent_examples.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEMO_SCRIPT = REPO_ROOT / "scripts" / "run_reference_agent_examples_demo.py"
+
+
+def test_reference_agent_examples_demo_runs_python_and_typescript_examples() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(DEMO_SCRIPT)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert payload["status"] == "pass"
+    assert payload["contract_fixture"] == "fixtures/reference_integrations/continuity_brief_agent_handoff_v1.json"
+    assert payload["outputs_match"] is True
+    assert payload["python_example"]["returncode"] == 0
+    assert payload["typescript_example"]["returncode"] == 0
+    assert payload["python_example"]["stdout"]["brief_type"] == "agent_handoff"
+    assert payload["python_example"]["stdout"]["next_suggested_action"] == "Next Action: Run release smoke"
+    assert payload["typescript_example"]["stdout"] == payload["python_example"]["stdout"]

--- a/tests/unit/test_phase14_reference_integrations.py
+++ b/tests/unit/test_phase14_reference_integrations.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_reference_path_guide_links_major_integration_routes() -> None:
+    guide = (REPO_ROOT / "docs" / "integrations" / "reference-paths.md").read_text(encoding="utf-8")
+
+    assert "POST /v1/continuity/brief" in guide
+    assert "scripts/run_hermes_bridge_demo.py" in guide
+    assert "scripts/use_alice_with_openclaw.sh" in guide
+    assert "phase14-provider-configuration.md" in guide
+    assert "three major adoption paths in this sprint" in guide
+
+
+def test_hermes_reference_doc_centers_provider_plus_mcp_and_one_call_continuity() -> None:
+    hermes_doc = (REPO_ROOT / "docs" / "integrations" / "hermes.md").read_text(encoding="utf-8")
+
+    assert "provider_plus_mcp" in hermes_doc
+    assert "alice_brief" in hermes_doc
+    assert "phase14-provider-configuration.md" in hermes_doc
+    assert "phase11-model-pack-compatibility.md" in hermes_doc
+    assert "scripts/run_hermes_bridge_demo.py" in hermes_doc
+
+
+def test_openclaw_reference_doc_covers_import_augmentation_and_one_call_reuse() -> None:
+    openclaw_doc = (REPO_ROOT / "docs" / "integrations" / "openclaw.md").read_text(encoding="utf-8")
+
+    assert "import plus augmentation" in openclaw_doc
+    assert "POST /v1/continuity/brief" in openclaw_doc
+    assert "alice_brief" in openclaw_doc
+    assert "scripts/use_alice_with_openclaw.sh" in openclaw_doc
+    assert "generic_python_agent.py" in openclaw_doc
+    assert "generic_typescript_agent.ts" in openclaw_doc
+
+
+def test_reference_agent_examples_doc_points_to_both_runnable_examples_and_demo() -> None:
+    examples_doc = (REPO_ROOT / "docs" / "examples" / "reference-agent-examples.md").read_text(encoding="utf-8")
+
+    assert "generic_python_agent.py" in examples_doc
+    assert "generic_typescript_agent.ts" in examples_doc
+    assert "ALICE_SESSION_TOKEN" in examples_doc
+    assert "scripts/run_reference_agent_examples_demo.py" in examples_doc
+    assert "--experimental-strip-types" in examples_doc

--- a/tests/unit/test_reference_agent_examples_contract.py
+++ b/tests/unit/test_reference_agent_examples_contract.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from alicebot_api.contracts import CONTINUITY_BRIEF_ASSEMBLY_VERSION_V0, ContinuityBriefRecord
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_PATH = (
+    REPO_ROOT / "fixtures" / "reference_integrations" / "continuity_brief_agent_handoff_v1.json"
+)
+
+
+def test_reference_agent_fixture_tracks_continuity_brief_contract() -> None:
+    payload = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    brief = payload["brief"]
+
+    required_top_level_keys = set(ContinuityBriefRecord.__annotations__)
+    assert required_top_level_keys.issubset(set(brief))
+    assert brief["assembly_version"] == CONTINUITY_BRIEF_ASSEMBLY_VERSION_V0
+    assert brief["brief_type"] == "agent_handoff"
+    assert brief["next_suggested_action"]["title"] == "Next Action: Run release smoke"
+    assert brief["open_loops"]["summary"]["total_count"] == 1
+    assert brief["trust_posture"]["open_conflict_count"] == 0


### PR DESCRIPTION
## Summary
- refresh the Hermes and OpenClaw integration docs around the shipped provider/pack/continuity surface
- add runnable generic Python and TypeScript examples, a canonical continuity-brief fixture, an integration-path guide, and a reproducible generic example demo helper
- update control docs and reference-integration validation so the P14-S4 docs/examples scope is packaged for external builders

## Validation
- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py tests/unit/test_phase14_reference_integrations.py tests/unit/test_reference_agent_examples_contract.py -q`
- `./.venv/bin/python -m pytest tests/integration/test_reference_agent_examples.py tests/unit/test_hermes_bridge_demo.py tests/integration/test_openclaw_import.py tests/integration/test_openclaw_one_command_demo.py tests/integration/test_openclaw_mcp_integration.py -q`

## Upgrade Overview

### Protected Areas
- [ ] memory schema
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact
This sprint is documentation/example/demo packaging on top of the shipped provider, model-pack, and one-call continuity baseline. It does not add new runtime substrate, but it does define the builder-facing guidance for how that shipped surface should be adopted.

### Migration / Rollout
No schema migration is required. Rollout is documentation and demo helper publication only.

### Operator Action
Operators can use the new generic demo helper and existing Hermes/OpenClaw demos as the reference validation path for external-builder adoption.

### Validation
- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py tests/unit/test_phase14_reference_integrations.py tests/unit/test_reference_agent_examples_contract.py -q`
- `./.venv/bin/python -m pytest tests/integration/test_reference_agent_examples.py tests/unit/test_hermes_bridge_demo.py tests/integration/test_openclaw_import.py tests/integration/test_openclaw_one_command_demo.py tests/integration/test_openclaw_mcp_integration.py -q`

### Rollback
Revert the squash merge commit to remove the reference-integration docs, examples, fixture, and demo helper. No data rollback is needed.