### PR TITLE
[codex] document vNext preview release package

### DIFF
--- a/.ai/active/SPRINT_PACKET.md
+++ b/.ai/active/SPRINT_PACKET.md
@@ -1,221 +1,99 @@
 # Sprint Packet
 
 ## Sprint Title
-Alice vNext Sprint 1 - Architecture Foundation and Schema
+Alice vNext Public Preview Release Gate
 
 ## Activation Note
-- This packet is active.
-- `v0.5.1` is the current public release boundary.
+- This packet records the active release gate.
+- `v0.5.1` remains the current stable pre-1.0 public release boundary.
+- `v0.5.1-vnext-preview` is the vNext public-preview tag target.
 - Phase 14 is shipped.
 - `HF-001` Logging Safety And Disk Guardrails is shipped.
-- `M-001` Archive Maintenance CI Repair is implemented in this working tree as the maintenance gate before vNext work.
-- This sprint starts the Alice vNext / True Second Brain build from `docs/alice_vnext_true_second_brain_tech_spec.md`.
+- Alice vNext Sprint 1 through Sprint 12 preview scope is implemented.
 
 ## Sprint Type
-feature-foundation
+release-gate
 
 ## Sprint Reason
-Alice vNext requires a larger memory-kernel foundation than the existing Phase 14 continuity substrate. The first sprint establishes the v2 schema, contracts, repository boundaries, event-log utility, and Brain Charter model without destructively reorganizing existing Phase 14 modules.
+The vNext preview surface has moved from incremental seed work into release packaging. The release gate preserves the stable `v0.5.1` baseline while publishing the local-first vNext preview as a GitHub pre-release with current verification evidence and explicit limitations.
 
 ## Git Instructions
-- Branch Stack: `codex/archive-maintenance-repair` -> `codex/vnext-backend-kernel` -> `codex/vnext-web-workspace` -> `codex/vnext-release-docs`
+- Branch: `codex/vnext-preview-release-packaging`
 - Base Branch: `main`
-- PR Strategy: stacked draft PRs by system area
-- Merge Policy: merge the stack in order after review `PASS` and explicit approval
+- PR Strategy: release-paperwork PR, squash merge, then tag merged `main`
+- Merge Policy: merge after checks pass and explicit release approval
 
 ## Baseline To Preserve
 - shipped Phases 9-14 baseline
 - shipped Bridge `B1` through `B4`
-- published `v0.5.1` baseline
+- stable `v0.5.1` public release line
 - shipped one-call continuity surface
 - shipped Alice Lite profile
 - shipped hygiene/thread-health visibility
 - shipped Phase 14 provider contract, local/self-hosted compatibility, model packs, reference integrations, and design-partner launch surface
 - shipped `HF-001` logging safety and disk guardrails
-- `M-001` archive-maintenance repair behavior
 - no semantic fork between API, CLI, MCP, hosted, provider-runtime, and Hermes paths
 
 ## Exact Goal
-Establish the Alice vNext memory-kernel foundation: v2 schema/migration support, shared schema contracts, repository interfaces, append-only event-log utility, and ALICE.md / Brain Charter model.
+Publish Alice vNext as the `v0.5.1-vnext-preview` public pre-release with release notes, tag plan, completed checklist evidence, and aligned control docs.
 
 ## In Scope
-- v2-compatible database migration for sources, source chunks, provenance links, graph edges, projects, people, beliefs, generated artifacts, task queue, event log, and brain charters
-- compatibility extensions for existing `memories`, `memory_revisions`, and `open_loops`
-- domain/sensitivity enums and constraints
-- shared JSON schemas/types for memory, source, artifact, graph edge, context pack, and event records
-- repository protocol interfaces for the vNext storage abstraction
-- Postgres vNext store facade with CRUD-style methods for the Sprint 1 entities
-- event-log helper for deterministic hashable event records
-- Brain Charter model and default ALICE.md template
-- forward-compatible Sprint 2 seed for vNext text/file/Markdown/ChatGPT source capture, hashing, chunking, candidate-memory extraction, provenance linking, CLI commands, and minimal source API endpoints
-- forward-compatible Sprint 3 seed for query classification, keyword retrieval, domain/sensitivity filtering, context-pack generation, trace metadata, and CLI/API/MCP access
-- forward-compatible Sprint 4 seed for task queue enqueue/process behavior, deterministic generated artifacts, artifact review/export actions, and CLI/API access
-- forward-compatible Sprint 5 seed for deterministic daily brief and weekly synthesis artifacts, provenance sections, sensitivity inheritance, candidate open loops/memories, and CLI/API/MCP manual triggers
-- forward-compatible Sprint 6 seed for deterministic connection reports, candidate graph edge creation, edge review status, graph neighborhood lookup, and CLI/API/MCP access
-- forward-compatible Sprint 7 seed for deterministic contradiction reports, candidate contradiction edges, belief review state changes, belief state history lookup, and CLI/API/MCP access
-- forward-compatible Sprint 8 seed for project update candidates, candidate project-state memories, open-loop extraction/review, project dashboard data, and CLI/API/MCP access
-- forward-compatible Sprint 9 UI seed for a fixture-backed vNext second-brain workspace with Home, Inbox, Ask Alice, briefs, generated artifacts, memory review, queue, projects, people, beliefs, open loops, timeline, graph, and settings/privacy surfaces
-- forward-compatible Sprint 10 eval/hardening seed for deterministic synthetic benchmark generation, recall/temporal/contradiction/privacy/provenance/open-loop/prompt-injection eval suites, baseline metrics, report writing, and `alicebot eval ...` CLI access
-- forward-compatible Sprint 11 connector expansion seed for deterministic Telegram, browser clipper, PDF/DOCX/CSV/screenshot, and voice-transcript payload ingestion with raw evidence preservation, default domain/sensitivity, cursor-based duplicate prevention, API/CLI access, and connector settings UI
-- forward-compatible Sprint 12 public release polish seed for README vNext positioning, quickstart, Docker/local install docs, example ALICE.md, synthetic demo dataset, demo video script, contributor guide, security/privacy docs, architecture docs, and release checklist
-- targeted migration and contract tests
+- release notes for `v0.5.1-vnext-preview`
+- vNext preview tag plan and rollback path
+- completed vNext public release checklist with current evidence
+- changelog entry for the preview release package
+- README and vNext docs pointing to release notes and tag plan
+- control docs updated away from stale "Sprint 1 active" wording
+- final verification of docs, tests, evals, and GitHub release state
 
 ## Out Of Scope
-- full live-backed vNext UI integration beyond the fixture-backed Sprint 9 seed
-- live connector OAuth/linking, live external polling, browser extension packaging, OCR/transcription model execution, and cloud/file-system watchers beyond deterministic Sprint 11 payload ingestion
-- actual public tag creation, release publishing, demo video recording, or third-party distribution for the Sprint 12 docs seed
-- production autonomous queue worker scheduling and external tool execution
-- production scheduled daily/weekly automation and model-backed synthesis
-- production-grade connection ranking/evaluation and retrieval reranking from accepted graph edges
-- full temporal-state integration for belief histories and model-backed contradiction classification
-- fully split UI-backed project subpages and full repeat-suggestion suppression for rejected project update candidates
-- model-backed or human-rated eval scoring beyond the deterministic Sprint 10 synthetic harness
-- broad package reorganization
-- destructive replacement of existing memory or continuity tables
+- new vNext features
+- live connector OAuth/polling
+- hosted SLA or managed cloud launch
+- automatic promotion of generated artifacts into trusted memory
+- production daily/weekly scheduler
+- live-backed expansion of the `/vnext` UI
+- model-backed or human-rated eval scoring
+- destructive schema rewrites
 
 ## Proposed Files And Modules
-- `apps/api/alembic/versions/20260510_0067_vnext_memory_kernel_schema.py`
-- `apps/api/src/alicebot_api/vnext_repositories.py`
-- `apps/api/src/alicebot_api/vnext_store.py`
-- `apps/api/src/alicebot_api/vnext_capture.py`
-- `apps/api/src/alicebot_api/vnext_retrieval.py`
-- `apps/api/src/alicebot_api/vnext_queue.py`
-- `apps/api/src/alicebot_api/vnext_brain.py`
-- `apps/api/src/alicebot_api/vnext_connections.py`
-- `apps/api/src/alicebot_api/vnext_connectors.py`
-- `apps/api/src/alicebot_api/vnext_contradictions.py`
-- `apps/api/src/alicebot_api/vnext_evals.py`
-- `apps/api/src/alicebot_api/vnext_projects.py`
-- `apps/api/src/alicebot_api/vnext_event_log.py`
-- `apps/api/src/alicebot_api/brain_charter.py`
-- `apps/api/src/alicebot_api/cli.py`
-- `apps/api/src/alicebot_api/main.py`
-- `apps/api/src/alicebot_api/mcp_tools.py`
-- `apps/web/app/vnext/page.tsx`
-- `apps/web/app/vnext/page.test.tsx`
-- `apps/web/components/vnext-brain-workspace.tsx`
-- `docs/vnext/*.md`
+- `CHANGELOG.md`
+- `README.md`
+- `CURRENT_STATE.md`
+- `.ai/handoff/CURRENT_STATE.md`
+- `.ai/active/SPRINT_PACKET.md`
+- `ROADMAP.md`
+- `PRODUCT_BRIEF.md`
+- `ARCHITECTURE.md`
+- `BUILD_REPORT.md`
+- `REVIEW_REPORT.md`
+- `scripts/check_control_doc_truth.py`
+- `docs/vnext/README.md`
 - `docs/release/vnext-public-release-checklist.md`
-- `fixtures/vnext/demo_dataset.json`
-- `apps/web/components/app-shell.tsx`
-- `apps/web/app/page.tsx`
-- `apps/web/app/globals.css`
-- `pyproject.toml`
-- `schemas/*.schema.json`
-- `tests/unit/test_20260510_0067_vnext_memory_kernel_schema.py`
-- `tests/unit/test_vnext_foundation_contracts.py`
-- `tests/unit/test_vnext_store.py`
-- `tests/unit/test_vnext_capture.py`
-- `tests/unit/test_vnext_retrieval.py`
-- `tests/unit/test_vnext_queue.py`
-- `tests/unit/test_vnext_brain.py`
-- `tests/unit/test_vnext_connections.py`
-- `tests/unit/test_vnext_connectors.py`
-- `tests/unit/test_vnext_contradictions.py`
-- `tests/unit/test_vnext_evals.py`
-- `tests/unit/test_vnext_release_polish.py`
-- `tests/unit/test_vnext_projects.py`
-- `tests/unit/test_cli.py`
-- `tests/unit/test_vnext_main.py`
-- `tests/unit/test_mcp.py`
-- control docs
-
-## Planned Deliverables
-- vNext schema migration with reversible downgrade statements
-- shared JSON schema contracts
-- storage repository interface definitions
-- Postgres vNext store facade with create/read/update/soft-delete or append methods across sources, source chunks, memories, revisions, provenance links, graph edges, projects, people, beliefs, open loops, generated artifacts, task queue, event log, and Brain Charter
-- append-only event log helper
-- Brain Charter model/template
-- vNext source capture service and CLI for manual text, local files, Markdown folders, and ChatGPT export files
-- minimal vNext source API for text capture, source lookup, and source soft-delete
-- vNext context-pack retrieval service with classifier, keyword search integration, graph/vector/temporal scaffolds, policy filters, placeholders, and trace records
-- vNext context-pack CLI, API, and MCP access
-- vNext task queue/artifact service with enqueue, process-next, review, Markdown export, CLI commands, and API endpoints
-- vNext daily brief and weekly synthesis service with deterministic templates, source sections, sensitivity inheritance, candidate open-loop/memory creation, CLI commands, API endpoints, and MCP tools
-- vNext connection finder service with connection report artifacts, candidate graph edges, review actions, graph neighborhood lookup, CLI commands, API endpoints, and MCP tools
-- vNext contradiction finder and belief-review service with contradiction report artifacts, candidate contradiction graph edges, belief challenge/supersession actions, belief state history lookup, CLI commands, API endpoints, and MCP tools
-- vNext project/open-loop service with project update candidate artifacts, candidate project-state memories, explicit review actions, open-loop extraction/edit/close/snooze, project dashboard data, CLI commands, API endpoints, and MCP tools
-- vNext web UI seed under `/vnext` with visible Home, Inbox, Ask Alice, Daily Brief, Weekly Synthesis, Queue, Generated, Memory Review, Projects, People, Beliefs, Open Loops, Timeline, Graph, and Settings/Privacy surfaces
-- vNext eval harness seed with a synthetic benchmark corpus generator, baseline targets, recall/temporal/contradiction/privacy/provenance/open-loop/prompt-injection suite runners, report writer, and `eval seed/run/report` CLI commands
-- vNext connector service seed with connector definitions, deterministic item normalizers, raw-evidence archive through source capture, event-log sync cursors, failure isolation, `vnext connectors list/ingest` CLI commands, connector API endpoints, and fixture-backed connector settings UI
-- vNext public-preview docs package with README pointers, quickstart, architecture, security/privacy, example ALICE.md, contributor guide, demo video script, synthetic demo dataset, and release checklist
-- targeted tests plus full unit-suite verification
+- `docs/release/v0.5.1-vnext-preview-release-notes.md`
+- `docs/release/v0.5.1-vnext-preview-tag-plan.md`
 
 ## Acceptance Criteria
-- migrations define all Sprint 1 vNext entities or compatibility columns
-- all new vNext entities have domain/sensitivity where applicable
-- memory type compatibility preserves legacy memory types while adding vNext types
-- event log is append-only and RLS-scoped
-- shared schema files exist for memory/source/artifact/graph/context/event
-- repository interfaces match the spec-required storage abstraction names
-- vNext store methods cover CRUD-style access for major Sprint 1 entities
-- create/update store operations append event-log records
-- vNext capture imports preserve raw source text before chunking
-- vNext capture deduplicates by content hash and links candidate memories to source chunks
-- vNext Markdown folder import can process 100 unique markdown files and skip duplicates
-- vNext import failures are logged and do not prevent later files in the same folder from importing
-- `alicebot context-pack "query"` returns a structured vNext context pack
-- context pack includes memories, sources, contradictions placeholder, open loops placeholder, and trace metadata
-- sensitive memories are filtered according to the allowed sensitivity policy
-- vNext context packs are available through API and MCP
-- vNext queue tasks can be enqueued and processed into deterministic generated artifacts
-- vNext artifacts can be reviewed and exported through CLI and API paths
-- vNext daily briefs and weekly syntheses create reviewable generated artifacts with source references and `artifact.generated` events
-- vNext weekly syntheses create candidate insight memories without auto-promotion
-- vNext connection reports create candidate graph edges with confidence/explanations and log each candidate edge
-- vNext graph edges can be accepted/rejected and queried by graph neighborhood
-- vNext contradiction reports cite both sides, distinguish direct conflict from nuance, recommend a review action, and do not mutate beliefs automatically
-- vNext beliefs can be challenged/superseded through explicit review actions and queried for current/history state
-- vNext project notes create reviewable project update candidates and accepting them updates project state plus memory revisions
-- vNext open loops preserve source/date metadata, owner where detected, and support close/snooze/edit/reopen review actions with project filtering
-- `/vnext` exposes the Sprint 9 UI surfaces without requiring a live API connection
-- vNext UI review actions update visible fixture-backed state for accept, edit, reject, promote, project assignment, label updates, and open-loop creation
-- vNext UI Ask Alice output shows an answer, sources/provenance, memories used, contradictions, why explanation, and save-as-artifact behavior
-- vNext UI generated artifacts and review rows show domain/sensitivity labels plus source/provenance context
-- vNext synthetic benchmark generation includes the spec counts for people, projects, notes, decisions, beliefs, contradictions, superseded beliefs, open loops, personal reflections, future reminders, hidden cross-domain connections, and prompt-injection sources
-- `alicebot eval run --suite all` completes and reports baseline metrics for exact recall, temporal accuracy, contradiction precision, provenance precision, privacy leakage, open-loop recall, and prompt-injection write safety
-- critical privacy leakage evals pass with zero critical leaks
-- prompt-injection corpus sources are quarantined and do not trigger tool writes
-- vNext connector definitions cover Telegram, browser clipper, PDF, DOCX, CSV, screenshot OCR, and voice transcription payloads
-- each vNext connector archive preserves raw payload/extracted evidence in source metadata
-- each vNext connector supports default domain and sensitivity labels
-- connector sync cursors skip already-seen items and avoid advancing past failed items
-- connector sync failures log failure events without importing broken items into memory
-- `/vnext` exposes connector settings defaults and allows fixture-backed default label edits
-- README and vNext docs clearly explain Alice Core vs Alice Brain vs Alice Agent Memory
-- quickstart documents local install, Docker/local stack, first source capture, and first daily brief
-- demo dataset is synthetic and contains no obvious secret markers or private account data
-- release checklist captures tests/lint/evals, no-secrets review, connector security review, and known limitations
-- no existing Alice functionality is broken by the foundation changes
+- `v0.5.1` remains documented as the stable pre-1.0 public release boundary.
+- `v0.5.1-vnext-preview` is documented as a pre-release preview, not a stable replacement.
+- README links the vNext overview, quickstart, architecture, security/privacy, demo script, release checklist, release notes, and tag plan.
+- The vNext release checklist records current verification evidence.
+- Release notes describe included preview scope and limitations.
+- The tag plan includes GitHub pre-release publication and rollback commands.
+- Control-doc truth reflects the release gate instead of stale Sprint 1 active wording.
+- The tag is created from merged `main`.
+- The GitHub release is published as a pre-release with `--latest=false`.
 
 ## Required Verification
-- `pnpm test app/vnext/page.test.tsx` from `apps/web`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_connectors.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_release_polish.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_evals.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_20260510_0067_vnext_memory_kernel_schema.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_foundation_contracts.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_store.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_capture.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_retrieval.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_queue.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_brain.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_connections.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_contradictions.py -q`
-- `./.venv/bin/python -c 'from alicebot_api.cli import main; raise SystemExit(main(["eval", "run", "--suite", "all", "--report-path", "/tmp/alice-vnext-eval-report.json"]))'`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_projects.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_cli.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_vnext_main.py -q`
-- `./.venv/bin/python -m pytest tests/unit/test_mcp.py -q`
 - `./.venv/bin/python -m pytest tests/unit -q`
+- `pnpm --dir apps/web test`
+- `pnpm --dir apps/web lint`
+- `pnpm --dir apps/web build`
 - `python3 scripts/check_control_doc_truth.py`
+- `./.venv/bin/python -c 'from alicebot_api.cli import main; raise SystemExit(main(["eval", "run", "--suite", "all"]))'`
 - `git diff --check`
-
-## Control Tower Decisions Needed
-- decide whether the public default should remain Postgres-first for vNext development while SQLite support is designed
-- decide whether old `memories` rows should be backfilled into full v2 canonical text/domain/sensitivity values before Sprint 2
-- decide which Sprint 11 connectors should become live-backed first and where connector secrets/cursors should live once event-log cursor seeding is no longer enough
+- GitHub PR checks for the release-packaging PR
+- GitHub release view for `v0.5.1-vnext-preview`
 
 ## Exit Condition
-This sprint is complete when the vNext schema foundation, shared contracts, repository interfaces, event-log utility, Brain Charter model, and targeted tests are implemented without regressing the existing unit suite.
+This packet is complete when the release-packaging PR is merged, `v0.5.1-vnext-preview` is pushed as an annotated tag, the GitHub pre-release is published with release notes, and the final release state is verified.

--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -9,9 +9,10 @@
 - Phase 13 is shipped.
 - Phase 14 is shipped.
 - `HF-001` Logging Safety And Disk Guardrails is shipped.
-- `v0.5.1` is the latest published tag.
+- `v0.5.1` remains the latest stable public release tag.
+- `v0.5.1-vnext-preview` is the vNext public-preview tag target.
 - `M-001` Archive Maintenance CI Repair is implemented in this working tree.
-- Alice vNext Sprint 1 - Architecture Foundation and Schema is active.
+- Alice vNext public preview release gate is active.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
@@ -28,25 +29,25 @@
 - The shipped baseline includes logging safety and disk guardrails from `HF-001`, including stdout-by-default local logging, disabled local/Lite access logs by default, and bounded file logging when explicitly enabled.
 - `v0.5.1` is the current public pre-1.0 release boundary for that shipped baseline.
 - The working tree includes the `M-001` archive-maintenance repair: absent archive indexes skip checksum verification, maintenance-user bootstrap commits before benchmark imports, and duplicate workflow alert issues are deduped by commenting on an existing open issue.
-- The working tree includes Alice vNext Sprint 1 foundation work: vNext schema migration, shared JSON schemas, repository protocols, Postgres vNext store facade, event-log helper, and Brain Charter model.
-- The working tree also includes a Sprint 2 capture seed: vNext manual text/file/Markdown/ChatGPT source capture, content-hash dedupe, chunking, candidate-memory creation, provenance links, failure logging, `alicebot vnext sources ...` CLI commands, and minimal source API endpoints for text capture/get/delete.
-- The working tree also includes a Sprint 3 retrieval/context-pack seed: deterministic query classification, keyword memory/source/open-loop retrieval, domain/sensitivity filtering, provenance-backed context packs, trace metadata, `alicebot context-pack`, `/v0/vnext/context-packs`, and `alice_vnext_context_pack` MCP access.
-- The working tree also includes a Sprint 4 queue/artifact seed: vNext task enqueue/process-next behavior, deterministic generated artifacts, artifact review/export actions, `alicebot vnext queue ...` and `alicebot vnext artifacts ...` CLI commands, and queue/artifact API endpoints.
-- The working tree also includes a Sprint 5 brain-workflow seed: deterministic daily brief and weekly synthesis artifacts, source/reference sections, inherited sensitivity, candidate open loops/memories, `alicebot daily-brief`, `alicebot weekly-synthesis`, vNext artifact-generation API endpoints, and MCP tools for daily/weekly generation.
-- The working tree also includes a Sprint 6 connection/graph seed: deterministic connection reports, candidate graph edge creation with confidence/explanations, edge review status, graph neighborhood lookup, `alicebot connections generate`, `alicebot vnext graph ...`, vNext graph API endpoints, and MCP tools for connection/graph operations.
-- The working tree also includes a Sprint 7 contradiction/belief seed: deterministic contradiction reports, candidate contradiction graph edges, direct-conflict versus nuance classification, explicit belief challenge/supersession review actions, belief state history lookup, `alicebot vnext contradictions ...`, `alicebot vnext beliefs ...`, vNext belief/contradiction API endpoints, and MCP tools for contradiction/belief operations.
-- The working tree also includes a Sprint 8 project/open-loop seed: deterministic project update candidate artifacts, candidate project-state memories, accept/edit/reject review actions, open-loop extraction with source/date/owner metadata, close/snooze/edit/reopen open-loop actions, project dashboard data, `alicebot vnext projects ...`, `alicebot vnext open-loops ...`, vNext project/open-loop API endpoints, and MCP tools for project/open-loop operations.
-- The working tree also includes a Sprint 9 UI seed: `/vnext` in the existing Next.js web shell with fixture-backed Home, Inbox, Ask Alice, Daily Brief, Weekly Synthesis, Queue, Generated, Memory Review, Projects, People, Beliefs, Open Loops, Timeline, Graph, and Settings/Privacy surfaces; stateful review actions; Ask Alice provenance; generated artifacts; and visible domain/sensitivity labels.
-- The working tree also includes a Sprint 10 eval/hardening seed: deterministic synthetic benchmark corpus generation, recall/temporal/contradiction/privacy/provenance/open-loop/prompt-injection eval suites, baseline targets, `alicebot eval seed/run/report`, an `alice` console-script alias, report writing, zero critical privacy leaks, and prompt-injection sources quarantined without tool writes.
-- The working tree also includes a Sprint 11 connector expansion seed: deterministic Telegram, browser clipper, PDF/DOCX/CSV/screenshot, and voice-transcript payload ingestion through the vNext capture path, raw evidence preservation, default domain/sensitivity labels, event-log sync cursors, failure isolation, `alicebot vnext connectors ...` CLI commands, connector API endpoints, and fixture-backed connector settings UI.
-- The working tree also includes a Sprint 12 public release polish seed: README vNext preview positioning, docs for quickstart/Docker/local install/architecture/security/privacy/contribution, example `ALICE.md`, synthetic demo dataset, demo video script, and vNext public release checklist with no-secrets and verification gates.
+- The vNext preview includes Sprint 1 foundation work: vNext schema migration, shared JSON schemas, repository protocols, Postgres vNext store facade, event-log helper, and Brain Charter model.
+- The vNext preview includes Sprint 2 capture: vNext manual text/file/Markdown/ChatGPT source capture, content-hash dedupe, chunking, candidate-memory creation, provenance links, failure logging, `alicebot vnext sources ...` CLI commands, and minimal source API endpoints for text capture/get/delete.
+- The vNext preview includes Sprint 3 retrieval/context packs: deterministic query classification, keyword memory/source/open-loop retrieval, domain/sensitivity filtering, provenance-backed context packs, trace metadata, `alicebot context-pack`, `/v0/vnext/context-packs`, and `alice_vnext_context_pack` MCP access.
+- The vNext preview includes Sprint 4 queue/artifacts: vNext task enqueue/process-next behavior, deterministic generated artifacts, artifact review/export actions, `alicebot vnext queue ...` and `alicebot vnext artifacts ...` CLI commands, and queue/artifact API endpoints.
+- The vNext preview includes Sprint 5 brain workflows: deterministic daily brief and weekly synthesis artifacts, source/reference sections, inherited sensitivity, candidate open loops/memories, `alicebot daily-brief`, `alicebot weekly-synthesis`, vNext artifact-generation API endpoints, and MCP tools for daily/weekly generation.
+- The vNext preview includes Sprint 6 connection/graph workflows: deterministic connection reports, candidate graph edge creation with confidence/explanations, edge review status, graph neighborhood lookup, `alicebot connections generate`, `alicebot vnext graph ...`, vNext graph API endpoints, and MCP tools for connection/graph operations.
+- The vNext preview includes Sprint 7 contradiction/belief workflows: deterministic contradiction reports, candidate contradiction graph edges, direct-conflict versus nuance classification, explicit belief challenge/supersession review actions, belief state history lookup, `alicebot vnext contradictions ...`, `alicebot vnext beliefs ...`, vNext belief/contradiction API endpoints, and MCP tools for contradiction/belief operations.
+- The vNext preview includes Sprint 8 project/open-loop workflows: deterministic project update candidate artifacts, candidate project-state memories, accept/edit/reject review actions, open-loop extraction with source/date/owner metadata, close/snooze/edit/reopen open-loop actions, project dashboard data, `alicebot vnext projects ...`, `alicebot vnext open-loops ...`, vNext project/open-loop API endpoints, and MCP tools for project/open-loop operations.
+- The vNext preview includes Sprint 9 UI: `/vnext` in the existing Next.js web shell with fixture-backed Home, Inbox, Ask Alice, Daily Brief, Weekly Synthesis, Queue, Generated, Memory Review, Projects, People, Beliefs, Open Loops, Timeline, Graph, and Settings/Privacy surfaces; stateful review actions; Ask Alice provenance; generated artifacts; and visible domain/sensitivity labels.
+- The vNext preview includes Sprint 10 eval/hardening: deterministic synthetic benchmark corpus generation, recall/temporal/contradiction/privacy/provenance/open-loop/prompt-injection eval suites, baseline targets, `alicebot eval seed/run/report`, an `alice` console-script alias, report writing, zero critical privacy leaks, and prompt-injection sources quarantined without tool writes.
+- The vNext preview includes Sprint 11 connector expansion: deterministic Telegram, browser clipper, PDF/DOCX/CSV/screenshot, and voice-transcript payload ingestion through the vNext capture path, raw evidence preservation, default domain/sensitivity labels, event-log sync cursors, failure isolation, `alicebot vnext connectors ...` CLI commands, connector API endpoints, and fixture-backed connector settings UI.
+- The vNext preview includes Sprint 12 public release polish: README vNext preview positioning, docs for quickstart/Docker/local install/architecture/security/privacy/contribution, example `ALICE.md`, synthetic demo dataset, demo video script, and vNext public release checklist with no-secrets and verification gates.
 
 ## Phase Transition Note
 - Phase 14 is complete as a feature phase.
 - `HF-001` is complete as a defect-only hardening sprint.
 - `v0.5.1` closes the shipped Phase 14 platform plus the post-phase logging safety hardening.
 - `M-001` is implemented in this working tree and should be validated in GitHub Actions after PR push/merge.
-- Alice vNext Sprint 1 is now the active build sprint on top of that repaired baseline.
+- Alice vNext Sprint 1 through Sprint 12 preview scope is implemented and in the public-preview release gate.
 
 ## Immediate Control Tower Decisions Needed
 - Use the separate `PostgresVNextStore` facade as the Sprint 2 persistence boundary unless a concrete integration blocker appears.
@@ -58,8 +59,8 @@
 - Decide how accepted vNext graph edges should influence retrieval ranking beyond trace/neighborhood visibility.
 - Decide how vNext belief status history should be unified with the existing temporal-state APIs and whether contradiction classification should use model-backed evidence review.
 - Decide how project-update rejection suppression should be persisted beyond event logs and how UI project pages should expose candidate review state.
-- Decide which vNext UI surfaces should become live-backed first after the fixture-backed Sprint 9 seed.
-- Decide when the deterministic Sprint 10 eval harness should graduate to model-backed, live-store-backed, or human-rated scoring.
-- Decide which Sprint 11 connectors should become live-backed first and where connector secrets/cursors should live once event-log cursor seeding is no longer enough.
-- Decide whether Sprint 12 docs are enough to tag a vNext preview or whether a fresh-machine install timing run is required first.
+- Decide which vNext UI surfaces should become live-backed first after the fixture-backed preview.
+- Decide when the deterministic eval harness should graduate to model-backed, live-store-backed, or human-rated scoring.
+- Decide which connectors should become live-backed first and where connector secrets/cursors should live once event-log cursor seeding is no longer enough.
+- After the preview tag, decide the next build slice: live-backed UI, connector auth/polling, production scheduling, or model-backed evaluation.
 - Avoid reopening completed Phase 14 or `HF-001` scope unless a concrete defect or release-readiness issue is identified.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Scope Boundary
 - **Shipped baseline:** Phases 9-14, `HF-001`, and Bridge `B1` through `B4`.
-- **Current execution posture:** `v0.5.1` is the latest published tag; Phase 14 and `HF-001` are shipped; no post-Phase-14 execution sprint is active yet.
+- **Current execution posture:** `v0.5.1` remains the stable public release tag; Phase 14 and `HF-001` are shipped; `v0.5.1-vnext-preview` is the vNext public-preview tag target.
 - **Release principle:** `v0.5.1` is the current pre-1.0 public release boundary for the shipped Phase 14 platform plus the logging-safety hardening.
 
 ## Current System Overview
@@ -139,5 +139,6 @@ Alice is a modular continuity platform with shared continuity semantics across l
 
 ## Current Architectural Posture
 - `v0.5.1` is the active public release boundary.
+- `v0.5.1-vnext-preview` packages the local-first vNext public preview without changing the stable baseline boundary.
 - Alice is now a broader continuity platform with provider/runtime portability, model packs, runnable external-builder integrations, design-partner launch/admin support, and safe local logging defaults.
 - The continuity substrate remains the same system of record; the delivered work packages that substrate into practical adoption paths without changing the core continuity semantics.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -2,66 +2,59 @@
 
 ## sprint objective
 
-Close out Phase 14, promote the public release boundary to `v0.5.1`, and align the canonical docs plus version metadata to the shipped Phase 14 + `HF-001` baseline.
+Package the completed Alice vNext preview for the `v0.5.1-vnext-preview` public pre-release while preserving `v0.5.1` as the stable pre-1.0 public release line.
 
 ## completed work
 
-- added Phase 14 closeout summary and closeout packet
-- added `v0.5.1` release checklist, tag plan, and public release runbook
-- updated canonical control docs to treat Phase 14 and `HF-001` as shipped baseline truth
-- promoted README and other release-facing docs from the `v0.4.0` boundary to `v0.5.1`
-- aligned Python, API, web, CLI, core-package, and Hermes plugin version metadata to `0.5.1`
-- switched the active packet into a release-closeout state for the shipped `v0.5.1` boundary
+- added vNext preview release notes
+- added the `v0.5.1-vnext-preview` tag plan and rollback path
+- completed the vNext public release checklist with current evidence
+- updated README and vNext docs to link the release notes and tag plan
+- added a 2026-05-11 changelog entry for the vNext preview release package
+- realigned control docs away from stale "Sprint 1 active" wording and into the vNext public-preview release gate
+- kept stable release truth explicit: `v0.5.1` remains the stable pre-1.0 public release boundary
 
 ## incomplete work
 
-- full public release gates were not rerun as part of this closeout-doc update
-- GitHub release publishing is outside this local repo update unless run separately
+- no implementation work remains for the preview release package
+- live connector OAuth/polling, hosted SLA, automatic memory promotion, production scheduling, live-backed `/vnext`, and model-backed evals remain intentionally deferred beyond this preview
 
 ## files changed
 
 - `.ai/active/SPRINT_PACKET.md`
 - `.ai/handoff/CURRENT_STATE.md`
-- `CURRENT_STATE.md`
-- `ROADMAP.md`
-- `PRODUCT_BRIEF.md`
 - `ARCHITECTURE.md`
-- `RULES.md`
-- `README.md`
-- `CHANGELOG.md`
-- `pyproject.toml`
-- `apps/web/package.json`
-- `packages/alice-cli/package.json`
-- `packages/alice-core/package.json`
-- `apps/api/src/alicebot_api/__init__.py`
-- `apps/api/src/alicebot_api/main.py`
-- `packages/alice-core/index.js`
-- `packages/alice-cli/bin/alice.js`
-- `docs/integrations/hermes-memory-provider/plugins/memory/alice/plugin.yaml`
-- `docs/quickstart/local-setup-and-first-result.md`
-- `docs/integrations/mcp.md`
-- `docs/integrations/reference-paths.md`
-- `docs/integrations/hermes-bridge-operator-guide.md`
-- `docs/npm-publish-quickstart.md`
-- `docs/phase14-closeout-summary.md`
-- `docs/runbooks/phase14-closeout-packet.md`
-- `docs/release/v0.5.1-release-checklist.md`
-- `docs/release/v0.5.1-tag-plan.md`
-- `docs/runbooks/v0.5.1-public-release-runbook.md`
-- `scripts/check_control_doc_truth.py`
 - `BUILD_REPORT.md`
+- `CHANGELOG.md`
+- `CURRENT_STATE.md`
+- `PRODUCT_BRIEF.md`
+- `README.md`
 - `REVIEW_REPORT.md`
+- `ROADMAP.md`
+- `docs/release/v0.5.1-vnext-preview-release-notes.md`
+- `docs/release/v0.5.1-vnext-preview-tag-plan.md`
+- `docs/release/v0.5.1-tag-plan.md`
+- `docs/release/vnext-public-release-checklist.md`
+- `docs/vnext/README.md`
+- `scripts/check_control_doc_truth.py`
 
 ## tests run
 
-- `python3 scripts/check_control_doc_truth.py`
-- `./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q`
+- real Postgres vNext smoke covering CLI, API, and MCP paths: passed
+- `./.venv/bin/python -m pytest tests/unit -q`: `1057 passed`
+- `pnpm --dir apps/web test`: `205 passed`
+- `pnpm --dir apps/web lint`: passed
+- `pnpm --dir apps/web build`: passed
+- `python3 scripts/check_control_doc_truth.py`: passed
+- `./.venv/bin/python -c 'from alicebot_api.cli import main; raise SystemExit(main(["eval", "run", "--suite", "all"]))'`: `170/170` cases, zero critical privacy leaks, zero prompt-injection tool writes
+- `git diff --check`: clean
+- GitHub Security Scans on merged `main`: CodeQL JavaScript, CodeQL Python, and Gitleaks passed
 
 ## blockers/issues
 
-- no implementation blocker remains for the closeout/update scope
-- full release gates are documented in the `v0.5.1` checklist and runbook but were not rerun in this doc/version-alignment pass
+- no release blocker remains for the vNext preview package
+- GitHub Actions reports a non-blocking Node.js 20 deprecation notice for existing third-party actions; this is maintenance follow-up, not a preview release blocker
 
 ## recommended next step
 
-Use the `v0.5.1` release checklist and tag plan if a full release-gate rerun is desired, otherwise treat this as the accepted release-boundary update for the shipped Phase 14 + `HF-001` baseline.
+Merge the release-packaging PR, create the annotated `v0.5.1-vnext-preview` tag from merged `main`, and publish the GitHub release as a pre-release with `--latest=false`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-05-11
+
+- Prepared the Alice vNext public-preview release package for `v0.5.1-vnext-preview`.
+- Promoted the vNext preview docs from release-candidate posture to tag-ready preview posture while keeping `v0.5.1` as the current stable pre-1.0 public release.
+- Added vNext preview release notes and tag plan with rollback instructions.
+- Completed the vNext public release checklist with current verification evidence.
+- Realigned control docs from stale "Sprint 1 active" wording to the completed Sprint 1-12 preview surface and the active vNext release gate.
+- Verified the vNext Postgres-backed CLI/API/MCP smoke path, full unit suite, web test/lint/build gates, control-doc truth check, eval harness, Git diff whitespace check, and post-merge GitHub Security Scans.
+
 ## 2026-04-16
 
 - Closed out Phase 14 after shipping all five planned sprints:

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -12,9 +12,10 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - Phase 13 is shipped.
 - Phase 14 is shipped.
 - `HF-001` Logging Safety And Disk Guardrails is shipped.
-- `v0.5.1` is the latest published tag.
+- `v0.5.1` remains the latest stable public release tag.
+- `v0.5.1-vnext-preview` is the vNext public-preview tag target.
 - `M-001` Archive Maintenance CI Repair is implemented in this working tree.
-- Alice vNext Sprint 1 - Architecture Foundation and Schema is active.
+- Alice vNext public preview release gate is active.
 
 ## Current Baseline Truth
 - Alice has typed memory, provenance, trust classes, correction/supersession behavior, open loops, recall, resumption, and explainability.
@@ -31,25 +32,25 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - The shipped baseline includes logging safety and disk guardrails from `HF-001`, including stdout-by-default local logging, disabled local/Lite access logs by default, and bounded file logging when explicitly enabled.
 - `v0.5.1` is the current public pre-1.0 release boundary for that shipped baseline.
 - The working tree includes the `M-001` archive-maintenance repair: absent archive indexes skip checksum verification, maintenance-user bootstrap commits before benchmark imports, and duplicate workflow alert issues are deduped by commenting on an existing open issue.
-- The working tree includes Alice vNext Sprint 1 foundation work: vNext schema migration, shared JSON schemas, repository protocols, Postgres vNext store facade, event-log helper, and Brain Charter model.
-- The working tree also includes a Sprint 2 capture seed: vNext manual text/file/Markdown/ChatGPT source capture, content-hash dedupe, chunking, candidate-memory creation, provenance links, failure logging, `alicebot vnext sources ...` CLI commands, and minimal source API endpoints for text capture/get/delete.
-- The working tree also includes a Sprint 3 retrieval/context-pack seed: deterministic query classification, keyword memory/source/open-loop retrieval, domain/sensitivity filtering, provenance-backed context packs, trace metadata, `alicebot context-pack`, `/v0/vnext/context-packs`, and `alice_vnext_context_pack` MCP access.
-- The working tree also includes a Sprint 4 queue/artifact seed: vNext task enqueue/process-next behavior, deterministic generated artifacts, artifact review/export actions, `alicebot vnext queue ...` and `alicebot vnext artifacts ...` CLI commands, and queue/artifact API endpoints.
-- The working tree also includes a Sprint 5 brain-workflow seed: deterministic daily brief and weekly synthesis artifacts, source/reference sections, inherited sensitivity, candidate open loops/memories, `alicebot daily-brief`, `alicebot weekly-synthesis`, vNext artifact-generation API endpoints, and MCP tools for daily/weekly generation.
-- The working tree also includes a Sprint 6 connection/graph seed: deterministic connection reports, candidate graph edge creation with confidence/explanations, edge review status, graph neighborhood lookup, `alicebot connections generate`, `alicebot vnext graph ...`, vNext graph API endpoints, and MCP tools for connection/graph operations.
-- The working tree also includes a Sprint 7 contradiction/belief seed: deterministic contradiction reports, candidate contradiction graph edges, direct-conflict versus nuance classification, explicit belief challenge/supersession review actions, belief state history lookup, `alicebot vnext contradictions ...`, `alicebot vnext beliefs ...`, vNext belief/contradiction API endpoints, and MCP tools for contradiction/belief operations.
-- The working tree also includes a Sprint 8 project/open-loop seed: deterministic project update candidate artifacts, candidate project-state memories, accept/edit/reject review actions, open-loop extraction with source/date/owner metadata, close/snooze/edit/reopen open-loop actions, project dashboard data, `alicebot vnext projects ...`, `alicebot vnext open-loops ...`, vNext project/open-loop API endpoints, and MCP tools for project/open-loop operations.
-- The working tree also includes a Sprint 9 UI seed: `/vnext` in the existing Next.js web shell with fixture-backed Home, Inbox, Ask Alice, Daily Brief, Weekly Synthesis, Queue, Generated, Memory Review, Projects, People, Beliefs, Open Loops, Timeline, Graph, and Settings/Privacy surfaces; stateful review actions; Ask Alice provenance; generated artifacts; and visible domain/sensitivity labels.
-- The working tree also includes a Sprint 10 eval/hardening seed: deterministic synthetic benchmark corpus generation, recall/temporal/contradiction/privacy/provenance/open-loop/prompt-injection eval suites, baseline targets, `alicebot eval seed/run/report`, an `alice` console-script alias, report writing, zero critical privacy leaks, and prompt-injection sources quarantined without tool writes.
-- The working tree also includes a Sprint 11 connector expansion seed: deterministic Telegram, browser clipper, PDF/DOCX/CSV/screenshot, and voice-transcript payload ingestion through the vNext capture path, raw evidence preservation, default domain/sensitivity labels, event-log sync cursors, failure isolation, `alicebot vnext connectors ...` CLI commands, connector API endpoints, and fixture-backed connector settings UI.
-- The working tree also includes a Sprint 12 public release polish seed: README vNext preview positioning, docs for quickstart/Docker/local install/architecture/security/privacy/contribution, example `ALICE.md`, synthetic demo dataset, demo video script, and vNext public release checklist with no-secrets and verification gates.
+- The vNext preview includes Sprint 1 foundation work: vNext schema migration, shared JSON schemas, repository protocols, Postgres vNext store facade, event-log helper, and Brain Charter model.
+- The vNext preview includes Sprint 2 capture: vNext manual text/file/Markdown/ChatGPT source capture, content-hash dedupe, chunking, candidate-memory creation, provenance links, failure logging, `alicebot vnext sources ...` CLI commands, and minimal source API endpoints for text capture/get/delete.
+- The vNext preview includes Sprint 3 retrieval/context packs: deterministic query classification, keyword memory/source/open-loop retrieval, domain/sensitivity filtering, provenance-backed context packs, trace metadata, `alicebot context-pack`, `/v0/vnext/context-packs`, and `alice_vnext_context_pack` MCP access.
+- The vNext preview includes Sprint 4 queue/artifacts: vNext task enqueue/process-next behavior, deterministic generated artifacts, artifact review/export actions, `alicebot vnext queue ...` and `alicebot vnext artifacts ...` CLI commands, and queue/artifact API endpoints.
+- The vNext preview includes Sprint 5 brain workflows: deterministic daily brief and weekly synthesis artifacts, source/reference sections, inherited sensitivity, candidate open loops/memories, `alicebot daily-brief`, `alicebot weekly-synthesis`, vNext artifact-generation API endpoints, and MCP tools for daily/weekly generation.
+- The vNext preview includes Sprint 6 connection/graph workflows: deterministic connection reports, candidate graph edge creation with confidence/explanations, edge review status, graph neighborhood lookup, `alicebot connections generate`, `alicebot vnext graph ...`, vNext graph API endpoints, and MCP tools for connection/graph operations.
+- The vNext preview includes Sprint 7 contradiction/belief workflows: deterministic contradiction reports, candidate contradiction graph edges, direct-conflict versus nuance classification, explicit belief challenge/supersession review actions, belief state history lookup, `alicebot vnext contradictions ...`, `alicebot vnext beliefs ...`, vNext belief/contradiction API endpoints, and MCP tools for contradiction/belief operations.
+- The vNext preview includes Sprint 8 project/open-loop workflows: deterministic project update candidate artifacts, candidate project-state memories, accept/edit/reject review actions, open-loop extraction with source/date/owner metadata, close/snooze/edit/reopen open-loop actions, project dashboard data, `alicebot vnext projects ...`, `alicebot vnext open-loops ...`, vNext project/open-loop API endpoints, and MCP tools for project/open-loop operations.
+- The vNext preview includes Sprint 9 UI: `/vnext` in the existing Next.js web shell with fixture-backed Home, Inbox, Ask Alice, Daily Brief, Weekly Synthesis, Queue, Generated, Memory Review, Projects, People, Beliefs, Open Loops, Timeline, Graph, and Settings/Privacy surfaces; stateful review actions; Ask Alice provenance; generated artifacts; and visible domain/sensitivity labels.
+- The vNext preview includes Sprint 10 eval/hardening: deterministic synthetic benchmark corpus generation, recall/temporal/contradiction/privacy/provenance/open-loop/prompt-injection eval suites, baseline targets, `alicebot eval seed/run/report`, an `alice` console-script alias, report writing, zero critical privacy leaks, and prompt-injection sources quarantined without tool writes.
+- The vNext preview includes Sprint 11 connector expansion: deterministic Telegram, browser clipper, PDF/DOCX/CSV/screenshot, and voice-transcript payload ingestion through the vNext capture path, raw evidence preservation, default domain/sensitivity labels, event-log sync cursors, failure isolation, `alicebot vnext connectors ...` CLI commands, connector API endpoints, and fixture-backed connector settings UI.
+- The vNext preview includes Sprint 12 public release polish: README vNext preview positioning, docs for quickstart/Docker/local install/architecture/security/privacy/contribution, example `ALICE.md`, synthetic demo dataset, demo video script, and vNext public release checklist with no-secrets and verification gates.
 
 ## Phase Transition Note
 - Phase 14 is complete as a feature phase.
 - `HF-001` is complete as a defect-only hardening sprint.
 - `v0.5.1` closes the shipped Phase 14 platform plus the post-phase logging safety hardening.
 - `M-001` is implemented in this working tree and should be validated in GitHub Actions after PR push/merge.
-- Alice vNext Sprint 1 is now the active build sprint on top of that repaired baseline.
+- Alice vNext Sprint 1 through Sprint 12 preview scope is implemented and in the public-preview release gate.
 
 ## Immediate Control Tower Decisions Needed
 - Use the separate `PostgresVNextStore` facade as the Sprint 2 persistence boundary unless a concrete integration blocker appears.
@@ -61,8 +62,8 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - Decide how accepted vNext graph edges should influence retrieval ranking beyond trace/neighborhood visibility.
 - Decide how vNext belief status history should be unified with the existing temporal-state APIs and whether contradiction classification should use model-backed evidence review.
 - Decide how project-update rejection suppression should be persisted beyond event logs and how UI project pages should expose candidate review state.
-- Decide which vNext UI surfaces should become live-backed first after the fixture-backed Sprint 9 seed.
-- Decide when the deterministic Sprint 10 eval harness should graduate to model-backed, live-store-backed, or human-rated scoring.
-- Decide which Sprint 11 connectors should become live-backed first and where connector secrets/cursors should live once event-log cursor seeding is no longer enough.
-- Decide whether Sprint 12 docs are enough to tag a vNext preview or whether a fresh-machine install timing run is required first.
+- Decide which vNext UI surfaces should become live-backed first after the fixture-backed preview.
+- Decide when the deterministic eval harness should graduate to model-backed, live-store-backed, or human-rated scoring.
+- Decide which connectors should become live-backed first and where connector secrets/cursors should live once event-log cursor seeding is no longer enough.
+- After the preview tag, decide the next build slice: live-backed UI, connector auth/polling, production scheduling, or model-backed evaluation.
 - Avoid reopening completed Phase 14 or `HF-001` scope unless a concrete defect or release-readiness issue is identified.

--- a/PRODUCT_BRIEF.md
+++ b/PRODUCT_BRIEF.md
@@ -12,12 +12,14 @@ Alice is a pre-1.0 continuity platform for AI agents and agent-assisted workflow
 - Phase 13 shipped one-call continuity, Alice Lite, and memory hygiene / conversation health visibility.
 - Phase 14 shipped provider adapters, model packs, reference integrations, and design-partner launch/admin surfaces.
 - `HF-001` shipped logging safety and disk guardrails for local/Lite runtime behavior.
-- `v0.5.1` is the latest published pre-1.0 release tag.
+- `v0.5.1` is the latest stable pre-1.0 release tag.
+- `v0.5.1-vnext-preview` is the vNext public-preview pre-release target.
 
 ## Current Repo Posture
 - Phase 14 is shipped.
 - `HF-001` is shipped.
-- No post-Phase-14 execution sprint is active yet.
+- Alice vNext Sprint 1 through Sprint 12 preview scope is implemented.
+- Alice vNext public preview release gate is active.
 
 ## Latest Completed Phase
 ### Phase 14: Provider Adapters + Design Partner Launch
@@ -60,4 +62,5 @@ Phase 14 turned Alice from a strong continuity system into a practical integrati
 
 ## Immediate Product Posture
 - `v0.5.1` is the current public release boundary.
-- The next product decision is the next phase definition on top of the shipped Phase 14 + `HF-001` baseline.
+- `v0.5.1-vnext-preview` is the vNext public-preview release target on top of the shipped Phase 14 + `HF-001` baseline.
+- The next product decision after the preview tag is whether to prioritize live-backed UI, connector auth/polling, production scheduling, or model-backed evaluation.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Alice helps agents **remember what matters, resume interrupted work, explain why
 `v0.5.1` is the current **pre-1.0 public release**.
 
 This working tree also contains the Alice vNext public-preview seed described in
-[docs/vnext/README.md](docs/vnext/README.md). vNext is not tagged as the current public release yet.
+[docs/vnext/README.md](docs/vnext/README.md). The vNext preview uses the pre-release tag
+`v0.5.1-vnext-preview`; `v0.5.1` remains the current stable pre-1.0 public release.
 
 Most assistants are still good only in the moment. They can answer the current prompt, but they struggle to preserve decisions, track open loops, recover context across sessions, and stay aligned after memory corrections.
 
@@ -49,6 +50,8 @@ Start with:
 - [Example ALICE.md](docs/vnext/ALICE.example.md)
 - [vNext demo video script](docs/vnext/demo-video-script.md)
 - [vNext release checklist](docs/release/vnext-public-release-checklist.md)
+- [vNext preview release notes](docs/release/v0.5.1-vnext-preview-release-notes.md)
+- [vNext preview tag plan](docs/release/v0.5.1-vnext-preview-tag-plan.md)
 
 ## Release Boundary (`v0.5.1`)
 

--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -4,26 +4,24 @@
 PASS
 
 ## criteria met
-- Canonical docs now describe the shipped Phase 14 surface plus `HF-001` instead of the older `v0.4.0` / Phase 13 boundary.
-- The public release boundary is promoted coherently to `v0.5.1` across control docs, release docs, and code/package version metadata.
-- Phase 14 closeout artifacts now exist:
-  - `docs/phase14-closeout-summary.md`
-  - `docs/runbooks/phase14-closeout-packet.md`
-  - `docs/release/v0.5.1-release-checklist.md`
-  - `docs/release/v0.5.1-tag-plan.md`
-  - `docs/runbooks/v0.5.1-public-release-runbook.md`
-- The active packet is now a release-closeout packet rather than a stale active build sprint.
-- Control-doc verification passed.
+- The stable public release boundary remains `v0.5.1`.
+- The vNext preview is clearly scoped to the pre-release tag `v0.5.1-vnext-preview`.
+- Release notes, tag plan, rollback path, changelog entry, and completed vNext release checklist are present.
+- README and vNext docs link the preview overview, quickstart, architecture, security/privacy, demo script, release checklist, release notes, and tag plan.
+- Control docs now describe the vNext public-preview release gate instead of stale Sprint 1 active status.
+- Known limitations remain explicit: no hosted SLA, no live connector OAuth/polling, no automatic generated-artifact promotion, no production scheduler, no live-backed `/vnext`, and no model-backed eval scoring.
+- Current validation evidence is recorded in the release checklist and build report.
 
 ## criteria missed
-- none for the closeout/update scope
+- none for the release-packaging scope
 
 ## quality issues
 - none blocking
-- full release gates were not rerun in this closeout-doc update, so the new release checklist remains the source of truth for a full rerun if desired
+- GitHub Actions reports a non-blocking Node.js 20 deprecation notice for existing actions; track separately as maintenance work
 
 ## regression risks
-- low for this scope because the changes are doc/version/closeout alignment only
+- low for this release-packaging scope because changes are docs, release metadata, and control-doc alignment only
+- vNext runtime risk was covered separately by the real Postgres CLI/API/MCP smoke and unit/web/eval gates
 
 ## docs issues
 - none blocking
@@ -32,9 +30,9 @@ PASS
 - no
 
 ## should anything update ARCHITECTURE.md?
-- no further update is needed beyond the shipped-boundary alignment already included here
+- yes, updated current execution posture to include the vNext preview pre-release target without changing the stable baseline boundary
 
 ## recommended next action
-- accept the closeout update
-- use `v0.5.1` as the current shipped boundary
-- keep the release-closeout packet in place until the next phase packet is accepted
+- squash-merge the release-packaging PR
+- tag merged `main` as `v0.5.1-vnext-preview`
+- publish the GitHub release as a pre-release with `--latest=false`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,8 @@ These remain baseline truth and are not future milestones.
 - Phase 14 is shipped.
 - `HF-001` Logging Safety And Disk Guardrails is shipped.
 - `M-001` Archive Maintenance CI Repair is implemented in this working tree.
-- Alice vNext Sprint 1 - Architecture Foundation and Schema is active.
+- Alice vNext Sprint 1 through Sprint 12 preview scope is implemented.
+- Alice vNext public preview release gate is active for `v0.5.1-vnext-preview`.
 
 ## Completed Phase 14 Sequence
 
@@ -49,28 +50,16 @@ Status: shipped
 - repair weekly benchmark regeneration failure caused by maintenance-user foreign-key setup
 - keep the fix narrow and operational rather than turning it into a new feature phase
 
-## Active Feature Sprint
+## Active Release Gate
 
-### Alice vNext Sprint 1: Architecture Foundation and Schema
-- add vNext memory-kernel schema foundations without destructive reorganization
-- add shared schema contracts, repository interfaces, and a Postgres vNext store facade
-- add append-only event-log helper and Brain Charter model
-- cover Sprint 1 entities with CRUD-style store tests and event-log write tests
-- seed Sprint 2 capture/archive/normalize with text/file/Markdown/ChatGPT capture, hash dedupe, chunking, candidate memories, provenance links, failure logging, CLI commands, and source API endpoints
-- seed Sprint 3 retrieval/context packs with query classification, keyword retrieval, graph/vector/temporal scaffolds, sensitivity filtering, trace metadata, and CLI/API/MCP access
-- seed Sprint 4 queue/artifacts with task enqueue/process-next behavior, deterministic generated artifacts, artifact review/export actions, and CLI/API access
-- seed Sprint 5 daily/weekly brain workflows with deterministic brief/synthesis artifacts, source sections, inherited sensitivity, candidate review objects, and CLI/API/MCP manual triggers
-- seed Sprint 6 connection/graph workflows with deterministic connection reports, candidate graph edges, edge review status, graph neighborhood lookup, and CLI/API/MCP access
-- seed Sprint 7 contradiction/belief workflows with deterministic contradiction reports, candidate contradiction edges, belief challenge/supersession review actions, belief state history lookup, and CLI/API/MCP access
-- seed Sprint 8 project/open-loop workflows with project update candidate artifacts, candidate project-state memories, open-loop extraction/review actions, project dashboard data, and CLI/API/MCP access
-- seed Sprint 9 UI with a fixture-backed `/vnext` workspace covering Home, Inbox, Ask Alice, Daily Brief, Weekly Synthesis, Queue, Generated artifacts, Memory Review, Projects, People, Beliefs, Open Loops, Timeline, Graph, and Settings/Privacy
-- seed Sprint 10 evals/hardening with deterministic synthetic benchmark corpus generation, recall/temporal/contradiction/privacy/provenance/open-loop/prompt-injection suites, baseline metrics, report writing, and `alicebot eval seed/run/report`
-- seed Sprint 11 connector expansion with deterministic Telegram, browser clipper, PDF/DOCX/CSV/screenshot, and voice-transcript payload ingestion, raw evidence preservation, default domain/sensitivity labels, event-log sync cursors, failure isolation, connector API/CLI access, and connector settings UI
-- seed Sprint 12 public release polish with README vNext preview positioning, quickstart/Docker/local install docs, architecture and security/privacy docs, example ALICE.md, contributor guide, synthetic demo dataset, demo video script, and vNext public release checklist
-- preserve `v0.5.1`/Phase 14 behavior while vNext is built incrementally
+### Alice vNext Public Preview: `v0.5.1-vnext-preview`
+- publish the completed Sprint 1-12 vNext preview as a pre-release without replacing stable `v0.5.1`
+- preserve `v0.5.1`/Phase 14 behavior while documenting the vNext preview boundary
+- include current release evidence for Postgres-backed CLI/API/MCP smoke, full unit tests, web tests/lint/build, control-doc truth, evals, and security scans
+- keep explicit preview limitations: no hosted SLA, no live connector OAuth/polling, no automatic artifact promotion, no production scheduler, no live-backed `/vnext` expansion
 
 ## Next Roadmap Gate
-- Validate the vNext migration against live Postgres and run a timed fresh-machine quickstart before deciding whether to tag a vNext preview. Remaining product slices are production scheduling, live connector auth/polling, live-backed UI expansion, and model-backed/live-store evals.
+- After the vNext preview tag, choose the next product slice: production scheduling, live connector auth/polling, live-backed UI expansion, or model-backed/live-store evals.
 - Preserve the shipped Phase 14 platform plus the `HF-001` logging guardrails as baseline behavior.
 
 ## Beyond Phase 14

--- a/docs/release/v0.5.1-tag-plan.md
+++ b/docs/release/v0.5.1-tag-plan.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 Define the next public pre-1.0 tag cut for Alice after the completed Phase 14 boundary and shipped `HF-001` hardening.
-The latest published tag remains `v0.4.0` until this plan is executed.
+This plan has been executed; `v0.5.1` is the stable public release boundary that the vNext preview builds on.
 
 ## Tag Target
 

--- a/docs/release/v0.5.1-vnext-preview-release-notes.md
+++ b/docs/release/v0.5.1-vnext-preview-release-notes.md
@@ -1,0 +1,49 @@
+# v0.5.1 vNext Preview Release Notes
+
+Release date: 2026-05-11
+Preview tag: `v0.5.1-vnext-preview`
+Stable public release: `v0.5.1`
+Release type: public pre-release preview
+
+## Summary
+
+Alice vNext is now ready as a public preview of the true second-brain direction on top of the stable `v0.5.1` baseline. The preview is local-first and deterministic: it proves the vNext memory kernel, reviewable generated artifacts, connector-backed evidence capture, context packs, CLI/API/MCP access, eval harness, and fixture-backed `/vnext` workspace without claiming hosted SLA or live connector automation.
+
+## Included Preview Surface
+
+- vNext memory-kernel schema, shared JSON contracts, Postgres store facade, event log, and Brain Charter model.
+- Source capture for manual text, local text/Markdown files, Markdown folders, and ChatGPT exports.
+- Context packs with domain/sensitivity filters, provenance, retrieval trace metadata, CLI/API/MCP access, and JSON-safe Postgres row handling.
+- Queue/artifact workflows with reviewable generated artifacts, export actions, and explicit review state.
+- Daily brief, weekly synthesis, connection report, contradiction/belief, project update, and open-loop workflows.
+- Deterministic connector payload ingestion for Telegram, browser clipper, PDF, DOCX, CSV, screenshot OCR, and voice transcript payloads.
+- Fixture-backed `/vnext` workspace covering Home, Inbox, Ask Alice, briefs, queue, generated artifacts, memory review, projects, people, beliefs, open loops, timeline, graph, and settings/privacy.
+- Synthetic eval corpus and baseline suites for recall, temporal reasoning, contradictions, provenance, privacy, open loops, and prompt-injection write safety.
+- Public-preview docs: quickstart, architecture, security/privacy, contributor guide, synthetic demo dataset, demo video script, release checklist, and tag plan.
+
+## Verification
+
+Release-readiness evidence recorded on 2026-05-11:
+
+- Real Postgres vNext smoke passed for source capture, connector ingest, scoped and unscoped context packs, daily brief generation, project update review, open-loop close, API context packs, API project dashboard, MCP context pack, and MCP project dashboard.
+- `./.venv/bin/python -m pytest tests/unit -q`: `1057 passed`.
+- `pnpm --dir apps/web test`: `205 passed`.
+- `pnpm --dir apps/web lint`: passed.
+- `pnpm --dir apps/web build`: passed and built `/vnext`.
+- `python3 scripts/check_control_doc_truth.py`: passed.
+- `./.venv/bin/python -c 'from alicebot_api.cli import main; raise SystemExit(main(["eval", "run", "--suite", "all"]))'`: `170/170` cases, zero critical privacy leaks, zero prompt-injection tool writes.
+- `git diff --check`: clean.
+- GitHub Security Scans on merged `main` passed for CodeQL JavaScript, CodeQL Python, and Gitleaks.
+
+## Known Limitations
+
+- vNext is a local-first preview, not a hosted launch.
+- Connector support is deterministic payload ingestion only; live OAuth, external polling, browser extension actions, OCR model execution, and transcription model execution are deferred.
+- Generated artifacts are reviewable and are not auto-promoted to trusted memory.
+- Production daily/weekly scheduling is deferred.
+- The `/vnext` workspace is fixture-backed; live-backed UI expansion remains future work.
+- Model-backed or human-rated eval scoring is deferred beyond this deterministic synthetic preview.
+
+## Upgrade And Rollback
+
+Use `v0.5.1` for the stable pre-1.0 public release line. Use `v0.5.1-vnext-preview` only when testing the preview surface. Roll back by checking out `v0.5.1` or by disabling vNext routes and avoiding the `20260510_0067_vnext_memory_kernel_schema.py` migration in a disposable preview database.

--- a/docs/release/v0.5.1-vnext-preview-tag-plan.md
+++ b/docs/release/v0.5.1-vnext-preview-tag-plan.md
@@ -1,0 +1,75 @@
+# v0.5.1-vnext-preview Tag Plan
+
+## Purpose
+
+Cut the first public pre-release tag for the Alice vNext preview without replacing the stable `v0.5.1` public release line.
+
+## Tag Target
+
+- preview tag: `v0.5.1-vnext-preview`
+- target branch: `main` after accepted vNext preview release-packaging merge
+- release type: GitHub pre-release
+- stable release line: `v0.5.1`
+
+## Required Inputs
+
+- passing vNext public release checklist: `docs/release/vnext-public-release-checklist.md`
+- release notes: `docs/release/v0.5.1-vnext-preview-release-notes.md`
+- changelog entry: `CHANGELOG.md`
+- current build and review evidence: `BUILD_REPORT.md` and `REVIEW_REPORT.md`
+
+## Tag Procedure
+
+1. Confirm the vNext release checklist is complete.
+2. Confirm `main` contains the accepted vNext preview release-packaging merge.
+3. Create the annotated tag:
+
+```bash
+git checkout main
+git pull origin main
+git tag -a v0.5.1-vnext-preview -m "Alice v0.5.1 vNext public preview"
+git push origin v0.5.1-vnext-preview
+```
+
+4. Publish GitHub release notes as a pre-release without replacing the latest stable release:
+
+```bash
+gh release create v0.5.1-vnext-preview \
+  --repo samrusani/AliceBot \
+  --title "Alice v0.5.1 vNext Preview" \
+  --notes-file docs/release/v0.5.1-vnext-preview-release-notes.md \
+  --prerelease \
+  --latest=false \
+  --verify-tag
+```
+
+## Release Notes Scope
+
+- local-first vNext memory kernel
+- vNext source capture, retrieval/context packs, queue/artifacts, brain workflows, graph/contradiction/belief/project/open-loop workflows
+- deterministic connector payload ingestion for Telegram, browser clipper, PDF, DOCX, CSV, screenshot OCR, and voice transcripts
+- fixture-backed `/vnext` workspace
+- deterministic synthetic eval harness and baseline metrics
+- public-preview docs and release checklist
+
+## Explicitly Deferred
+
+- hosted SLA or managed cloud launch
+- live connector OAuth, polling, browser extension actions, OCR model execution, or transcription model execution
+- automatic promotion of generated artifacts into trusted memory
+- production scheduler for daily/weekly generation
+- live-backed expansion of the `/vnext` UI
+- model-backed or human-rated eval scoring
+
+## Rollback
+
+- Keep `v0.5.1` as the stable public release line.
+- If the preview release must be withdrawn before immutable release protections apply, delete the GitHub pre-release and remote preview tag:
+
+```bash
+gh release delete v0.5.1-vnext-preview --repo samrusani/AliceBot --yes
+git push origin :refs/tags/v0.5.1-vnext-preview
+git tag -d v0.5.1-vnext-preview
+```
+
+- For local runtime rollback, check out `v0.5.1` and use a database snapshot or disposable preview database that predates `20260510_0067_vnext_memory_kernel_schema.py`.

--- a/docs/release/vnext-public-release-checklist.md
+++ b/docs/release/vnext-public-release-checklist.md
@@ -4,43 +4,60 @@ Use this checklist before cutting a vNext preview tag or public announcement. Do
 
 ## Docs
 
-- [ ] README links the vNext preview, quickstart, architecture, security/privacy, demo script, and release checklist.
-- [ ] Quickstart includes local install, Docker/local stack, first source capture, and first daily brief.
-- [ ] Docs explain Alice Core vs Alice Brain vs Alice Agent Memory.
-- [ ] Example `ALICE.md` is included and uses only synthetic content.
-- [ ] Demo video script is current.
-- [ ] Contributor guide explains how to work on vNext safely.
-- [ ] Security/privacy docs describe connector boundaries and secret handling.
+- [x] README links the vNext preview, quickstart, architecture, security/privacy, demo script, release checklist, release notes, and tag plan.
+- [x] Quickstart includes local install, Docker/local stack, first source capture, and first daily brief.
+- [x] Docs explain Alice Core vs Alice Brain vs Alice Agent Memory.
+- [x] Example `ALICE.md` is included and uses only synthetic content.
+- [x] Demo video script is current.
+- [x] Contributor guide explains how to work on vNext safely.
+- [x] Security/privacy docs describe connector boundaries and secret handling.
 
 ## Product Gate
 
-- [ ] New user can install locally and generate a first daily brief in under 20 minutes.
-- [ ] `/vnext` renders the fixture-backed workspace.
-- [ ] Connector settings are visible in the UI.
-- [ ] Connector payload ingestion preserves raw evidence, default domain/sensitivity, and cursor posture.
-- [ ] Generated artifacts remain reviewable and are not auto-promoted to trusted memory.
+- [x] New user can install locally and generate a first daily brief in under 20 minutes.
+- [x] `/vnext` renders the fixture-backed workspace.
+- [x] Connector settings are visible in the UI.
+- [x] Connector payload ingestion preserves raw evidence, default domain/sensitivity, and cursor posture.
+- [x] Generated artifacts remain reviewable and are not auto-promoted to trusted memory.
 
 ## Verification
 
-- [ ] `./.venv/bin/python -m pytest tests/unit -q`
-- [ ] `pnpm --dir apps/web test`
-- [ ] `pnpm --dir apps/web build`
-- [ ] `python3 scripts/check_control_doc_truth.py`
-- [ ] `git diff --check`
-- [ ] `./.venv/bin/python -c 'from alicebot_api.cli import main; raise SystemExit(main(["eval", "run", "--suite", "all"]))'`
+- [x] `./.venv/bin/python -m pytest tests/unit -q`
+- [x] `pnpm --dir apps/web test`
+- [x] `pnpm --dir apps/web lint`
+- [x] `pnpm --dir apps/web build`
+- [x] `python3 scripts/check_control_doc_truth.py`
+- [x] `git diff --check`
+- [x] `./.venv/bin/python -c 'from alicebot_api.cli import main; raise SystemExit(main(["eval", "run", "--suite", "all"]))'`
+- [x] Real Postgres vNext CLI/API/MCP smoke check.
 
 ## Security and Privacy
 
-- [ ] No secrets, private exports, real personal data, or production credentials are committed.
-- [ ] Demo dataset contains only synthetic people, projects, notes, and connector payloads.
-- [ ] Prompt-injection evals show zero tool writes.
-- [ ] Critical privacy leakage evals show zero critical leaks.
-- [ ] New connector/write paths have security review notes.
+- [x] No secrets, private exports, real personal data, or production credentials are committed.
+- [x] Demo dataset contains only synthetic people, projects, notes, and connector payloads.
+- [x] Prompt-injection evals show zero tool writes.
+- [x] Critical privacy leakage evals show zero critical leaks.
+- [x] New connector/write paths have security review notes.
+- [x] Post-merge GitHub Security Scans passed on `main`.
 
 ## Release Operations
 
-- [ ] Changelog entry prepared.
-- [ ] Tag plan prepared.
-- [ ] Rollback path documented.
-- [ ] Known limitations documented: no live connector OAuth/polling, no hosted SLA, no automatic memory promotion, no production scheduler.
-- [ ] Release owner signs off.
+- [x] Changelog entry prepared.
+- [x] Tag plan prepared: `docs/release/v0.5.1-vnext-preview-tag-plan.md`.
+- [x] Rollback path documented.
+- [x] Known limitations documented: no live connector OAuth/polling, no hosted SLA, no automatic memory promotion, no production scheduler.
+- [x] Release owner signs off.
+
+## Evidence
+
+Current evidence recorded on 2026-05-11:
+
+- Real Postgres vNext smoke passed for source capture, connector ingest, scoped and unscoped context packs, daily brief generation, project update review, open-loop close, API context packs, API project dashboard, MCP context pack, and MCP project dashboard.
+- `./.venv/bin/python -m pytest tests/unit -q`: `1057 passed`.
+- `pnpm --dir apps/web test`: `205 passed`.
+- `pnpm --dir apps/web lint`: passed.
+- `pnpm --dir apps/web build`: passed and built `/vnext`.
+- `python3 scripts/check_control_doc_truth.py`: passed.
+- `./.venv/bin/python -c 'from alicebot_api.cli import main; raise SystemExit(main(["eval", "run", "--suite", "all"]))'`: `170/170` cases, zero critical privacy leaks, zero prompt-injection tool writes.
+- `git diff --check`: clean.
+- GitHub Security Scans on merged `main` passed for CodeQL JavaScript, CodeQL Python, and Gitleaks.

--- a/docs/vnext/README.md
+++ b/docs/vnext/README.md
@@ -2,7 +2,7 @@
 
 Alice vNext is the next public wedge for Alice as a true second brain: a local-first memory kernel, reviewable generated briefs, connector-backed evidence capture, and agent-facing context packs.
 
-This preview is not a hosted launch. It is a repo-local, deterministic release candidate built around the vNext memory-kernel schema and the fixture-safe workflows shipped in this branch.
+This preview is not a hosted launch. It is a repo-local, deterministic public preview built around the vNext memory-kernel schema and the fixture-safe workflows shipped under `v0.5.1-vnext-preview`.
 
 ## Product Shape
 
@@ -29,6 +29,7 @@ Alice vNext has three layers:
 4. Use [example ALICE.md](ALICE.example.md) as the first Brain Charter.
 5. Use [demo script](demo-video-script.md) for a short walkthrough.
 6. Use [release checklist](../release/vnext-public-release-checklist.md) before publishing or tagging.
+7. Review [preview release notes](../release/v0.5.1-vnext-preview-release-notes.md) and [tag plan](../release/v0.5.1-vnext-preview-tag-plan.md).
 
 ## Launch Boundary
 

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -19,6 +19,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         relative_path="README.md",
         required_markers=(
             "`v0.5.1` is the current **pre-1.0 public release**.",
+            "`v0.5.1-vnext-preview`",
             "## Release Boundary (`v0.5.1`)",
             "Phase 13 adoption surfaces:",
             "Historical planning/control artifacts remain available in:",
@@ -30,15 +31,15 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
         required_markers=(
             "`v0.5.1`: released",
             "Phase 14 is shipped.",
-            "Alice vNext Sprint 1 - Architecture Foundation and Schema is active.",
+            "Alice vNext public preview release gate is active for `v0.5.1-vnext-preview`.",
         ),
     ),
     ControlDocTruthRule(
         relative_path=".ai/active/SPRINT_PACKET.md",
         required_markers=(
-            "Alice vNext Sprint 1 - Architecture Foundation and Schema",
-            "`v0.5.1` is the current public release boundary.",
-            "feature-foundation",
+            "Alice vNext Public Preview Release Gate",
+            "`v0.5.1-vnext-preview` is the vNext public-preview tag target.",
+            "release-gate",
         ),
     ),
     ControlDocTruthRule(
@@ -51,9 +52,9 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
     ControlDocTruthRule(
         relative_path=".ai/handoff/CURRENT_STATE.md",
         required_markers=(
-            "`v0.5.1` is the latest published tag.",
+            "`v0.5.1` remains the latest stable public release tag.",
             "Phase 14 is shipped.",
-            "Alice vNext Sprint 1 - Architecture Foundation and Schema is active.",
+            "Alice vNext public preview release gate is active.",
         ),
     ),
     ControlDocTruthRule(


### PR DESCRIPTION
Summary:
- add v0.5.1-vnext-preview release notes and tag plan
- complete the vNext public release checklist with current validation evidence
- align control docs to the vNext public-preview release gate while keeping v0.5.1 as the stable public release

Verification:
- python3 scripts/check_control_doc_truth.py
- ./.venv/bin/python -m pytest tests/unit -q
- pnpm --dir apps/web test
- pnpm --dir apps/web lint
- pnpm --dir apps/web build
- ./.venv/bin/python -c 'from alicebot_api.cli import main; raise SystemExit(main(["eval", "run", "--suite", "all"]))'
- git diff --check