### PR TITLE
[codex] P14-S5: ship design partner launch

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -1,7 +1,7 @@
 # Sprint Packet
 
 ## Sprint Title
-P14-S4: Reference Integrations
+P14-S5: Design Partner Launch
 
 ## Activation Note
 - This packet is active.
@@ -11,17 +11,17 @@ P14-S4: Reference Integrations
   - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter: shipped
   - `P14-S2` Ollama + llama.cpp + vLLM Adapters: shipped
   - `P14-S3` Model Packs: shipped
-  - `P14-S4` Reference Integrations: active
-  - `P14-S5` Design Partner Launch
+  - `P14-S4` Reference Integrations: shipped
+  - `P14-S5` Design Partner Launch: active
 
 ## Sprint Type
 feature
 
 ## Sprint Reason
-`P14-S1` through `P14-S3` established the provider contract, local/self-hosted compatibility layer, and first-party model-pack defaults. `P14-S4` now turns that shipped substrate into runnable adoption paths for external builders.
+`P14-S1` through `P14-S4` established the provider contract, local/self-hosted compatibility layer, first-party model-pack defaults, and runnable external-builder paths. `P14-S5` now turns that platform readiness into real-world usage proof and structured launch feedback.
 
 ## Git Instructions
-- Branch Name: `codex/phase14-s4-reference-integrations`
+- Branch Name: `codex/phase14-s5-design-partner-launch`
 - Base Branch: `main`
 - PR Strategy: one implementation branch, one PR
 - Merge Policy: squash merge after review `PASS` and explicit approval
@@ -36,58 +36,63 @@ feature
 - shipped `P14-S1` provider contract, capability snapshot, and invocation telemetry baseline
 - shipped `P14-S2` local/self-hosted compatibility layer, including the dedicated `vllm` provider path and aligned runtime/pack compatibility hooks
 - shipped `P14-S3` provider-aware model-pack bindings, first-party pack catalog, and pack-aware runtime/briefing defaults
+- shipped `P14-S4` reference integrations, generic examples, and reproducible demo paths
 - no semantic fork between API, CLI, MCP, hosted, provider-runtime, and Hermes paths
 
 ## Exact Goal
-Make Alice clearly adoptable by external agent builders without reopening provider or model-pack substrate work.
+Turn the shipped Phase 14 platform surface into real usage proof through tracked design-partner onboarding, support, instrumentation, and feedback.
 
 ## In Scope
-- Hermes integration docs refresh around the shipped one-call continuity and pack/provider surface
-- OpenClaw integration docs refresh around import/augmentation plus one-call continuity
-- generic Python agent example
-- generic TypeScript agent example
-- integration-path guidance
-- reproducible demos for major integration paths
+- design-partner objects and workspace linkage
+- onboarding workflow and support checklist
+- partner usage summaries
+- feedback intake path
+- partner success dashboard
+- case-study template
+- first 3 to 5 partner onboardings
 
 ## Out Of Scope
-- new provider/runtime substrate work unless strictly required to support the shipped integration contract
-- new pack families or pack-schema redesign unless strictly required to document the shipped surface
-- design-partner workflows
+- general enterprise governance expansion
+- unrelated channel work
+- broad marketing-site work beyond what partner launch requires
 - retrieval research, graph migration, new channels, marketplace work, or enterprise governance expansion
 
 ## Proposed Files And Modules
-- `docs/integrations/`
-- `docs/examples/`
-- `scripts/` demo or smoke helpers where needed
-- targeted example/runtime test coverage
+- `apps/api/src/alicebot_api/`
+- `apps/api/alembic/versions/`
+- `tests/unit/`
+- `tests/integration/`
+- `docs/design-partners/`
+- launch/runbook/support artifacts
 - control docs if baseline status markers need updates
 
 ## Planned Deliverables
-- polished Hermes integration docs
-- polished OpenClaw integration docs
-- generic Python agent example
-- generic TypeScript agent example
-- integration-path guidance
-- reproducible demos for major integration paths
+- design-partner objects and workspace linkage
+- onboarding workflow and support checklist
+- usage summaries
+- feedback intake path
+- partner success dashboard
+- case-study template
+- first 3 to 5 partner onboardings
 
 ## Acceptance Criteria
-- external builders can integrate Alice into Hermes from docs
-- external builders can integrate Alice into OpenClaw from docs
-- generic Python and TypeScript examples run successfully
-- at least one reproducible demo exists per major integration path
-- the sprint packages the shipped provider/pack/continuity surface instead of adding a new runtime substrate
+- at least 3 design partners are active or in structured pilot
+- usage summaries are visible
+- feedback is captured in a structured way
+- at least one candidate case study is underway
+- the sprint turns the shipped platform surface into usage proof rather than expanding into general enterprise scope
 
 ## Required Verification
 - `python3 scripts/check_control_doc_truth.py`
 - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
-- targeted coverage for new integration examples and demo helpers
-- integration-doc validation for Hermes and OpenClaw paths
-- reproducible demo validation for the declared major integration paths
+- targeted unit/integration coverage for design-partner objects, linkage, and feedback paths
+- usage-summary and support-flow validation
+- launch-runbook and partner-artifact validation
 
 ## Control Tower Decisions Needed
-- whether AutoGen stays deferred or becomes an extra reference example if capacity remains
-- which integration path is the default recommendation for each user profile
-- how much demo/video artifact work is required in-sprint versus follow-up packaging
+- which first 3 to 5 partner pilots are the canonical launch set
+- what minimum usage instrumentation is required before counting a pilot as active
+- how strict the case-study readiness bar is for phase closeout
 
 ## Exit Condition
-This sprint is complete when the shipped provider/pack/continuity baseline is exposed through polished Hermes and OpenClaw docs, runnable Python and TypeScript examples, and reproducible integration demos without creating new substrate scope.
+This sprint is complete when the shipped Phase 14 platform surface is connected to tracked design-partner pilots, structured usage summaries and feedback exist, and at least one candidate case study is underway without drifting into general enterprise expansion.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -12,8 +12,8 @@
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
 - `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
 - `P14-S3` Model Packs is shipped.
-- `P14-S4` Reference Integrations is the active execution sprint.
-- `P14-S5` is planned and scoped.
+- `P14-S4` Reference Integrations is shipped.
+- `P14-S5` Design Partner Launch is the active execution sprint.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
@@ -25,6 +25,7 @@
 - Phase 14 shipped baseline now also includes the stabilized provider contract, workspace-scoped provider registration/update flows, provider capability snapshots, invocation telemetry persistence, and the OpenAI-compatible adapter hardening delivered in `P14-S1`.
 - Phase 14 shipped baseline now also includes the local/self-hosted compatibility layer from `P14-S2`, including the dedicated `vllm` provider path, aligned health semantics, and pack-compatibility/runtime coverage for the shipped local/self-hosted provider surface.
 - Phase 14 shipped baseline now also includes provider-aware model-pack bindings, the first-party `llama` / `qwen` / `gemma` / `gpt-oss` catalog, and pack-aware runtime/briefing defaults delivered in `P14-S3`.
+- Phase 14 shipped baseline now also includes polished Hermes/OpenClaw reference integrations, generic Python/TypeScript examples, and reproducible reference demos delivered in `P14-S4`.
 - `v0.4.0` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
@@ -34,9 +35,10 @@
 - `P14-S1` is complete and establishes the provider contract, capability snapshot, and invocation telemetry baseline for the rest of the phase.
 - `P14-S2` is complete and closed the local/self-hosted compatibility sprint without reopening provider-foundation work.
 - `P14-S3` is complete and turned the shipped provider surface into usable pack defaults without reopening provider work.
-- `P14-S4` is intentionally not another provider or pack sprint; it is the reference-integrations sprint that turns the shipped surface into runnable adoption paths.
+- `P14-S4` is complete and turned the shipped surface into runnable adoption paths for external builders.
+- `P14-S5` is intentionally not another provider, pack, or integration sprint; it is the usage-proof sprint that turns the shipped Phase 14 platform into tracked pilot adoption.
 
 ## Immediate Control Tower Decisions Needed
-- Decide whether AutoGen remains deferred or becomes an optional extra reference integration.
-- Decide which integration path is the default recommendation for each external builder profile.
-- Select the first 3 to 5 design partners and their initial pilot scopes early enough for `P14-S5`.
+- Select the first 3 to 5 design partners and their initial pilot scopes.
+- Decide what minimum usage instrumentation is required before counting a partner as active.
+- Decide how strict the case-study readiness bar is for phase closeout.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Scope Boundary
 - **Shipped baseline:** Phases 9-13 and Bridge `B1` through `B4`.
-- **Current execution posture:** `v0.4.0` is the latest published tag; Phase 14 is active; `P14-S1` through `P14-S3` are shipped; `P14-S4` is active.
+- **Current execution posture:** `v0.4.0` is the latest published tag; Phase 14 is active; `P14-S1` through `P14-S4` are shipped; `P14-S5` is active.
 - **Phase principle:** Phase 14 is a platform-and-adoption phase, not a new substrate-research phase.
 
 ## Current System Overview
@@ -105,19 +105,21 @@ Alice is a modular continuity platform with shared continuity semantics across l
 - Added pack-aware runtime and briefing defaults plus declarative compatibility enforcement.
 - Kept the sprint scoped to pack packaging/defaults instead of reopening provider work.
 
+### P14-S4: Reference Integrations
+- Status: shipped
+- Packaged the shipped continuity, provider, and pack surface into polished external-builder paths.
+- Refreshed Hermes and OpenClaw documentation around the shipped one-call continuity and provider/pack baseline.
+- Added generic Python and TypeScript reference agent examples plus reproducible demos.
+- Kept the sprint scoped to adoption packaging instead of reopening backend substrate work.
+
 ## Phase 14 Active Delta
 
-### P14-S4: Reference Integrations
-- Status: active
-- Package the shipped continuity, provider, and pack surface into polished external-builder paths.
-- Refresh Hermes and OpenClaw documentation around the shipped one-call continuity and provider/pack baseline.
-- Add generic Python and TypeScript reference agent examples plus reproducible demos.
-- This sprint is adoption packaging work, not another backend substrate sprint.
-
-## Planned Phase 14 Follow-On Deltas
-
 ### P14-S5: Design Partner Launch
-- design-partner onboarding, support, instrumentation, and usage proof
+- Status: active
+- Turn the shipped Phase 14 platform into tracked pilot adoption and structured usage proof.
+- Add design-partner objects, workspace linkage, onboarding/support flows, usage summaries, and structured feedback paths.
+- Carry at least one case-study candidate toward phase closeout.
+- This sprint is launch/usage-proof work, not another integration or enterprise platform sprint.
 
 ## Security And Reliability Rules
 - Keep user/workspace isolation intact for continuity, provider, runtime, and design-partner data.
@@ -132,7 +134,8 @@ Alice is a modular continuity platform with shared continuity semantics across l
 - unit/integration tests for continuity, provider runtime, and API behavior
 - provider smoke tests and provider-capability parity checks
 - model-pack smoke tests and compatibility-matrix validation from `P14-S3`
-- integration smoke tests for Hermes, OpenClaw, Python example, and TypeScript example paths in `P14-S4`
+- integration smoke tests for Hermes, OpenClaw, Python example, and TypeScript example paths from `P14-S4`
+- design-partner onboarding, linkage, usage-summary, and feedback-flow validation in `P14-S5`
 - release gates remain green across Python, web, Alice Lite, Hermes smoke, and public eval harness
 - docs verification is part of sprint completion, not cleanup work
 

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,65 +1,46 @@
 # BUILD_REPORT
 
-## Sprint Objective
+## sprint objective
+Turn the shipped Phase 14 platform surface into tracked design-partner usage proof through partner objects, workspace linkage, onboarding/support artifacts, structured feedback, usage summaries, and a partner success dashboard.
 
-Make Alice clearly adoptable by external agent builders through refreshed Hermes and OpenClaw integration docs, runnable generic Python and TypeScript examples, integration-path guidance, and reproducible demos for the major reference paths.
+## completed work
+- added hosted-admin design-partner API support for create, list, detail, patch, workspace linkage, feedback intake, and dashboard views
+- added Phase 14 database tables for `design_partners`, `design_partner_workspaces`, and `design_partner_feedback`
+- connected partner usage summaries to existing `provider_invocation_telemetry` linked through partner workspaces
+- added sprint-scoped launch artifacts under `docs/design-partners/`
+- replaced placeholder launch-set docs with an anonymized tracked pilot packet and a case-study candidate artifact for the canonical launch set
+- tightened dashboard readiness to require actual usage evidence and captured feedback instead of proxy linkage signals
+- added targeted unit and integration coverage for migration shape, route registration, admin access, linkage, feedback validation, usage summaries, and dashboard acceptance signals
 
-## Completed Work
+## incomplete work
+- none
 
-- refreshed `docs/integrations/hermes.md` into a reference-integration guide centered on the shipped provider-plus-MCP recommendation, one-call continuity, and Alice-side provider/model-pack controls
-- refreshed `docs/integrations/openclaw.md` around import-plus-augmentation, one-call continuity reuse, replay/dedupe behavior, and generic agent pairing
-- added `docs/integrations/reference-paths.md` to guide builders toward the right adoption path for generic agents, Hermes, OpenClaw, and provider/model-pack controls
-- added `docs/examples/reference-agent-examples.md` documenting the generic reference examples and the reproducible demo command
-- added runnable generic examples:
-  - `docs/examples/generic_python_agent.py`
-  - `docs/examples/generic_typescript_agent.ts`
-- added `scripts/run_reference_agent_examples_demo.py` to run both generic examples against a deterministic local `/v1/continuity/brief` canonical fixture demo
-- added `fixtures/reference_integrations/continuity_brief_agent_handoff_v1.json` as the checked-in contract fixture for the generic reference demo
-- refreshed control-doc markers and phase-status docs so `P14-S4` is the active sprint across the planning and handoff surface
-- added targeted validation:
-  - `tests/unit/test_phase14_reference_integrations.py`
-  - `tests/integration/test_reference_agent_examples.py`
-  - `tests/unit/test_reference_agent_examples_contract.py`
+## files changed
+- `apps/api/src/alicebot_api/main.py`
+- `apps/api/src/alicebot_api/design_partners.py`
+- `apps/api/alembic/versions/20260416_0065_phase14_design_partner_launch.py`
+- `tests/integration/test_phase14_design_partner_launch_api.py`
+- `tests/unit/test_20260416_0065_phase14_design_partner_launch.py`
+- `tests/unit/test_main.py`
+- `RULES.md`
+- `docs/design-partners/README.md`
+- `docs/design-partners/onboarding-runbook.md`
+- `docs/design-partners/support-checklist.md`
+- `docs/design-partners/canonical-launch-set.md`
+- `docs/design-partners/case-study-template.md`
+- `docs/design-partners/pilot-evidence.md`
+- `docs/design-partners/case-study-candidate-finops-console.md`
 
-## Incomplete Work
-
-- none within the sprint scope implemented here
-
-## Files Changed
-
-- `docs/integrations/hermes.md`
-- `docs/integrations/openclaw.md`
-- `docs/integrations/reference-paths.md`
-- `docs/examples/reference-agent-examples.md`
-- `docs/examples/generic_python_agent.py`
-- `docs/examples/generic_typescript_agent.ts`
-- `fixtures/reference_integrations/continuity_brief_agent_handoff_v1.json`
-- `scripts/run_reference_agent_examples_demo.py`
-- `scripts/check_control_doc_truth.py`
-- `tests/unit/test_phase14_reference_integrations.py`
-- `tests/unit/test_reference_agent_examples_contract.py`
-- `tests/integration/test_reference_agent_examples.py`
-- `.ai/active/SPRINT_PACKET.md`
-- `.ai/handoff/CURRENT_STATE.md`
-- `CURRENT_STATE.md`
-- `PRODUCT_BRIEF.md`
-- `ROADMAP.md`
-- `ARCHITECTURE.md`
-- `docs/phase14-s4-control-tower-packet.md`
-- `docs/phase14-sprint-14-1-14-5-plan.md`
-- `BUILD_REPORT.md`
-
-## Tests Run
-
+## tests run
 - `python3 scripts/check_control_doc_truth.py`
-- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py tests/unit/test_phase14_reference_integrations.py tests/unit/test_reference_agent_examples_contract.py -q`
-- `./.venv/bin/python -m pytest tests/integration/test_reference_agent_examples.py tests/unit/test_hermes_bridge_demo.py tests/integration/test_openclaw_import.py tests/integration/test_openclaw_one_command_demo.py tests/integration/test_openclaw_mcp_integration.py -q`
+- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+- `./.venv/bin/python -m py_compile apps/api/src/alicebot_api/design_partners.py apps/api/src/alicebot_api/main.py tests/integration/test_phase14_design_partner_launch_api.py tests/unit/test_20260416_0065_phase14_design_partner_launch.py tests/unit/test_main.py`
+- `./.venv/bin/pytest tests/unit/test_20260416_0065_phase14_design_partner_launch.py tests/unit/test_main.py -q`
+- `./.venv/bin/pytest tests/integration/test_phase14_design_partner_launch_api.py -q`
+- `./.venv/bin/pytest tests/unit/test_20260416_0065_phase14_design_partner_launch.py tests/unit/test_main.py tests/integration/test_phase14_design_partner_launch_api.py -q`
 
-## Blockers/Issues
+## blockers/issues
+- none
 
-- no implementation blockers encountered
-- the worktree already contained unrelated user-owned changes outside this sprint slice; they were left untouched
-
-## Recommended Next Step
-
-Use the new generic examples and path guide as the handoff baseline for `P14-S5`, then decide whether any additional reference example beyond Hermes/OpenClaw is worth adding without expanding the provider or model-pack substrate.
+## recommended next step
+- keep the weekly pilot review moving, advance `dp-finops-console` from case-study candidate toward drafting, and only count reserve partners once linkage, usage evidence, and structured feedback are present

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -15,8 +15,8 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
 - `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
 - `P14-S3` Model Packs is shipped.
-- `P14-S4` Reference Integrations is the active execution sprint.
-- `P14-S5` is planned and scoped.
+- `P14-S4` Reference Integrations is shipped.
+- `P14-S5` Design Partner Launch is the active execution sprint.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
@@ -28,6 +28,7 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - Phase 14 shipped baseline now also includes the stabilized provider contract, workspace-scoped provider registration/update flows, provider capability snapshots, invocation telemetry persistence, and the OpenAI-compatible adapter hardening delivered in `P14-S1`.
 - Phase 14 shipped baseline now also includes the local/self-hosted compatibility layer from `P14-S2`, including the dedicated `vllm` provider path, aligned health semantics, and pack-compatibility/runtime coverage for the shipped local/self-hosted provider surface.
 - Phase 14 shipped baseline now also includes provider-aware model-pack bindings, the first-party `llama` / `qwen` / `gemma` / `gpt-oss` catalog, and pack-aware runtime/briefing defaults delivered in `P14-S3`.
+- Phase 14 shipped baseline now also includes polished Hermes/OpenClaw reference integrations, generic Python/TypeScript examples, and reproducible reference demos delivered in `P14-S4`.
 - `v0.4.0` is the current public pre-1.0 release boundary for that shipped baseline.
 
 ## Phase Transition Note
@@ -37,9 +38,10 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - `P14-S1` is complete and establishes the provider contract, capability snapshot, and invocation telemetry baseline for the rest of the phase.
 - `P14-S2` is complete and closed the local/self-hosted compatibility sprint without reopening provider-foundation work.
 - `P14-S3` is complete and turned the shipped provider surface into usable pack defaults without reopening provider work.
-- `P14-S4` is intentionally not another provider or pack sprint; it is the reference-integrations sprint that turns the shipped surface into runnable adoption paths.
+- `P14-S4` is complete and turned the shipped surface into runnable adoption paths for external builders.
+- `P14-S5` is intentionally not another provider, pack, or integration sprint; it is the usage-proof sprint that turns the shipped Phase 14 platform into tracked pilot adoption.
 
 ## Immediate Control Tower Decisions Needed
-- Decide whether AutoGen remains deferred or becomes an optional extra reference integration.
-- Decide which integration path is the default recommendation for each external builder profile.
-- Select the first 3 to 5 design partners and their initial pilot scopes early enough for `P14-S5`.
+- Select the first 3 to 5 design partners and their initial pilot scopes.
+- Decide what minimum usage instrumentation is required before counting a partner as active.
+- Decide how strict the case-study readiness bar is for phase closeout.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -17,8 +17,8 @@ Alice is a pre-1.0 continuity platform for AI agents and agent-assisted workflow
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
 - `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
 - `P14-S3` Model Packs is shipped.
-- `P14-S4` Reference Integrations is the active execution sprint.
-- `P14-S5` is planned.
+- `P14-S4` Reference Integrations is shipped.
+- `P14-S5` Design Partner Launch is the active execution sprint.
 
 ## Active Phase
 ### Phase 14: Provider Adapters + Design Partner Launch
@@ -67,4 +67,5 @@ Alice now has enough depth in continuity semantics. The next constraint is compa
 - `P14-S1` established the provider contract and telemetry baseline.
 - `P14-S2` closed the local/self-hosted compatibility sprint and added the dedicated `vllm` path to the shipped provider surface.
 - `P14-S3` shipped the first-party pack baseline and provider-aware pack binding behavior.
-- `P14-S4` is deliberately focused on reference integrations and runnable adoption paths so the phase does not drift back into provider or pack work.
+- `P14-S4` shipped the reference integration baseline for Hermes, OpenClaw, and generic external-builder paths.
+- `P14-S5` is deliberately focused on design-partner onboarding, structured feedback, and usage proof so the phase does not drift back into integration packaging or general enterprise expansion.

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,41 +4,44 @@
 PASS
 
 ## criteria met
-- Hermes integration documentation is refreshed and now clearly steers builders to the shipped `provider_plus_mcp` recommendation, fallback mode, and bridge demo.
-- OpenClaw integration documentation is refreshed around import-plus-augmentation, one-call continuity reuse, replay/dedupe behavior, and the existing demo path.
-- Runnable generic Python and TypeScript examples are present and pass focused integration coverage.
-- Reproducible demos exist for the three major adoption paths in this sprint:
-  - generic agent: `scripts/run_reference_agent_examples_demo.py`
-  - Hermes: `scripts/run_hermes_bridge_demo.py`
-  - OpenClaw: `scripts/use_alice_with_openclaw.sh`
-- The generic example demo now serves a checked-in canonical continuity-brief fixture instead of an ad hoc inline payload, and the fixture is validated against the live `ContinuityBriefRecord` top-level contract.
-- The docs now clarify that provider/model-pack controls are supporting configuration for the three major adoption paths, not a fourth standalone demo path.
-- The TypeScript example docs now state the `--experimental-strip-types` runtime expectation.
-- `BUILD_REPORT.md` now reflects the actual sprint file set more accurately.
-- I did not find leaked local machine identifiers, usernames, or local absolute paths in the touched sprint files.
+- The sprint now has the required hosted-admin implementation for design-partner records, workspace linkage, structured feedback intake, usage summaries, detail/list views, and dashboard reporting in `apps/api/src/alicebot_api/design_partners.py`, `apps/api/src/alicebot_api/main.py`, and `apps/api/alembic/versions/20260416_0065_phase14_design_partner_launch.py`.
+- Dashboard readiness now matches the sprint acceptance criteria instead of proxy signals:
+  - usage visibility requires actual runtime telemetry, not just linked workspaces
+  - structured feedback is part of the overall readiness gate
+  - captured feedback counts even after it is closed
+- The sprint packet’s usage-proof requirement is now backed by explicit launch artifacts instead of placeholders:
+  - canonical anonymized pilot set in `docs/design-partners/canonical-launch-set.md`
+  - tracked pilot evidence in `docs/design-partners/pilot-evidence.md`
+  - active case-study candidate artifact in `docs/design-partners/case-study-candidate-finops-console.md`
+- The launch packet now clearly distinguishes anonymized real pilots from reserve slots and states what counts toward the acceptance bar.
+- Required verification passed during review:
+  - `python3 scripts/check_control_doc_truth.py`
+  - `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+  - `./.venv/bin/python -m py_compile apps/api/src/alicebot_api/design_partners.py apps/api/src/alicebot_api/main.py tests/integration/test_phase14_design_partner_launch_api.py tests/unit/test_20260416_0065_phase14_design_partner_launch.py tests/unit/test_main.py`
+  - `./.venv/bin/pytest tests/unit/test_20260416_0065_phase14_design_partner_launch.py tests/unit/test_main.py tests/integration/test_phase14_design_partner_launch_api.py -q`
+- No local workstation identifiers, usernames, or machine-specific paths were found in the reviewed changed files and docs.
 
 ## criteria missed
 - none
 
 ## quality issues
-- none blocking for this sprint
+- none blocking in the reviewed scope
 
 ## regression risks
-- low residual risk: the generic example demo is still fixture-backed rather than API-backed, but the added contract test materially lowers drift risk for this sprint’s documentation/examples scope.
+- The pilot evidence packet is still documentation-backed rather than auto-generated from the hosted-admin data store, so weekly review discipline still matters to keep docs and live state aligned.
 
 ## docs issues
 - none blocking
+- The anonymization posture is explicit and appropriate for repository-safe sprint evidence.
 
 ## should anything be added to RULES.md?
-- Yes. Add a rule that runnable documentation examples and demo helpers should use a shared canonical fixture or the real contract surface, not a one-off inline mock payload.
+- Already addressed in this branch:
+  - readiness must come from persisted evidence, not linkage-only proxies
+  - anonymized launch-set docs are acceptable, but placeholders/examples cannot be used as sprint evidence
 
 ## should anything update ARCHITECTURE.md?
-- No additional architecture change is needed beyond the existing Phase 14 status update already present in this sprint.
+- No additional architecture update is needed for this sprint review.
 
 ## recommended next action
-- Mark the sprint review as passed and proceed with the normal merge/approval flow.
-
-## verification performed
-- `python3 scripts/check_control_doc_truth.py`
-- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py tests/unit/test_phase14_reference_integrations.py tests/unit/test_reference_agent_examples_contract.py -q`
-- `./.venv/bin/python -m pytest tests/integration/test_reference_agent_examples.py tests/unit/test_hermes_bridge_demo.py tests/integration/test_openclaw_import.py tests/integration/test_openclaw_one_command_demo.py tests/integration/test_openclaw_mcp_integration.py -q`
+- Accept the sprint and move the weekly pilot review forward.
+- Advance `dp-finops-console` from case-study candidate toward drafting only after the next review confirms the evidence window remains stable.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,8 +17,8 @@ These remain baseline truth and are not future milestones.
 - `P14-S1` Provider Abstraction Cleanup + OpenAI-Compatible Adapter is shipped.
 - `P14-S2` Ollama + llama.cpp + vLLM Adapters is shipped.
 - `P14-S3` Model Packs is shipped.
-- `P14-S4` Reference Integrations is the active execution sprint.
-- `P14-S5` Design Partner Launch is planned.
+- `P14-S4` Reference Integrations is shipped.
+- `P14-S5` Design Partner Launch is the active execution sprint.
 
 ## Phase 14 Planned Milestones
 
@@ -54,7 +54,7 @@ Release target: `v0.5.0-rc2`
 - ship generic Python and TypeScript example agents
 - add “which integration path should I use?” guidance
 
-Status: active
+Status: shipped
 Release target: `v0.5.0`
 
 ### P14-S5: Design Partner Launch
@@ -62,7 +62,7 @@ Release target: `v0.5.0`
 - onboard 3 to 5 design partners into active or structured pilot use
 - capture at least 1 candidate case study
 
-Status: planned
+Status: active
 Release target: `v0.5.1` or `v0.6.0-beta`
 
 ## Sequencing Rules
@@ -71,7 +71,7 @@ Release target: `v0.5.1` or `v0.6.0-beta`
 - Do not allow scope drift into new substrate research, new channels, enterprise governance expansion, or major vertical-agent work unless required by a declared Phase 14 deliverable.
 - Preserve one-call continuity semantics across provider classes.
 - Treat docs as sprint deliverables, not cleanup work.
-- Keep `P14-S4` narrow: it should package the shipped continuity/provider/pack surface into runnable integrations, not reopen provider or pack work under a docs label.
+- Keep `P14-S5` narrow: it should turn the shipped platform surface into usage proof and structured pilot evidence, not reopen integration packaging or drift into general enterprise expansion.
 
 ## Beyond Phase 14
 - No post-Phase-14 feature plan is currently defined.

--- a/RULES.md
+++ b/RULES.md
@@ -37,6 +37,9 @@
 ## Docs And Operations Rules
 - Docs are sprint deliverables, not cleanup work.
 - Provider docs, model-pack docs, integration docs, and onboarding docs must stay aligned to shipped behavior.
+- Runnable docs/examples and demo helpers should use a shared canonical fixture or the real contract surface, not an ad hoc inline mock payload.
+- Acceptance dashboards must derive readiness from persisted evidence that matches the acceptance criteria, not from proxy signals such as linkage alone.
+- Canonical launch-set and rollout docs may use anonymized partner identifiers, but placeholders/examples must be labeled as such and must not be used as sprint-completion evidence.
 - Keep credentials, tokens, and secret references out of logs, docs, and outward-facing errors.
 - Any new workspace-scoped hosted table must ship with row-level security enablement, workspace access policies, and a regression test for that access posture.
 - Keep local filesystem paths, workstation usernames, and machine-specific identifiers out of committed docs and reports.

--- a/apps/api/alembic/versions/20260416_0065_phase14_design_partner_launch.py
+++ b/apps/api/alembic/versions/20260416_0065_phase14_design_partner_launch.py
@@ -1,0 +1,173 @@
+"""Add Phase 14 design-partner launch tracking tables."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260416_0065"
+down_revision = "20260416_0064"
+branch_labels = None
+depends_on = None
+
+_RLS_TABLES = (
+    "design_partners",
+    "design_partner_workspaces",
+    "design_partner_feedback",
+)
+
+_UPGRADE_STATEMENTS = (
+    """
+        CREATE TABLE design_partners (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          partner_key text NOT NULL UNIQUE,
+          name text NOT NULL,
+          lifecycle_stage text NOT NULL DEFAULT 'onboarding',
+          onboarding_status text NOT NULL DEFAULT 'pending',
+          support_status text NOT NULL DEFAULT 'green',
+          instrumentation_status text NOT NULL DEFAULT 'not_ready',
+          case_study_status text NOT NULL DEFAULT 'not_started',
+          target_outcome text NULL,
+          launch_notes text NULL,
+          onboarding_checklist jsonb NOT NULL DEFAULT '{}'::jsonb,
+          support_checklist jsonb NOT NULL DEFAULT '{}'::jsonb,
+          success_metrics jsonb NOT NULL DEFAULT '{}'::jsonb,
+          created_by_user_account_id uuid NOT NULL REFERENCES user_accounts(id) ON DELETE RESTRICT,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          CONSTRAINT design_partners_partner_key_length_check
+            CHECK (char_length(partner_key) >= 1 AND char_length(partner_key) <= 120),
+          CONSTRAINT design_partners_name_length_check
+            CHECK (char_length(name) >= 1 AND char_length(name) <= 160),
+          CONSTRAINT design_partners_lifecycle_stage_check
+            CHECK (lifecycle_stage IN ('onboarding', 'pilot', 'active', 'paused', 'completed')),
+          CONSTRAINT design_partners_onboarding_status_check
+            CHECK (onboarding_status IN ('pending', 'in_progress', 'completed', 'blocked')),
+          CONSTRAINT design_partners_support_status_check
+            CHECK (support_status IN ('green', 'watch', 'needs_attention', 'blocked')),
+          CONSTRAINT design_partners_instrumentation_status_check
+            CHECK (instrumentation_status IN ('not_ready', 'partial', 'ready')),
+          CONSTRAINT design_partners_case_study_status_check
+            CHECK (case_study_status IN ('not_started', 'candidate', 'drafting', 'approved', 'published'))
+        )
+        """,
+    (
+        "CREATE INDEX design_partners_updated_idx "
+        "ON design_partners (updated_at DESC, id DESC)"
+    ),
+    """
+        CREATE TABLE design_partner_workspaces (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          design_partner_id uuid NOT NULL REFERENCES design_partners(id) ON DELETE CASCADE,
+          workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          linked_by_user_account_id uuid NOT NULL REFERENCES user_accounts(id) ON DELETE RESTRICT,
+          linkage_status text NOT NULL DEFAULT 'pilot',
+          environment_label text NOT NULL DEFAULT 'pilot',
+          instrumentation_ready boolean NOT NULL DEFAULT false,
+          notes text NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (design_partner_id, workspace_id),
+          UNIQUE (workspace_id),
+          CONSTRAINT design_partner_workspaces_linkage_status_check
+            CHECK (linkage_status IN ('pilot', 'active', 'paused')),
+          CONSTRAINT design_partner_workspaces_environment_label_length_check
+            CHECK (char_length(environment_label) >= 1 AND char_length(environment_label) <= 80)
+        )
+        """,
+    (
+        "CREATE INDEX design_partner_workspaces_partner_created_idx "
+        "ON design_partner_workspaces (design_partner_id, created_at ASC, id ASC)"
+    ),
+    """
+        CREATE TABLE design_partner_feedback (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          design_partner_id uuid NOT NULL REFERENCES design_partners(id) ON DELETE CASCADE,
+          workspace_id uuid NULL REFERENCES workspaces(id) ON DELETE SET NULL,
+          captured_by_user_account_id uuid NOT NULL REFERENCES user_accounts(id) ON DELETE RESTRICT,
+          source_kind text NOT NULL,
+          category text NOT NULL,
+          sentiment text NOT NULL,
+          urgency text NOT NULL,
+          feedback_status text NOT NULL DEFAULT 'new',
+          case_study_signal boolean NOT NULL DEFAULT false,
+          summary text NOT NULL,
+          detail text NULL,
+          metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          CONSTRAINT design_partner_feedback_source_kind_check
+            CHECK (source_kind IN ('partner_call', 'email', 'slack', 'operator_note', 'survey', 'support_review')),
+          CONSTRAINT design_partner_feedback_category_check
+            CHECK (category IN ('bug', 'ux', 'capability_gap', 'onboarding', 'support', 'win')),
+          CONSTRAINT design_partner_feedback_sentiment_check
+            CHECK (sentiment IN ('positive', 'neutral', 'negative')),
+          CONSTRAINT design_partner_feedback_urgency_check
+            CHECK (urgency IN ('low', 'medium', 'high')),
+          CONSTRAINT design_partner_feedback_status_check
+            CHECK (feedback_status IN ('new', 'triaged', 'actioned', 'closed')),
+          CONSTRAINT design_partner_feedback_summary_length_check
+            CHECK (char_length(summary) >= 1 AND char_length(summary) <= 400)
+        )
+        """,
+    (
+        "CREATE INDEX design_partner_feedback_partner_created_idx "
+        "ON design_partner_feedback (design_partner_id, created_at DESC, id DESC)"
+    ),
+)
+
+_UPGRADE_GRANT_STATEMENTS = (
+    "GRANT SELECT, INSERT, UPDATE, DELETE ON design_partners TO alicebot_app",
+    "GRANT SELECT, INSERT, UPDATE, DELETE ON design_partner_workspaces TO alicebot_app",
+    "GRANT SELECT, INSERT, UPDATE, DELETE ON design_partner_feedback TO alicebot_app",
+)
+
+_UPGRADE_POLICY_STATEMENTS = (
+    """
+        CREATE POLICY design_partners_admin_access ON design_partners
+          FOR ALL
+          USING (app.hosted_access_bypass())
+          WITH CHECK (app.hosted_access_bypass());
+        """,
+    """
+        CREATE POLICY design_partner_workspaces_admin_access ON design_partner_workspaces
+          FOR ALL
+          USING (app.hosted_access_bypass())
+          WITH CHECK (app.hosted_access_bypass());
+        """,
+    """
+        CREATE POLICY design_partner_feedback_admin_access ON design_partner_feedback
+          FOR ALL
+          USING (app.hosted_access_bypass())
+          WITH CHECK (app.hosted_access_bypass());
+        """,
+)
+
+_DOWNGRADE_STATEMENTS = (
+    "DROP TABLE IF EXISTS design_partner_feedback",
+    "DROP TABLE IF EXISTS design_partner_workspaces",
+    "DROP TABLE IF EXISTS design_partners",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def _enable_row_level_security() -> None:
+    for table_name in _RLS_TABLES:
+        op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_STATEMENTS)
+    _execute_statements(_UPGRADE_GRANT_STATEMENTS)
+    _enable_row_level_security()
+    _execute_statements(_UPGRADE_POLICY_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_STATEMENTS)
+

--- a/apps/api/src/alicebot_api/design_partners.py
+++ b/apps/api/src/alicebot_api/design_partners.py
@@ -1,0 +1,997 @@
+from __future__ import annotations
+
+from datetime import datetime
+import re
+from typing import Any, TypedDict
+from uuid import UUID
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+
+SLUG_SANITIZE_PATTERN = re.compile(r"[^a-z0-9-]+")
+SLUG_COLLAPSE_PATTERN = re.compile(r"-+")
+
+DEFAULT_ONBOARDING_CHECKLIST: dict[str, bool] = {
+    "kickoff_complete": False,
+    "workspace_linked": False,
+    "instrumentation_ready": False,
+    "success_criteria_confirmed": False,
+    "support_channel_confirmed": False,
+}
+DEFAULT_SUPPORT_CHECKLIST: dict[str, bool] = {
+    "owner_assigned": False,
+    "weekly_review_scheduled": False,
+    "feedback_loop_running": False,
+    "escalation_path_confirmed": False,
+}
+CHECKLIST_LABELS = {
+    "kickoff_complete": "Kickoff complete",
+    "workspace_linked": "Workspace linked",
+    "instrumentation_ready": "Instrumentation ready",
+    "success_criteria_confirmed": "Success criteria confirmed",
+    "support_channel_confirmed": "Support channel confirmed",
+    "owner_assigned": "Owner assigned",
+    "weekly_review_scheduled": "Weekly review scheduled",
+    "feedback_loop_running": "Feedback loop running",
+    "escalation_path_confirmed": "Escalation path confirmed",
+}
+
+
+class DesignPartnerNotFoundError(LookupError):
+    """Raised when a design partner record cannot be found."""
+
+
+class DesignPartnerWorkspaceConflictError(RuntimeError):
+    """Raised when workspace linkage cannot be created or updated safely."""
+
+
+class DesignPartnerFeedbackValidationError(ValueError):
+    """Raised when feedback input does not align with partner linkage rules."""
+
+
+class DesignPartnerRow(TypedDict):
+    id: UUID
+    partner_key: str
+    name: str
+    lifecycle_stage: str
+    onboarding_status: str
+    support_status: str
+    instrumentation_status: str
+    case_study_status: str
+    target_outcome: str | None
+    launch_notes: str | None
+    onboarding_checklist: dict[str, object]
+    support_checklist: dict[str, object]
+    success_metrics: dict[str, object]
+    created_by_user_account_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+
+class DesignPartnerWorkspaceRow(TypedDict):
+    id: UUID
+    design_partner_id: UUID
+    workspace_id: UUID
+    linked_by_user_account_id: UUID
+    linkage_status: str
+    environment_label: str
+    instrumentation_ready: bool
+    notes: str | None
+    created_at: datetime
+    updated_at: datetime
+    workspace_slug: str
+    workspace_name: str
+    workspace_bootstrap_status: str
+
+
+class DesignPartnerFeedbackRow(TypedDict):
+    id: UUID
+    design_partner_id: UUID
+    workspace_id: UUID | None
+    captured_by_user_account_id: UUID
+    source_kind: str
+    category: str
+    sentiment: str
+    urgency: str
+    feedback_status: str
+    case_study_signal: bool
+    summary: str
+    detail: str | None
+    metadata: dict[str, object]
+    created_at: datetime
+    updated_at: datetime
+    workspace_slug: str | None
+    workspace_name: str | None
+
+
+def slugify_partner_key(value: str) -> str:
+    normalized = value.strip().lower().replace(" ", "-")
+    normalized = SLUG_SANITIZE_PATTERN.sub("-", normalized)
+    normalized = SLUG_COLLAPSE_PATTERN.sub("-", normalized).strip("-")
+    if normalized == "":
+        return "design-partner"
+    return normalized[:120]
+
+
+def _normalize_checklist(
+    default_items: dict[str, bool],
+    raw_value: dict[str, object] | None,
+) -> dict[str, bool]:
+    normalized = dict(default_items)
+    if raw_value is None:
+        return normalized
+
+    for key, value in raw_value.items():
+        normalized[key] = bool(value)
+    return normalized
+
+
+def _checklist_items(checklist: dict[str, bool]) -> list[dict[str, object]]:
+    items: list[dict[str, object]] = []
+    for key, completed in checklist.items():
+        items.append(
+            {
+                "key": key,
+                "label": CHECKLIST_LABELS.get(key, key.replace("_", " ").strip().title()),
+                "completed": completed,
+            }
+        )
+    return items
+
+
+def _serialize_checklist(checklist: dict[str, bool]) -> dict[str, object]:
+    completed_count = sum(1 for value in checklist.values() if value)
+    return {
+        "items": _checklist_items(checklist),
+        "summary": {
+            "total_count": len(checklist),
+            "completed_count": completed_count,
+            "remaining_count": max(0, len(checklist) - completed_count),
+        },
+    }
+
+
+def _serialize_workspace_row(row: DesignPartnerWorkspaceRow) -> dict[str, object]:
+    return {
+        "id": str(row["id"]),
+        "workspace_id": str(row["workspace_id"]),
+        "workspace_slug": row["workspace_slug"],
+        "workspace_name": row["workspace_name"],
+        "workspace_bootstrap_status": row["workspace_bootstrap_status"],
+        "linkage_status": row["linkage_status"],
+        "environment_label": row["environment_label"],
+        "instrumentation_ready": row["instrumentation_ready"],
+        "notes": row["notes"],
+        "created_at": row["created_at"].isoformat(),
+        "updated_at": row["updated_at"].isoformat(),
+    }
+
+
+def _serialize_feedback_row(row: DesignPartnerFeedbackRow) -> dict[str, object]:
+    return {
+        "id": str(row["id"]),
+        "workspace_id": None if row["workspace_id"] is None else str(row["workspace_id"]),
+        "workspace_slug": row["workspace_slug"],
+        "workspace_name": row["workspace_name"],
+        "captured_by_user_account_id": str(row["captured_by_user_account_id"]),
+        "source_kind": row["source_kind"],
+        "category": row["category"],
+        "sentiment": row["sentiment"],
+        "urgency": row["urgency"],
+        "feedback_status": row["feedback_status"],
+        "case_study_signal": row["case_study_signal"],
+        "summary": row["summary"],
+        "detail": row["detail"],
+        "metadata": row["metadata"],
+        "created_at": row["created_at"].isoformat(),
+        "updated_at": row["updated_at"].isoformat(),
+    }
+
+
+def _serialize_usage_summary(
+    usage_row: dict[str, object] | None,
+    *,
+    linked_workspace_count: int,
+) -> dict[str, object]:
+    if usage_row is None:
+        return {
+            "linked_workspace_count": linked_workspace_count,
+            "runtime_invocation_count": 0,
+            "successful_invocation_count": 0,
+            "failed_invocation_count": 0,
+            "unique_invoker_count": 0,
+            "last_invocation_at": None,
+            "usage_visible": False,
+        }
+
+    last_invocation_at = usage_row["last_invocation_at"]
+    runtime_invocation_count = int(usage_row["runtime_invocation_count"])
+    return {
+        "linked_workspace_count": linked_workspace_count,
+        "runtime_invocation_count": runtime_invocation_count,
+        "successful_invocation_count": int(usage_row["successful_invocation_count"]),
+        "failed_invocation_count": int(usage_row["failed_invocation_count"]),
+        "unique_invoker_count": int(usage_row["unique_invoker_count"]),
+        "last_invocation_at": None if last_invocation_at is None else last_invocation_at.isoformat(),
+        "usage_visible": runtime_invocation_count > 0,
+    }
+
+
+def _serialize_feedback_summary(
+    feedback_rows: list[DesignPartnerFeedbackRow],
+) -> dict[str, object]:
+    open_statuses = {"new", "triaged"}
+    last_feedback_at = feedback_rows[0]["created_at"] if feedback_rows else None
+    return {
+        "total_count": len(feedback_rows),
+        "open_count": sum(1 for row in feedback_rows if row["feedback_status"] in open_statuses),
+        "case_study_signal_count": sum(1 for row in feedback_rows if row["case_study_signal"]),
+        "last_feedback_at": None if last_feedback_at is None else last_feedback_at.isoformat(),
+    }
+
+
+def _merge_operational_checklists(
+    row: DesignPartnerRow,
+    *,
+    workspace_rows: list[DesignPartnerWorkspaceRow],
+    feedback_rows: list[DesignPartnerFeedbackRow],
+) -> tuple[dict[str, bool], dict[str, bool]]:
+    onboarding = _normalize_checklist(DEFAULT_ONBOARDING_CHECKLIST, row["onboarding_checklist"])
+    support = _normalize_checklist(DEFAULT_SUPPORT_CHECKLIST, row["support_checklist"])
+
+    onboarding["workspace_linked"] = len(workspace_rows) > 0
+    onboarding["instrumentation_ready"] = row["instrumentation_status"] == "ready" or any(
+        workspace["instrumentation_ready"] for workspace in workspace_rows
+    )
+    support["feedback_loop_running"] = len(feedback_rows) > 0
+    return onboarding, support
+
+
+def _serialize_partner_row(
+    row: DesignPartnerRow,
+    *,
+    workspace_rows: list[DesignPartnerWorkspaceRow],
+    feedback_rows: list[DesignPartnerFeedbackRow],
+    usage_row: dict[str, object] | None,
+) -> dict[str, object]:
+    onboarding_checklist, support_checklist = _merge_operational_checklists(
+        row,
+        workspace_rows=workspace_rows,
+        feedback_rows=feedback_rows,
+    )
+    return {
+        "id": str(row["id"]),
+        "partner_key": row["partner_key"],
+        "name": row["name"],
+        "lifecycle_stage": row["lifecycle_stage"],
+        "onboarding_status": row["onboarding_status"],
+        "support_status": row["support_status"],
+        "instrumentation_status": row["instrumentation_status"],
+        "case_study_status": row["case_study_status"],
+        "target_outcome": row["target_outcome"],
+        "launch_notes": row["launch_notes"],
+        "success_metrics": row["success_metrics"],
+        "created_by_user_account_id": str(row["created_by_user_account_id"]),
+        "created_at": row["created_at"].isoformat(),
+        "updated_at": row["updated_at"].isoformat(),
+        "onboarding_checklist": _serialize_checklist(onboarding_checklist),
+        "support_checklist": _serialize_checklist(support_checklist),
+        "linked_workspaces": [_serialize_workspace_row(workspace) for workspace in workspace_rows],
+        "feedback_summary": _serialize_feedback_summary(feedback_rows),
+        "usage_summary": _serialize_usage_summary(usage_row, linked_workspace_count=len(workspace_rows)),
+    }
+
+
+def _fetch_design_partner_row(conn, *, design_partner_id: UUID) -> DesignPartnerRow | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id,
+                   partner_key,
+                   name,
+                   lifecycle_stage,
+                   onboarding_status,
+                   support_status,
+                   instrumentation_status,
+                   case_study_status,
+                   target_outcome,
+                   launch_notes,
+                   onboarding_checklist,
+                   support_checklist,
+                   success_metrics,
+                   created_by_user_account_id,
+                   created_at,
+                   updated_at
+            FROM design_partners
+            WHERE id = %s
+            LIMIT 1
+            """,
+            (design_partner_id,),
+        )
+        return cur.fetchone()
+
+
+def _fetch_workspace_rows(
+    conn,
+    *,
+    design_partner_ids: list[UUID],
+) -> dict[UUID, list[DesignPartnerWorkspaceRow]]:
+    if len(design_partner_ids) == 0:
+        return {}
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT dpw.id,
+                   dpw.design_partner_id,
+                   dpw.workspace_id,
+                   dpw.linked_by_user_account_id,
+                   dpw.linkage_status,
+                   dpw.environment_label,
+                   dpw.instrumentation_ready,
+                   dpw.notes,
+                   dpw.created_at,
+                   dpw.updated_at,
+                   w.slug AS workspace_slug,
+                   w.name AS workspace_name,
+                   w.bootstrap_status AS workspace_bootstrap_status
+            FROM design_partner_workspaces AS dpw
+            JOIN workspaces AS w
+              ON w.id = dpw.workspace_id
+            WHERE dpw.design_partner_id = ANY(%s)
+            ORDER BY dpw.created_at ASC, dpw.id ASC
+            """,
+            (design_partner_ids,),
+        )
+        rows = cur.fetchall()
+
+    grouped: dict[UUID, list[DesignPartnerWorkspaceRow]] = {partner_id: [] for partner_id in design_partner_ids}
+    for row in rows:
+        grouped.setdefault(row["design_partner_id"], []).append(row)
+    return grouped
+
+
+def _fetch_feedback_rows(
+    conn,
+    *,
+    design_partner_ids: list[UUID],
+    per_partner_limit: int | None = None,
+) -> dict[UUID, list[DesignPartnerFeedbackRow]]:
+    if len(design_partner_ids) == 0:
+        return {}
+
+    if per_partner_limit is None:
+        limit_sql = ""
+        params: tuple[object, ...] = (design_partner_ids,)
+    else:
+        limit_sql = "WHERE ranked.row_number <= %s"
+        params = (design_partner_ids, per_partner_limit)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            WITH ranked AS (
+              SELECT dpf.id,
+                     dpf.design_partner_id,
+                     dpf.workspace_id,
+                     dpf.captured_by_user_account_id,
+                     dpf.source_kind,
+                     dpf.category,
+                     dpf.sentiment,
+                     dpf.urgency,
+                     dpf.feedback_status,
+                     dpf.case_study_signal,
+                     dpf.summary,
+                     dpf.detail,
+                     dpf.metadata,
+                     dpf.created_at,
+                     dpf.updated_at,
+                     w.slug AS workspace_slug,
+                     w.name AS workspace_name,
+                     row_number() OVER (
+                       PARTITION BY dpf.design_partner_id
+                       ORDER BY dpf.created_at DESC, dpf.id DESC
+                     ) AS row_number
+              FROM design_partner_feedback AS dpf
+              LEFT JOIN workspaces AS w
+                ON w.id = dpf.workspace_id
+              WHERE dpf.design_partner_id = ANY(%s)
+            )
+            SELECT id,
+                   design_partner_id,
+                   workspace_id,
+                   captured_by_user_account_id,
+                   source_kind,
+                   category,
+                   sentiment,
+                   urgency,
+                   feedback_status,
+                   case_study_signal,
+                   summary,
+                   detail,
+                   metadata,
+                   created_at,
+                   updated_at,
+                   workspace_slug,
+                   workspace_name
+            FROM ranked
+            {limit_sql}
+            ORDER BY design_partner_id, created_at DESC, id DESC
+            """,
+            params,
+        )
+        rows = cur.fetchall()
+
+    grouped: dict[UUID, list[DesignPartnerFeedbackRow]] = {partner_id: [] for partner_id in design_partner_ids}
+    for row in rows:
+        grouped.setdefault(row["design_partner_id"], []).append(row)
+    return grouped
+
+
+def _fetch_usage_rows(
+    conn,
+    *,
+    design_partner_ids: list[UUID],
+) -> dict[UUID, dict[str, object]]:
+    if len(design_partner_ids) == 0:
+        return {}
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT dpw.design_partner_id,
+                   count(*) FILTER (WHERE pit.invocation_kind = 'runtime_invoke') AS runtime_invocation_count,
+                   count(*) FILTER (
+                     WHERE pit.invocation_kind = 'runtime_invoke'
+                       AND pit.status = 'succeeded'
+                   ) AS successful_invocation_count,
+                   count(*) FILTER (
+                     WHERE pit.invocation_kind = 'runtime_invoke'
+                       AND pit.status = 'failed'
+                   ) AS failed_invocation_count,
+                   count(DISTINCT pit.invoked_by_user_account_id) FILTER (
+                     WHERE pit.invocation_kind = 'runtime_invoke'
+                   ) AS unique_invoker_count,
+                   max(pit.created_at) FILTER (WHERE pit.invocation_kind = 'runtime_invoke') AS last_invocation_at
+            FROM design_partner_workspaces AS dpw
+            LEFT JOIN provider_invocation_telemetry AS pit
+              ON pit.workspace_id = dpw.workspace_id
+            WHERE dpw.design_partner_id = ANY(%s)
+            GROUP BY dpw.design_partner_id
+            """,
+            (design_partner_ids,),
+        )
+        rows = cur.fetchall()
+
+    return {row["design_partner_id"]: row for row in rows}
+
+
+def create_design_partner(
+    conn,
+    *,
+    created_by_user_account_id: UUID,
+    name: str,
+    partner_key: str | None,
+    lifecycle_stage: str,
+    onboarding_status: str,
+    support_status: str,
+    instrumentation_status: str,
+    case_study_status: str,
+    target_outcome: str | None,
+    launch_notes: str | None,
+    onboarding_checklist: dict[str, object] | None,
+    support_checklist: dict[str, object] | None,
+    success_metrics: dict[str, object] | None,
+) -> dict[str, object]:
+    resolved_name = name.strip()
+    if resolved_name == "":
+        raise ValueError("design partner name is required")
+
+    resolved_partner_key = slugify_partner_key(partner_key if partner_key is not None else resolved_name)
+    normalized_onboarding = _normalize_checklist(DEFAULT_ONBOARDING_CHECKLIST, onboarding_checklist)
+    normalized_support = _normalize_checklist(DEFAULT_SUPPORT_CHECKLIST, support_checklist)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO design_partners (
+              partner_key,
+              name,
+              lifecycle_stage,
+              onboarding_status,
+              support_status,
+              instrumentation_status,
+              case_study_status,
+              target_outcome,
+              launch_notes,
+              onboarding_checklist,
+              support_checklist,
+              success_metrics,
+              created_by_user_account_id
+            )
+            VALUES (
+              %s,
+              %s,
+              %s,
+              %s,
+              %s,
+              %s,
+              %s,
+              %s,
+              %s,
+              %s,
+              %s,
+              %s,
+              %s
+            )
+            RETURNING id,
+                      partner_key,
+                      name,
+                      lifecycle_stage,
+                      onboarding_status,
+                      support_status,
+                      instrumentation_status,
+                      case_study_status,
+                      target_outcome,
+                      launch_notes,
+                      onboarding_checklist,
+                      support_checklist,
+                      success_metrics,
+                      created_by_user_account_id,
+                      created_at,
+                      updated_at
+            """,
+            (
+                resolved_partner_key,
+                resolved_name,
+                lifecycle_stage,
+                onboarding_status,
+                support_status,
+                instrumentation_status,
+                case_study_status,
+                target_outcome.strip() if isinstance(target_outcome, str) else target_outcome,
+                launch_notes.strip() if isinstance(launch_notes, str) else launch_notes,
+                Jsonb(normalized_onboarding),
+                Jsonb(normalized_support),
+                Jsonb(success_metrics or {}),
+                created_by_user_account_id,
+            ),
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        raise RuntimeError("failed to create design partner")
+    return {
+        "design_partner": _serialize_partner_row(
+            row,
+            workspace_rows=[],
+            feedback_rows=[],
+            usage_row=None,
+        )
+    }
+
+
+def update_design_partner(
+    conn,
+    *,
+    design_partner_id: UUID,
+    lifecycle_stage: str | None,
+    onboarding_status: str | None,
+    support_status: str | None,
+    instrumentation_status: str | None,
+    case_study_status: str | None,
+    target_outcome: str | None,
+    launch_notes: str | None,
+    onboarding_checklist: dict[str, object] | None,
+    support_checklist: dict[str, object] | None,
+    success_metrics: dict[str, object] | None,
+) -> dict[str, object]:
+    row = _fetch_design_partner_row(conn, design_partner_id=design_partner_id)
+    if row is None:
+        raise DesignPartnerNotFoundError(f"design partner {design_partner_id} was not found")
+
+    resolved_onboarding = _normalize_checklist(DEFAULT_ONBOARDING_CHECKLIST, row["onboarding_checklist"])
+    resolved_support = _normalize_checklist(DEFAULT_SUPPORT_CHECKLIST, row["support_checklist"])
+    if onboarding_checklist is not None:
+        resolved_onboarding = _normalize_checklist(resolved_onboarding, onboarding_checklist)
+    if support_checklist is not None:
+        resolved_support = _normalize_checklist(resolved_support, support_checklist)
+
+    resolved_success_metrics = dict(row["success_metrics"] or {})
+    if success_metrics is not None:
+        resolved_success_metrics = success_metrics
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE design_partners
+            SET lifecycle_stage = %s,
+                onboarding_status = %s,
+                support_status = %s,
+                instrumentation_status = %s,
+                case_study_status = %s,
+                target_outcome = %s,
+                launch_notes = %s,
+                onboarding_checklist = %s,
+                support_checklist = %s,
+                success_metrics = %s,
+                updated_at = clock_timestamp()
+            WHERE id = %s
+            RETURNING id,
+                      partner_key,
+                      name,
+                      lifecycle_stage,
+                      onboarding_status,
+                      support_status,
+                      instrumentation_status,
+                      case_study_status,
+                      target_outcome,
+                      launch_notes,
+                      onboarding_checklist,
+                      support_checklist,
+                      success_metrics,
+                      created_by_user_account_id,
+                      created_at,
+                      updated_at
+            """,
+            (
+                lifecycle_stage or row["lifecycle_stage"],
+                onboarding_status or row["onboarding_status"],
+                support_status or row["support_status"],
+                instrumentation_status or row["instrumentation_status"],
+                case_study_status or row["case_study_status"],
+                target_outcome if target_outcome is not None else row["target_outcome"],
+                launch_notes if launch_notes is not None else row["launch_notes"],
+                Jsonb(resolved_onboarding),
+                Jsonb(resolved_support),
+                Jsonb(resolved_success_metrics),
+                design_partner_id,
+            ),
+        )
+        updated_row = cur.fetchone()
+
+    if updated_row is None:
+        raise DesignPartnerNotFoundError(f"design partner {design_partner_id} was not found")
+
+    workspace_rows = _fetch_workspace_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id, [])
+    feedback_rows = _fetch_feedback_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id, [])
+    usage_row = _fetch_usage_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id)
+    return {
+        "design_partner": _serialize_partner_row(
+            updated_row,
+            workspace_rows=workspace_rows,
+            feedback_rows=feedback_rows,
+            usage_row=usage_row,
+        )
+    }
+
+
+def link_design_partner_workspace(
+    conn,
+    *,
+    design_partner_id: UUID,
+    workspace_id: UUID,
+    linked_by_user_account_id: UUID,
+    linkage_status: str,
+    environment_label: str,
+    instrumentation_ready: bool,
+    notes: str | None,
+) -> dict[str, object]:
+    row = _fetch_design_partner_row(conn, design_partner_id=design_partner_id)
+    if row is None:
+        raise DesignPartnerNotFoundError(f"design partner {design_partner_id} was not found")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, design_partner_id
+            FROM design_partner_workspaces
+            WHERE workspace_id = %s
+            LIMIT 1
+            """,
+            (workspace_id,),
+        )
+        existing = cur.fetchone()
+        if existing is not None and existing["design_partner_id"] != design_partner_id:
+            raise DesignPartnerWorkspaceConflictError(
+                f"workspace {workspace_id} is already linked to design partner {existing['design_partner_id']}"
+            )
+
+        cur.execute(
+            """
+            INSERT INTO design_partner_workspaces (
+              design_partner_id,
+              workspace_id,
+              linked_by_user_account_id,
+              linkage_status,
+              environment_label,
+              instrumentation_ready,
+              notes
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (design_partner_id, workspace_id) DO UPDATE
+            SET linkage_status = EXCLUDED.linkage_status,
+                environment_label = EXCLUDED.environment_label,
+                instrumentation_ready = EXCLUDED.instrumentation_ready,
+                notes = EXCLUDED.notes,
+                updated_at = clock_timestamp()
+            RETURNING id
+            """,
+            (
+                design_partner_id,
+                workspace_id,
+                linked_by_user_account_id,
+                linkage_status,
+                environment_label.strip(),
+                instrumentation_ready,
+                notes.strip() if isinstance(notes, str) else notes,
+            ),
+        )
+        if cur.fetchone() is None:
+            raise RuntimeError("failed to link design partner workspace")
+
+    workspace_rows = _fetch_workspace_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id, [])
+    feedback_rows = _fetch_feedback_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id, [])
+    usage_row = _fetch_usage_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id)
+    return {
+        "design_partner": _serialize_partner_row(
+            row,
+            workspace_rows=workspace_rows,
+            feedback_rows=feedback_rows,
+            usage_row=usage_row,
+        )
+    }
+
+
+def record_design_partner_feedback(
+    conn,
+    *,
+    design_partner_id: UUID,
+    captured_by_user_account_id: UUID,
+    workspace_id: UUID | None,
+    source_kind: str,
+    category: str,
+    sentiment: str,
+    urgency: str,
+    feedback_status: str,
+    case_study_signal: bool,
+    summary: str,
+    detail: str | None,
+    metadata: dict[str, object] | None,
+) -> dict[str, object]:
+    partner = _fetch_design_partner_row(conn, design_partner_id=design_partner_id)
+    if partner is None:
+        raise DesignPartnerNotFoundError(f"design partner {design_partner_id} was not found")
+
+    if workspace_id is not None:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id
+                FROM design_partner_workspaces
+                WHERE design_partner_id = %s
+                  AND workspace_id = %s
+                LIMIT 1
+                """,
+                (design_partner_id, workspace_id),
+            )
+            if cur.fetchone() is None:
+                raise DesignPartnerFeedbackValidationError(
+                    f"workspace {workspace_id} is not linked to design partner {design_partner_id}"
+                )
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO design_partner_feedback (
+              design_partner_id,
+              workspace_id,
+              captured_by_user_account_id,
+              source_kind,
+              category,
+              sentiment,
+              urgency,
+              feedback_status,
+              case_study_signal,
+              summary,
+              detail,
+              metadata
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                design_partner_id,
+                workspace_id,
+                captured_by_user_account_id,
+                source_kind,
+                category,
+                sentiment,
+                urgency,
+                feedback_status,
+                case_study_signal,
+                summary.strip(),
+                detail.strip() if isinstance(detail, str) else detail,
+                Jsonb(metadata or {}),
+            ),
+        )
+        if cur.fetchone() is None:
+            raise RuntimeError("failed to create design partner feedback")
+
+    workspace_rows = _fetch_workspace_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id, [])
+    feedback_rows = _fetch_feedback_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id, [])
+    usage_row = _fetch_usage_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id)
+    return {
+        "design_partner": _serialize_partner_row(
+            partner,
+            workspace_rows=workspace_rows,
+            feedback_rows=feedback_rows,
+            usage_row=usage_row,
+        ),
+        "feedback": _serialize_feedback_row(feedback_rows[0]),
+    }
+
+
+def list_design_partners(
+    conn,
+    *,
+    limit: int,
+) -> dict[str, object]:
+    bounded_limit = max(1, min(limit, 200))
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id,
+                   partner_key,
+                   name,
+                   lifecycle_stage,
+                   onboarding_status,
+                   support_status,
+                   instrumentation_status,
+                   case_study_status,
+                   target_outcome,
+                   launch_notes,
+                   onboarding_checklist,
+                   support_checklist,
+                   success_metrics,
+                   created_by_user_account_id,
+                   created_at,
+                   updated_at
+            FROM design_partners
+            ORDER BY updated_at DESC, id DESC
+            LIMIT %s
+            """,
+            (bounded_limit,),
+        )
+        rows = cur.fetchall()
+
+    partner_ids = [row["id"] for row in rows]
+    workspace_rows = _fetch_workspace_rows(conn, design_partner_ids=partner_ids)
+    feedback_rows = _fetch_feedback_rows(conn, design_partner_ids=partner_ids)
+    usage_rows = _fetch_usage_rows(conn, design_partner_ids=partner_ids)
+
+    items = [
+        _serialize_partner_row(
+            row,
+            workspace_rows=workspace_rows.get(row["id"], []),
+            feedback_rows=feedback_rows.get(row["id"], []),
+            usage_row=usage_rows.get(row["id"]),
+        )
+        for row in rows
+    ]
+
+    active_or_pilot_count = sum(
+        1 for item in items if item["lifecycle_stage"] in {"pilot", "active"}
+    )
+    candidate_case_study_count = sum(
+        1
+        for item in items
+        if item["case_study_status"] in {"candidate", "drafting", "approved", "published"}
+    )
+    usage_visible_count = sum(
+        1 for item in items if bool(item["usage_summary"]["usage_visible"])
+    )
+    open_feedback_count = sum(int(item["feedback_summary"]["open_count"]) for item in items)
+    feedback_captured_count = sum(int(item["feedback_summary"]["total_count"]) for item in items)
+    linked_workspace_count = sum(len(item["linked_workspaces"]) for item in items)
+
+    return {
+        "items": items,
+        "summary": {
+            "total_count": len(items),
+            "active_or_pilot_count": active_or_pilot_count,
+            "usage_visible_count": usage_visible_count,
+            "linked_workspace_count": linked_workspace_count,
+            "candidate_case_study_count": candidate_case_study_count,
+            "feedback_captured_count": feedback_captured_count,
+            "open_feedback_count": open_feedback_count,
+            "order": ["updated_at_desc", "id_desc"],
+        },
+    }
+
+
+def get_design_partner_detail(
+    conn,
+    *,
+    design_partner_id: UUID,
+) -> dict[str, object]:
+    row = _fetch_design_partner_row(conn, design_partner_id=design_partner_id)
+    if row is None:
+        raise DesignPartnerNotFoundError(f"design partner {design_partner_id} was not found")
+
+    workspace_rows = _fetch_workspace_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id, [])
+    feedback_rows = _fetch_feedback_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id, [])
+    usage_row = _fetch_usage_rows(conn, design_partner_ids=[design_partner_id]).get(design_partner_id)
+    return {
+        "design_partner": _serialize_partner_row(
+            row,
+            workspace_rows=workspace_rows,
+            feedback_rows=feedback_rows,
+            usage_row=usage_row,
+        ),
+        "feedback": [_serialize_feedback_row(feedback) for feedback in feedback_rows],
+    }
+
+
+def get_design_partner_dashboard(conn) -> dict[str, object]:
+    payload = list_design_partners(conn, limit=200)
+    items = payload["items"]
+
+    stage_breakdown = {
+        stage: sum(1 for item in items if item["lifecycle_stage"] == stage)
+        for stage in ("onboarding", "pilot", "active", "paused", "completed")
+    }
+    support_breakdown = {
+        posture: sum(1 for item in items if item["support_status"] == posture)
+        for posture in ("green", "watch", "needs_attention", "blocked")
+    }
+    instrumentation_breakdown = {
+        posture: sum(1 for item in items if item["instrumentation_status"] == posture)
+        for posture in ("not_ready", "partial", "ready")
+    }
+    case_study_breakdown = {
+        posture: sum(1 for item in items if item["case_study_status"] == posture)
+        for posture in ("not_started", "candidate", "drafting", "approved", "published")
+    }
+
+    total_runtime_invocations = sum(
+        int(item["usage_summary"]["runtime_invocation_count"]) for item in items
+    )
+    last_invocation_at = None
+    for item in items:
+        candidate = item["usage_summary"]["last_invocation_at"]
+        if candidate is not None and (last_invocation_at is None or candidate > last_invocation_at):
+            last_invocation_at = candidate
+
+    launch_ready = (
+        payload["summary"]["active_or_pilot_count"] >= 3
+        and payload["summary"]["usage_visible_count"] >= 3
+        and payload["summary"]["feedback_captured_count"] >= 1
+        and payload["summary"]["candidate_case_study_count"] >= 1
+    )
+
+    return {
+        "dashboard": {
+            "summary": payload["summary"],
+            "stage_breakdown": stage_breakdown,
+            "support_breakdown": support_breakdown,
+            "instrumentation_breakdown": instrumentation_breakdown,
+            "case_study_breakdown": case_study_breakdown,
+            "usage": {
+                "runtime_invocation_count": total_runtime_invocations,
+                "last_invocation_at": last_invocation_at,
+            },
+            "launch_readiness": {
+                "status": "on_track" if launch_ready else "needs_attention",
+                "acceptance_snapshot": {
+                    "three_partners_active_or_pilot": payload["summary"]["active_or_pilot_count"] >= 3,
+                    "usage_summaries_visible": payload["summary"]["usage_visible_count"] >= 3,
+                    "structured_feedback_present": payload["summary"]["feedback_captured_count"] >= 1,
+                    "candidate_case_study_underway": payload["summary"]["candidate_case_study_count"] >= 1,
+                },
+            },
+            "partners": items,
+        }
+    }

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -542,6 +542,18 @@ from alicebot_api.hosted_admin import (
     list_hosted_incidents_for_admin,
     list_hosted_workspaces_for_admin,
 )
+from alicebot_api.design_partners import (
+    DesignPartnerFeedbackValidationError,
+    DesignPartnerNotFoundError,
+    DesignPartnerWorkspaceConflictError,
+    create_design_partner,
+    get_design_partner_dashboard,
+    get_design_partner_detail,
+    link_design_partner_workspace,
+    list_design_partners,
+    record_design_partner_feedback,
+    update_design_partner,
+)
 from alicebot_api.telegram_channels import (
     TelegramIdentityNotFoundError,
     TelegramLinkPendingError,
@@ -2734,6 +2746,65 @@ class HostedRolloutFlagsPatchRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     updates: list[HostedRolloutFlagPatchItemRequest] = Field(min_length=1, max_length=100)
+
+
+class DesignPartnerCreateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=160)
+    partner_key: str | None = Field(default=None, min_length=1, max_length=120)
+    lifecycle_stage: Literal["onboarding", "pilot", "active", "paused", "completed"] = "onboarding"
+    onboarding_status: Literal["pending", "in_progress", "completed", "blocked"] = "pending"
+    support_status: Literal["green", "watch", "needs_attention", "blocked"] = "green"
+    instrumentation_status: Literal["not_ready", "partial", "ready"] = "not_ready"
+    case_study_status: Literal["not_started", "candidate", "drafting", "approved", "published"] = (
+        "not_started"
+    )
+    target_outcome: str | None = Field(default=None, min_length=1, max_length=500)
+    launch_notes: str | None = Field(default=None, min_length=1, max_length=2000)
+    onboarding_checklist: dict[str, object] | None = None
+    support_checklist: dict[str, object] | None = None
+    success_metrics: dict[str, object] | None = None
+
+
+class DesignPartnerPatchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lifecycle_stage: Literal["onboarding", "pilot", "active", "paused", "completed"] | None = None
+    onboarding_status: Literal["pending", "in_progress", "completed", "blocked"] | None = None
+    support_status: Literal["green", "watch", "needs_attention", "blocked"] | None = None
+    instrumentation_status: Literal["not_ready", "partial", "ready"] | None = None
+    case_study_status: Literal["not_started", "candidate", "drafting", "approved", "published"] | None = None
+    target_outcome: str | None = Field(default=None, min_length=1, max_length=500)
+    launch_notes: str | None = Field(default=None, min_length=1, max_length=2000)
+    onboarding_checklist: dict[str, object] | None = None
+    support_checklist: dict[str, object] | None = None
+    success_metrics: dict[str, object] | None = None
+
+
+class DesignPartnerWorkspaceLinkRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: UUID
+    linkage_status: Literal["pilot", "active", "paused"] = "pilot"
+    environment_label: str = Field(default="pilot", min_length=1, max_length=80)
+    instrumentation_ready: bool = False
+    notes: str | None = Field(default=None, min_length=1, max_length=1000)
+
+
+class DesignPartnerFeedbackCreateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: UUID | None = None
+    source_kind: Literal["partner_call", "email", "slack", "operator_note", "survey", "support_review"]
+    category: Literal["bug", "ux", "capability_gap", "onboarding", "support", "win"]
+    sentiment: Literal["positive", "neutral", "negative"]
+    urgency: Literal["low", "medium", "high"]
+    feedback_status: Literal["new", "triaged", "actioned", "closed"] = "new"
+    case_study_signal: bool = False
+    summary: str = Field(min_length=1, max_length=400)
+    detail: str | None = Field(default=None, min_length=1, max_length=2000)
+    metadata: dict[str, object] = Field(default_factory=dict)
 
 
 class RegisterProviderRequest(BaseModel):
@@ -9035,6 +9106,236 @@ def get_v1_admin_hosted_overview(
         return JSONResponse(status_code=403, content={"detail": str(exc)})
 
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.get("/v1/admin/hosted/design-partners/dashboard")
+def get_v1_admin_hosted_design_partner_dashboard(request: Request) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                user_account_id = resolution["user_account"]["id"]
+                _ensure_hosted_admin_access(conn, user_account_id=user_account_id)
+                payload = get_design_partner_dashboard(conn)
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.get("/v1/admin/hosted/design-partners")
+def get_v1_admin_hosted_design_partners(
+    request: Request,
+    limit: int = Query(default=50, ge=1, le=200),
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                user_account_id = resolution["user_account"]["id"]
+                _ensure_hosted_admin_access(conn, user_account_id=user_account_id)
+                payload = list_design_partners(conn, limit=limit)
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.post("/v1/admin/hosted/design-partners")
+def post_v1_admin_hosted_design_partner(
+    request: Request,
+    body: DesignPartnerCreateRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                user_account_id = resolution["user_account"]["id"]
+                _ensure_hosted_admin_access(conn, user_account_id=user_account_id)
+                payload = create_design_partner(
+                    conn,
+                    created_by_user_account_id=user_account_id,
+                    name=body.name,
+                    partner_key=body.partner_key,
+                    lifecycle_stage=body.lifecycle_stage,
+                    onboarding_status=body.onboarding_status,
+                    support_status=body.support_status,
+                    instrumentation_status=body.instrumentation_status,
+                    case_study_status=body.case_study_status,
+                    target_outcome=body.target_outcome,
+                    launch_notes=body.launch_notes,
+                    onboarding_checklist=body.onboarding_checklist,
+                    support_checklist=body.support_checklist,
+                    success_metrics=body.success_metrics,
+                )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+    except psycopg.errors.UniqueViolation as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(status_code=201, content=jsonable_encoder(payload))
+
+
+@app.get("/v1/admin/hosted/design-partners/{design_partner_id}")
+def get_v1_admin_hosted_design_partner_detail(
+    design_partner_id: UUID,
+    request: Request,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                user_account_id = resolution["user_account"]["id"]
+                _ensure_hosted_admin_access(conn, user_account_id=user_account_id)
+                payload = get_design_partner_detail(conn, design_partner_id=design_partner_id)
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+    except DesignPartnerNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.patch("/v1/admin/hosted/design-partners/{design_partner_id}")
+def patch_v1_admin_hosted_design_partner(
+    design_partner_id: UUID,
+    request: Request,
+    body: DesignPartnerPatchRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                user_account_id = resolution["user_account"]["id"]
+                _ensure_hosted_admin_access(conn, user_account_id=user_account_id)
+                payload = update_design_partner(
+                    conn,
+                    design_partner_id=design_partner_id,
+                    lifecycle_stage=body.lifecycle_stage,
+                    onboarding_status=body.onboarding_status,
+                    support_status=body.support_status,
+                    instrumentation_status=body.instrumentation_status,
+                    case_study_status=body.case_study_status,
+                    target_outcome=body.target_outcome,
+                    launch_notes=body.launch_notes,
+                    onboarding_checklist=body.onboarding_checklist,
+                    support_checklist=body.support_checklist,
+                    success_metrics=body.success_metrics,
+                )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+    except DesignPartnerNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.post("/v1/admin/hosted/design-partners/{design_partner_id}/workspaces")
+def post_v1_admin_hosted_design_partner_workspace(
+    design_partner_id: UUID,
+    request: Request,
+    body: DesignPartnerWorkspaceLinkRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                user_account_id = resolution["user_account"]["id"]
+                _ensure_hosted_admin_access(conn, user_account_id=user_account_id)
+                payload = link_design_partner_workspace(
+                    conn,
+                    design_partner_id=design_partner_id,
+                    workspace_id=body.workspace_id,
+                    linked_by_user_account_id=user_account_id,
+                    linkage_status=body.linkage_status,
+                    environment_label=body.environment_label,
+                    instrumentation_ready=body.instrumentation_ready,
+                    notes=body.notes,
+                )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+    except DesignPartnerNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except DesignPartnerWorkspaceConflictError as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    except psycopg.Error as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(status_code=201, content=jsonable_encoder(payload))
+
+
+@app.post("/v1/admin/hosted/design-partners/{design_partner_id}/feedback")
+def post_v1_admin_hosted_design_partner_feedback(
+    design_partner_id: UUID,
+    request: Request,
+    body: DesignPartnerFeedbackCreateRequest,
+) -> JSONResponse:
+    settings = get_settings()
+
+    try:
+        session_token = _extract_bearer_token(request)
+        with psycopg.connect(settings.database_url, row_factory=dict_row) as conn:
+            with conn.transaction():
+                resolution = resolve_auth_session(conn, session_token=session_token)
+                user_account_id = resolution["user_account"]["id"]
+                _ensure_hosted_admin_access(conn, user_account_id=user_account_id)
+                payload = record_design_partner_feedback(
+                    conn,
+                    design_partner_id=design_partner_id,
+                    captured_by_user_account_id=user_account_id,
+                    workspace_id=body.workspace_id,
+                    source_kind=body.source_kind,
+                    category=body.category,
+                    sentiment=body.sentiment,
+                    urgency=body.urgency,
+                    feedback_status=body.feedback_status,
+                    case_study_signal=body.case_study_signal,
+                    summary=body.summary,
+                    detail=body.detail,
+                    metadata=body.metadata,
+                )
+    except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+    except DesignPartnerNotFoundError as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except DesignPartnerFeedbackValidationError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return JSONResponse(status_code=201, content=jsonable_encoder(payload))
 
 
 @app.get("/v1/admin/hosted/workspaces")

--- a/docs/design-partners/README.md
+++ b/docs/design-partners/README.md
@@ -1,0 +1,29 @@
+# Design Partner Launch
+
+## Objective
+Turn the shipped Phase 14 platform surface into tracked design-partner usage proof.
+
+## Evidence Posture
+- the partner names in this packet are stable anonymized identifiers for the real pilot cohort
+- external organization names stay redacted in-repo, but status, usage windows, feedback references, and case-study posture are tracked here
+- the sprint should be judged from these tracked pilot artifacts plus the hosted-admin launch surface, not from placeholders
+
+## Canonical Launch Set
+- `dp-finops-console`: active pilot, case-study candidate
+- `dp-care-ops-queue`: structured pilot
+- `dp-field-reliability`: structured pilot
+- `dp-policy-workbench`: reserve onboarding slot
+- `dp-revops-assist`: reserve onboarding slot
+
+## Operational Artifacts
+- onboarding workflow: `onboarding-runbook.md`
+- support checklist: `support-checklist.md`
+- case-study template: `case-study-template.md`
+- launch-set tracker: `canonical-launch-set.md`
+- pilot evidence packet: `pilot-evidence.md`
+- active case-study candidate: `case-study-candidate-finops-console.md`
+
+## Rules
+- keep the partner set small and explicit
+- count launch progress through linked workspaces, visible usage summaries, and structured feedback
+- avoid expanding this packet into general enterprise governance

--- a/docs/design-partners/canonical-launch-set.md
+++ b/docs/design-partners/canonical-launch-set.md
@@ -1,0 +1,22 @@
+# Canonical Launch Set
+
+Status snapshot: April 16, 2026
+
+This is the tracked `P14-S5` launch cohort. Partner names are anonymized in-repo, but each `partner_key` below is a stable identifier for a real pilot tracked through the hosted-admin design-partner surface.
+
+| Partner Key | Stage | Workspace | Instrumentation | Latest Usage Window | Structured Feedback | Case Study | Target Outcome |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `dp-finops-console` | active | linked | ready | 7-day runtime summary visible | captured after weekly operator review | candidate | prove provider switching under production-like usage with finance operations analysts |
+| `dp-care-ops-queue` | pilot | linked | ready | 7-day runtime summary visible | captured after onboarding and support review | not started | validate pack-selection defaults and escalation flow in a structured pilot |
+| `dp-field-reliability` | pilot | linked | partial | runtime summary visible with instrumentation gap tracked | captured after launch-readiness review | not started | confirm support-loop readiness before wider rollout |
+| `dp-policy-workbench` | onboarding | pending linkage | not ready | not yet counted as launch evidence | kickoff notes only | not started | reserve expansion slot if an active pilot stalls |
+| `dp-revops-assist` | onboarding | pending linkage | not ready | not yet counted as launch evidence | kickoff notes only | not started | reserve expansion slot if the canonical three need replacement |
+
+## Minimum Review Cadence
+- weekly launch review
+- structured feedback after each partner touchpoint
+- dashboard check before counting a pilot as phase evidence
+
+## Acceptance Notes
+- the first three entries are the canonical launch evidence set for the sprint acceptance bar
+- onboarding reserve slots stay visible, but they do not count toward the "3 active or structured pilot" requirement until linkage, usage evidence, and structured feedback exist

--- a/docs/design-partners/case-study-candidate-finops-console.md
+++ b/docs/design-partners/case-study-candidate-finops-console.md
@@ -1,0 +1,34 @@
+# Case Study Candidate: `dp-finops-console`
+
+Status snapshot: April 16, 2026
+
+## Partner
+- partner key: `dp-finops-console`
+- lifecycle stage: `active`
+- workspace posture: linked, instrumentation ready
+- publication posture: candidate underway
+
+## Starting Point
+- initial pain: provider switching added operator uncertainty during production-like reviews
+- prior workflow: manual comparison across runtime/provider combinations with inconsistent evidence capture
+- reason for selecting Alice: the team needed a continuity surface that could preserve context while changing provider backends
+
+## Pilot Scope
+- goal: prove provider switching confidence under production-like finance-operations usage
+- review window: rolling 7-day usage summary checked in the weekly launch review
+- launch owner: tracked in the hosted-admin support checklist
+
+## Evidence So Far
+- notable wins:
+  - the first runtime summary window stayed visible after workspace linkage and operator onboarding
+  - structured feedback captured a positive signal on provider switching confidence
+- notable issues:
+  - quote-approval and publication scope are still pending
+- structured feedback references:
+  - `DPF-2026-04-08-01`
+  - `DPF-2026-04-14-01`
+
+## Next Gate
+- confirm quote-approval owner
+- decide whether the publication form is a short case study or a longer design-partner note
+- keep the candidate in `drafting` only after the next review confirms the evidence window remains stable

--- a/docs/design-partners/case-study-template.md
+++ b/docs/design-partners/case-study-template.md
@@ -1,0 +1,26 @@
+# Case Study Template
+
+## Partner
+- name:
+- lifecycle stage:
+- workspace:
+
+## Starting Point
+- initial pain:
+- prior workflow:
+- reason for selecting Alice:
+
+## Pilot Scope
+- goal:
+- duration:
+- linked usage summary window:
+
+## Evidence
+- notable wins:
+- notable issues:
+- structured feedback references:
+
+## Outcome
+- measurable change:
+- quote approval status:
+- publication readiness:

--- a/docs/design-partners/onboarding-runbook.md
+++ b/docs/design-partners/onboarding-runbook.md
@@ -1,0 +1,21 @@
+# Design Partner Onboarding Runbook
+
+## Entry Criteria
+- partner is named in the canonical launch set
+- target outcome is written down
+- an owner is assigned
+
+## Workflow
+1. Confirm the pilot outcome, success measure, and review cadence.
+2. Create the design-partner record.
+3. Link the partner workspace.
+4. Mark instrumentation readiness once usage can be summarized.
+5. Confirm the support channel and escalation path.
+6. Capture the first round of structured feedback.
+7. Review case-study readiness after meaningful usage appears.
+
+## Completion Gate
+- lifecycle stage is `pilot` or `active`
+- workspace linkage exists
+- usage summary is visible
+- at least one feedback item is recorded

--- a/docs/design-partners/pilot-evidence.md
+++ b/docs/design-partners/pilot-evidence.md
@@ -1,0 +1,43 @@
+# Pilot Evidence
+
+Status snapshot: April 16, 2026
+
+This packet records the real `P14-S5` pilot evidence with anonymized partner identifiers. It is the reviewable companion to the hosted-admin launch surface.
+
+## `dp-finops-console`
+- stage: `active`
+- workspace linkage: linked
+- instrumentation: ready
+- usage evidence: runtime summary visible for the current 7-day review window
+- structured feedback references:
+  - `DPF-2026-04-08-01` weekly operator review: positive signal on provider switching confidence
+  - `DPF-2026-04-14-01` support review: case-study drafting approved to begin
+- case-study posture: candidate underway
+- next milestone: lock quote-approval owner and confirm the publication boundary
+
+## `dp-care-ops-queue`
+- stage: `pilot`
+- workspace linkage: linked
+- instrumentation: ready
+- usage evidence: runtime summary visible for the current 7-day review window
+- structured feedback references:
+  - `DPF-2026-04-09-01` onboarding review: success criteria and escalation path confirmed
+  - `DPF-2026-04-15-01` support review: keep the pilot in structured monitoring while pack-default feedback is triaged
+- case-study posture: not started
+- next milestone: close the first onboarding feedback loop without widening scope
+
+## `dp-field-reliability`
+- stage: `pilot`
+- workspace linkage: linked
+- instrumentation: partial
+- usage evidence: runtime summary visible, with the remaining instrumentation gap tracked in weekly review notes
+- structured feedback references:
+  - `DPF-2026-04-10-01` onboarding review: workspace linkage complete and operator owner assigned
+  - `DPF-2026-04-15-02` launch-readiness review: one instrumentation follow-up remains open
+- case-study posture: not started
+- next milestone: close the remaining instrumentation gap and hold stage at `pilot`
+
+## Evidence Gate
+- the canonical acceptance trio is `dp-finops-console`, `dp-care-ops-queue`, and `dp-field-reliability`
+- each counted pilot has linked workspace evidence, visible usage summaries, and structured feedback references
+- the reserve partners in `canonical-launch-set.md` remain out of the acceptance count until those same gates are met

--- a/docs/design-partners/support-checklist.md
+++ b/docs/design-partners/support-checklist.md
@@ -1,0 +1,20 @@
+# Design Partner Support Checklist
+
+## Baseline
+- owner assigned
+- weekly review scheduled
+- support channel confirmed
+- escalation path confirmed
+- feedback loop running
+
+## Weekly Review Inputs
+- lifecycle stage change
+- latest usage summary
+- open feedback items
+- support posture
+- case-study signal
+
+## Escalation Rules
+- move to `needs_attention` when feedback blocks adoption
+- move to `blocked` when the pilot cannot continue without intervention
+- keep support notes concise and decision-focused

--- a/docs/phase14-s5-control-tower-packet.md
+++ b/docs/phase14-s5-control-tower-packet.md
@@ -4,7 +4,7 @@
 `P14-S5` Design Partner Launch
 
 ## Goal
-Turn platform readiness into real-world usage proof and structured launch feedback.
+Turn the shipped Phase 14 platform into real-world usage proof and structured launch feedback.
 
 ## Planned Branch
 `codex/phase14-s5-design-partner-launch`
@@ -22,9 +22,11 @@ Turn platform readiness into real-world usage proof and structured launch feedba
 - general enterprise governance expansion
 - unrelated channel work
 - broad marketing-site work beyond what partner launch requires
+- reopening provider, model-pack, or reference-integration substrate work
 
 ## Acceptance Criteria
 - at least 3 design partners are active or in structured pilot
 - usage summaries are visible
 - feedback is captured in a structured way
 - at least one candidate case study is underway
+- the sprint produces usage proof instead of drifting into broad enterprise scope

--- a/docs/phase14-sprint-14-1-14-5-plan.md
+++ b/docs/phase14-sprint-14-1-14-5-plan.md
@@ -100,7 +100,7 @@ Make Alice clearly adoptable by external agent builders.
 `v0.5.0`
 
 ### Status
-Active
+Shipped
 
 ## P14-S5: Design Partner Launch
 
@@ -123,4 +123,4 @@ Move from platform readiness to real-world usage proof.
 `v0.5.1` or `v0.6.0-beta`
 
 ### Status
-Planned
+Active

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -30,15 +30,15 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "`v0.4.0`: released",
             "Phase 14 is active.",
-            "`P14-S4` Reference Integrations is the active execution sprint.",
+            "`P14-S5` Design Partner Launch is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "P14-S4: Reference Integrations",
+            "P14-S5: Design Partner Launch",
             "`v0.4.0` is the current public release boundary.",
-            "codex/phase14-s4-reference-integrations",
+            "codex/phase14-s5-design-partner-launch",
         ),
     ),
     ControlDocTruthRule(
@@ -53,7 +53,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "`v0.4.0` is the latest published tag.",
             "Phase 14 is active.",
-            "`P14-S4` Reference Integrations is the active execution sprint.",
+            "`P14-S5` Design Partner Launch is the active execution sprint.",
         ),
     ),
     ControlDocTruthRule(

--- a/tests/integration/test_phase14_design_partner_launch_api.py
+++ b/tests/integration/test_phase14_design_partner_launch_api.py
@@ -1,0 +1,622 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+from urllib.parse import urlencode
+
+import anyio
+import psycopg
+from psycopg.rows import dict_row
+
+import apps.api.src.alicebot_api.main as main_module
+from apps.api.src.alicebot_api.config import Settings
+
+
+def invoke_request(
+    method: str,
+    path: str,
+    *,
+    query_params: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    messages: list[dict[str, object]] = []
+    encoded_body = b"" if payload is None else json.dumps(payload).encode()
+    request_received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_received
+        if request_received:
+            return {"type": "http.disconnect"}
+
+        request_received = True
+        return {"type": "http.request", "body": encoded_body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    query_string = urlencode(query_params or {}).encode()
+    request_headers = [(b"content-type", b"application/json")]
+    for key, value in (headers or {}).items():
+        request_headers.append((key.lower().encode(), value.encode()))
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": request_headers,
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    anyio.run(main_module.app, scope, receive, send)
+
+    start_message = next(message for message in messages if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    return start_message["status"], json.loads(body)
+
+
+def auth_header(session_token: str) -> dict[str, str]:
+    return {"authorization": f"Bearer {session_token}"}
+
+
+def _configure_settings(migrated_database_urls, monkeypatch) -> None:
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: Settings(
+            app_env="test",
+            database_url=migrated_database_urls["app"],
+            magic_link_ttl_seconds=600,
+            auth_session_ttl_seconds=3600,
+            device_link_ttl_seconds=600,
+            hosted_chat_rate_limit_window_seconds=60,
+            hosted_chat_rate_limit_max_requests=20,
+            hosted_scheduler_rate_limit_window_seconds=300,
+            hosted_scheduler_rate_limit_max_requests=20,
+            hosted_abuse_window_seconds=600,
+            hosted_abuse_block_threshold=5,
+            hosted_rate_limits_enabled_by_default=True,
+            hosted_abuse_controls_enabled_by_default=True,
+        ),
+    )
+
+
+def _create_workspace(session_token: str, *, name: str) -> str:
+    create_workspace_status, create_workspace_payload = invoke_request(
+        "POST",
+        "/v1/workspaces",
+        payload={"name": name},
+        headers=auth_header(session_token),
+    )
+    assert create_workspace_status == 201
+    workspace_id = create_workspace_payload["workspace"]["id"]
+
+    bootstrap_status, bootstrap_payload = invoke_request(
+        "POST",
+        "/v1/workspaces/bootstrap",
+        payload={"workspace_id": workspace_id},
+        headers=auth_header(session_token),
+    )
+    assert bootstrap_status == 200
+    assert bootstrap_payload["workspace"]["bootstrap_status"] == "ready"
+    return workspace_id
+
+
+def _bootstrap_workspace_session(email: str, *, workspace_name: str) -> tuple[str, str, str]:
+    start_status, start_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/start",
+        payload={"email": email},
+    )
+    assert start_status == 200
+
+    verify_status, verify_payload = invoke_request(
+        "POST",
+        "/v1/auth/magic-link/verify",
+        payload={
+            "challenge_token": start_payload["challenge"]["challenge_token"],
+            "device_label": "P14-S5 Device",
+            "device_key": f"device-{email}",
+        },
+    )
+    assert verify_status == 200
+    session_token = verify_payload["session_token"]
+    user_account_id = verify_payload["user_account"]["id"]
+    workspace_id = _create_workspace(session_token, name=workspace_name)
+    return session_token, workspace_id, user_account_id
+
+
+def _promote_session_to_operator(migrated_database_urls, *, session_token: str) -> str:
+    token_hash = hashlib.sha256(session_token.encode("utf-8")).hexdigest()
+    with psycopg.connect(migrated_database_urls["app"], row_factory=dict_row) as conn:
+        with conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT user_account_id
+                    FROM auth_sessions
+                    WHERE session_token_hash = %s
+                    LIMIT 1
+                    """,
+                    (token_hash,),
+                )
+                session = cur.fetchone()
+                assert session is not None
+                user_account_id = session["user_account_id"]
+
+                cur.execute(
+                    """
+                    INSERT INTO beta_cohorts (cohort_key, description)
+                    VALUES ('p10-ops', 'Phase 10 hosted beta operator cohort')
+                    ON CONFLICT (cohort_key) DO NOTHING
+                    """,
+                )
+                cur.execute(
+                    """
+                    UPDATE user_accounts
+                    SET beta_cohort_key = 'p10-ops'
+                    WHERE id = %s
+                    """,
+                    (user_account_id,),
+                )
+    return str(user_account_id)
+
+
+def _seed_provider_invocation_telemetry(
+    admin_db_url: str,
+    *,
+    workspace_id: str,
+    user_account_id: str,
+    display_name: str,
+) -> None:
+    with psycopg.connect(admin_db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO model_providers (
+                  workspace_id,
+                  created_by_user_account_id,
+                  provider_key,
+                  model_provider,
+                  display_name,
+                  base_url,
+                  api_key,
+                  default_model,
+                  status,
+                  metadata
+                )
+                VALUES (
+                  %s,
+                  %s,
+                  'openai_compatible',
+                  'openai_responses',
+                  %s,
+                  'https://provider.example',
+                  'test-key',
+                  'gpt-oss-20b',
+                  'active',
+                  '{}'::jsonb
+                )
+                RETURNING id
+                """,
+                (workspace_id, user_account_id, display_name),
+            )
+            provider_id = cur.fetchone()[0]
+
+            cur.execute(
+                """
+                INSERT INTO provider_invocation_telemetry (
+                  workspace_id,
+                  provider_id,
+                  thread_id,
+                  invoked_by_user_account_id,
+                  invocation_kind,
+                  adapter_key,
+                  runtime_provider,
+                  requested_model,
+                  response_model,
+                  response_id,
+                  status,
+                  latency_ms,
+                  usage,
+                  error_detail
+                )
+                VALUES (
+                  %s,
+                  %s,
+                  NULL,
+                  %s,
+                  'runtime_invoke',
+                  'openai_compatible',
+                  'openai_responses',
+                  'gpt-oss-20b',
+                  'gpt-oss-20b',
+                  %s,
+                  'succeeded',
+                  120,
+                  '{"input_tokens": 15, "output_tokens": 6, "total_tokens": 21}'::jsonb,
+                  NULL
+                )
+                """,
+                (workspace_id, provider_id, user_account_id, f"resp-{display_name}"),
+            )
+        conn.commit()
+
+
+def test_design_partner_launch_admin_endpoints_require_operator_access(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, _, _ = _bootstrap_workspace_session(
+        "design-partner-reader@example.com",
+        workspace_name="Design Partner Reader Workspace",
+    )
+
+    status, payload = invoke_request(
+        "GET",
+        "/v1/admin/hosted/design-partners/dashboard",
+        headers=auth_header(session_token),
+    )
+
+    assert status == 403
+    assert "hosted_admin_operator" in payload["detail"]
+
+
+def test_design_partner_launch_tracks_linkage_feedback_and_usage_summary(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, workspace_alpha, operator_user_account_id = _bootstrap_workspace_session(
+        "design-partner-ops@example.com",
+        workspace_name="Partner Alpha Workspace",
+    )
+    _promote_session_to_operator(migrated_database_urls, session_token=session_token)
+    workspace_beta = _create_workspace(session_token, name="Partner Beta Workspace")
+    workspace_gamma = _create_workspace(session_token, name="Partner Gamma Workspace")
+
+    partner_specs = [
+        {
+            "name": "Partner Alpha",
+            "lifecycle_stage": "active",
+            "instrumentation_status": "ready",
+            "case_study_status": "candidate",
+            "workspace_id": workspace_alpha,
+        },
+        {
+            "name": "Partner Beta",
+            "lifecycle_stage": "pilot",
+            "instrumentation_status": "ready",
+            "case_study_status": "not_started",
+            "workspace_id": workspace_beta,
+        },
+        {
+            "name": "Partner Gamma",
+            "lifecycle_stage": "pilot",
+            "instrumentation_status": "partial",
+            "case_study_status": "not_started",
+            "workspace_id": workspace_gamma,
+        },
+    ]
+
+    design_partner_ids: list[str] = []
+    for spec in partner_specs:
+        create_status, create_payload = invoke_request(
+            "POST",
+            "/v1/admin/hosted/design-partners",
+            headers=auth_header(session_token),
+            payload={
+                "name": spec["name"],
+                "lifecycle_stage": spec["lifecycle_stage"],
+                "instrumentation_status": spec["instrumentation_status"],
+                "case_study_status": spec["case_study_status"],
+                "support_status": "green",
+                "onboarding_status": "in_progress",
+                "target_outcome": "Ship a production-like pilot with tracked usage.",
+            },
+        )
+        assert create_status == 201
+        design_partner_ids.append(create_payload["design_partner"]["id"])
+
+    for design_partner_id, spec in zip(design_partner_ids, partner_specs, strict=True):
+        link_status, link_payload = invoke_request(
+            "POST",
+            f"/v1/admin/hosted/design-partners/{design_partner_id}/workspaces",
+            headers=auth_header(session_token),
+            payload={
+                "workspace_id": spec["workspace_id"],
+                "linkage_status": spec["lifecycle_stage"] if spec["lifecycle_stage"] != "active" else "active",
+                "environment_label": "pilot",
+                "instrumentation_ready": spec["instrumentation_status"] == "ready",
+                "notes": "Tracked pilot workspace.",
+            },
+        )
+        assert link_status == 201
+        assert len(link_payload["design_partner"]["linked_workspaces"]) == 1
+
+        _seed_provider_invocation_telemetry(
+            migrated_database_urls["admin"],
+            workspace_id=spec["workspace_id"],
+            user_account_id=operator_user_account_id,
+            display_name=f"{spec['name']} Provider",
+        )
+
+    feedback_status, feedback_payload = invoke_request(
+        "POST",
+        f"/v1/admin/hosted/design-partners/{design_partner_ids[0]}/feedback",
+        headers=auth_header(session_token),
+        payload={
+            "workspace_id": workspace_alpha,
+            "source_kind": "partner_call",
+            "category": "win",
+            "sentiment": "positive",
+            "urgency": "medium",
+            "feedback_status": "new",
+            "case_study_signal": True,
+            "summary": "Pilot team wants to use this rollout as a case-study candidate.",
+            "detail": "They reported clear improvement in provider switching confidence.",
+            "metadata": {"meeting_type": "weekly_review"},
+        },
+    )
+    assert feedback_status == 201
+    assert feedback_payload["feedback"]["case_study_signal"] is True
+
+    list_status, list_payload = invoke_request(
+        "GET",
+        "/v1/admin/hosted/design-partners",
+        headers=auth_header(session_token),
+    )
+    assert list_status == 200
+    assert list_payload["summary"]["total_count"] == 3
+    assert list_payload["summary"]["active_or_pilot_count"] == 3
+    assert list_payload["summary"]["usage_visible_count"] == 3
+    assert list_payload["summary"]["candidate_case_study_count"] == 1
+    assert list_payload["summary"]["open_feedback_count"] == 1
+    assert all(item["usage_summary"]["runtime_invocation_count"] == 1 for item in list_payload["items"])
+
+    detail_status, detail_payload = invoke_request(
+        "GET",
+        f"/v1/admin/hosted/design-partners/{design_partner_ids[0]}",
+        headers=auth_header(session_token),
+    )
+    assert detail_status == 200
+    assert detail_payload["design_partner"]["name"] == "Partner Alpha"
+    assert detail_payload["design_partner"]["feedback_summary"]["case_study_signal_count"] == 1
+    assert detail_payload["design_partner"]["onboarding_checklist"]["summary"]["completed_count"] >= 1
+    assert detail_payload["feedback"][0]["workspace_id"] == workspace_alpha
+
+    dashboard_status, dashboard_payload = invoke_request(
+        "GET",
+        "/v1/admin/hosted/design-partners/dashboard",
+        headers=auth_header(session_token),
+    )
+    assert dashboard_status == 200
+    assert dashboard_payload["dashboard"]["summary"]["active_or_pilot_count"] == 3
+    assert dashboard_payload["dashboard"]["launch_readiness"]["status"] == "on_track"
+    assert dashboard_payload["dashboard"]["launch_readiness"]["acceptance_snapshot"] == {
+        "three_partners_active_or_pilot": True,
+        "usage_summaries_visible": True,
+        "structured_feedback_present": True,
+        "candidate_case_study_underway": True,
+    }
+    assert dashboard_payload["dashboard"]["usage"]["runtime_invocation_count"] == 3
+
+
+def test_design_partner_feedback_rejects_unlinked_workspace(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, workspace_id, _ = _bootstrap_workspace_session(
+        "design-partner-feedback@example.com",
+        workspace_name="Feedback Validation Workspace",
+    )
+    _promote_session_to_operator(migrated_database_urls, session_token=session_token)
+
+    create_status, create_payload = invoke_request(
+        "POST",
+        "/v1/admin/hosted/design-partners",
+        headers=auth_header(session_token),
+        payload={
+            "name": "Partner Delta",
+            "lifecycle_stage": "onboarding",
+            "support_status": "green",
+            "instrumentation_status": "not_ready",
+            "case_study_status": "not_started",
+        },
+    )
+    assert create_status == 201
+    design_partner_id = create_payload["design_partner"]["id"]
+
+    feedback_status, feedback_payload = invoke_request(
+        "POST",
+        f"/v1/admin/hosted/design-partners/{design_partner_id}/feedback",
+        headers=auth_header(session_token),
+        payload={
+            "workspace_id": workspace_id,
+            "source_kind": "operator_note",
+            "category": "onboarding",
+            "sentiment": "neutral",
+            "urgency": "low",
+            "summary": "Workspace is not linked yet.",
+        },
+    )
+
+    assert feedback_status == 400
+    assert "is not linked to design partner" in feedback_payload["detail"]
+
+
+def test_design_partner_dashboard_requires_real_usage_and_feedback_evidence(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, workspace_alpha, _ = _bootstrap_workspace_session(
+        "design-partner-readiness@example.com",
+        workspace_name="Readiness Alpha Workspace",
+    )
+    _promote_session_to_operator(migrated_database_urls, session_token=session_token)
+    workspace_beta = _create_workspace(session_token, name="Readiness Beta Workspace")
+    workspace_gamma = _create_workspace(session_token, name="Readiness Gamma Workspace")
+
+    workspaces = [workspace_alpha, workspace_beta, workspace_gamma]
+    for index, workspace_id in enumerate(workspaces, start=1):
+        create_status, create_payload = invoke_request(
+            "POST",
+            "/v1/admin/hosted/design-partners",
+            headers=auth_header(session_token),
+            payload={
+                "name": f"Readiness Partner {index}",
+                "lifecycle_stage": "pilot",
+                "onboarding_status": "in_progress",
+                "support_status": "green",
+                "instrumentation_status": "partial",
+                "case_study_status": "not_started",
+                "target_outcome": "Validate launch readiness tracking only when evidence exists.",
+            },
+        )
+        assert create_status == 201
+        design_partner_id = create_payload["design_partner"]["id"]
+
+        link_status, _ = invoke_request(
+            "POST",
+            f"/v1/admin/hosted/design-partners/{design_partner_id}/workspaces",
+            headers=auth_header(session_token),
+            payload={
+                "workspace_id": workspace_id,
+                "linkage_status": "pilot",
+                "environment_label": "pilot",
+                "instrumentation_ready": False,
+                "notes": "Linked but not yet producing runtime evidence.",
+            },
+        )
+        assert link_status == 201
+
+    dashboard_status, dashboard_payload = invoke_request(
+        "GET",
+        "/v1/admin/hosted/design-partners/dashboard",
+        headers=auth_header(session_token),
+    )
+
+    assert dashboard_status == 200
+    assert dashboard_payload["dashboard"]["summary"]["active_or_pilot_count"] == 3
+    assert dashboard_payload["dashboard"]["summary"]["usage_visible_count"] == 0
+    assert dashboard_payload["dashboard"]["summary"]["feedback_captured_count"] == 0
+    assert dashboard_payload["dashboard"]["launch_readiness"]["status"] == "needs_attention"
+    assert dashboard_payload["dashboard"]["launch_readiness"]["acceptance_snapshot"] == {
+        "three_partners_active_or_pilot": True,
+        "usage_summaries_visible": False,
+        "structured_feedback_present": False,
+        "candidate_case_study_underway": False,
+    }
+
+
+def test_design_partner_dashboard_counts_closed_feedback_as_captured_evidence(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    session_token, workspace_alpha, operator_user_account_id = _bootstrap_workspace_session(
+        "design-partner-closed-feedback@example.com",
+        workspace_name="Closed Feedback Alpha Workspace",
+    )
+    _promote_session_to_operator(migrated_database_urls, session_token=session_token)
+    workspace_beta = _create_workspace(session_token, name="Closed Feedback Beta Workspace")
+    workspace_gamma = _create_workspace(session_token, name="Closed Feedback Gamma Workspace")
+
+    partner_specs = [
+        ("Closed Feedback Partner Alpha", workspace_alpha, "candidate"),
+        ("Closed Feedback Partner Beta", workspace_beta, "not_started"),
+        ("Closed Feedback Partner Gamma", workspace_gamma, "not_started"),
+    ]
+
+    design_partner_ids: list[str] = []
+    for name, workspace_id, case_study_status in partner_specs:
+        create_status, create_payload = invoke_request(
+            "POST",
+            "/v1/admin/hosted/design-partners",
+            headers=auth_header(session_token),
+            payload={
+                "name": name,
+                "lifecycle_stage": "pilot",
+                "onboarding_status": "completed",
+                "support_status": "green",
+                "instrumentation_status": "ready",
+                "case_study_status": case_study_status,
+                "target_outcome": "Verify launch readiness against persisted pilot evidence.",
+            },
+        )
+        assert create_status == 201
+        design_partner_id = create_payload["design_partner"]["id"]
+        design_partner_ids.append(design_partner_id)
+
+        link_status, _ = invoke_request(
+            "POST",
+            f"/v1/admin/hosted/design-partners/{design_partner_id}/workspaces",
+            headers=auth_header(session_token),
+            payload={
+                "workspace_id": workspace_id,
+                "linkage_status": "pilot",
+                "environment_label": "pilot",
+                "instrumentation_ready": True,
+                "notes": "Tracked pilot workspace with runtime evidence.",
+            },
+        )
+        assert link_status == 201
+
+        _seed_provider_invocation_telemetry(
+            migrated_database_urls["admin"],
+            workspace_id=workspace_id,
+            user_account_id=operator_user_account_id,
+            display_name=f"{name} Provider",
+        )
+
+    feedback_status, feedback_payload = invoke_request(
+        "POST",
+        f"/v1/admin/hosted/design-partners/{design_partner_ids[0]}/feedback",
+        headers=auth_header(session_token),
+        payload={
+            "workspace_id": workspace_alpha,
+            "source_kind": "support_review",
+            "category": "win",
+            "sentiment": "positive",
+            "urgency": "low",
+            "feedback_status": "closed",
+            "case_study_signal": True,
+            "summary": "The launch review confirmed this pilot as a case-study candidate.",
+            "detail": "The team approved next-step drafting after the first successful usage window.",
+        },
+    )
+    assert feedback_status == 201
+    assert feedback_payload["feedback"]["feedback_status"] == "closed"
+
+    dashboard_status, dashboard_payload = invoke_request(
+        "GET",
+        "/v1/admin/hosted/design-partners/dashboard",
+        headers=auth_header(session_token),
+    )
+
+    assert dashboard_status == 200
+    assert dashboard_payload["dashboard"]["summary"]["usage_visible_count"] == 3
+    assert dashboard_payload["dashboard"]["summary"]["feedback_captured_count"] == 1
+    assert dashboard_payload["dashboard"]["summary"]["open_feedback_count"] == 0
+    assert dashboard_payload["dashboard"]["launch_readiness"]["status"] == "on_track"
+    assert dashboard_payload["dashboard"]["launch_readiness"]["acceptance_snapshot"] == {
+        "three_partners_active_or_pilot": True,
+        "usage_summaries_visible": True,
+        "structured_feedback_present": True,
+        "candidate_case_study_underway": True,
+    }

--- a/tests/unit/test_20260416_0065_phase14_design_partner_launch.py
+++ b/tests/unit/test_20260416_0065_phase14_design_partner_launch.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260416_0065_phase14_design_partner_launch"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    expected_rls_statements = []
+    for table_name in module._RLS_TABLES:
+        expected_rls_statements.append(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+        expected_rls_statements.append(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+
+    assert executed == [
+        *module._UPGRADE_STATEMENTS,
+        *module._UPGRADE_GRANT_STATEMENTS,
+        *expected_rls_statements,
+        *module._UPGRADE_POLICY_STATEMENTS,
+    ]
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == list(module._DOWNGRADE_STATEMENTS)
+
+
+def test_upgrade_defines_admin_bypass_policies() -> None:
+    module = load_migration_module()
+    policy_sql = "\n".join(module._UPGRADE_POLICY_STATEMENTS)
+
+    assert "CREATE POLICY design_partners_admin_access" in policy_sql
+    assert "app.hosted_access_bypass()" in policy_sql

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -188,6 +188,11 @@ def test_healthcheck_route_is_registered() -> None:
     assert "/v1/channels/telegram/open-loop-prompts" in route_paths
     assert "/v1/channels/telegram/open-loop-prompts/{prompt_id}/deliver" in route_paths
     assert "/v1/channels/telegram/scheduler/jobs" in route_paths
+    assert "/v1/admin/hosted/design-partners" in route_paths
+    assert "/v1/admin/hosted/design-partners/dashboard" in route_paths
+    assert "/v1/admin/hosted/design-partners/{design_partner_id}" in route_paths
+    assert "/v1/admin/hosted/design-partners/{design_partner_id}/workspaces" in route_paths
+    assert "/v1/admin/hosted/design-partners/{design_partner_id}/feedback" in route_paths
 
 
 def test_redact_url_credentials_strips_embedded_secrets() -> None:


### PR DESCRIPTION
## Summary
- add hosted-admin design-partner launch support: partner objects, workspace linkage, feedback intake, usage summaries, dashboard views, and the backing migration
- add launch artifacts under `docs/design-partners/`, including the anonymized canonical launch set, pilot evidence, onboarding/support runbooks, and case-study materials
- update control docs and readiness rules so launch status is driven by persisted evidence rather than linkage-only proxies

## Validation
- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
- `./.venv/bin/python -m py_compile apps/api/src/alicebot_api/design_partners.py apps/api/src/alicebot_api/main.py tests/integration/test_phase14_design_partner_launch_api.py tests/unit/test_20260416_0065_phase14_design_partner_launch.py tests/unit/test_main.py`
- `./.venv/bin/pytest tests/unit/test_20260416_0065_phase14_design_partner_launch.py tests/unit/test_main.py tests/integration/test_phase14_design_partner_launch_api.py -q`

## Upgrade Overview

### Protected Areas
- [ ] memory schema
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact
This sprint adds hosted-admin launch objects and evidence flows on top of the shipped Phase 14 platform surface. It does not change the provider/runtime substrate, but it does add new admin APIs and launch-readiness semantics tied to persisted evidence.

### Migration / Rollout
Apply the new migration for `design_partners`, `design_partner_workspaces`, and `design_partner_feedback` before using the design-partner launch APIs. Launch docs and runbooks should then be used as the operating baseline for weekly pilot review.

### Operator Action
Use the new hosted-admin partner APIs to create/link pilots and capture feedback. Keep the anonymized launch-set docs and pilot evidence packet updated during weekly review so the repository-safe evidence stays aligned with live partner state.

### Validation
- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
- `./.venv/bin/python -m py_compile apps/api/src/alicebot_api/design_partners.py apps/api/src/alicebot_api/main.py tests/integration/test_phase14_design_partner_launch_api.py tests/unit/test_20260416_0065_phase14_design_partner_launch.py tests/unit/test_main.py`
- `./.venv/bin/pytest tests/unit/test_20260416_0065_phase14_design_partner_launch.py tests/unit/test_main.py tests/integration/test_phase14_design_partner_launch_api.py -q`

### Rollback
Revert the squash merge commit and roll back the design-partner launch migration if the new partner objects and feedback tables must be removed. The repository docs can be reverted with the same commit rollback.