### PR TITLE
[codex] Phase 14 security end: harden owner writes and secrets

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -46,12 +46,12 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3

--- a/apps/api/alembic/versions/20260416_0066_hosted_control_plane_owner_writes.py
+++ b/apps/api/alembic/versions/20260416_0066_hosted_control_plane_owner_writes.py
@@ -1,0 +1,166 @@
+"""Restrict hosted control-plane writes to workspace owners."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260416_0066"
+down_revision = "20260416_0065"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_DROP_STATEMENTS = (
+    "DROP POLICY IF EXISTS workspace_model_pack_bindings_workspace_access ON workspace_model_pack_bindings",
+    "DROP POLICY IF EXISTS model_packs_workspace_access ON model_packs",
+    "DROP POLICY IF EXISTS provider_capabilities_workspace_access ON provider_capabilities",
+    "DROP POLICY IF EXISTS model_providers_workspace_access ON model_providers",
+)
+
+_UPGRADE_CREATE_STATEMENTS = (
+    """
+        CREATE POLICY model_providers_select_access ON model_providers
+          FOR SELECT
+          USING (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY model_providers_insert_owner_access ON model_providers
+          FOR INSERT
+          WITH CHECK (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY model_providers_update_owner_access ON model_providers
+          FOR UPDATE
+          USING (app.hosted_workspace_owner_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY model_providers_delete_owner_access ON model_providers
+          FOR DELETE
+          USING (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY provider_capabilities_select_access ON provider_capabilities
+          FOR SELECT
+          USING (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY provider_capabilities_insert_owner_access ON provider_capabilities
+          FOR INSERT
+          WITH CHECK (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY provider_capabilities_update_owner_access ON provider_capabilities
+          FOR UPDATE
+          USING (app.hosted_workspace_owner_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY provider_capabilities_delete_owner_access ON provider_capabilities
+          FOR DELETE
+          USING (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY model_packs_select_access ON model_packs
+          FOR SELECT
+          USING (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY model_packs_insert_owner_access ON model_packs
+          FOR INSERT
+          WITH CHECK (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY model_packs_update_owner_access ON model_packs
+          FOR UPDATE
+          USING (app.hosted_workspace_owner_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY model_packs_delete_owner_access ON model_packs
+          FOR DELETE
+          USING (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY workspace_model_pack_bindings_select_access ON workspace_model_pack_bindings
+          FOR SELECT
+          USING (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY workspace_model_pack_bindings_insert_owner_access ON workspace_model_pack_bindings
+          FOR INSERT
+          WITH CHECK (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY workspace_model_pack_bindings_update_owner_access ON workspace_model_pack_bindings
+          FOR UPDATE
+          USING (app.hosted_workspace_owner_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY workspace_model_pack_bindings_delete_owner_access ON workspace_model_pack_bindings
+          FOR DELETE
+          USING (app.hosted_workspace_owner_allowed(workspace_id));
+        """,
+)
+
+_DOWNGRADE_DROP_STATEMENTS = (
+    "DROP POLICY IF EXISTS workspace_model_pack_bindings_delete_owner_access ON workspace_model_pack_bindings",
+    "DROP POLICY IF EXISTS workspace_model_pack_bindings_update_owner_access ON workspace_model_pack_bindings",
+    "DROP POLICY IF EXISTS workspace_model_pack_bindings_insert_owner_access ON workspace_model_pack_bindings",
+    "DROP POLICY IF EXISTS workspace_model_pack_bindings_select_access ON workspace_model_pack_bindings",
+    "DROP POLICY IF EXISTS model_packs_delete_owner_access ON model_packs",
+    "DROP POLICY IF EXISTS model_packs_update_owner_access ON model_packs",
+    "DROP POLICY IF EXISTS model_packs_insert_owner_access ON model_packs",
+    "DROP POLICY IF EXISTS model_packs_select_access ON model_packs",
+    "DROP POLICY IF EXISTS provider_capabilities_delete_owner_access ON provider_capabilities",
+    "DROP POLICY IF EXISTS provider_capabilities_update_owner_access ON provider_capabilities",
+    "DROP POLICY IF EXISTS provider_capabilities_insert_owner_access ON provider_capabilities",
+    "DROP POLICY IF EXISTS provider_capabilities_select_access ON provider_capabilities",
+    "DROP POLICY IF EXISTS model_providers_delete_owner_access ON model_providers",
+    "DROP POLICY IF EXISTS model_providers_update_owner_access ON model_providers",
+    "DROP POLICY IF EXISTS model_providers_insert_owner_access ON model_providers",
+    "DROP POLICY IF EXISTS model_providers_select_access ON model_providers",
+)
+
+_DOWNGRADE_CREATE_STATEMENTS = (
+    """
+        CREATE POLICY model_providers_workspace_access ON model_providers
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY provider_capabilities_workspace_access ON provider_capabilities
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY model_packs_workspace_access ON model_packs
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+    """
+        CREATE POLICY workspace_model_pack_bindings_workspace_access ON workspace_model_pack_bindings
+          FOR ALL
+          USING (app.hosted_workspace_access_allowed(workspace_id))
+          WITH CHECK (app.hosted_workspace_access_allowed(workspace_id));
+        """,
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute_statements(_UPGRADE_DROP_STATEMENTS)
+    _execute_statements(_UPGRADE_CREATE_STATEMENTS)
+
+
+def downgrade() -> None:
+    _execute_statements(_DOWNGRADE_DROP_STATEMENTS)
+    _execute_statements(_DOWNGRADE_CREATE_STATEMENTS)

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -3089,6 +3089,11 @@ def _ensure_hosted_admin_access(conn, *, user_account_id: UUID) -> None:
     set_hosted_admin_bypass(conn, True)
 
 
+def _ensure_workspace_owner_access(*, workspace, user_account_id: UUID) -> None:
+    if workspace["owner_user_account_id"] != user_account_id:
+        raise PermissionError("workspace owner access is required")
+
+
 def _allow_raw_evidence_debug_access(settings: Settings) -> bool:
     return settings.app_env in {"development", "test"}
 
@@ -7649,6 +7654,11 @@ def bootstrap_v1_workspace(
                     workspace_id=workspace["id"],
                     created_by_user_account_id=user_account_id,
                 )
+                ensure_tier1_model_packs_for_workspace(
+                    store=store,
+                    workspace_id=workspace["id"],
+                    created_by_user_account_id=user_account_id,
+                )
                 preferences = ensure_user_preferences(conn, user_account_id=user_account_id)
                 status_payload = get_bootstrap_status(
                     conn,
@@ -7756,6 +7766,10 @@ def register_v1_provider(request: Request, body: RegisterProviderRequest) -> JSO
                 )
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+                _ensure_workspace_owner_access(
+                    workspace=workspace,
+                    user_account_id=resolution["user_account"]["id"],
+                )
 
                 store = ContinuityStore(conn)
                 provider, capability = _register_workspace_provider(
@@ -7785,6 +7799,8 @@ def register_v1_provider(request: Request, body: RegisterProviderRequest) -> JSO
         return JSONResponse(status_code=422, content={"detail": str(exc)})
     except ProviderSecretManagerError as exc:
         return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -7818,6 +7834,10 @@ def register_v1_ollama_provider(
                 )
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+                _ensure_workspace_owner_access(
+                    workspace=workspace,
+                    user_account_id=resolution["user_account"]["id"],
+                )
 
                 store = ContinuityStore(conn)
                 provider, capability = _register_workspace_provider(
@@ -7847,6 +7867,8 @@ def register_v1_ollama_provider(
         return JSONResponse(status_code=422, content={"detail": str(exc)})
     except ProviderSecretManagerError as exc:
         return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -7880,6 +7902,10 @@ def register_v1_llamacpp_provider(
                 )
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+                _ensure_workspace_owner_access(
+                    workspace=workspace,
+                    user_account_id=resolution["user_account"]["id"],
+                )
 
                 store = ContinuityStore(conn)
                 provider, capability = _register_workspace_provider(
@@ -7909,6 +7935,8 @@ def register_v1_llamacpp_provider(
         return JSONResponse(status_code=422, content={"detail": str(exc)})
     except ProviderSecretManagerError as exc:
         return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -7942,6 +7970,10 @@ def register_v1_vllm_provider(
                 )
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+                _ensure_workspace_owner_access(
+                    workspace=workspace,
+                    user_account_id=resolution["user_account"]["id"],
+                )
 
                 store = ContinuityStore(conn)
                 provider, capability = _register_workspace_provider(
@@ -7971,6 +8003,8 @@ def register_v1_vllm_provider(
         return JSONResponse(status_code=422, content={"detail": str(exc)})
     except ProviderSecretManagerError as exc:
         return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -8011,6 +8045,10 @@ def register_v1_azure_provider(
                 )
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+                _ensure_workspace_owner_access(
+                    workspace=workspace,
+                    user_account_id=resolution["user_account"]["id"],
+                )
 
                 store = ContinuityStore(conn)
                 provider, capability = _register_workspace_azure_provider(
@@ -8040,6 +8078,8 @@ def register_v1_azure_provider(
         return JSONResponse(status_code=422, content={"detail": str(exc)})
     except ProviderSecretManagerError as exc:
         return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -8107,6 +8147,10 @@ def get_v1_provider(provider_id: UUID, request: Request) -> JSONResponse:
                 )
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+                _ensure_workspace_owner_access(
+                    workspace=workspace,
+                    user_account_id=resolution["user_account"]["id"],
+                )
 
                 store = ContinuityStore(conn)
                 provider = store.get_model_provider_for_workspace_optional(
@@ -8155,6 +8199,10 @@ def update_v1_provider(
                 )
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+                _ensure_workspace_owner_access(
+                    workspace=workspace,
+                    user_account_id=resolution["user_account"]["id"],
+                )
 
                 store = ContinuityStore(conn)
                 provider = store.get_model_provider_for_workspace_optional(
@@ -8192,6 +8240,8 @@ def update_v1_provider(
         return JSONResponse(status_code=422, content={"detail": str(exc)})
     except ProviderSecretManagerError as exc:
         return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -8222,6 +8272,10 @@ def test_v1_provider(request: Request, body: TestProviderRequest) -> JSONRespons
                 )
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+                _ensure_workspace_owner_access(
+                    workspace=workspace,
+                    user_account_id=resolution["user_account"]["id"],
+                )
 
                 store = ContinuityStore(conn)
                 provider = store.get_model_provider_for_workspace_optional(
@@ -8338,6 +8392,8 @@ def test_v1_provider(request: Request, body: TestProviderRequest) -> JSONRespons
         return JSONResponse(status_code=422, content={"detail": str(exc)})
     except ProviderSecretManagerError as exc:
         return JSONResponse(status_code=500, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -8378,11 +8434,6 @@ def list_v1_model_packs(request: Request) -> JSONResponse:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
 
                 store = ContinuityStore(conn)
-                ensure_tier1_model_packs_for_workspace(
-                    store=store,
-                    workspace_id=workspace["id"],
-                    created_by_user_account_id=resolution["user_account"]["id"],
-                )
                 packs = store.list_model_packs_for_workspace(workspace_id=workspace["id"])
     except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
         return JSONResponse(status_code=401, content={"detail": str(exc)})
@@ -8428,11 +8479,6 @@ def get_v1_model_pack(
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
 
                 store = ContinuityStore(conn)
-                ensure_tier1_model_packs_for_workspace(
-                    store=store,
-                    workspace_id=workspace["id"],
-                    created_by_user_account_id=resolution["user_account"]["id"],
-                )
                 pack = store.get_model_pack_for_workspace_optional(
                     workspace_id=workspace["id"],
                     pack_id=normalized_pack_id,
@@ -8480,6 +8526,10 @@ def create_v1_model_pack(request: Request, body: CreateModelPackRequest) -> JSON
                 )
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+                _ensure_workspace_owner_access(
+                    workspace=workspace,
+                    user_account_id=resolution["user_account"]["id"],
+                )
 
                 store = ContinuityStore(conn)
                 ensure_tier1_model_packs_for_workspace(
@@ -8521,6 +8571,8 @@ def create_v1_model_pack(request: Request, body: CreateModelPackRequest) -> JSON
             status_code=409,
             content={"detail": "model pack pack_id and pack_version must be unique within the workspace"},
         )
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
     except ModelPackValidationError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
@@ -8550,6 +8602,10 @@ def bind_v1_model_pack(pack_id: str, request: Request, body: BindModelPackReques
                 )
                 if workspace is None:
                     return JSONResponse(status_code=404, content={"detail": "no workspace is currently selected"})
+                _ensure_workspace_owner_access(
+                    workspace=workspace,
+                    user_account_id=resolution["user_account"]["id"],
+                )
 
                 store = ContinuityStore(conn)
                 ensure_tier1_model_packs_for_workspace(
@@ -8603,6 +8659,8 @@ def bind_v1_model_pack(pack_id: str, request: Request, body: BindModelPackReques
                     )
     except (AuthSessionInvalidError, AuthSessionExpiredError, AuthSessionRevokedDeviceError) as exc:
         return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
     except ModelPackCompatibilityError as exc:
         return JSONResponse(status_code=409, content={"detail": str(exc)})
     except ModelPackValidationError as exc:
@@ -8706,11 +8764,6 @@ def invoke_v1_runtime(request: Request, body: RuntimeInvokeRequest) -> JSONRespo
                         status_code=404,
                         content={"detail": f"provider {body.provider_id} was not found"},
                     )
-                ensure_tier1_model_packs_for_workspace(
-                    store=store,
-                    workspace_id=workspace["id"],
-                    created_by_user_account_id=resolution["user_account"]["id"],
-                )
                 selected_pack = resolve_workspace_model_pack_selection(
                     store=store,
                     workspace_id=workspace["id"],

--- a/apps/api/src/alicebot_api/provider_secrets.py
+++ b/apps/api/src/alicebot_api/provider_secrets.py
@@ -11,6 +11,7 @@ from alicebot_api.config import Settings
 _SECRET_REF_PREFIX = "provider_secret_ref:"
 _SECRET_DIRECTORY_MODE = 0o700
 _SECRET_FILE_MODE = 0o600
+_DEFAULT_PROVIDER_SECRET_ROOT = Path("~/.alicebot/provider-secrets")
 
 
 class ProviderSecretManagerError(RuntimeError):
@@ -20,7 +21,7 @@ class ProviderSecretManagerError(RuntimeError):
 def _secret_root(settings: Settings) -> Path:
     configured_url = settings.provider_secret_manager_url.strip()
     if configured_url == "":
-        return (Path(settings.task_workspace_root) / "provider-secrets").expanduser().resolve()
+        return _normalize_secret_path(_DEFAULT_PROVIDER_SECRET_ROOT)
 
     parsed = urlparse(configured_url)
     if parsed.scheme != "file":
@@ -29,19 +30,55 @@ def _secret_root(settings: Settings) -> Path:
     root_path = Path(unquote(parsed.path or "/"))
     if parsed.netloc not in ("", "localhost"):
         root_path = Path(f"/{parsed.netloc}{root_path.as_posix()}")
-    return root_path.expanduser().resolve()
+    return _normalize_secret_path(root_path)
+
+
+def _absolute_path(path: Path) -> Path:
+    expanded = path.expanduser()
+    if expanded.is_absolute():
+        return Path(os.path.abspath(os.fspath(expanded)))
+    return Path(os.path.abspath(os.fspath(Path.cwd() / expanded)))
+
+
+def _ensure_no_symlink_components(path: Path) -> None:
+    absolute_path = _absolute_path(path)
+    current = Path(absolute_path.anchor or "/")
+    for part in absolute_path.parts[1:]:
+        current = current / part
+        try:
+            if current.is_symlink():
+                raise ProviderSecretManagerError("provider secret paths must not contain symlinks")
+        except OSError as exc:
+            raise ProviderSecretManagerError(
+                "provider secret path could not be validated"
+            ) from exc
+
+
+def _normalize_secret_path(path: Path) -> Path:
+    normalized = _absolute_path(path)
+    _ensure_no_symlink_components(normalized)
+    return normalized
 
 
 def _ensure_private_directory(directory: Path) -> None:
+    _ensure_no_symlink_components(directory)
     try:
         directory.mkdir(parents=True, exist_ok=True, mode=_SECRET_DIRECTORY_MODE)
         directory.chmod(_SECRET_DIRECTORY_MODE)
     except OSError as exc:
         raise ProviderSecretManagerError("provider secret directory permissions could not be secured") from exc
+    _ensure_no_symlink_components(directory)
+    if directory.is_symlink() or not directory.is_dir():
+        raise ProviderSecretManagerError("provider secret directory permissions could not be secured")
 
 
 def _resolve_secret_path(*, root: Path, secret_ref: str) -> Path:
-    candidate = (root / secret_ref).resolve()
+    secret_path = Path(secret_ref)
+    if secret_path.is_absolute():
+        raise ProviderSecretManagerError(
+            f"provider secret {secret_ref} is outside the configured root"
+        )
+    candidate = Path(os.path.abspath(os.fspath(root / secret_path)))
     try:
         candidate.relative_to(root)
     except ValueError as exc:
@@ -49,6 +86,18 @@ def _resolve_secret_path(*, root: Path, secret_ref: str) -> Path:
             f"provider secret {secret_ref} is outside the configured root"
         ) from exc
     return candidate
+
+
+def _ensure_secret_file_is_not_symlink(*, path: Path, secret_ref: str) -> None:
+    try:
+        if path.is_symlink():
+            raise ProviderSecretManagerError(
+                f"provider secret {secret_ref} must not be stored behind a symlink"
+            )
+    except OSError as exc:
+        raise ProviderSecretManagerError(
+            f"provider secret {secret_ref} could not be validated"
+        ) from exc
 
 
 def encode_provider_secret_ref(*, secret_ref: str) -> str:
@@ -76,6 +125,8 @@ def write_provider_api_key(*, settings: Settings, secret_ref: str, api_key: str)
     _ensure_private_directory(root)
     path = _resolve_secret_path(root=root, secret_ref=secret_ref)
     _ensure_private_directory(path.parent)
+    _ensure_no_symlink_components(path.parent)
+    _ensure_secret_file_is_not_symlink(path=path, secret_ref=secret_ref)
     temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     payload = {"api_key": api_key}
     try:
@@ -104,6 +155,8 @@ def resolve_provider_api_key(*, settings: Settings, api_key_field: str) -> str:
 
     secret_ref = _decode_provider_secret_ref(api_key_field)
     path = _resolve_secret_path(root=_secret_root(settings), secret_ref=secret_ref)
+    _ensure_no_symlink_components(path.parent)
+    _ensure_secret_file_is_not_symlink(path=path, secret_ref=secret_ref)
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:

--- a/tests/integration/test_phase11_model_packs_api.py
+++ b/tests/integration/test_phase11_model_packs_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import socket
 from typing import Any
 from urllib.parse import urlencode
@@ -12,6 +13,10 @@ import pytest
 
 import apps.api.src.alicebot_api.main as main_module
 from apps.api.src.alicebot_api.config import Settings
+
+TEST_PROVIDER_SECRET_MANAGER_URL = (
+    f"file://{(Path('/tmp').resolve() / 'alicebot-phase11-model-pack-secrets').as_posix()}"
+)
 
 
 def invoke_request(
@@ -91,6 +96,7 @@ def _configure_settings(migrated_database_urls, monkeypatch) -> None:
         "get_settings",
         lambda: Settings(
             database_url=migrated_database_urls["app"],
+            provider_secret_manager_url=TEST_PROVIDER_SECRET_MANAGER_URL,
             magic_link_ttl_seconds=600,
             auth_session_ttl_seconds=3600,
             device_link_ttl_seconds=600,
@@ -163,6 +169,34 @@ def _seed_thread_for_user(*, admin_db_url: str, user_id: str, email: str) -> str
             )
         conn.commit()
     return thread_id
+
+
+def _grant_workspace_member_access(
+    *,
+    admin_db_url: str,
+    workspace_id: str,
+    user_account_id: str,
+) -> None:
+    with psycopg.connect(admin_db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO workspace_members (workspace_id, user_account_id, role)
+                VALUES (%s, %s, 'member')
+                ON CONFLICT (workspace_id, user_account_id) DO UPDATE
+                SET role = EXCLUDED.role
+                """,
+                (workspace_id, user_account_id),
+            )
+            cur.execute(
+                """
+                UPDATE auth_sessions
+                SET workspace_id = %s
+                WHERE user_account_id = %s
+                """,
+                (workspace_id, user_account_id),
+            )
+        conn.commit()
 
 
 class FakeHTTPResponse:
@@ -719,6 +753,69 @@ def test_phase11_model_pack_smoke_covers_local_provider_paths(
     assert "http://ollama.example:11434/api/chat" in captured_urls
     assert "http://llamacpp.example:8080/v1/chat/completions" in captured_urls
     assert "http://vllm.example:8001/v1/chat/completions" in captured_urls
+
+
+def test_phase14_model_pack_control_plane_requires_workspace_owner(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    owner_session_token, owner_workspace_id, _ = _bootstrap_workspace_session(
+        "model-pack-owner-control@example.com"
+    )
+    member_session_token, _, member_user_account_id = _bootstrap_workspace_session(
+        "model-pack-member-control@example.com"
+    )
+    _grant_workspace_member_access(
+        admin_db_url=migrated_database_urls["admin"],
+        workspace_id=owner_workspace_id,
+        user_account_id=member_user_account_id,
+    )
+
+    create_status, create_payload = invoke_request(
+        "POST",
+        "/v1/model-packs",
+        payload={
+            "pack_id": "member-pack",
+            "pack_version": "1.0.0",
+            "display_name": "Member Pack",
+            "family": "custom",
+            "description": "Member should not be able to create this.",
+            "briefing_strategy": "compact",
+            "briefing_max_tokens": 160,
+            "contract": {
+                "contract_version": "model_pack_contract_v1",
+                "context": {},
+                "tools": {"mode": "none"},
+                "response": {},
+                "compatibility": {
+                    "provider_keys": ["openai_compatible"],
+                    "runtime_providers": ["openai_responses"],
+                },
+            },
+        },
+        headers=auth_header(member_session_token),
+    )
+    assert create_status == 403
+    assert create_payload["detail"] == "workspace owner access is required"
+
+    bind_status, bind_payload = invoke_request(
+        "POST",
+        "/v1/model-packs/llama/bind",
+        payload={"pack_version": "1.0.0"},
+        headers=auth_header(member_session_token),
+    )
+    assert bind_status == 403
+    assert bind_payload["detail"] == "workspace owner access is required"
+
+    owner_bind_status, owner_bind_payload = invoke_request(
+        "POST",
+        "/v1/model-packs/llama/bind",
+        payload={"pack_version": "1.0.0"},
+        headers=auth_header(owner_session_token),
+    )
+    assert owner_bind_status == 200
+    assert owner_bind_payload["binding"]["model_pack"]["pack_id"] == "llama"
 
 
 def test_phase11_workspace_model_pack_binding_is_workspace_isolated(migrated_database_urls, monkeypatch) -> None:

--- a/tests/integration/test_phase11_provider_runtime_api.py
+++ b/tests/integration/test_phase11_provider_runtime_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from io import BytesIO
 import json
+from pathlib import Path
 import socket
 from typing import Any
 from urllib.error import HTTPError
@@ -14,6 +15,10 @@ import pytest
 
 import apps.api.src.alicebot_api.main as main_module
 from apps.api.src.alicebot_api.config import Settings, WorkspaceProviderConfig
+
+TEST_PROVIDER_SECRET_MANAGER_URL = (
+    f"file://{(Path('/tmp').resolve() / 'alicebot-phase11-provider-runtime-secrets').as_posix()}"
+)
 
 
 def invoke_request(
@@ -93,6 +98,7 @@ def _configure_settings(migrated_database_urls, monkeypatch) -> None:
         "get_settings",
         lambda: Settings(
             database_url=migrated_database_urls["app"],
+            provider_secret_manager_url=TEST_PROVIDER_SECRET_MANAGER_URL,
             magic_link_ttl_seconds=600,
             auth_session_ttl_seconds=3600,
             device_link_ttl_seconds=600,
@@ -165,6 +171,34 @@ def _seed_thread_for_user(*, admin_db_url: str, user_id: str, email: str) -> str
             )
         conn.commit()
     return thread_id
+
+
+def _grant_workspace_member_access(
+    *,
+    admin_db_url: str,
+    workspace_id: str,
+    user_account_id: str,
+) -> None:
+    with psycopg.connect(admin_db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO workspace_members (workspace_id, user_account_id, role)
+                VALUES (%s, %s, 'member')
+                ON CONFLICT (workspace_id, user_account_id) DO UPDATE
+                SET role = EXCLUDED.role
+                """,
+                (workspace_id, user_account_id),
+            )
+            cur.execute(
+                """
+                UPDATE auth_sessions
+                SET workspace_id = %s
+                WHERE user_account_id = %s
+                """,
+                (workspace_id, user_account_id),
+            )
+        conn.commit()
 
 
 class FakeHTTPResponse:
@@ -632,6 +666,73 @@ def test_phase11_local_provider_test_runtime_invoke_and_workspace_isolation(
     assert "http://ollama.example:11434/api/chat" in captured_urls
     assert "http://llamacpp.example:8080/v1/chat/completions" in captured_urls
     assert "http://vllm.example:8001/v1/chat/completions" in captured_urls
+
+
+def test_phase14_provider_control_plane_requires_workspace_owner(
+    migrated_database_urls,
+    monkeypatch,
+) -> None:
+    _configure_settings(migrated_database_urls, monkeypatch)
+    install_openai_compatible_success(monkeypatch)
+    owner_session_token, owner_workspace_id, _ = _bootstrap_workspace_session(
+        "provider-owner-control@example.com"
+    )
+    member_session_token, _, member_user_account_id = _bootstrap_workspace_session(
+        "provider-member-control@example.com"
+    )
+    _grant_workspace_member_access(
+        admin_db_url=migrated_database_urls["admin"],
+        workspace_id=owner_workspace_id,
+        user_account_id=member_user_account_id,
+    )
+
+    register_status, register_payload = invoke_request(
+        "POST",
+        "/v1/providers",
+        payload={
+            "provider_key": "openai_compatible",
+            "display_name": "Member Controlled Provider",
+            "base_url": "https://provider.example/v1",
+            "api_key": "provider-secret-key",
+            "default_model": "gpt-5-mini",
+        },
+        headers=auth_header(member_session_token),
+    )
+    assert register_status == 403
+    assert register_payload["detail"] == "workspace owner access is required"
+
+    owner_register_status, owner_register_payload = invoke_request(
+        "POST",
+        "/v1/providers",
+        payload={
+            "provider_key": "openai_compatible",
+            "display_name": "Owner Controlled Provider",
+            "base_url": "https://provider.example/v1",
+            "api_key": "provider-secret-key",
+            "default_model": "gpt-5-mini",
+        },
+        headers=auth_header(owner_session_token),
+    )
+    assert owner_register_status == 201
+    provider_id = owner_register_payload["provider"]["id"]
+
+    update_status, update_payload = invoke_request(
+        "PATCH",
+        f"/v1/providers/{provider_id}",
+        payload={"display_name": "Renamed By Member"},
+        headers=auth_header(member_session_token),
+    )
+    assert update_status == 403
+    assert update_payload["detail"] == "workspace owner access is required"
+
+    provider_test_status, provider_test_payload = invoke_request(
+        "POST",
+        "/v1/providers/test",
+        payload={"provider_id": provider_id},
+        headers=auth_header(member_session_token),
+    )
+    assert provider_test_status == 403
+    assert provider_test_payload["detail"] == "workspace owner access is required"
 
 
 def test_phase13_hosted_provider_rows_respect_workspace_rls(

--- a/tests/unit/test_20260416_0066_hosted_control_plane_owner_writes.py
+++ b/tests/unit/test_20260416_0066_hosted_control_plane_owner_writes.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import importlib
+
+
+MODULE_NAME = "apps.api.alembic.versions.20260416_0066_hosted_control_plane_owner_writes"
+
+
+def load_migration_module():
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_upgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.upgrade()
+
+    assert executed == [
+        *module._UPGRADE_DROP_STATEMENTS,
+        *module._UPGRADE_CREATE_STATEMENTS,
+    ]
+
+
+def test_downgrade_executes_expected_statements_in_order(monkeypatch) -> None:
+    module = load_migration_module()
+    executed: list[str] = []
+
+    monkeypatch.setattr(module.op, "execute", executed.append)
+
+    module.downgrade()
+
+    assert executed == [
+        *module._DOWNGRADE_DROP_STATEMENTS,
+        *module._DOWNGRADE_CREATE_STATEMENTS,
+    ]
+
+
+def test_upgrade_restricts_control_plane_writes_to_workspace_owners() -> None:
+    module = load_migration_module()
+    policy_sql = "\n".join(module._UPGRADE_CREATE_STATEMENTS)
+
+    assert "CREATE POLICY model_providers_select_access" in policy_sql
+    assert "CREATE POLICY model_providers_insert_owner_access" in policy_sql
+    assert "CREATE POLICY workspace_model_pack_bindings_delete_owner_access" in policy_sql
+    assert "app.hosted_workspace_access_allowed(workspace_id)" in policy_sql
+    assert "app.hosted_workspace_owner_allowed(workspace_id)" in policy_sql

--- a/tests/unit/test_provider_secrets.py
+++ b/tests/unit/test_provider_secrets.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from uuid import uuid4
 
+import pytest
+
 from alicebot_api.config import Settings
 from alicebot_api.provider_secrets import (
+    ProviderSecretManagerError,
+    _secret_root,
     build_provider_secret_ref,
     encode_provider_secret_ref,
     resolve_provider_api_key,
@@ -38,3 +42,29 @@ def test_provider_secret_resolution_allows_legacy_plaintext_keys() -> None:
     )
 
     assert resolved == "legacy-plaintext-key"
+
+
+def test_provider_secret_default_root_uses_private_home_dir(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    root = _secret_root(Settings())
+
+    assert root == tmp_path / ".alicebot" / "provider-secrets"
+
+
+def test_provider_secret_rejects_symlinked_root(tmp_path: Path) -> None:
+    attacker_root = tmp_path / "attacker"
+    attacker_root.mkdir()
+    linked_root = tmp_path / "linked-secrets"
+    linked_root.symlink_to(attacker_root, target_is_directory=True)
+    settings = Settings(provider_secret_manager_url=f"file://{linked_root}")
+    secret_ref = build_provider_secret_ref(workspace_id=uuid4())
+
+    with pytest.raises(ProviderSecretManagerError, match="symlink"):
+        write_provider_api_key(
+            settings=settings,
+            secret_ref=secret_ref,
+            api_key="provider-secret-key",
+        )
+
+    assert list(attacker_root.rglob("*.json")) == []


### PR DESCRIPTION
## Summary
- restrict hosted control-plane writes for providers and model packs to workspace owners, backed by the new RLS migration
- harden provider secret storage against absolute-path and symlink abuse, and cover the new behavior in unit tests
- pin a few GitHub Actions references that were still floating on major tags

## Validation
- `./.venv/bin/python -m pytest tests/unit/test_provider_secrets.py tests/unit/test_20260416_0066_hosted_control_plane_owner_writes.py tests/integration/test_phase11_provider_runtime_api.py tests/integration/test_phase11_model_packs_api.py -q` -> `30 passed`

## Notes
- outside the sprint-control flow by explicit owner approval