### PR TITLE
[codex] fix vNext Postgres smoke blockers

### DIFF
--- a/apps/api/src/alicebot_api/vnext_store.py
+++ b/apps/api/src/alicebot_api/vnext_store.py
@@ -424,8 +424,8 @@ class PostgresVNextStore:
             f"""
                 SELECT {EVENT_LOG_COLUMNS}
                 FROM event_log
-                WHERE (%s IS NULL OR target_type = %s)
-                  AND (%s IS NULL OR target_id = %s)
+                WHERE (%s::text IS NULL OR target_type = %s)
+                  AND (%s::text IS NULL OR target_id = %s)
                 ORDER BY occurred_at DESC, id DESC
                 """,
             (target_type, target_type, target_id, target_id),
@@ -1166,8 +1166,8 @@ class PostgresVNextStore:
             f"""
                 SELECT {GRAPH_EDGE_COLUMNS}
                 FROM graph_edges
-                WHERE (%s IS NULL OR from_id = %s)
-                  AND (%s IS NULL OR to_id = %s)
+                WHERE (%s::text IS NULL OR from_id = %s)
+                  AND (%s::text IS NULL OR to_id = %s)
                   AND valid_to IS NULL
                 ORDER BY created_at DESC, id DESC
                 """,
@@ -1292,7 +1292,7 @@ class PostgresVNextStore:
             f"""
                 SELECT {PROJECT_COLUMNS}
                 FROM projects
-                WHERE (%s IS NULL OR status = %s)
+                WHERE (%s::text IS NULL OR status = %s)
                   AND (%s::text[] IS NULL OR domain = ANY(%s::text[]) OR domain = 'unknown')
                   AND (%s::text[] IS NULL OR sensitivity = ANY(%s::text[]))
                 ORDER BY updated_at DESC, created_at DESC, id DESC
@@ -1533,7 +1533,7 @@ class PostgresVNextStore:
                 JOIN memories m
                   ON m.id = b.memory_id
                  AND m.user_id = b.user_id
-                WHERE (%s IS NULL OR b.status = %s)
+                WHERE (%s::text IS NULL OR b.status = %s)
                   AND m.deleted_at IS NULL
                   AND (%s::text[] IS NULL OR m.domain = ANY(%s::text[]) OR m.domain = 'unknown')
                   AND (%s::text[] IS NULL OR m.sensitivity = ANY(%s::text[]))
@@ -1696,11 +1696,11 @@ class PostgresVNextStore:
             f"""
                 SELECT {OPEN_LOOP_COLUMNS}
                 FROM open_loops
-                WHERE (%s IS NULL OR status = %s)
+                WHERE (%s::text IS NULL OR status = %s)
                   AND (%s::text[] IS NULL OR domain = ANY(%s::text[]) OR domain = 'unknown')
                   AND (%s::text[] IS NULL OR sensitivity = ANY(%s::text[]))
-                  AND (%s IS NULL OR project_id = %s::uuid)
-                  AND (%s IS NULL OR person_id = %s::uuid)
+                  AND (%s::uuid IS NULL OR project_id = %s::uuid)
+                  AND (%s::uuid IS NULL OR person_id = %s::uuid)
                 ORDER BY opened_at DESC, created_at DESC, id DESC
                 LIMIT %s
                 """,
@@ -1832,7 +1832,7 @@ class PostgresVNextStore:
                   %s,
                   %s,
                   %s,
-                  %s::uuid,
+                  %s::timestamptz,
                   %s
                 )
                 RETURNING {ARTIFACT_COLUMNS}
@@ -1884,7 +1884,7 @@ class PostgresVNextStore:
             f"""
                 SELECT {ARTIFACT_COLUMNS}
                 FROM generated_artifacts
-                WHERE (%s IS NULL OR artifact_type = %s)
+                WHERE (%s::text IS NULL OR artifact_type = %s)
                   AND (%s::text[] IS NULL OR domain = ANY(%s::text[]) OR domain = 'unknown')
                   AND (%s::text[] IS NULL OR sensitivity = ANY(%s::text[]))
                 ORDER BY created_at DESC, id DESC

--- a/tests/unit/test_vnext_store.py
+++ b/tests/unit/test_vnext_store.py
@@ -181,6 +181,9 @@ def test_keyword_search_methods_apply_domain_sensitivity_and_limit_filters() -> 
     assert source_params is not None
     assert source_params[-1] == 3
     assert "FROM open_loops" in open_loop_query
+    assert "%s::text IS NULL OR status = %s" in open_loop_query
+    assert "%s::uuid IS NULL OR project_id = %s::uuid" in open_loop_query
+    assert "%s::uuid IS NULL OR person_id = %s::uuid" in open_loop_query
     assert open_loop_params == (
         "open",
         "open",
@@ -215,7 +218,7 @@ def test_list_artifacts_applies_type_domain_sensitivity_and_limit_filters() -> N
     assert artifacts[0]["id"] == "artifact-1"
     query, params = cursor.executed[0]
     assert "FROM generated_artifacts" in query
-    assert "artifact_type = %s" in query
+    assert "%s::text IS NULL OR artifact_type = %s" in query
     assert "domain = ANY" in query
     assert "sensitivity = ANY" in query
     assert params == (
@@ -257,7 +260,7 @@ def test_list_beliefs_joins_memory_domain_sensitivity_filters() -> None:
     query, params = cursor.executed[0]
     assert "FROM beliefs b" in query
     assert "JOIN memories m" in query
-    assert "b.status = %s" in query
+    assert "%s::text IS NULL OR b.status = %s" in query
     assert "m.domain = ANY" in query
     assert "m.sensitivity = ANY" in query
     assert params == (
@@ -360,6 +363,7 @@ def test_memory_revision_provenance_and_graph_methods_write_audit_events() -> No
     assert any("INSERT INTO provenance_links" in query for query, _params in cursor.executed)
     assert any("INSERT INTO graph_edges" in query for query, _params in cursor.executed)
     assert any("UPDATE graph_edges" in query for query, _params in cursor.executed)
+    assert any("%s::text IS NULL OR from_id = %s" in query for query, _params in cursor.executed)
     update_edge_query, update_edge_params = cursor.executed[-4]
     assert "metadata_json = metadata_json || %s" in update_edge_query
     assert update_edge_params is not None
@@ -418,6 +422,7 @@ def test_project_people_belief_and_open_loop_methods_write_audit_events() -> Non
     assert _event_log_insert_count(cursor) == 9
     assert "INSERT INTO projects" in cursor.executed[0][0]
     assert "FROM projects" in cursor.executed[3][0]
+    assert "%s::text IS NULL OR status = %s" in cursor.executed[3][0]
     assert cursor.executed[3][1] == ("active", "active", ["project"], ["project"], ["private"], ["private"], 3)
     assert "UPDATE projects" in cursor.executed[4][0]
     assert "INSERT INTO people" in cursor.executed[6][0]
@@ -528,6 +533,9 @@ def test_append_and_list_event_log_records_use_integrity_payload() -> None:
     assert isinstance(event_insert_params[7], Jsonb)
     assert event_insert_params[7].obj == {"b": 2, "a": 1}
     assert event_insert_params[10] == event["integrity_hash"]
+    event_list_query = cursor.executed[1][0]
+    assert "%s::text IS NULL OR target_type = %s" in event_list_query
+    assert "%s::text IS NULL OR target_id = %s" in event_list_query
 
 
 def test_jsonb_and_event_hash_normalize_postgres_scalar_values() -> None:


### PR DESCRIPTION
## Summary
- Cast nullable vNext SQL filter placeholders so psycopg/Postgres can infer parameter types in real queries.
- Fix generated artifact insertion so `promoted_at` is treated as `timestamptz`, not `uuid`.
- Tighten store tests around the Postgres casts that fake cursors previously missed.

## Root Cause
The release-readiness Postgres smoke exercised paths that string/fake cursor tests did not: connector cursor lookup hit untyped optional filters, and daily-brief artifact creation hit a bad `promoted_at` placeholder cast.

## Validation
- Real Postgres vNext smoke covering CLI source capture, connector ingest, scoped/unscoped context pack, daily brief, project update review, open-loop close, API context pack/dashboard, and MCP vNext context pack/dashboard
- `./.venv/bin/python -m pytest tests/unit -q`
- `python3 scripts/check_control_doc_truth.py`
- `./.venv/bin/python -c 'from alicebot_api.cli import main; raise SystemExit(main(["eval", "run", "--suite", "all"]))'`\n- `pnpm --dir apps/web test`\n- `pnpm --dir apps/web lint`\n- `pnpm --dir apps/web build`\n- `git diff --check`