### PR TITLE
[codex] Phase 14 refactor end: unify db context helpers

### DIFF
--- a/apps/api/alembic/versions/20260310_0001_foundation_continuity.py
+++ b/apps/api/alembic/versions/20260310_0001_foundation_continuity.py
@@ -11,6 +11,7 @@ branch_labels = None
 depends_on = None
 
 _RLS_TABLES = ("users", "threads", "sessions", "events")
+_RLS_ACTIONS = ("ENABLE", "FORCE")
 
 _UPGRADE_BOOTSTRAP_STATEMENTS = (
     "CREATE EXTENSION IF NOT EXISTS pgcrypto",
@@ -148,10 +149,13 @@ def _execute_statements(statements: tuple[str, ...]) -> None:
         op.execute(statement)
 
 
+def _row_level_security_statements(table_name: str) -> tuple[str, ...]:
+    return tuple(f"ALTER TABLE {table_name} {action} ROW LEVEL SECURITY" for action in _RLS_ACTIONS)
+
+
 def _enable_row_level_security() -> None:
     for table_name in _RLS_TABLES:
-        op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
-        op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+        _execute_statements(_row_level_security_statements(table_name))
 
 
 def upgrade() -> None:

--- a/apps/api/src/alicebot_api/db.py
+++ b/apps/api/src/alicebot_api/db.py
@@ -12,6 +12,8 @@ SET_CURRENT_USER_SQL = "SELECT set_config('app.current_user_id', %s, true)"
 SET_CURRENT_USER_ACCOUNT_SQL = "SELECT set_config('app.current_user_account_id', %s, true)"
 SET_HOSTED_ADMIN_BYPASS_SQL = "SELECT set_config('app.hosted_admin_bypass', %s, true)"
 SET_HOSTED_SERVICE_BYPASS_SQL = "SELECT set_config('app.hosted_service_bypass', %s, true)"
+ENABLED_SESSION_FLAG = "true"
+DISABLED_SESSION_FLAG = "false"
 ConnectionRow = dict[str, object]
 UserConnection = psycopg.Connection[ConnectionRow]
 
@@ -27,24 +29,29 @@ def ping_database(database_url: str, timeout_seconds: int) -> bool:
         return False
 
 
-def set_current_user(conn: psycopg.Connection, user_id: UUID) -> None:
+def _set_connection_context(conn: psycopg.Connection, sql: str, value: str) -> None:
     with conn.cursor() as cur:
-        cur.execute(SET_CURRENT_USER_SQL, (str(user_id),))
+        cur.execute(sql, (value,))
+
+
+def _session_flag(enabled: bool) -> str:
+    return ENABLED_SESSION_FLAG if enabled else DISABLED_SESSION_FLAG
+
+
+def set_current_user(conn: psycopg.Connection, user_id: UUID) -> None:
+    _set_connection_context(conn, SET_CURRENT_USER_SQL, str(user_id))
 
 
 def set_current_user_account(conn: psycopg.Connection, user_account_id: UUID) -> None:
-    with conn.cursor() as cur:
-        cur.execute(SET_CURRENT_USER_ACCOUNT_SQL, (str(user_account_id),))
+    _set_connection_context(conn, SET_CURRENT_USER_ACCOUNT_SQL, str(user_account_id))
 
 
 def set_hosted_admin_bypass(conn: psycopg.Connection, enabled: bool) -> None:
-    with conn.cursor() as cur:
-        cur.execute(SET_HOSTED_ADMIN_BYPASS_SQL, ("true" if enabled else "false",))
+    _set_connection_context(conn, SET_HOSTED_ADMIN_BYPASS_SQL, _session_flag(enabled))
 
 
 def set_hosted_service_bypass(conn: psycopg.Connection, enabled: bool) -> None:
-    with conn.cursor() as cur:
-        cur.execute(SET_HOSTED_SERVICE_BYPASS_SQL, ("true" if enabled else "false",))
+    _set_connection_context(conn, SET_HOSTED_SERVICE_BYPASS_SQL, _session_flag(enabled))
 
 
 @contextmanager

--- a/tests/unit/test_20260310_0001_foundation_continuity.py
+++ b/tests/unit/test_20260310_0001_foundation_continuity.py
@@ -63,3 +63,12 @@ def test_base_schema_keeps_thread_created_index_for_deterministic_review_queries
     module = load_migration_module()
 
     assert "CREATE INDEX threads_user_created_idx" in module._UPGRADE_SCHEMA_STATEMENT
+
+
+def test_row_level_security_statements_cover_enable_and_force_modes() -> None:
+    module = load_migration_module()
+
+    assert module._row_level_security_statements("users") == (
+        "ALTER TABLE users ENABLE ROW LEVEL SECURITY",
+        "ALTER TABLE users FORCE ROW LEVEL SECURITY",
+    )

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from uuid import uuid4
 
 import psycopg
+import pytest
 
 from alicebot_api import db
 
@@ -105,23 +106,27 @@ def test_set_current_user_account_sets_database_context() -> None:
     ]
 
 
-def test_set_hosted_admin_bypass_sets_database_context() -> None:
+@pytest.mark.parametrize(
+    ("setter", "enabled", "expected_query", "expected_params"),
+    [
+        (db.set_hosted_admin_bypass, True, db.SET_HOSTED_ADMIN_BYPASS_SQL, ("true",)),
+        (db.set_hosted_admin_bypass, False, db.SET_HOSTED_ADMIN_BYPASS_SQL, ("false",)),
+        (db.set_hosted_service_bypass, True, db.SET_HOSTED_SERVICE_BYPASS_SQL, ("true",)),
+        (db.set_hosted_service_bypass, False, db.SET_HOSTED_SERVICE_BYPASS_SQL, ("false",)),
+    ],
+)
+def test_bypass_context_setters_write_expected_flags(
+    setter,
+    enabled: bool,
+    expected_query: str,
+    expected_params: tuple[str],
+) -> None:
     connection = RecordingConnection()
 
-    db.set_hosted_admin_bypass(connection, True)
+    setter(connection, enabled)
 
     assert connection.cursor_instance.executed == [
-        ("SELECT set_config('app.hosted_admin_bypass', %s, true)", ("true",)),
-    ]
-
-
-def test_set_hosted_service_bypass_sets_database_context() -> None:
-    connection = RecordingConnection()
-
-    db.set_hosted_service_bypass(connection, True)
-
-    assert connection.cursor_instance.executed == [
-        ("SELECT set_config('app.hosted_service_bypass', %s, true)", ("true",)),
+        (expected_query, expected_params),
     ]
 
 


### PR DESCRIPTION
## Summary
- factor shared connection-context writes in `db.py` into small helper functions
- reuse a shared row-level-security statement helper in the foundation continuity migration
- tighten the related unit coverage to cover both bypass setters and the RLS statement helper

## Validation
- `./.venv/bin/python -m pytest tests/unit/test_db.py tests/unit/test_20260310_0001_foundation_continuity.py -q` -> `15 passed`

## Notes
- outside the sprint-control flow by explicit owner approval