### PR TITLE
[codex] repair archive maintenance workflow

### DIFF
--- a/.github/workflows/archive-maintenance.yml
+++ b/.github/workflows/archive-maintenance.yml
@@ -138,7 +138,7 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const schedule = `${{ steps.schedule.outputs.schedule }}`;
             const title = `[ops] archive maintenance failure (${schedule})`;
-            const body = [
+            const bodyLines = [
               'Archive maintenance job failed.',
               '',
               `- schedule: ${schedule}`,
@@ -146,7 +146,28 @@ jobs:
               `- commit: ${context.sha}`,
               '',
               'Please inspect the uploaded maintenance artifacts and logs.'
-            ].join('\n');
+            ];
+            const body = bodyLines.join('\n');
+
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const existing = openIssues.find(
+              (issue) => issue.title === title && !issue.pull_request
+            );
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+              return;
+            }
 
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/scripts/run_archive_maintenance.py
+++ b/scripts/run_archive_maintenance.py
@@ -70,6 +70,11 @@ DEFAULT_PHASE9_REPORT_PATH = REPO_ROOT / "eval" / "reports" / "phase9_eval_lates
 DEFAULT_USER_EMAIL = "maintenance-bot@example.invalid"
 DEFAULT_USER_DISPLAY_NAME = "Maintenance Bot"
 _MAX_SANITIZED_REPORT_MESSAGE_CHARS = 200
+ENSURE_MAINTENANCE_USER_SQL = """
+                INSERT INTO users (id, email, display_name)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (id) DO NOTHING
+                """
 
 JOB_STATUS = Literal["pass", "warn", "fail", "skipped"]
 
@@ -589,11 +594,24 @@ def _regenerate_benchmarks(
 
 def _ensure_user(store: ContinuityStore, *, user_id: UUID, email: str, display_name: str) -> None:
     with store.conn.cursor() as cur:
-        cur.execute("SELECT 1 FROM users WHERE id = %s", (user_id,))
-        exists = cur.fetchone() is not None
-    if exists:
-        return
-    store.create_user(user_id, email, display_name)
+        cur.execute(ENSURE_MAINTENANCE_USER_SQL, (user_id, email, display_name))
+
+
+def _ensure_user_committed(
+    *,
+    database_url: str,
+    user_id: UUID,
+    email: str,
+    display_name: str,
+) -> None:
+    with user_connection(database_url, user_id) as conn:
+        store = ContinuityStore(conn)
+        _ensure_user(
+            store,
+            user_id=user_id,
+            email=email,
+            display_name=display_name,
+        )
 
 
 def _serialize_job(job: MaintenanceJobResult) -> dict[str, object]:
@@ -759,6 +777,13 @@ def main() -> int:
     run_started = _iso8601_utc(_utc_now())
     jobs: list[MaintenanceJobResult] = []
 
+    _ensure_user_committed(
+        database_url=str(args.database_url),
+        user_id=user_id,
+        email=str(args.user_email),
+        display_name=str(args.display_name),
+    )
+
     jobs.append(
         _run_job(
             job_key="checksum_verification",
@@ -771,12 +796,6 @@ def main() -> int:
 
     with user_connection(str(args.database_url), user_id) as conn:
         store = ContinuityStore(conn)
-        _ensure_user(
-            store,
-            user_id=user_id,
-            email=str(args.user_email),
-            display_name=str(args.display_name),
-        )
 
         jobs.append(
             _run_job(

--- a/tests/unit/test_archive_maintenance.py
+++ b/tests/unit/test_archive_maintenance.py
@@ -3,9 +3,39 @@ from __future__ import annotations
 from datetime import UTC, datetime
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from uuid import UUID, uuid4
 
 import scripts.run_archive_maintenance as maintenance
+
+
+class _CursorStub:
+    def __init__(self, calls: list[tuple[str, tuple[object, ...]]]) -> None:
+        self._calls = calls
+
+    def __enter__(self) -> "_CursorStub":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        del exc_type
+        del exc
+        del traceback
+
+    def execute(self, query: str, params: tuple[object, ...]) -> None:
+        self._calls.append((query, params))
+
+
+class _ConnectionStub:
+    def __init__(self, calls: list[tuple[str, tuple[object, ...]]]) -> None:
+        self._calls = calls
+
+    def cursor(self) -> _CursorStub:
+        return _CursorStub(self._calls)
+
+
+class _UserStoreStub:
+    def __init__(self, calls: list[tuple[str, tuple[object, ...]]]) -> None:
+        self.conn = _ConnectionStub(calls)
 
 
 def _write_go_summary(path: Path) -> None:
@@ -133,6 +163,97 @@ def test_run_job_sanitizes_unhandled_exception_message() -> None:
 
     assert result.status == "fail"
     assert result.errors == ["unhandled_exception:RuntimeError"]
+
+
+def test_ensure_user_uses_idempotent_insert() -> None:
+    calls: list[tuple[str, tuple[object, ...]]] = []
+    user_id = UUID("00000000-0000-0000-0000-000000000001")
+
+    maintenance._ensure_user(  # type: ignore[attr-defined]
+        _UserStoreStub(calls),  # type: ignore[arg-type]
+        user_id=user_id,
+        email="maintenance-bot@example.invalid",
+        display_name="Maintenance Bot",
+    )
+
+    assert len(calls) == 1
+    query, params = calls[0]
+    assert "ON CONFLICT (id) DO NOTHING" in query
+    assert params == (user_id, "maintenance-bot@example.invalid", "Maintenance Bot")
+
+
+def test_main_commits_maintenance_user_before_stateful_jobs(monkeypatch, tmp_path: Path) -> None:
+    events: list[str] = []
+    user_id = UUID("00000000-0000-0000-0000-000000000001")
+
+    class _StatefulConnectionContext:
+        def __enter__(self) -> object:
+            events.append("stateful_connection_opened")
+            return object()
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+            del exc_type
+            del exc
+            del traceback
+            events.append("stateful_connection_closed")
+
+    monkeypatch.setattr(
+        maintenance,
+        "_parse_args",
+        lambda: SimpleNamespace(
+            database_url="postgresql://example",
+            user_id=str(user_id),
+            schedule="weekly",
+            report_path=str(tmp_path / "maintenance_status_latest.json"),
+            history_dir=str(tmp_path / "history"),
+            archive_index_path=str(tmp_path / "missing" / "index.json"),
+            checksum_manifest_path=str(tmp_path / "archive_checksum_manifest.json"),
+            stale_markers_path=str(tmp_path / "stale_fact_markers_latest.json"),
+            benchmark_report_path=str(tmp_path / "phase9_eval_latest.json"),
+            include_benchmark=True,
+            user_email="maintenance-bot@example.invalid",
+            display_name="Maintenance Bot",
+        ),
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "_ensure_user_committed",
+        lambda **kwargs: events.append("user_bootstrap_committed"),
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "user_connection",
+        lambda *_args, **_kwargs: _StatefulConnectionContext(),
+    )
+    monkeypatch.setattr(maintenance, "ContinuityStore", lambda _conn: object())
+    monkeypatch.setattr(
+        maintenance,
+        "_verify_archive_checksums",
+        lambda **_kwargs: {"status": "skipped", "details": {}, "errors": []},
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "_mark_stale_facts",
+        lambda **_kwargs: {"status": "pass", "details": {}},
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "_reembed_missing_segments",
+        lambda **_kwargs: {"status": "pass", "details": {}},
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "_recompute_pattern_candidates",
+        lambda **_kwargs: {"status": "pass", "details": {}},
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "_regenerate_benchmarks",
+        lambda **_kwargs: {"status": "pass", "details": {"benchmark_status": "pass"}},
+    )
+
+    assert maintenance.main() == 0
+    assert events.index("user_bootstrap_committed") < events.index("stateful_connection_opened")
 
 
 class _StaleStoreStub:


### PR DESCRIPTION
## Summary
- Make archive-maintenance failure issue handling idempotent by commenting on an existing open failure issue when present.
- Bootstrap the maintenance user with an idempotent insert before stateful archive jobs run.
- Add focused unit coverage for the new maintenance-user and workflow behavior.

## Validation
- `./.venv/bin/python -m pytest tests/unit/test_archive_maintenance.py -q`
- Final top-of-stack validation also passed: full Python unit suite, full web test suite, web lint, web build, control-doc truth check, `git diff --check`, and vNext eval suite.