### PR TITLE
[codex] fix vNext runtime review issues

### DIFF
--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -213,9 +213,11 @@ from alicebot_api.vnext_evals import (
 from alicebot_api.vnext_projects import ProjectAutomationRequest, VNextProjectService, VNextProjectValidationError
 from alicebot_api.vnext_queue import QueueTaskRequest, VNextQueueService, VNextQueueValidationError
 from alicebot_api.vnext_retrieval import VNextRetrievalRequest, VNextRetrievalService, VNextRetrievalValidationError
+from alicebot_api.vnext_json import json_safe
 from alicebot_api.vnext_store import PostgresVNextStore
 
 DEFAULT_CLI_USER_ID = "00000000-0000-0000-0000-000000000001"
+DEFAULT_VNEXT_SENSITIVITY_ALLOWED = ("public", "internal", "private", "unknown")
 MAINTENANCE_REPORT_PATH_ENV = "ALICEBOT_MAINTENANCE_REPORT_PATH"
 DEFAULT_MAINTENANCE_REPORT_PATH = (
     Path(__file__).resolve().parents[4] / "artifacts" / "ops" / "maintenance_status_latest.json"
@@ -488,6 +490,15 @@ def _run_capture(ctx: CLIContext, args: argparse.Namespace) -> str:
     return format_capture_output(payload)
 
 
+def _json_dumps(value: object) -> str:
+    return json.dumps(json_safe(value), indent=2, sort_keys=True)
+
+
+def _vnext_sensitivity_allowed(args: argparse.Namespace) -> tuple[str, ...]:
+    values = getattr(args, "sensitivity_allowed", None)
+    return tuple(values) if values else DEFAULT_VNEXT_SENSITIVITY_ALLOWED
+
+
 def _run_vnext_sources_capture_text(ctx: CLIContext, args: argparse.Namespace) -> str:
     raw_text = " ".join(args.raw_text).strip()
     with _vnext_store_context(ctx) as store:
@@ -497,7 +508,7 @@ def _run_vnext_sources_capture_text(ctx: CLIContext, args: argparse.Namespace) -
             domain=args.domain,
             sensitivity=args.sensitivity,
         )
-    return json.dumps(result.to_record(), indent=2, sort_keys=True)
+    return _json_dumps(result.to_record())
 
 
 def _run_vnext_sources_capture_file(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -507,7 +518,7 @@ def _run_vnext_sources_capture_file(ctx: CLIContext, args: argparse.Namespace) -
             domain=args.domain,
             sensitivity=args.sensitivity,
         )
-    return json.dumps(result.to_record(), indent=2, sort_keys=True)
+    return _json_dumps(result.to_record())
 
 
 def _run_vnext_sources_import_markdown(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -517,7 +528,7 @@ def _run_vnext_sources_import_markdown(ctx: CLIContext, args: argparse.Namespace
             domain=args.domain,
             sensitivity=args.sensitivity,
         )
-    return json.dumps(result.to_record(), indent=2, sort_keys=True)
+    return _json_dumps(result.to_record())
 
 
 def _run_vnext_sources_import_chatgpt(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -527,7 +538,7 @@ def _run_vnext_sources_import_chatgpt(ctx: CLIContext, args: argparse.Namespace)
             domain=args.domain,
             sensitivity=args.sensitivity,
         )
-    return json.dumps(result.to_record(), indent=2, sort_keys=True)
+    return _json_dumps(result.to_record())
 
 
 def _run_vnext_connectors_list(_ctx: CLIContext, _args: argparse.Namespace) -> str:
@@ -536,7 +547,7 @@ def _run_vnext_connectors_list(_ctx: CLIContext, _args: argparse.Namespace) -> s
         "count": len(list_connector_definitions()),
         "order": [definition.name for definition in list_connector_definitions()],
     }
-    return json.dumps(payload, indent=2, sort_keys=True)
+    return _json_dumps(payload)
 
 
 def _run_vnext_connectors_ingest(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -548,7 +559,7 @@ def _run_vnext_connectors_ingest(ctx: CLIContext, args: argparse.Namespace) -> s
             default_domain=args.domain,
             default_sensitivity=args.sensitivity,
         )
-    return json.dumps(result.to_record(), indent=2, sort_keys=True)
+    return _json_dumps(result.to_record())
 
 
 def _run_context_pack(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -560,20 +571,20 @@ def _run_context_pack(ctx: CLIContext, args: argparse.Namespace) -> str:
                 domains=tuple(args.domain),
                 projects=tuple(args.project),
                 people=tuple(args.person),
-                sensitivity_allowed=tuple(args.sensitivity_allowed),
+                sensitivity_allowed=_vnext_sensitivity_allowed(args),
                 include_sources=not args.no_sources,
                 include_contradictions=not args.no_contradictions,
                 max_items=args.max_items,
                 max_tokens=args.max_tokens,
             )
         )
-    return json.dumps(payload, indent=2, sort_keys=True)
+    return _json_dumps(payload)
 
 
 def _brain_artifact_request_from_args(args: argparse.Namespace) -> BrainArtifactRequest:
     return BrainArtifactRequest(
         domains=tuple(args.domain),
-        sensitivity_allowed=tuple(args.sensitivity_allowed),
+        sensitivity_allowed=_vnext_sensitivity_allowed(args),
         generated_for=args.generated_for,
         source_limit=args.source_limit,
         memory_limit=args.memory_limit,
@@ -588,21 +599,21 @@ def _run_daily_brief(ctx: CLIContext, args: argparse.Namespace) -> str:
     del args.generate
     with _vnext_store_context(ctx) as store:
         artifact = VNextBrainService(store).generate_daily_brief(_brain_artifact_request_from_args(args))
-    return json.dumps(artifact, indent=2, sort_keys=True)
+    return _json_dumps(artifact)
 
 
 def _run_weekly_synthesis(ctx: CLIContext, args: argparse.Namespace) -> str:
     del args.generate
     with _vnext_store_context(ctx) as store:
         artifact = VNextBrainService(store).generate_weekly_synthesis(_brain_artifact_request_from_args(args))
-    return json.dumps(artifact, indent=2, sort_keys=True)
+    return _json_dumps(artifact)
 
 
 def _connection_finder_request_from_args(args: argparse.Namespace) -> ConnectionFinderRequest:
     return ConnectionFinderRequest(
         query=getattr(args, "query", "") or "",
         domains=tuple(args.domain),
-        sensitivity_allowed=tuple(args.sensitivity_allowed),
+        sensitivity_allowed=_vnext_sensitivity_allowed(args),
         max_connections=args.max_connections,
         auto_accept_threshold=args.auto_accept_threshold,
     )
@@ -611,26 +622,26 @@ def _connection_finder_request_from_args(args: argparse.Namespace) -> Connection
 def _run_connections_generate(ctx: CLIContext, args: argparse.Namespace) -> str:
     with _vnext_store_context(ctx) as store:
         artifact = VNextConnectionService(store).generate_connection_report(_connection_finder_request_from_args(args))
-    return json.dumps(artifact, indent=2, sort_keys=True)
+    return _json_dumps(artifact)
 
 
 def _run_vnext_graph_review(ctx: CLIContext, args: argparse.Namespace) -> str:
     with _vnext_store_context(ctx) as store:
         edge = VNextConnectionService(store).review_edge(edge_id=args.edge_id, action=args.action)
-    return json.dumps(edge, indent=2, sort_keys=True)
+    return _json_dumps(edge)
 
 
 def _run_vnext_graph_neighborhood(ctx: CLIContext, args: argparse.Namespace) -> str:
     with _vnext_store_context(ctx) as store:
         payload = VNextConnectionService(store).graph_neighborhood(target_id=args.target_id)
-    return json.dumps(payload, indent=2, sort_keys=True)
+    return _json_dumps(payload)
 
 
 def _contradiction_finder_request_from_args(args: argparse.Namespace) -> ContradictionFinderRequest:
     return ContradictionFinderRequest(
         query=getattr(args, "query", "") or "",
         domains=tuple(args.domain),
-        sensitivity_allowed=tuple(args.sensitivity_allowed),
+        sensitivity_allowed=_vnext_sensitivity_allowed(args),
         max_contradictions=args.max_contradictions,
     )
 
@@ -640,7 +651,7 @@ def _run_vnext_contradictions_generate(ctx: CLIContext, args: argparse.Namespace
         artifact = VNextContradictionService(store).generate_contradiction_report(
             _contradiction_finder_request_from_args(args)
         )
-    return json.dumps(artifact, indent=2, sort_keys=True)
+    return _json_dumps(artifact)
 
 
 def _run_vnext_belief_review(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -651,19 +662,19 @@ def _run_vnext_belief_review(ctx: CLIContext, args: argparse.Namespace) -> str:
             confidence=args.confidence,
             superseded_by=args.superseded_by,
         )
-    return json.dumps(belief, indent=2, sort_keys=True)
+    return _json_dumps(belief)
 
 
 def _run_vnext_belief_state(ctx: CLIContext, args: argparse.Namespace) -> str:
     with _vnext_store_context(ctx) as store:
         payload = VNextContradictionService(store).belief_state(belief_id=args.belief_id)
-    return json.dumps(payload, indent=2, sort_keys=True)
+    return _json_dumps(payload)
 
 
 def _project_automation_request_from_args(args: argparse.Namespace) -> ProjectAutomationRequest:
     return ProjectAutomationRequest(
         domains=tuple(args.domain),
-        sensitivity_allowed=tuple(args.sensitivity_allowed),
+        sensitivity_allowed=_vnext_sensitivity_allowed(args),
         project_id=getattr(args, "project_id", None),
         person_id=getattr(args, "person_id", None),
         max_items=args.max_items,
@@ -673,7 +684,7 @@ def _project_automation_request_from_args(args: argparse.Namespace) -> ProjectAu
 def _run_vnext_project_update_candidate(ctx: CLIContext, args: argparse.Namespace) -> str:
     with _vnext_store_context(ctx) as store:
         artifact = VNextProjectService(store).generate_project_update_candidate(_project_automation_request_from_args(args))
-    return json.dumps(artifact, indent=2, sort_keys=True)
+    return _json_dumps(artifact)
 
 
 def _run_vnext_project_update_review(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -683,22 +694,22 @@ def _run_vnext_project_update_review(ctx: CLIContext, args: argparse.Namespace) 
             action=args.action,
             edited_current_state=args.edited_current_state,
         )
-    return json.dumps(artifact, indent=2, sort_keys=True)
+    return _json_dumps(artifact)
 
 
 def _run_vnext_project_dashboard(ctx: CLIContext, args: argparse.Namespace) -> str:
     with _vnext_store_context(ctx) as store:
         payload = VNextProjectService(store).project_dashboard(
             project_id=args.project_id,
-            sensitivity_allowed=tuple(args.sensitivity_allowed),
+            sensitivity_allowed=_vnext_sensitivity_allowed(args),
         )
-    return json.dumps(payload, indent=2, sort_keys=True)
+    return _json_dumps(payload)
 
 
 def _run_vnext_open_loops_extract(ctx: CLIContext, args: argparse.Namespace) -> str:
     with _vnext_store_context(ctx) as store:
         loops = VNextProjectService(store).extract_open_loops(_project_automation_request_from_args(args))
-    return json.dumps({"open_loops": loops, "created_count": len(loops)}, indent=2, sort_keys=True)
+    return _json_dumps({"open_loops": loops, "created_count": len(loops)})
 
 
 def _run_vnext_open_loop_review(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -712,7 +723,7 @@ def _run_vnext_open_loop_review(ctx: CLIContext, args: argparse.Namespace) -> st
             priority=args.priority,
             resolution_note=args.resolution_note,
         )
-    return json.dumps(loop, indent=2, sort_keys=True)
+    return _json_dumps(loop)
 
 
 def _run_vnext_queue_add(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -728,13 +739,13 @@ def _run_vnext_queue_add(ctx: CLIContext, args: argparse.Namespace) -> str:
                 write_policy=args.write_policy,
             )
         )
-    return json.dumps(task, indent=2, sort_keys=True)
+    return _json_dumps(task)
 
 
 def _run_vnext_queue_process_next(ctx: CLIContext, _args: argparse.Namespace) -> str:
     with _vnext_store_context(ctx) as store:
         result = VNextQueueService(store).process_next_task()
-    return json.dumps(result.to_record(), indent=2, sort_keys=True)
+    return _json_dumps(result.to_record())
 
 
 def _run_vnext_artifact_review(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -743,7 +754,7 @@ def _run_vnext_artifact_review(ctx: CLIContext, args: argparse.Namespace) -> str
             artifact_id=args.artifact_id,
             action=args.action,
         )
-    return json.dumps(artifact, indent=2, sort_keys=True)
+    return _json_dumps(artifact)
 
 
 def _run_vnext_artifact_export(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -752,7 +763,7 @@ def _run_vnext_artifact_export(ctx: CLIContext, args: argparse.Namespace) -> str
             artifact_id=args.artifact_id,
             output_dir=args.output_dir,
         )
-    return json.dumps({"artifact_id": args.artifact_id, "output_path": str(output_path)}, indent=2, sort_keys=True)
+    return _json_dumps({"artifact_id": args.artifact_id, "output_path": str(output_path)})
 
 
 def _run_mutation_generate(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -1526,7 +1537,7 @@ def build_parser() -> argparse.ArgumentParser:
     context_pack_parser.add_argument(
         "--sensitivity-allowed",
         action="append",
-        default=["public", "internal", "private", "unknown"],
+        default=None,
         help="Allowed sensitivity. Repeatable.",
     )
     context_pack_parser.add_argument("--max-items", type=int, default=8, help="Maximum selected memories.")
@@ -1546,7 +1557,7 @@ def build_parser() -> argparse.ArgumentParser:
     daily_brief_parser.add_argument(
         "--sensitivity-allowed",
         action="append",
-        default=["public", "internal", "private", "unknown"],
+        default=None,
         help="Allowed sensitivity. Repeatable.",
     )
     daily_brief_parser.add_argument("--source-limit", type=int, default=8, help="Maximum source inputs.")
@@ -1575,7 +1586,7 @@ def build_parser() -> argparse.ArgumentParser:
     weekly_synthesis_parser.add_argument(
         "--sensitivity-allowed",
         action="append",
-        default=["public", "internal", "private", "unknown"],
+        default=None,
         help="Allowed sensitivity. Repeatable.",
     )
     weekly_synthesis_parser.add_argument("--source-limit", type=int, default=8, help="Maximum source inputs.")
@@ -1605,7 +1616,7 @@ def build_parser() -> argparse.ArgumentParser:
     connections_generate_parser.add_argument(
         "--sensitivity-allowed",
         action="append",
-        default=["public", "internal", "private", "unknown"],
+        default=None,
         help="Allowed sensitivity. Repeatable.",
     )
     connections_generate_parser.add_argument(
@@ -1772,7 +1783,7 @@ def build_parser() -> argparse.ArgumentParser:
     vnext_contradictions_generate_parser.add_argument(
         "--sensitivity-allowed",
         action="append",
-        default=["public", "internal", "private", "unknown"],
+        default=None,
         help="Allowed sensitivity. Repeatable.",
     )
     vnext_contradictions_generate_parser.add_argument(
@@ -1817,7 +1828,7 @@ def build_parser() -> argparse.ArgumentParser:
     vnext_project_update_parser.add_argument(
         "--sensitivity-allowed",
         action="append",
-        default=["public", "internal", "private", "unknown"],
+        default=None,
         help="Allowed sensitivity. Repeatable.",
     )
     vnext_project_update_parser.add_argument("--max-items", type=int, default=8, help="Maximum selected inputs.")
@@ -1837,7 +1848,7 @@ def build_parser() -> argparse.ArgumentParser:
     vnext_project_dashboard_parser.add_argument(
         "--sensitivity-allowed",
         action="append",
-        default=["public", "internal", "private", "unknown"],
+        default=None,
         help="Allowed sensitivity. Repeatable.",
     )
     vnext_project_dashboard_parser.set_defaults(handler=_run_vnext_project_dashboard)
@@ -1857,7 +1868,7 @@ def build_parser() -> argparse.ArgumentParser:
     vnext_open_loops_extract_parser.add_argument(
         "--sensitivity-allowed",
         action="append",
-        default=["public", "internal", "private", "unknown"],
+        default=None,
         help="Allowed sensitivity. Repeatable.",
     )
     vnext_open_loops_extract_parser.add_argument("--max-items", type=int, default=8, help="Maximum selected sources.")

--- a/apps/api/src/alicebot_api/mcp_tools.py
+++ b/apps/api/src/alicebot_api/mcp_tools.py
@@ -129,6 +129,7 @@ from alicebot_api.vnext_connections import ConnectionFinderRequest, VNextConnect
 from alicebot_api.vnext_contradictions import ContradictionFinderRequest, VNextContradictionService
 from alicebot_api.vnext_projects import ProjectAutomationRequest, VNextProjectService
 from alicebot_api.vnext_retrieval import VNextRetrievalRequest, VNextRetrievalService
+from alicebot_api.vnext_json import json_safe
 from alicebot_api.vnext_store import PostgresVNextStore
 
 
@@ -501,6 +502,7 @@ def _build_recall_query(arguments: Mapping[str, object], *, limit: int) -> Conti
 
 
 def _canonicalize_json(value: object) -> object:
+    value = json_safe(value)
     if isinstance(value, dict):
         return {
             key: _canonicalize_json(value[key])

--- a/apps/api/src/alicebot_api/vnext_event_log.py
+++ b/apps/api/src/alicebot_api/vnext_event_log.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from datetime import UTC, datetime
 import hashlib
 import json
+from typing import cast
 from uuid import uuid4
 
+from alicebot_api.vnext_json import json_safe
 from alicebot_api.vnext_repositories import EventStore, JsonObject
 
 
@@ -12,8 +14,8 @@ def _utc_now_iso() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
-def stable_json_dumps(payload: JsonObject) -> str:
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+def stable_json_dumps(payload: object) -> str:
+    return json.dumps(json_safe(payload), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 
 
 def integrity_hash_for_event(event: JsonObject) -> str:
@@ -41,10 +43,11 @@ def build_event_log_record(
         "target_type": target_type,
         "target_id": target_id,
         "occurred_at": occurred_at or _utc_now_iso(),
-        "payload_json": payload or {},
+        "payload_json": json_safe(payload or {}),
         "trace_id": trace_id,
         "run_id": run_id,
     }
+    event = cast(JsonObject, json_safe(event))
     event["integrity_hash"] = integrity_hash_for_event(event)
     return event
 

--- a/apps/api/src/alicebot_api/vnext_json.py
+++ b/apps/api/src/alicebot_api/vnext_json.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from uuid import UUID
+
+
+def json_safe(value: object) -> object:
+    """Return a JSON-serializable representation of vNext row payloads."""
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(key): json_safe(child) for key, child in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [json_safe(child) for child in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)

--- a/apps/api/src/alicebot_api/vnext_projects.py
+++ b/apps/api/src/alicebot_api/vnext_projects.py
@@ -389,10 +389,17 @@ class VNextProjectService:
         project_id = str(metadata.get("project_id"))
         candidate_memory_id = str(metadata.get("candidate_memory_id"))
         self.store.update_project(project_id=project_id, patch={"current_state": current_state})
-        self.store.update_memory(memory_id=candidate_memory_id, patch={"status": "active", "canonical_text": current_state})
+        updated_memory = self.store.update_memory(
+            memory_id=candidate_memory_id,
+            patch={"status": "active", "canonical_text": current_state},
+        )
+        memory_key = str(updated_memory.get("memory_key", "")).strip()
+        if memory_key == "":
+            raise VNextProjectValidationError("candidate memory is missing memory_key")
         self.store.append_revision(
             {
                 "memory_id": candidate_memory_id,
+                "memory_key": memory_key,
                 "revision_type": "edited" if action == "edit" else "promoted",
                 "action": "project_update_review",
                 "text_after": current_state,
@@ -427,7 +434,7 @@ class VNextProjectService:
         if self.store.get_open_loop(loop_id) is None:
             raise VNextProjectValidationError(f"open loop {loop_id} was not found")
         if action == "close":
-            return self.store.update_open_loop_status(loop_id=loop_id, status="closed", resolution_note=resolution_note)
+            return self.store.update_open_loop_status(loop_id=loop_id, status="resolved", resolution_note=resolution_note)
         if action == "reopen":
             return self.store.update_open_loop_status(loop_id=loop_id, status="open")
         patch: JsonObject = {}

--- a/apps/api/src/alicebot_api/vnext_retrieval.py
+++ b/apps/api/src/alicebot_api/vnext_retrieval.py
@@ -177,8 +177,6 @@ def _infer_domains(lowered_query: str) -> list[str]:
         domains.extend(["project", "professional"])
     if _contains_any(lowered_query, ("family", "health", "spiritual", "money", "legal")):
         domains.append("personal")
-    if not domains:
-        domains.append("unknown")
     return domains
 
 
@@ -281,19 +279,19 @@ class VNextRetrievalService:
 
         memory_rows = self.store.search_memories(
             query=request.query,
-            domains=domains,
+            domains=domains or None,
             sensitivity_allowed=sensitivity_allowed,
             limit=max(request.max_items * 2, request.max_items),
         )
         source_rows = self.store.search_sources(
             query=request.query,
-            domains=domains,
+            domains=domains or None,
             sensitivity_allowed=sensitivity_allowed,
             limit=max(DEFAULT_SOURCE_LIMIT, request.max_items),
         )
         open_loop_rows = self.store.list_open_loops(
             status="open",
-            domains=domains,
+            domains=domains or None,
             sensitivity_allowed=sensitivity_allowed,
             limit=DEFAULT_OPEN_LOOP_LIMIT,
         )

--- a/apps/api/src/alicebot_api/vnext_store.py
+++ b/apps/api/src/alicebot_api/vnext_store.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from datetime import date, datetime
 from typing import Any, cast
-from uuid import UUID
 
 import psycopg
 from psycopg.types.json import Jsonb
 
 from alicebot_api.store import ContinuityStoreInvariantError
 from alicebot_api.vnext_event_log import build_event_log_record
+from alicebot_api.vnext_json import json_safe
 from alicebot_api.vnext_repositories import JsonObject
 
 
@@ -278,29 +277,17 @@ BRAIN_CHARTER_COLUMNS = """
 def _json_object(value: object | None) -> Jsonb:
     if value is None:
         value = {}
-    return Jsonb(value)
+    return Jsonb(_json_safe(value))
 
 
 def _json_list(value: object | None) -> Jsonb:
     if value is None:
         value = []
-    return Jsonb(value)
+    return Jsonb(_json_safe(value))
 
 
 def _json_safe(value: object) -> object:
-    if isinstance(value, UUID):
-        return str(value)
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if isinstance(value, date):
-        return value.isoformat()
-    if isinstance(value, dict):
-        return {str(key): _json_safe(child) for key, child in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_json_safe(child) for child in value]
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    return str(value)
+    return json_safe(value)
 
 
 def _sorted_field_names(record: JsonObject) -> list[str]:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from datetime import UTC, datetime
 import json
 from pathlib import Path
 from uuid import UUID, uuid4
@@ -95,6 +96,17 @@ def test_parser_routes_required_commands() -> None:
     for argv, expected_handler_name in cases:
         parsed = parser.parse_args(argv)
         assert parsed.handler.__name__ == expected_handler_name
+
+
+def test_parser_preserves_explicit_vnext_sensitivity_filter() -> None:
+    parser = cli_module.build_parser()
+    explicit = parser.parse_args(["context-pack", "coffee", "--sensitivity-allowed", "public"])
+    omitted = parser.parse_args(["context-pack", "coffee"])
+
+    assert explicit.sensitivity_allowed == ["public"]
+    assert cli_module._vnext_sensitivity_allowed(explicit) == ("public",)
+    assert omitted.sensitivity_allowed is None
+    assert cli_module._vnext_sensitivity_allowed(omitted) == ("public", "internal", "private", "unknown")
 
 
 class FakeVNextCliStore:
@@ -477,26 +489,29 @@ def test_vnext_connector_cli_lists_and_ingests_payload_file(monkeypatch, tmp_pat
 
 def test_context_pack_cli_returns_structured_vnext_pack(monkeypatch) -> None:
     store = FakeVNextCliStore()
+    memory_id = uuid4()
+    source_id = uuid4()
+    captured_at = datetime(2026, 5, 10, 0, 0, tzinfo=UTC)
     store.memories.append(
         {
-            "id": "memory-1",
+            "id": memory_id,
             "memory_type": "semantic",
             "canonical_text": "Alice context packs need provenance.",
             "status": "active",
             "confidence": 0.8,
             "domain": "project",
             "sensitivity": "private",
-            "first_seen_at": "2026-05-10T00:00:00Z",
-            "last_seen_at": "2026-05-10T00:00:00Z",
+            "first_seen_at": captured_at,
+            "last_seen_at": captured_at,
         }
     )
     store.sources.append(
         {
-            "id": "source-1",
+            "id": source_id,
             "source_type": "manual_text",
             "title": "Alice context source",
             "content_hash": "sha256:abc",
-            "captured_at": "2026-05-10T00:00:00Z",
+            "captured_at": captured_at,
             "domain": "project",
             "sensitivity": "private",
         }
@@ -520,8 +535,10 @@ def test_context_pack_cli_returns_structured_vnext_pack(monkeypatch) -> None:
 
     payload = json.loads(output)
     assert payload["query_interpretation"]["query_type"] == "strategic_synthesis"
-    assert payload["relevant_memories"][0]["id"] == "memory-1"
-    assert payload["sources"][0]["id"] == "source-1"
+    assert payload["relevant_memories"][0]["id"] == str(memory_id)
+    assert payload["relevant_memories"][0]["first_seen_at"] == "2026-05-10T00:00:00+00:00"
+    assert payload["sources"][0]["id"] == str(source_id)
+    assert payload["sources"][0]["captured_at"] == "2026-05-10T00:00:00+00:00"
     assert payload["trace"]["selected_count"] == 2
 
 

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from io import BytesIO
-from uuid import UUID
+import json
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -337,6 +339,65 @@ def test_alice_vnext_context_pack_mcp_tool(monkeypatch) -> None:
     assert payload["sources"][0]["id"] == "source-1"
     assert payload["trace_id"] == payload["trace"]["trace_id"]
     assert store.events[-1]["event_type"] == "retrieval.context_pack_compiled"
+
+
+def test_alice_vnext_context_pack_mcp_tool_normalizes_row_scalars(monkeypatch) -> None:
+    store = FakeVNextMCPStore()
+    memory_id = uuid4()
+    source_id = uuid4()
+    captured_at = datetime(2026, 5, 10, 9, 0, tzinfo=UTC)
+
+    def search_memories(**_kwargs) -> list[dict[str, object]]:
+        return [
+            {
+                "id": memory_id,
+                "memory_type": "semantic",
+                "canonical_text": "Coffee preference is pour over.",
+                "status": "active",
+                "confidence": 0.9,
+                "domain": "personal",
+                "sensitivity": "private",
+                "first_seen_at": captured_at,
+                "last_seen_at": captured_at,
+            }
+        ]
+
+    def search_sources(**_kwargs) -> list[dict[str, object]]:
+        return [
+            {
+                "id": source_id,
+                "source_type": "manual_text",
+                "title": "Coffee note",
+                "content_hash": "sha256:coffee",
+                "captured_at": captured_at,
+                "domain": "personal",
+                "sensitivity": "private",
+            }
+        ]
+
+    store.search_memories = search_memories  # type: ignore[method-assign]
+    store.search_sources = search_sources  # type: ignore[method-assign]
+
+    @contextmanager
+    def fake_vnext_store_context(_context):
+        yield store
+
+    monkeypatch.setattr(mcp_tools_module, "_vnext_store_context", fake_vnext_store_context)
+    context = MCPRuntimeContext(
+        database_url="postgresql://localhost/alicebot",
+        user_id=UUID("11111111-1111-4111-8111-111111111111"),
+    )
+
+    payload = call_mcp_tool(
+        context,
+        name="alice_vnext_context_pack",
+        arguments={"query": "coffee preference"},
+    )
+
+    json.dumps(payload)
+    assert payload["relevant_memories"][0]["id"] == str(memory_id)
+    assert payload["relevant_memories"][0]["first_seen_at"] == "2026-05-10T09:00:00+00:00"
+    assert payload["sources"][0]["id"] == str(source_id)
 
 
 def test_alice_generate_daily_and_weekly_brief_mcp_tools(monkeypatch) -> None:

--- a/tests/unit/test_vnext_projects.py
+++ b/tests/unit/test_vnext_projects.py
@@ -238,6 +238,7 @@ def test_accepting_project_update_updates_project_promotes_memory_and_appends_re
     assert store.projects["project-1"]["current_state"] == "Alice vNext project automation is under review."
     assert store.memories["memory-2"]["status"] == "active"
     assert store.revisions[0]["memory_id"] == "memory-2"
+    assert store.revisions[0]["memory_key"] == store.memories["memory-2"]["memory_key"]
     assert store.revisions[0]["revision_type"] == "edited"
     assert store.events[-1]["event_type"] == "project.update_candidate_accepted"
 
@@ -268,7 +269,7 @@ def test_open_loop_extraction_and_review_support_source_owner_and_filters() -> N
     assert loops[0]["metadata_json"]["source_captured_at"] == "2026-05-10T09:00:00Z"
     assert loops[0]["metadata_json"]["owner"] == "Samir"
     assert snoozed["due_at"] == "2026-05-12T09:00:00Z"
-    assert closed["status"] == "closed"
+    assert closed["status"] == "resolved"
     assert dashboard["project"]["id"] == "project-1"
     assert dashboard["counts"]["open_loops"] == 1
 

--- a/tests/unit/test_vnext_retrieval.py
+++ b/tests/unit/test_vnext_retrieval.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from alicebot_api.vnext_retrieval import VNextRetrievalRequest, VNextRetrievalService, classify_query, query_terms
 
 
+_UNSET = object()
+
+
 class InMemoryVNextRetrievalStore:
     def __init__(
         self,
@@ -17,6 +20,9 @@ class InMemoryVNextRetrievalStore:
         self.open_loops = open_loops or []
         self.provenance_links = provenance_links or []
         self.events: list[dict[str, object]] = []
+        self.memory_search_domains: object = _UNSET
+        self.source_search_domains: object = _UNSET
+        self.open_loop_domains: object = _UNSET
 
     def append_event(self, event: dict[str, object]) -> dict[str, object]:
         self.events.append(event)
@@ -30,7 +36,8 @@ class InMemoryVNextRetrievalStore:
         sensitivity_allowed: list[str] | None = None,
         limit: int = 8,
     ) -> list[dict[str, object]]:
-        del query, domains, sensitivity_allowed
+        del query, sensitivity_allowed
+        self.memory_search_domains = domains
         return self.memories[:limit]
 
     def search_sources(
@@ -41,7 +48,8 @@ class InMemoryVNextRetrievalStore:
         sensitivity_allowed: list[str] | None = None,
         limit: int = 8,
     ) -> list[dict[str, object]]:
-        del query, domains, sensitivity_allowed
+        del query, sensitivity_allowed
+        self.source_search_domains = domains
         return self.sources[:limit]
 
     def list_open_loops(
@@ -52,7 +60,8 @@ class InMemoryVNextRetrievalStore:
         sensitivity_allowed: list[str] | None = None,
         limit: int = 8,
     ) -> list[dict[str, object]]:
-        del domains, sensitivity_allowed
+        del sensitivity_allowed
+        self.open_loop_domains = domains
         rows = [row for row in self.open_loops if status is None or row.get("status") == status]
         return rows[:limit]
 
@@ -206,6 +215,40 @@ def test_context_pack_filters_sensitive_memories_and_records_trace_exclusion() -
     excluded = [candidate for candidate in pack["trace"]["candidates"] if candidate["target_id"] == "memory-secret"]
     assert excluded[0]["selected"] is False
     assert excluded[0]["exclusion_reason"] == "sensitivity_filtered"
+
+
+def test_unscoped_query_does_not_filter_to_unknown_domain() -> None:
+    store = InMemoryVNextRetrievalStore(
+        memories=[
+            {
+                "id": "memory-personal",
+                "memory_type": "semantic",
+                "canonical_text": "Coffee preference is pour over.",
+                "status": "active",
+                "confidence": 0.8,
+                "domain": "personal",
+                "sensitivity": "private",
+            }
+        ],
+        sources=[
+            {
+                "id": "source-personal",
+                "source_type": "manual_text",
+                "title": "Coffee preference",
+                "content_hash": "sha256:coffee",
+                "domain": "personal",
+                "sensitivity": "private",
+            }
+        ],
+    )
+
+    pack = VNextRetrievalService(store).compile_context_pack(VNextRetrievalRequest(query="coffee preference"))
+
+    assert pack["query_interpretation"]["domains"] == []
+    assert store.memory_search_domains is None
+    assert store.source_search_domains is None
+    assert store.open_loop_domains is None
+    assert pack["relevant_memories"][0]["id"] == "memory-personal"
 
 
 def test_context_pack_records_missing_information_when_no_candidates_match() -> None:

--- a/tests/unit/test_vnext_store.py
+++ b/tests/unit/test_vnext_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
@@ -527,3 +528,48 @@ def test_append_and_list_event_log_records_use_integrity_payload() -> None:
     assert isinstance(event_insert_params[7], Jsonb)
     assert event_insert_params[7].obj == {"b": 2, "a": 1}
     assert event_insert_params[10] == event["integrity_hash"]
+
+
+def test_jsonb_and_event_hash_normalize_postgres_scalar_values() -> None:
+    project_id = uuid4()
+    captured_at = datetime(2026, 5, 10, 12, 30, tzinfo=UTC)
+    event = build_event_log_record(
+        event_type="project.update_candidate_created",
+        actor_type="system",
+        target_type="project",
+        target_id=str(project_id),
+        payload={
+            "project_id": project_id,
+            "source": {
+                "captured_at": captured_at,
+            },
+        },
+    )
+    cursor = RecordingCursor(fetchone_results=[{"id": str(project_id)}, _event_row(project_id)])
+    store = PostgresVNextStore(RecordingConnection(cursor))
+
+    store.create_project(
+        {
+            "id": str(project_id),
+            "name": "Alice vNext",
+            "slug": "alice-vnext",
+            "metadata_json": {
+                "candidate_memory_id": project_id,
+                "source_captured_at": captured_at,
+            },
+        }
+    )
+
+    assert event["payload_json"] == {
+        "project_id": str(project_id),
+        "source": {
+            "captured_at": "2026-05-10T12:30:00+00:00",
+        },
+    }
+    project_insert_params = cursor.executed[0][1]
+    assert project_insert_params is not None
+    assert isinstance(project_insert_params[-1], Jsonb)
+    assert project_insert_params[-1].obj == {
+        "candidate_memory_id": str(project_id),
+        "source_captured_at": "2026-05-10T12:30:00+00:00",
+    }


### PR DESCRIPTION
## Summary

Fixes the six vNext review findings that could break Postgres-backed runtime paths or widen context visibility beyond an explicit CLI filter.

## Upgrade Overview

### Protected Areas

- [x] continuity APIs

### Compatibility Impact

The CLI and MCP response shapes are unchanged, but UUID and datetime values are now serialized as strings before output. Explicit CLI sensitivity filters now narrow access as requested instead of being added to the permissive default.

### Migration / Rollout

No database migration is required. The change is a runtime hotfix for vNext serialization, filtering, revision creation, open-loop status persistence, and retrieval scoping.

### Operator Action

Operators do not need to run manual remediation. After deployment, retry any failed vNext CLI/API/MCP workflow that previously hit JSON serialization, project update review, open-loop close, or overly narrow domain retrieval behavior.

### Validation

Regression tests cover real UUID/datetime-like row values, explicit sensitivity narrowing, project update revision keys, valid open-loop close status, and unscoped domain retrieval. Full unit tests pass locally.

### Rollback

Rollback is the previous `main` commit before this hotfix. That restores the old behavior but reintroduces the reviewed runtime failures and explicit-filter privacy issue.

## Root Cause

The vNext tests used string-heavy fakes, while real psycopg rows can contain UUID and datetime values. Those values were passed into Jsonb wrappers, event integrity hashing, CLI JSON output, and MCP payloads without normalization. Separately, argparse `append` defaults made explicit sensitivity filters additive instead of restrictive, project update revisions omitted the NOT NULL `memory_key`, close persisted an unsupported open-loop status, and unscoped retrieval inferred an `unknown`-only domain filter.

## Changes

- Adds shared vNext JSON normalization for UUID, datetime, date, tuple/list, and dict payloads.
- Normalizes Jsonb payloads, event payloads, event integrity hashes, CLI JSON output, and MCP tool output.
- Preserves explicit CLI `--sensitivity-allowed` values and applies the permissive default only when omitted.
- Includes `memory_key` when accepting/editing project update candidate revisions.
- Maps open-loop close actions to persisted `resolved` status.
- Leaves generic retrieval queries unscoped instead of filtering to `unknown` domain only.
- Adds regressions covering UUID/datetime rows, explicit sensitivity narrowing, project revision keys, valid close status, and unscoped domain retrieval.

## Validation

- `./.venv/bin/python -m pytest tests/unit/test_vnext_store.py tests/unit/test_vnext_retrieval.py tests/unit/test_vnext_projects.py tests/unit/test_cli.py tests/unit/test_mcp.py -q` -> 49 passed
- `./.venv/bin/python -m pytest tests/unit/test_vnext_*.py tests/unit/test_cli.py tests/unit/test_mcp.py -q` -> 105 passed
- `./.venv/bin/python -m pytest tests/unit -q` -> 1057 passed
- `git diff --check` -> clean
