### PR TITLE
[codex] Add vNext agentic control plane scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Alice vNext is the next release candidate for the true second-brain product. It 
 
 - **Alice Core**: local-first storage, provenance, policy, event logging, revisions, graph objects, sources, and connector evidence.
 - **Alice Brain**: user-facing second-brain workflows such as daily briefs, weekly syntheses, context packs, contradiction reports, project updates, open loops, and reviewable artifacts.
-- **Alice Agent Memory**: CLI, API, and MCP surfaces that let agents capture, retrieve, resume, explain, and generate context without owning the memory store.
+- **Alice Agent Memory**: CLI, API, and MCP surfaces that let agents capture, retrieve, resume, explain, generate context, propose memory, and trigger governed workflows without owning the memory store.
 
-The vNext preview currently includes deterministic source capture, retrieval/context packs, queue/artifact workflows, daily and weekly brain artifacts, connection/contradiction/project/open-loop workflows, synthetic evals, deterministic connector payload ingestion, and a fixture-backed `/vnext` workspace.
+The vNext preview currently includes deterministic source capture, retrieval/context packs, queue/artifact workflows, daily and weekly brain artifacts, connection/contradiction/project/open-loop workflows, synthetic evals, deterministic connector payload ingestion, agent identity/policy auditing, a governed local scheduler with due scans, and a live/fixture-backed `/vnext` operator workspace.
 
 Start with:
 
@@ -52,6 +52,7 @@ Start with:
 - [vNext release checklist](docs/release/vnext-public-release-checklist.md)
 - [vNext preview release notes](docs/release/v0.5.1-vnext-preview-release-notes.md)
 - [vNext preview tag plan](docs/release/v0.5.1-vnext-preview-tag-plan.md)
+- [Agentic control plane CTO summary](docs/vnext-agentic-control-plane-cto-summary.md)
 
 ## Release Boundary (`v0.5.1`)
 
@@ -392,6 +393,7 @@ Deferred beyond `v0.5.1`:
 - [vNext Quickstart](docs/vnext/quickstart.md)
 - [vNext Architecture](docs/vnext/architecture.md)
 - [vNext Security and Privacy](docs/vnext/security-privacy.md)
+- [Agentic Control Plane CTO Summary](docs/vnext-agentic-control-plane-cto-summary.md)
 - [Quickstart](docs/quickstart/local-setup-and-first-result.md)
 - [Architecture](ARCHITECTURE.md)
 - [MCP](docs/integrations/mcp.md)

--- a/apps/api/alembic/versions/20260511_0068_agentic_control_plane_scheduler.py
+++ b/apps/api/alembic/versions/20260511_0068_agentic_control_plane_scheduler.py
@@ -1,0 +1,200 @@
+"""Add vNext agent control plane and governed scheduler state."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260511_0068"
+down_revision = "20260510_0067"
+branch_labels = None
+depends_on = None
+
+
+AGENT_TYPES = (
+    "personal_assistant",
+    "coding_agent",
+    "research_agent",
+    "workflow_agent",
+    "unknown",
+)
+
+PERMISSION_PROFILES = (
+    "read_only_agent",
+    "project_scoped_agent",
+    "trusted_local_agent",
+    "memory_proposal_agent",
+    "admin_agent",
+)
+
+WORKFLOW_TYPES = (
+    "daily_brief",
+    "weekly_synthesis",
+    "connection_report",
+    "contradiction_report",
+    "open_loop_review",
+    "project_update_scan",
+)
+
+RUN_STATUSES = ("started", "succeeded", "failed")
+TRIGGER_TYPES = ("user", "agent", "scheduler", "system")
+
+_AGENT_TYPES_SQL = ", ".join(f"'{value}'" for value in AGENT_TYPES)
+_PERMISSION_PROFILES_SQL = ", ".join(f"'{value}'" for value in PERMISSION_PROFILES)
+_WORKFLOW_TYPES_SQL = ", ".join(f"'{value}'" for value in WORKFLOW_TYPES)
+_RUN_STATUSES_SQL = ", ".join(f"'{value}'" for value in RUN_STATUSES)
+_TRIGGER_TYPES_SQL = ", ".join(f"'{value}'" for value in TRIGGER_TYPES)
+
+_RLS_TABLES = ("agent_identities", "scheduler_workflows", "scheduler_runs")
+
+
+_UPGRADE_SCHEMA = f"""
+        CREATE TABLE agent_identities (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          agent_id text NOT NULL,
+          agent_type text NOT NULL DEFAULT 'unknown',
+          permission_profile text NOT NULL DEFAULT 'read_only_agent',
+          display_name text NULL,
+          project_scope_json jsonb NOT NULL DEFAULT '[]'::jsonb,
+          metadata_json jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          UNIQUE (id, user_id),
+          UNIQUE (user_id, agent_id),
+          CONSTRAINT agent_identities_agent_type_check
+            CHECK (agent_type IN ({_AGENT_TYPES_SQL})),
+          CONSTRAINT agent_identities_permission_profile_check
+            CHECK (permission_profile IN ({_PERMISSION_PROFILES_SQL})),
+          CONSTRAINT agent_identities_project_scope_json_array_check
+            CHECK (jsonb_typeof(project_scope_json) = 'array'),
+          CONSTRAINT agent_identities_metadata_json_object_check
+            CHECK (jsonb_typeof(metadata_json) = 'object')
+        );
+
+        CREATE TABLE scheduler_workflows (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          workflow_type text NOT NULL,
+          enabled boolean NOT NULL DEFAULT false,
+          paused boolean NOT NULL DEFAULT false,
+          schedule_json jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+          timezone text NOT NULL DEFAULT 'UTC',
+          next_run_at timestamptz NULL,
+          last_run_id uuid NULL,
+          last_run_at timestamptz NULL,
+          last_result text NULL,
+          last_error text NULL,
+          created_at timestamptz NOT NULL DEFAULT now(),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          metadata_json jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+          UNIQUE (id, user_id),
+          UNIQUE (user_id, workflow_type),
+          CONSTRAINT scheduler_workflows_type_check
+            CHECK (workflow_type IN ({_WORKFLOW_TYPES_SQL})),
+          CONSTRAINT scheduler_workflows_schedule_json_object_check
+            CHECK (jsonb_typeof(schedule_json) = 'object'),
+          CONSTRAINT scheduler_workflows_metadata_json_object_check
+            CHECK (jsonb_typeof(metadata_json) = 'object')
+        );
+
+        CREATE TABLE scheduler_runs (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          workflow_id uuid NULL,
+          workflow_type text NOT NULL,
+          status text NOT NULL DEFAULT 'started',
+          triggered_by text NOT NULL DEFAULT 'user',
+          trace_id text NOT NULL,
+          started_at timestamptz NOT NULL DEFAULT now(),
+          finished_at timestamptz NULL,
+          artifact_id uuid NULL,
+          error_message text NULL,
+          policy_decision_json jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+          agent_identity_json jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+          metadata_json jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+          UNIQUE (id, user_id),
+          CONSTRAINT scheduler_runs_workflow_fkey
+            FOREIGN KEY (workflow_id, user_id)
+            REFERENCES scheduler_workflows(id, user_id)
+            ON DELETE SET NULL,
+          CONSTRAINT scheduler_runs_artifact_fkey
+            FOREIGN KEY (artifact_id, user_id)
+            REFERENCES generated_artifacts(id, user_id)
+            ON DELETE SET NULL,
+          CONSTRAINT scheduler_runs_type_check
+            CHECK (workflow_type IN ({_WORKFLOW_TYPES_SQL})),
+          CONSTRAINT scheduler_runs_status_check
+            CHECK (status IN ({_RUN_STATUSES_SQL})),
+          CONSTRAINT scheduler_runs_triggered_by_check
+            CHECK (triggered_by IN ({_TRIGGER_TYPES_SQL})),
+          CONSTRAINT scheduler_runs_policy_decision_json_object_check
+            CHECK (jsonb_typeof(policy_decision_json) = 'object'),
+          CONSTRAINT scheduler_runs_agent_identity_json_object_check
+            CHECK (jsonb_typeof(agent_identity_json) = 'object'),
+          CONSTRAINT scheduler_runs_metadata_json_object_check
+            CHECK (jsonb_typeof(metadata_json) = 'object')
+        );
+
+        ALTER TABLE scheduler_workflows
+          ADD CONSTRAINT scheduler_workflows_last_run_fkey
+          FOREIGN KEY (last_run_id, user_id)
+          REFERENCES scheduler_runs(id, user_id)
+          ON DELETE SET NULL;
+
+        CREATE INDEX agent_identities_user_profile_idx
+          ON agent_identities (user_id, permission_profile, updated_at DESC, id DESC);
+        CREATE INDEX scheduler_workflows_user_state_idx
+          ON scheduler_workflows (user_id, enabled, paused, next_run_at ASC NULLS LAST, workflow_type);
+        CREATE INDEX scheduler_runs_user_workflow_started_idx
+          ON scheduler_runs (user_id, workflow_type, started_at DESC, id DESC);
+        """
+
+_GRANTS = (
+    "GRANT SELECT, INSERT, UPDATE ON agent_identities TO alicebot_app",
+    "GRANT SELECT, INSERT, UPDATE ON scheduler_workflows TO alicebot_app",
+    "GRANT SELECT, INSERT, UPDATE ON scheduler_runs TO alicebot_app",
+)
+
+_POLICIES = """
+        CREATE POLICY agent_identities_is_owner ON agent_identities
+          USING (user_id = app.current_user_id())
+          WITH CHECK (user_id = app.current_user_id());
+
+        CREATE POLICY scheduler_workflows_is_owner ON scheduler_workflows
+          USING (user_id = app.current_user_id())
+          WITH CHECK (user_id = app.current_user_id());
+
+        CREATE POLICY scheduler_runs_is_owner ON scheduler_runs
+          USING (user_id = app.current_user_id())
+          WITH CHECK (user_id = app.current_user_id());
+        """
+
+_DOWNGRADE = (
+    "DROP TABLE IF EXISTS scheduler_runs",
+    "DROP TABLE IF EXISTS scheduler_workflows",
+    "DROP TABLE IF EXISTS agent_identities",
+)
+
+
+def _execute_statements(statements: tuple[str, ...]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def _enable_row_level_security() -> None:
+    for table_name in _RLS_TABLES:
+        op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+
+
+def upgrade() -> None:
+    op.execute(_UPGRADE_SCHEMA)
+    _execute_statements(_GRANTS)
+    _enable_row_level_security()
+    op.execute(_POLICIES)
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE scheduler_workflows DROP CONSTRAINT IF EXISTS scheduler_workflows_last_run_fkey")
+    _execute_statements(_DOWNGRADE)

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -9,7 +9,7 @@ import json
 import os
 from pathlib import Path
 import sys
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import psycopg
 
@@ -187,6 +187,13 @@ from alicebot_api.trusted_fact_promotions import (
     list_trusted_fact_patterns,
     list_trusted_fact_playbooks,
 )
+from alicebot_api.vnext_agent_control import (
+    AgentIdentity,
+    agent_metadata,
+    append_policy_events,
+    ensure_policy_allowed,
+    evaluate_agent_policy,
+)
 from alicebot_api.vnext_capture import VNextCaptureService, VNextCaptureValidationError
 from alicebot_api.vnext_brain import BrainArtifactRequest, VNextBrainService, VNextBrainValidationError
 from alicebot_api.vnext_connections import (
@@ -213,6 +220,8 @@ from alicebot_api.vnext_evals import (
 from alicebot_api.vnext_projects import ProjectAutomationRequest, VNextProjectService, VNextProjectValidationError
 from alicebot_api.vnext_queue import QueueTaskRequest, VNextQueueService, VNextQueueValidationError
 from alicebot_api.vnext_retrieval import VNextRetrievalRequest, VNextRetrievalService, VNextRetrievalValidationError
+from alicebot_api.vnext_scheduler import SchedulerRunRequest, VNextSchedulerService, VNextSchedulerValidationError
+from alicebot_api.vnext_event_log import append_event
 from alicebot_api.vnext_json import json_safe
 from alicebot_api.vnext_store import PostgresVNextStore
 
@@ -271,6 +280,15 @@ def _add_scope_filter_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--person", default=None, help="Optional person scope.")
     parser.add_argument("--since", type=_parse_datetime, default=None, help="Optional start time (ISO-8601).")
     parser.add_argument("--until", type=_parse_datetime, default=None, help="Optional end time (ISO-8601).")
+
+
+def _add_vnext_agent_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--agent-id", default=None, help="Agent id for agent-originated vNext actions.")
+    parser.add_argument("--agent-type", default="unknown", help="Agent type.")
+    parser.add_argument("--agent-run-id", default=None, help="Agent run id.")
+    parser.add_argument("--agent-task-id", default=None, help="Agent task id.")
+    parser.add_argument("--project-scope", action="append", default=[], help="Allowed project scope. Repeatable.")
+    parser.add_argument("--permission-profile", default="read_only_agent", help="Agent permission profile.")
 
 
 def _add_task_brief_arguments(parser: argparse.ArgumentParser) -> None:
@@ -499,6 +517,54 @@ def _vnext_sensitivity_allowed(args: argparse.Namespace) -> tuple[str, ...]:
     return tuple(values) if values else DEFAULT_VNEXT_SENSITIVITY_ALLOWED
 
 
+def _vnext_agent_identity_from_args(args: argparse.Namespace) -> AgentIdentity | None:
+    agent_id = getattr(args, "agent_id", None)
+    if not agent_id:
+        return None
+    return AgentIdentity(
+        agent_id=agent_id,
+        agent_type=getattr(args, "agent_type", None) or "unknown",
+        agent_run_id=getattr(args, "agent_run_id", None),
+        task_id=getattr(args, "agent_task_id", None),
+        project_scope=tuple(getattr(args, "project_scope", None) or ()),
+        permission_profile=getattr(args, "permission_profile", None) or "read_only_agent",
+    )
+
+
+def _vnext_policy_checked_for_args(
+    store: PostgresVNextStore,
+    args: argparse.Namespace,
+    *,
+    action: str,
+    domains: tuple[str, ...] = (),
+    workflow_type: str | None = None,
+    write_policy: str | None = None,
+) -> tuple[AgentIdentity | None, str, str | None, object]:
+    identity = _vnext_agent_identity_from_args(args)
+    if identity is not None:
+        store.upsert_agent_identity(
+            {
+                "agent_id": identity.agent_id,
+                "agent_type": identity.agent_type,
+                "permission_profile": identity.permission_profile,
+                "project_scope_json": list(identity.project_scope),
+                "metadata_json": {"last_agent_run_id": identity.agent_run_id, "last_task_id": identity.task_id},
+            },
+            actor_type="agent",
+        )
+    decision = evaluate_agent_policy(
+        identity=identity,
+        action=action,
+        domains=domains,
+        sensitivity_allowed=_vnext_sensitivity_allowed(args),
+        project_scope=tuple(getattr(args, "project_scope", None) or ()),
+        workflow_type=workflow_type,
+        write_policy=write_policy,
+    )
+    append_policy_events(store, identity=identity, decision=decision)
+    return identity, ("agent" if identity is not None else "user"), identity.agent_id if identity is not None else None, decision
+
+
 def _run_vnext_sources_capture_text(ctx: CLIContext, args: argparse.Namespace) -> str:
     raw_text = " ".join(args.raw_text).strip()
     with _vnext_store_context(ctx) as store:
@@ -607,6 +673,358 @@ def _run_weekly_synthesis(ctx: CLIContext, args: argparse.Namespace) -> str:
     with _vnext_store_context(ctx) as store:
         artifact = VNextBrainService(store).generate_weekly_synthesis(_brain_artifact_request_from_args(args))
     return _json_dumps(artifact)
+
+
+def _run_vnext_agent_propose_memory(ctx: CLIContext, args: argparse.Namespace) -> str:
+    if not getattr(args, "agent_id", None):
+        raise ValueError("--agent-id is required")
+    blocked_decision = None
+    memory: JsonObject | None = None
+    decision = None
+    with _vnext_store_context(ctx) as store:
+        identity, _actor_type, _actor_id, decision = _vnext_policy_checked_for_args(
+            store,
+            args,
+            action="memory.propose",
+            domains=(args.domain,),
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            if identity is None:
+                raise ValueError("--agent-id is required")
+            memory = store.create_memory(
+                {
+                    "memory_type": args.memory_type,
+                    "memory_key": f"agent_proposal.{args.proposal_type}.{uuid4()}",
+                    "value": {"proposal_type": args.proposal_type, "text": args.canonical_text, "rationale": args.rationale},
+                    "status": "candidate",
+                    "confidence": args.confidence,
+                    "title": args.title,
+                    "canonical_text": args.canonical_text,
+                    "summary": args.canonical_text[:280],
+                    "domain": args.domain,
+                    "sensitivity": args.sensitivity,
+                    "metadata_json": {
+                        "proposal_type": args.proposal_type,
+                        "review_required": True,
+                        **agent_metadata(identity, decision),
+                    },
+                },
+                actor_type="agent",
+            )
+            append_event(
+                store,
+                event_type="agent.memory_proposed",
+                actor_type="agent",
+                actor_id=identity.agent_id,
+                target_type="memory",
+                target_id=str(memory["id"]),
+                trace_id=decision.trace_id,
+                run_id=identity.agent_run_id,
+                payload={"proposal_type": args.proposal_type, "agent_identity": identity.to_record()},
+            )
+    if blocked_decision is not None:
+        ensure_policy_allowed(blocked_decision)
+    if memory is None or decision is None:
+        raise RuntimeError("agent memory proposal did not complete")
+    return _json_dumps({"proposal": memory, "policy_decision": decision.to_record(), "review_required": True})
+
+
+def _run_vnext_scheduler_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
+    with _vnext_store_context(ctx) as store:
+        payload = VNextSchedulerService(store).status()
+    return _json_dumps(payload)
+
+
+def _run_vnext_scheduler_run_now(ctx: CLIContext, args: argparse.Namespace) -> str:
+    blocked_decision = None
+    payload = None
+    decision = None
+    with _vnext_store_context(ctx) as store:
+        identity, actor_type, _actor_id, decision = _vnext_policy_checked_for_args(
+            store,
+            args,
+            action="scheduler.run_now",
+            domains=tuple(args.domain),
+            workflow_type=args.workflow_type,
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextSchedulerService(store).run_now(
+                SchedulerRunRequest(
+                    workflow_type=args.workflow_type,
+                    domains=decision.effective_domains,
+                    sensitivity_allowed=decision.effective_sensitivity_allowed,
+                    generated_for=args.generated_for,
+                    triggered_by=actor_type,
+                    agent_identity=identity,
+                    policy_decision=decision,
+                )
+            )
+    if blocked_decision is not None:
+        ensure_policy_allowed(blocked_decision)
+    if payload is None or decision is None:
+        raise RuntimeError("scheduler run-now did not complete")
+    return _json_dumps({**payload, "policy_decision": decision.to_record()})
+
+
+def _run_vnext_scheduler_run_due(ctx: CLIContext, args: argparse.Namespace) -> str:
+    blocked_decision = None
+    payload = None
+    decision = None
+    with _vnext_store_context(ctx) as store:
+        identity, actor_type, _actor_id, decision = _vnext_policy_checked_for_args(
+            store,
+            args,
+            action="scheduler.run_due",
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextSchedulerService(store).run_due_workflows(
+                limit=args.limit,
+                triggered_by=actor_type if identity is not None else "scheduler",
+                agent_identity=identity,
+                policy_decision=decision,
+            )
+    if blocked_decision is not None:
+        ensure_policy_allowed(blocked_decision)
+    if payload is None or decision is None:
+        raise RuntimeError("scheduler run-due did not complete")
+    return _json_dumps({**payload, "policy_decision": decision.to_record()})
+
+
+def _run_vnext_scheduler_pause(ctx: CLIContext, args: argparse.Namespace) -> str:
+    blocked_decision = None
+    payload = None
+    decision = None
+    with _vnext_store_context(ctx) as store:
+        _identity, actor_type, _actor_id, decision = _vnext_policy_checked_for_args(
+            store,
+            args,
+            action="scheduler.pause",
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextSchedulerService(store).pause_all(actor_type=actor_type)
+    if blocked_decision is not None:
+        ensure_policy_allowed(blocked_decision)
+    if payload is None or decision is None:
+        raise RuntimeError("scheduler pause did not complete")
+    return _json_dumps({**payload, "policy_decision": decision.to_record()})
+
+
+def _run_vnext_scheduler_resume(ctx: CLIContext, args: argparse.Namespace) -> str:
+    blocked_decision = None
+    payload = None
+    decision = None
+    with _vnext_store_context(ctx) as store:
+        _identity, actor_type, _actor_id, decision = _vnext_policy_checked_for_args(
+            store,
+            args,
+            action="scheduler.resume",
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextSchedulerService(store).resume_all(actor_type=actor_type)
+    if blocked_decision is not None:
+        ensure_policy_allowed(blocked_decision)
+    if payload is None or decision is None:
+        raise RuntimeError("scheduler resume did not complete")
+    return _json_dumps({**payload, "policy_decision": decision.to_record()})
+
+
+def _run_vnext_smoke_agentic_scheduler(ctx: CLIContext, _args: argparse.Namespace) -> str:
+    smoke_run_id = f"cli-agentic-scheduler-smoke-{uuid4()}"
+    with _vnext_store_context(ctx) as store:
+        service = VNextSchedulerService(store)
+        initial_status = service.status()
+        daily_workflow = service.configure_workflow(
+            workflow_type="daily_brief",
+            enabled=True,
+            paused=False,
+            schedule_json={"kind": "daily", "time_of_day": "08:00", "days_of_week": ["monday"]},
+            timezone="UTC",
+            actor_type="user",
+        )
+        weekly_workflow = service.configure_workflow(
+            workflow_type="weekly_synthesis",
+            enabled=True,
+            paused=False,
+            schedule_json={"kind": "weekly", "day_of_week": "monday", "time_of_day": "09:00"},
+            timezone="UTC",
+            actor_type="user",
+        )
+        identity = AgentIdentity(
+            agent_id="hermes",
+            agent_type="personal_assistant",
+            agent_run_id=smoke_run_id,
+            project_scope=("Alice",),
+            permission_profile="trusted_local_agent",
+        )
+        store.upsert_agent_identity(
+            {
+                "agent_id": identity.agent_id,
+                "agent_type": identity.agent_type,
+                "permission_profile": identity.permission_profile,
+                "project_scope_json": list(identity.project_scope),
+                "metadata_json": {"last_agent_run_id": identity.agent_run_id, "last_task_id": identity.task_id},
+            },
+            actor_type="agent",
+        )
+        proposal_decision = evaluate_agent_policy(
+            identity=identity,
+            action="memory.propose",
+            domains=("project",),
+            sensitivity_allowed=("private",),
+            project_scope=identity.project_scope,
+        )
+        append_policy_events(store, identity=identity, decision=proposal_decision)
+        ensure_policy_allowed(proposal_decision)
+        proposal = store.create_memory(
+            {
+                "memory_type": "semantic",
+                "memory_key": f"agent_proposal.smoke.{uuid4()}",
+                "value": {
+                    "proposal_type": "candidate_memory",
+                    "text": "Agentic scheduler smoke validates proposal-only memory writes.",
+                },
+                "status": "candidate",
+                "confidence": 0.5,
+                "title": "Agentic scheduler smoke proposal",
+                "canonical_text": "Agentic scheduler smoke validates proposal-only memory writes.",
+                "summary": "Agentic scheduler smoke validates proposal-only memory writes.",
+                "domain": "project",
+                "sensitivity": "private",
+                "metadata_json": {
+                    "proposal_type": "candidate_memory",
+                    "review_required": True,
+                    **agent_metadata(identity, proposal_decision),
+                },
+            },
+            actor_type="agent",
+        )
+        append_event(
+            store,
+            event_type="agent.memory_proposed",
+            actor_type="agent",
+            actor_id=identity.agent_id,
+            target_type="memory",
+            target_id=str(proposal["id"]),
+            trace_id=proposal_decision.trace_id,
+            run_id=identity.agent_run_id,
+            payload={"proposal_type": "candidate_memory", "agent_identity": identity.to_record()},
+        )
+        daily_decision = evaluate_agent_policy(
+            identity=identity,
+            action="scheduler.run_now",
+            domains=("project",),
+            sensitivity_allowed=("public", "internal", "private", "unknown"),
+            project_scope=identity.project_scope,
+            workflow_type="daily_brief",
+        )
+        append_policy_events(store, identity=identity, decision=daily_decision)
+        ensure_policy_allowed(daily_decision)
+        daily_run = service.run_now(
+            SchedulerRunRequest(
+                workflow_type="daily_brief",
+                domains=daily_decision.effective_domains,
+                sensitivity_allowed=daily_decision.effective_sensitivity_allowed,
+                triggered_by="agent",
+                agent_identity=identity,
+                policy_decision=daily_decision,
+            )
+        )
+        weekly_decision = evaluate_agent_policy(
+            identity=identity,
+            action="scheduler.run_now",
+            domains=("project",),
+            sensitivity_allowed=("public", "internal", "private", "unknown"),
+            project_scope=identity.project_scope,
+            workflow_type="weekly_synthesis",
+        )
+        append_policy_events(store, identity=identity, decision=weekly_decision)
+        ensure_policy_allowed(weekly_decision)
+        weekly_run = service.run_now(
+            SchedulerRunRequest(
+                workflow_type="weekly_synthesis",
+                domains=weekly_decision.effective_domains,
+                sensitivity_allowed=weekly_decision.effective_sensitivity_allowed,
+                triggered_by="agent",
+                agent_identity=identity,
+                policy_decision=weekly_decision,
+            )
+        )
+        due_decision = evaluate_agent_policy(
+            identity=identity,
+            action="scheduler.run_due",
+            project_scope=identity.project_scope,
+        )
+        append_policy_events(store, identity=identity, decision=due_decision)
+        ensure_policy_allowed(due_decision)
+        store.update_scheduler_workflow(
+            workflow_type="daily_brief",
+            patch={"enabled": True, "paused": False, "next_run_at": "2000-01-01T00:00:00+00:00"},
+            actor_type="system",
+        )
+        due_payload = service.run_due_workflows(
+            limit=1,
+            triggered_by="agent",
+            agent_identity=identity,
+            policy_decision=due_decision,
+        )
+        readonly_identity = AgentIdentity(
+            agent_id="readonly-smoke",
+            agent_type="unknown",
+            agent_run_id=smoke_run_id,
+            permission_profile="read_only_agent",
+        )
+        blocked_decision = evaluate_agent_policy(identity=readonly_identity, action="scheduler.pause")
+        append_policy_events(store, identity=readonly_identity, decision=blocked_decision)
+        pause_payload = service.pause_all(actor_type="user")
+        resume_payload = service.resume_all(actor_type="user")
+        final_status = service.status()
+
+    gates = {
+        "scheduler_defaults_exist": len(initial_status.get("workflows", [])) >= 6,
+        "scheduler_disabled_by_default": initial_status.get("disabled_by_default") is True,
+        "daily_workflow_enabled": daily_workflow.get("enabled") is True,
+        "weekly_workflow_enabled": weekly_workflow.get("enabled") is True,
+        "memory_proposal_candidate": proposal.get("status") == "candidate",
+        "daily_run_succeeded": (daily_run.get("run") or {}).get("status") == "succeeded",
+        "weekly_run_succeeded": (weekly_run.get("run") or {}).get("status") == "succeeded",
+        "due_scan_executed": due_payload.get("due_count") == 1
+        and ((due_payload.get("runs") or [{}])[0].get("run") or {}).get("status") == "succeeded",
+        "scheduler_artifacts_reviewable": (daily_run.get("artifact") or {}).get("status") == "needs_review"
+        and (weekly_run.get("artifact") or {}).get("status") == "needs_review",
+        "blocked_policy_recorded": blocked_decision.decision == "blocked",
+        "pause_resume_completed": pause_payload.get("paused_count", 0) >= 6 and resume_payload.get("resumed_count", 0) >= 6,
+        "run_history_visible": len(final_status.get("recent_runs", [])) >= 2,
+    }
+    payload = {
+        "status": "passed" if all(gates.values()) else "failed",
+        "smoke": "agentic-scheduler",
+        "gates": gates,
+        "agent_identity": identity.to_record(),
+        "proposal_id": str(proposal.get("id")),
+        "daily_run_id": str((daily_run.get("run") or {}).get("id")),
+        "weekly_run_id": str((weekly_run.get("run") or {}).get("id")),
+        "due_run_id": str((((due_payload.get("runs") or [{}])[0].get("run") or {}).get("id"))),
+        "policy_decisions": {
+            "proposal": proposal_decision.to_record(),
+            "daily_run": daily_decision.to_record(),
+            "weekly_run": weekly_decision.to_record(),
+            "due_run": due_decision.to_record(),
+            "blocked": blocked_decision.to_record(),
+        },
+    }
+    if payload["status"] != "passed":
+        raise RuntimeError(_json_dumps(payload))
+    return _json_dumps(payload)
 
 
 def _connection_finder_request_from_args(args: argparse.Namespace) -> ConnectionFinderRequest:
@@ -1887,6 +2305,64 @@ def build_parser() -> argparse.ArgumentParser:
     vnext_open_loop_review_parser.add_argument("--resolution-note", default=None, help="Resolution note for close.")
     vnext_open_loop_review_parser.set_defaults(handler=_run_vnext_open_loop_review)
 
+    vnext_agents_parser = vnext_subparsers.add_parser("agents", help="Submit and inspect vNext agent proposals.")
+    vnext_agents_subparsers = vnext_agents_parser.add_subparsers(dest="vnext_agents_command", required=True)
+    vnext_agent_propose_parser = vnext_agents_subparsers.add_parser(
+        "propose-memory",
+        help="Submit an agent memory proposal for review.",
+    )
+    _add_vnext_agent_arguments(vnext_agent_propose_parser)
+    vnext_agent_propose_parser.add_argument("--proposal-type", default="candidate_memory", help="Proposal type.")
+    vnext_agent_propose_parser.add_argument("--memory-type", default="semantic", help="Stored candidate memory type.")
+    vnext_agent_propose_parser.add_argument("--title", required=True, help="Proposal title.")
+    vnext_agent_propose_parser.add_argument("--canonical-text", required=True, help="Canonical memory text.")
+    vnext_agent_propose_parser.add_argument("--domain", default="unknown", help="Domain label.")
+    vnext_agent_propose_parser.add_argument("--sensitivity", default="unknown", help="Sensitivity label.")
+    vnext_agent_propose_parser.add_argument(
+        "--sensitivity-allowed",
+        action="append",
+        default=None,
+        help="Allowed sensitivity. Repeatable.",
+    )
+    vnext_agent_propose_parser.add_argument("--confidence", type=float, default=0.5, help="Proposal confidence.")
+    vnext_agent_propose_parser.add_argument("--rationale", default=None, help="Proposal rationale.")
+    vnext_agent_propose_parser.set_defaults(handler=_run_vnext_agent_propose_memory)
+
+    vnext_scheduler_parser = vnext_subparsers.add_parser("scheduler", help="Governed local vNext scheduler controls.")
+    vnext_scheduler_subparsers = vnext_scheduler_parser.add_subparsers(dest="vnext_scheduler_command", required=True)
+    vnext_scheduler_status_parser = vnext_scheduler_subparsers.add_parser("status", help="Show scheduler status.")
+    vnext_scheduler_status_parser.set_defaults(handler=_run_vnext_scheduler_status)
+    vnext_scheduler_run_parser = vnext_scheduler_subparsers.add_parser("run-now", help="Run a workflow now.")
+    _add_vnext_agent_arguments(vnext_scheduler_run_parser)
+    vnext_scheduler_run_parser.add_argument("workflow_type", help="Workflow type, such as daily_brief.")
+    vnext_scheduler_run_parser.add_argument("--generated-for", default=None, help="YYYY-MM-DD generation date.")
+    vnext_scheduler_run_parser.add_argument("--domain", action="append", default=[], help="Allowed domain. Repeatable.")
+    vnext_scheduler_run_parser.add_argument(
+        "--sensitivity-allowed",
+        action="append",
+        default=None,
+        help="Allowed sensitivity. Repeatable.",
+    )
+    vnext_scheduler_run_parser.set_defaults(handler=_run_vnext_scheduler_run_now)
+    vnext_scheduler_run_due_parser = vnext_scheduler_subparsers.add_parser("run-due", help="Run enabled workflows whose next_run_at is due.")
+    _add_vnext_agent_arguments(vnext_scheduler_run_due_parser)
+    vnext_scheduler_run_due_parser.add_argument("--limit", type=int, default=10, help="Maximum due workflows to run.")
+    vnext_scheduler_run_due_parser.set_defaults(handler=_run_vnext_scheduler_run_due)
+    vnext_scheduler_pause_parser = vnext_scheduler_subparsers.add_parser("pause", help="Pause all scheduler workflows.")
+    _add_vnext_agent_arguments(vnext_scheduler_pause_parser)
+    vnext_scheduler_pause_parser.set_defaults(handler=_run_vnext_scheduler_pause)
+    vnext_scheduler_resume_parser = vnext_scheduler_subparsers.add_parser("resume", help="Resume all scheduler workflows.")
+    _add_vnext_agent_arguments(vnext_scheduler_resume_parser)
+    vnext_scheduler_resume_parser.set_defaults(handler=_run_vnext_scheduler_resume)
+
+    vnext_smoke_parser = vnext_subparsers.add_parser("smoke", help="Run vNext smoke checks.")
+    vnext_smoke_subparsers = vnext_smoke_parser.add_subparsers(dest="vnext_smoke_command", required=True)
+    vnext_smoke_agentic_scheduler_parser = vnext_smoke_subparsers.add_parser(
+        "agentic-scheduler",
+        help="Run the agentic control-plane and governed scheduler smoke.",
+    )
+    vnext_smoke_agentic_scheduler_parser.set_defaults(handler=_run_vnext_smoke_agentic_scheduler)
+
     mutations_parser = subparsers.add_parser("mutations", help="Generate, inspect, and apply memory operations.")
     mutations_subparsers = mutations_parser.add_subparsers(dest="mutations_command", required=True)
 
@@ -2619,6 +3095,7 @@ def main(argv: list[str] | None = None) -> int:
         output = handler(ctx, args)
     except (
         ValueError,
+        PermissionError,
         psycopg.Error,
         ContinuityCaptureValidationError,
         VNextCaptureValidationError,
@@ -2629,6 +3106,7 @@ def main(argv: list[str] | None = None) -> int:
         VNextProjectValidationError,
         VNextQueueValidationError,
         VNextRetrievalValidationError,
+        VNextSchedulerValidationError,
         ContinuityLifecycleValidationError,
         ContinuityLifecycleNotFoundError,
         ContinuityRecallValidationError,

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -11,7 +11,7 @@ import re
 import threading
 import time
 from typing import Annotated, Awaitable, Callable, Literal, TypedDict
-from uuid import UUID
+from uuid import UUID, uuid4
 from fastapi import FastAPI, Query, Request, Response
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -462,6 +462,15 @@ from alicebot_api.trusted_fact_promotions import (
     list_trusted_fact_patterns,
     list_trusted_fact_playbooks,
 )
+from alicebot_api.vnext_agent_control import (
+    AgentIdentity,
+    AgentIdentityValidationError,
+    AgentPolicyBlockedError,
+    PolicyDecision,
+    agent_metadata,
+    append_policy_events,
+    evaluate_agent_policy,
+)
 from alicebot_api.vnext_brain import BrainArtifactRequest, VNextBrainService, VNextBrainValidationError
 from alicebot_api.vnext_capture import VNextCaptureService, VNextCaptureValidationError
 from alicebot_api.vnext_connections import (
@@ -479,6 +488,7 @@ from alicebot_api.vnext_contradictions import (
     VNextContradictionService,
     VNextContradictionValidationError,
 )
+from alicebot_api.vnext_event_log import append_event
 from alicebot_api.vnext_projects import ProjectAutomationRequest, VNextProjectService, VNextProjectValidationError
 from alicebot_api.vnext_queue import (
     QueueTaskRequest,
@@ -487,6 +497,14 @@ from alicebot_api.vnext_queue import (
     VNextQueueValidationError,
 )
 from alicebot_api.vnext_retrieval import VNextRetrievalRequest, VNextRetrievalService, VNextRetrievalValidationError
+from alicebot_api.vnext_scheduler import (
+    SchedulerRunRequest,
+    VNextSchedulerService,
+    VNextSchedulerValidationError,
+    WORKFLOW_TYPES,
+    default_schedule,
+    validate_schedule,
+)
 from alicebot_api.vnext_store import PostgresVNextStore
 from alicebot_api.continuity_lifecycle import (
     ContinuityLifecycleNotFoundError,
@@ -1173,7 +1191,27 @@ class ContinuityCaptureRequest(BaseModel):
     explicit_signal: str | None = Field(default=None, min_length=1, max_length=100)
 
 
-class VNextSourceCaptureRequest(BaseModel):
+class VNextAgentIdentityRequest(BaseModel):
+    agent_id: str = Field(min_length=1, max_length=120)
+    agent_type: str = Field(default="unknown", min_length=1, max_length=80)
+    agent_run_id: str | None = Field(default=None, min_length=1, max_length=160)
+    task_id: str | None = Field(default=None, min_length=1, max_length=160)
+    project_scope: list[str] = Field(default_factory=list)
+    permission_profile: str | None = Field(default=None, min_length=1, max_length=80)
+
+
+class VNextAgentRequest(BaseModel):
+    agent_identity: VNextAgentIdentityRequest | None = None
+    agent_id: str | None = Field(default=None, min_length=1, max_length=120)
+    agent_type: str | None = Field(default=None, min_length=1, max_length=80)
+    agent_run_id: str | None = Field(default=None, min_length=1, max_length=160)
+    task_id: str | None = Field(default=None, min_length=1, max_length=160)
+    project_scope: list[str] = Field(default_factory=list)
+    permission_profile: str | None = Field(default=None, min_length=1, max_length=80)
+    trace_id: str | None = Field(default=None, min_length=1, max_length=160)
+
+
+class VNextSourceCaptureRequest(VNextAgentRequest):
     user_id: UUID
     raw_text: str = Field(min_length=1, max_length=200_000)
     title: str | None = Field(default=None, min_length=1, max_length=280)
@@ -1181,47 +1219,47 @@ class VNextSourceCaptureRequest(BaseModel):
     sensitivity: str = Field(default="unknown", min_length=1, max_length=80)
 
 
-class VNextConnectorSyncRequest(BaseModel):
+class VNextConnectorSyncRequest(VNextAgentRequest):
     user_id: UUID
     items: list[dict[str, object]] = Field(default_factory=list)
     default_domain: str | None = Field(default=None, min_length=1, max_length=80)
     default_sensitivity: str | None = Field(default=None, min_length=1, max_length=80)
 
 
-class VNextContextPackRequest(BaseModel):
+class VNextContextPackRequest(VNextAgentRequest):
     user_id: UUID
     query: str = Field(min_length=1, max_length=4000)
     scope: dict[str, object] = Field(default_factory=dict)
     options: dict[str, object] = Field(default_factory=dict)
 
 
-class VNextBrainArtifactGenerateRequest(BaseModel):
+class VNextBrainArtifactGenerateRequest(VNextAgentRequest):
     user_id: UUID
     scope: dict[str, object] = Field(default_factory=dict)
     options: dict[str, object] = Field(default_factory=dict)
 
 
-class VNextConnectionReportGenerateRequest(BaseModel):
-    user_id: UUID
-    query: str = Field(default="", max_length=4000)
-    scope: dict[str, object] = Field(default_factory=dict)
-    options: dict[str, object] = Field(default_factory=dict)
-
-
-class VNextContradictionReportGenerateRequest(BaseModel):
+class VNextConnectionReportGenerateRequest(VNextAgentRequest):
     user_id: UUID
     query: str = Field(default="", max_length=4000)
     scope: dict[str, object] = Field(default_factory=dict)
     options: dict[str, object] = Field(default_factory=dict)
 
 
-class VNextProjectAutomationRequest(BaseModel):
+class VNextContradictionReportGenerateRequest(VNextAgentRequest):
+    user_id: UUID
+    query: str = Field(default="", max_length=4000)
+    scope: dict[str, object] = Field(default_factory=dict)
+    options: dict[str, object] = Field(default_factory=dict)
+
+
+class VNextProjectAutomationRequest(VNextAgentRequest):
     user_id: UUID
     scope: dict[str, object] = Field(default_factory=dict)
     options: dict[str, object] = Field(default_factory=dict)
 
 
-class VNextProjectCreateRequest(BaseModel):
+class VNextProjectCreateRequest(VNextAgentRequest):
     user_id: UUID
     name: str = Field(min_length=1, max_length=280)
     slug: str | None = Field(default=None, min_length=1, max_length=280)
@@ -1232,13 +1270,13 @@ class VNextProjectCreateRequest(BaseModel):
     sensitivity: str = Field(default="private", min_length=1, max_length=80)
 
 
-class VNextProjectUpdateReviewRequest(BaseModel):
+class VNextProjectUpdateReviewRequest(VNextAgentRequest):
     user_id: UUID
     action: str = Field(min_length=1, max_length=40)
     edited_current_state: str | None = Field(default=None, min_length=1, max_length=4000)
 
 
-class VNextOpenLoopReviewRequest(BaseModel):
+class VNextOpenLoopReviewRequest(VNextAgentRequest):
     user_id: UUID
     action: str = Field(min_length=1, max_length=40)
     title: str | None = Field(default=None, min_length=1, max_length=280)
@@ -1248,7 +1286,7 @@ class VNextOpenLoopReviewRequest(BaseModel):
     resolution_note: str | None = Field(default=None, min_length=1, max_length=4000)
 
 
-class VNextOpenLoopCreateRequest(BaseModel):
+class VNextOpenLoopCreateRequest(VNextAgentRequest):
     user_id: UUID
     title: str = Field(min_length=1, max_length=280)
     description: str | None = Field(default=None, min_length=1, max_length=4000)
@@ -1261,7 +1299,7 @@ class VNextOpenLoopCreateRequest(BaseModel):
     sensitivity: str = Field(default="unknown", min_length=1, max_length=80)
 
 
-class VNextMemoryReviewRequest(BaseModel):
+class VNextMemoryReviewRequest(VNextAgentRequest):
     user_id: UUID
     action: str = Field(min_length=1, max_length=40)
     title: str | None = Field(default=None, min_length=1, max_length=280)
@@ -1273,7 +1311,7 @@ class VNextMemoryReviewRequest(BaseModel):
     reason: str | None = Field(default=None, min_length=1, max_length=4000)
 
 
-class VNextQueueTaskCreateRequest(BaseModel):
+class VNextQueueTaskCreateRequest(VNextAgentRequest):
     user_id: UUID
     title: str = Field(min_length=1, max_length=280)
     task_type: str = Field(min_length=1, max_length=80)
@@ -1285,33 +1323,33 @@ class VNextQueueTaskCreateRequest(BaseModel):
     allowed_sources_json: list[object] = Field(default_factory=list)
 
 
-class VNextQueueProcessNextRequest(BaseModel):
+class VNextQueueProcessNextRequest(VNextAgentRequest):
     user_id: UUID
 
 
-class VNextArtifactReviewRequest(BaseModel):
-    user_id: UUID
-    action: str = Field(min_length=1, max_length=40)
-
-
-class VNextGraphEdgeReviewRequest(BaseModel):
+class VNextArtifactReviewRequest(VNextAgentRequest):
     user_id: UUID
     action: str = Field(min_length=1, max_length=40)
 
 
-class VNextBeliefReviewRequest(BaseModel):
+class VNextGraphEdgeReviewRequest(VNextAgentRequest):
+    user_id: UUID
+    action: str = Field(min_length=1, max_length=40)
+
+
+class VNextBeliefReviewRequest(VNextAgentRequest):
     user_id: UUID
     action: str = Field(min_length=1, max_length=40)
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
     superseded_by: str | None = Field(default=None, min_length=1, max_length=120)
 
 
-class VNextArtifactExportRequest(BaseModel):
+class VNextArtifactExportRequest(VNextAgentRequest):
     user_id: UUID
     output_dir: str = Field(min_length=1, max_length=1000)
 
 
-class VNextBrainCharterUpsertRequest(BaseModel):
+class VNextBrainCharterUpsertRequest(VNextAgentRequest):
     user_id: UUID
     content_markdown: str = Field(min_length=1, max_length=200_000)
     owner_json: dict[str, object] = Field(default_factory=dict)
@@ -1323,6 +1361,42 @@ class VNextBrainCharterUpsertRequest(BaseModel):
     autonomous_rules_json: list[object] = Field(default_factory=list)
     quality_standard_json: list[object] = Field(default_factory=list)
     sensitivity: str = Field(default="private", min_length=1, max_length=80)
+
+
+class VNextMemoryProposalRequest(VNextAgentRequest):
+    user_id: UUID
+    proposal_type: str = Field(default="candidate_memory", min_length=1, max_length=80)
+    title: str = Field(min_length=1, max_length=280)
+    canonical_text: str = Field(min_length=1, max_length=20_000)
+    source_refs: list[object] = Field(default_factory=list)
+    domain: str = Field(default="unknown", min_length=1, max_length=80)
+    sensitivity: str = Field(default="unknown", min_length=1, max_length=80)
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    rationale: str | None = Field(default=None, min_length=1, max_length=4000)
+    review_required: bool = True
+
+
+class VNextSchedulerWorkflowPatchRequest(VNextAgentRequest):
+    user_id: UUID
+    enabled: bool | None = None
+    paused: bool | None = None
+    schedule_json: dict[str, object] | None = None
+    timezone: str | None = Field(default=None, min_length=1, max_length=120)
+
+
+class VNextSchedulerRunNowRequest(VNextAgentRequest):
+    user_id: UUID
+    scope: dict[str, object] = Field(default_factory=dict)
+    options: dict[str, object] = Field(default_factory=dict)
+
+
+class VNextSchedulerRunDueRequest(VNextAgentRequest):
+    user_id: UUID
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class VNextSchedulerControlRequest(VNextAgentRequest):
+    user_id: UUID
 
 
 def _vnext_public_error_response(*, status_code: int, detail: str) -> JSONResponse:
@@ -1377,6 +1451,74 @@ def _vnext_status_counts(rows: list[dict[str, object]], *, field: str = "status"
     return counts
 
 
+def _vnext_agent_identity(request: VNextAgentRequest) -> AgentIdentity | None:
+    payload = request.model_dump(mode="json")
+    return AgentIdentity.from_payload(payload)
+
+
+def _vnext_permission_response(decision: PolicyDecision) -> JSONResponse:
+    return JSONResponse(
+        status_code=403,
+        content=jsonable_encoder(
+            {
+                "detail": "agent policy blocked this action",
+                "policy_decision": decision.to_record(),
+            }
+        ),
+    )
+
+
+def _vnext_agent_actor(identity: AgentIdentity | None, *, fallback: str = "user") -> tuple[str, str | None]:
+    if identity is None:
+        return fallback, None
+    return identity.actor_type, identity.agent_id
+
+
+def _vnext_agent_record(store: PostgresVNextStore, identity: AgentIdentity | None) -> None:
+    if identity is None:
+        return
+    store.upsert_agent_identity(
+        {
+            "agent_id": identity.agent_id,
+            "agent_type": identity.agent_type,
+            "permission_profile": identity.permission_profile,
+            "project_scope_json": list(identity.project_scope),
+            "metadata_json": {
+                "last_agent_run_id": identity.agent_run_id,
+                "last_task_id": identity.task_id,
+            },
+        },
+        actor_type="agent",
+    )
+
+
+def _vnext_policy_checked(
+    *,
+    store: PostgresVNextStore,
+    identity: AgentIdentity | None,
+    action: str,
+    domains: tuple[str, ...] = (),
+    sensitivity_allowed: tuple[str, ...] = ("public", "internal", "private", "unknown"),
+    project_scope: tuple[str, ...] = (),
+    workflow_type: str | None = None,
+    write_policy: str | None = None,
+    target_type: str | None = None,
+    target_id: str | None = None,
+) -> PolicyDecision:
+    _vnext_agent_record(store, identity)
+    decision = evaluate_agent_policy(
+        identity=identity,
+        action=action,
+        domains=domains,
+        sensitivity_allowed=sensitivity_allowed,
+        project_scope=project_scope,
+        workflow_type=workflow_type,
+        write_policy=write_policy,
+    )
+    append_policy_events(store, identity=identity, decision=decision, target_type=target_type, target_id=target_id)
+    return decision
+
+
 def _vnext_workspace_payload(store: PostgresVNextStore) -> dict[str, object]:
     sensitivity_allowed = ["public", "internal", "private", "unknown"]
     sources = store.list_sources(sensitivity_allowed=sensitivity_allowed, limit=20)
@@ -1393,6 +1535,9 @@ def _vnext_workspace_payload(store: PostgresVNextStore) -> dict[str, object]:
     beliefs = store.list_beliefs(status=None, sensitivity_allowed=sensitivity_allowed, limit=12)
     tasks = store.list_tasks(status=None, limit=12)
     recent_events = store.list_events(limit=20)
+    agent_identities = store.list_agent_identities(limit=20)
+    agent_events = store.list_agent_events(limit=50)
+    scheduler_status = VNextSchedulerService(store).status()
     project_service = VNextProjectService(store)
     project_dashboards: list[dict[str, object]] = []
     for project in projects[:5]:
@@ -1410,6 +1555,8 @@ def _vnext_workspace_payload(store: PostgresVNextStore) -> dict[str, object]:
             "open_loop_count": len([loop for loop in open_loops if loop.get("status") == "open"]),
             "project_count": len(projects),
             "event_count": len(recent_events),
+            "agent_count": len(agent_identities),
+            "scheduler_enabled_count": int(scheduler_status["enabled_count"]),
             "memory_status_counts": _vnext_status_counts(memories),
             "artifact_status_counts": _vnext_status_counts(artifacts),
             "open_loop_status_counts": _vnext_status_counts(open_loops),
@@ -1424,18 +1571,47 @@ def _vnext_workspace_payload(store: PostgresVNextStore) -> dict[str, object]:
         "beliefs": beliefs,
         "tasks": tasks,
         "recent_events": recent_events,
+        "agent_activity": {
+            "agents": agent_identities,
+            "recent_events": agent_events,
+            "policy_blocks": [
+                event
+                for event in agent_events
+                if event.get("event_type") in {"agent.policy_blocked", "agent.policy_filtered"}
+            ],
+            "generated_artifacts": [
+                artifact
+                for artifact in artifacts
+                if isinstance(artifact.get("metadata_json"), dict)
+                and artifact["metadata_json"].get("generated_by") == "agent"
+            ],
+            "pending_review_items": [
+                memory
+                for memory in review_memories
+                if isinstance(memory.get("metadata_json"), dict)
+                and memory["metadata_json"].get("agent_id") is not None
+            ],
+        },
+        "scheduler": scheduler_status,
         "brain_charter": store.get_brain_charter(),
     }
 
 
-def _vnext_brain_artifact_request(request: VNextBrainArtifactGenerateRequest) -> BrainArtifactRequest:
+def _vnext_brain_artifact_request(
+    request: VNextBrainArtifactGenerateRequest,
+    *,
+    identity: AgentIdentity | None = None,
+    decision: PolicyDecision | None = None,
+) -> BrainArtifactRequest:
     scope = request.scope
     options = request.options
     generated_for = options.get("generated_for") or scope.get("generated_for")
+    actor_type, actor_id = _vnext_agent_actor(identity, fallback="system")
     return BrainArtifactRequest(
-        domains=_vnext_string_list(scope, "domains"),
-        sensitivity_allowed=_vnext_string_list(options, "sensitivity_allowed")
-        or ("public", "internal", "private", "unknown"),
+        domains=decision.effective_domains if decision is not None else _vnext_string_list(scope, "domains"),
+        sensitivity_allowed=decision.effective_sensitivity_allowed
+        if decision is not None
+        else _vnext_string_list(options, "sensitivity_allowed") or ("public", "internal", "private", "unknown"),
         generated_for=str(generated_for) if isinstance(generated_for, str) else None,
         source_limit=_vnext_int(options, "source_limit", 8),
         memory_limit=_vnext_int(options, "memory_limit", 8),
@@ -1443,6 +1619,13 @@ def _vnext_brain_artifact_request(request: VNextBrainArtifactGenerateRequest) ->
         artifact_limit=_vnext_int(options, "artifact_limit", 4),
         discover_open_loops=_vnext_bool(options, "discover_open_loops", True),
         create_candidate_memories=_vnext_bool(options, "create_candidate_memories", True),
+        generated_by=actor_type,
+        actor_id=actor_id,
+        trace_id=request.trace_id,
+        run_id=identity.agent_run_id if identity is not None else None,
+        agent_identity=identity.to_record() if identity is not None else None,
+        policy_decision=decision.to_record() if decision is not None else None,
+        metadata_json=agent_metadata(identity, decision),
     )
 
 
@@ -1469,18 +1652,32 @@ def _vnext_contradiction_request(request: VNextContradictionReportGenerateReques
     )
 
 
-def _vnext_project_automation_request(request: VNextProjectAutomationRequest) -> ProjectAutomationRequest:
+def _vnext_project_automation_request(
+    request: VNextProjectAutomationRequest,
+    *,
+    identity: AgentIdentity | None = None,
+    decision: PolicyDecision | None = None,
+) -> ProjectAutomationRequest:
     options = request.options
     scope = request.scope
     project_id = options.get("project_id") or scope.get("project_id")
     person_id = options.get("person_id") or scope.get("person_id")
+    actor_type, actor_id = _vnext_agent_actor(identity, fallback="system")
     return ProjectAutomationRequest(
-        domains=_vnext_string_list(scope, "domains"),
-        sensitivity_allowed=_vnext_string_list(options, "sensitivity_allowed")
-        or ("public", "internal", "private", "unknown"),
+        domains=decision.effective_domains if decision is not None else _vnext_string_list(scope, "domains"),
+        sensitivity_allowed=decision.effective_sensitivity_allowed
+        if decision is not None
+        else _vnext_string_list(options, "sensitivity_allowed") or ("public", "internal", "private", "unknown"),
         project_id=str(project_id) if isinstance(project_id, str) else None,
         person_id=str(person_id) if isinstance(person_id, str) else None,
         max_items=_vnext_int(options, "max_items", 8),
+        generated_by=actor_type,
+        actor_id=actor_id,
+        trace_id=request.trace_id,
+        run_id=identity.agent_run_id if identity is not None else None,
+        agent_identity=identity.to_record() if identity is not None else None,
+        policy_decision=decision.to_record() if decision is not None else None,
+        metadata_json=agent_metadata(identity, decision),
     )
 
 
@@ -5696,17 +5893,45 @@ def get_vnext_workspace(user_id: UUID) -> JSONResponse:
 @app.post("/v0/vnext/sources")
 def create_vnext_source(request: VNextSourceCaptureRequest) -> JSONResponse:
     settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
 
     try:
         with user_connection(settings.database_url, request.user_id) as conn:
-            payload = VNextCaptureService(PostgresVNextStore(conn)).capture_text(
+            store = PostgresVNextStore(conn)
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="source.capture",
+                domains=(request.domain,),
+                sensitivity_allowed=(request.sensitivity,),
+                project_scope=tuple(request.project_scope),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            actor_type, actor_id = _vnext_agent_actor(identity, fallback="user")
+            payload = VNextCaptureService(
+                store,
+                actor_type=actor_type,
+                actor_id=actor_id,
+                trace_id=request.trace_id or decision.trace_id,
+                run_id=identity.agent_run_id if identity is not None else None,
+                agent_identity=identity.to_record() if identity is not None else None,
+                policy_decision=decision.to_record(),
+            ).capture_text(
                 request.raw_text,
                 title=request.title,
                 domain=request.domain,
                 sensitivity=request.sensitivity,
             ).to_record()
+            if identity is not None:
+                append_policy_events(store, identity=identity, decision=decision, target_type="source", target_id=str(payload.get("source_id")))
     except VNextCaptureValidationError:
         return _vnext_public_error_response(status_code=400, detail="vNext source capture request is invalid")
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
 
     return JSONResponse(
         status_code=201,
@@ -5823,25 +6048,68 @@ def create_vnext_context_pack(request: VNextContextPackRequest) -> JSONResponse:
     settings = get_settings()
     scope = request.scope
     options = request.options
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
 
     try:
+        requested_domains = _vnext_string_list(scope, "domains")
+        requested_sensitivity = _vnext_string_list(options, "sensitivity_allowed") or (
+            "public",
+            "internal",
+            "private",
+            "unknown",
+        )
         retrieval_request = VNextRetrievalRequest(
             query=request.query,
-            domains=_vnext_string_list(scope, "domains"),
+            domains=requested_domains,
             projects=_vnext_string_list(scope, "projects"),
             people=_vnext_string_list(scope, "people"),
             time_window=str(scope.get("time_window", "all")),
-            sensitivity_allowed=_vnext_string_list(options, "sensitivity_allowed")
-            or ("public", "internal", "private", "unknown"),
+            sensitivity_allowed=requested_sensitivity,
             include_sources=_vnext_bool(options, "include_sources", True),
             include_contradictions=_vnext_bool(options, "include_contradictions", True),
             max_items=_vnext_int(options, "max_items", 8),
             max_tokens=_vnext_int(options, "max_tokens", 8000),
         )
         with user_connection(settings.database_url, request.user_id) as conn:
-            payload = VNextRetrievalService(PostgresVNextStore(conn)).compile_context_pack(retrieval_request)
+            store = PostgresVNextStore(conn)
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="context_pack.request",
+                domains=requested_domains,
+                sensitivity_allowed=requested_sensitivity,
+                project_scope=tuple(request.project_scope) or _vnext_string_list(scope, "projects"),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            actor_type, actor_id = _vnext_agent_actor(identity, fallback="system")
+            payload = VNextRetrievalService(store).compile_context_pack(
+                VNextRetrievalRequest(
+                    query=retrieval_request.query,
+                    domains=decision.effective_domains,
+                    projects=retrieval_request.projects,
+                    people=retrieval_request.people,
+                    time_window=retrieval_request.time_window,
+                    sensitivity_allowed=decision.effective_sensitivity_allowed,
+                    include_sources=retrieval_request.include_sources,
+                    include_contradictions=retrieval_request.include_contradictions,
+                    max_items=retrieval_request.max_items,
+                    max_tokens=retrieval_request.max_tokens,
+                    actor_type=actor_type,
+                    actor_id=actor_id,
+                    agent_identity=identity.to_record() if identity is not None else None,
+                    policy_decision=decision.to_record(),
+                    trace_id=request.trace_id or decision.trace_id,
+                    run_id=identity.agent_run_id if identity is not None else None,
+                )
+            )
     except VNextRetrievalValidationError:
         return _vnext_public_error_response(status_code=400, detail="vNext context-pack request is invalid")
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
 
     return JSONResponse(
         status_code=201,
@@ -5939,21 +6207,176 @@ def review_vnext_memory(memory_id: UUID, request: VNextMemoryReviewRequest) -> J
             },
             actor_type="user",
         )
+        review_event = {
+            "accept": "review.item_accepted",
+            "promote": "review.item_accepted",
+            "reject": "review.item_rejected",
+            "edit": "review.item_edited",
+            "private": "review.item_edited",
+            "assign_project": "review.item_edited",
+        }[action]
+        append_event(
+            store,
+            event_type=review_event,
+            actor_type="user",
+            target_type="memory",
+            target_id=str(memory_id),
+            payload={"action": action, "project_id": request.project_id},
+        )
 
     return JSONResponse(status_code=200, content=jsonable_encoder({"memory": updated}))
+
+
+def _vnext_memory_type_for_proposal(proposal_type: str) -> str:
+    mapping = {
+        "candidate_memory": "semantic",
+        "project_update": "project_state",
+        "open_loop": "open_loop",
+        "belief_update": "belief",
+        "contradiction": "contradiction",
+        "graph_edge": "semantic",
+        "artifact_summary": "artifact_summary",
+        "decision": "decision",
+        "recent_change": "semantic",
+    }
+    return mapping.get(proposal_type, "semantic")
+
+
+@app.post("/v0/vnext/memory-proposals")
+def create_vnext_memory_proposal(request: VNextMemoryProposalRequest) -> JSONResponse:
+    settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
+    if identity is None:
+        return _vnext_public_error_response(status_code=400, detail="agent identity is required for memory proposals")
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            store = PostgresVNextStore(conn)
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="memory.propose",
+                domains=(request.domain,),
+                sensitivity_allowed=(request.sensitivity,),
+                project_scope=tuple(request.project_scope),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            proposal_id = str(uuid4())
+            metadata = {
+                "proposal_id": proposal_id,
+                "proposal_type": request.proposal_type,
+                "source_refs": request.source_refs,
+                "project_scope": list(request.project_scope),
+                "rationale": request.rationale,
+                "review_required": True,
+                **agent_metadata(identity, decision),
+            }
+            memory = store.create_memory(
+                {
+                    "memory_type": _vnext_memory_type_for_proposal(request.proposal_type),
+                    "memory_key": f"agent_proposal.{request.proposal_type}.{proposal_id}",
+                    "value": {
+                        "proposal_type": request.proposal_type,
+                        "text": request.canonical_text,
+                        "source_refs": request.source_refs,
+                        "rationale": request.rationale,
+                    },
+                    "status": "candidate",
+                    "confidence": request.confidence,
+                    "title": request.title,
+                    "canonical_text": request.canonical_text,
+                    "summary": request.canonical_text[:280],
+                    "domain": request.domain,
+                    "sensitivity": request.sensitivity,
+                    "metadata_json": metadata,
+                },
+                actor_type="agent",
+            )
+            store.append_revision(
+                {
+                    "memory_id": str(memory["id"]),
+                    "memory_key": str(memory["memory_key"]),
+                    "new_value": memory.get("value"),
+                    "revision_type": "created",
+                    "action": "agent_memory_proposal",
+                    "text_after": request.canonical_text,
+                    "reason": request.rationale or "Agent proposed memory for human review.",
+                    "actor_type": "agent",
+                    "actor_id": identity.agent_id,
+                    "metadata_json": metadata,
+                },
+                actor_type="agent",
+            )
+            append_event(
+                store,
+                event_type="agent.memory_proposed",
+                actor_type="agent",
+                actor_id=identity.agent_id,
+                target_type="memory",
+                target_id=str(memory["id"]),
+                trace_id=request.trace_id or decision.trace_id,
+                run_id=identity.agent_run_id,
+                payload={"proposal_type": request.proposal_type, "agent_identity": identity.to_record(), "policy_decision": decision.to_record()},
+            )
+            append_event(
+                store,
+                event_type="review.item_created",
+                actor_type="agent",
+                actor_id=identity.agent_id,
+                target_type="memory",
+                target_id=str(memory["id"]),
+                trace_id=request.trace_id or decision.trace_id,
+                run_id=identity.agent_run_id,
+                payload={"review_required": True, "proposal_type": request.proposal_type},
+            )
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
+
+    return JSONResponse(
+        status_code=201,
+        content=jsonable_encoder({"proposal": memory, "policy_decision": decision.to_record(), "review_required": True}),
+    )
 
 
 @app.post("/v0/vnext/artifacts/generate/daily-brief")
 def generate_vnext_daily_brief(request: VNextBrainArtifactGenerateRequest) -> JSONResponse:
     settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
 
     try:
         with user_connection(settings.database_url, request.user_id) as conn:
-            payload = VNextBrainService(PostgresVNextStore(conn)).generate_daily_brief(
-                _vnext_brain_artifact_request(request)
+            store = PostgresVNextStore(conn)
+            requested_domains = _vnext_string_list(request.scope, "domains")
+            requested_sensitivity = _vnext_string_list(request.options, "sensitivity_allowed") or (
+                "public",
+                "internal",
+                "private",
+                "unknown",
+            )
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="artifact.generate",
+                domains=requested_domains,
+                sensitivity_allowed=requested_sensitivity,
+                project_scope=tuple(request.project_scope) or _vnext_string_list(request.scope, "projects"),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            payload = VNextBrainService(store).generate_daily_brief(
+                _vnext_brain_artifact_request(request, identity=identity, decision=decision)
             )
     except VNextBrainValidationError:
         return _vnext_public_error_response(status_code=400, detail="vNext daily brief request is invalid")
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
 
     return JSONResponse(
         status_code=201,
@@ -5964,14 +6387,38 @@ def generate_vnext_daily_brief(request: VNextBrainArtifactGenerateRequest) -> JS
 @app.post("/v0/vnext/artifacts/generate/weekly-synthesis")
 def generate_vnext_weekly_synthesis(request: VNextBrainArtifactGenerateRequest) -> JSONResponse:
     settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
 
     try:
         with user_connection(settings.database_url, request.user_id) as conn:
-            payload = VNextBrainService(PostgresVNextStore(conn)).generate_weekly_synthesis(
-                _vnext_brain_artifact_request(request)
+            store = PostgresVNextStore(conn)
+            requested_domains = _vnext_string_list(request.scope, "domains")
+            requested_sensitivity = _vnext_string_list(request.options, "sensitivity_allowed") or (
+                "public",
+                "internal",
+                "private",
+                "unknown",
+            )
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="artifact.generate",
+                domains=requested_domains,
+                sensitivity_allowed=requested_sensitivity,
+                project_scope=tuple(request.project_scope) or _vnext_string_list(request.scope, "projects"),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            payload = VNextBrainService(store).generate_weekly_synthesis(
+                _vnext_brain_artifact_request(request, identity=identity, decision=decision)
             )
     except VNextBrainValidationError:
         return _vnext_public_error_response(status_code=400, detail="vNext weekly synthesis request is invalid")
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
 
     return JSONResponse(
         status_code=201,
@@ -6018,24 +6465,49 @@ def generate_vnext_contradiction_report(request: VNextContradictionReportGenerat
 @app.post("/v0/vnext/queue/tasks")
 def create_vnext_queue_task(request: VNextQueueTaskCreateRequest) -> JSONResponse:
     settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
 
     try:
         with user_connection(settings.database_url, request.user_id) as conn:
-            payload = VNextQueueService(PostgresVNextStore(conn)).enqueue_task(
+            store = PostgresVNextStore(conn)
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="queue_task.create",
+                domains=(request.domain,),
+                sensitivity_allowed=(request.sensitivity,),
+                project_scope=tuple(request.project_scope),
+                write_policy=request.write_policy,
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            actor_type, actor_id = _vnext_agent_actor(identity, fallback="user")
+            payload = VNextQueueService(store).enqueue_task(
                 QueueTaskRequest(
                     title=request.title,
                     task_type=request.task_type,
                     instructions=request.instructions,
-                    requested_by="api",
+                    requested_by=identity.agent_id if identity is not None else "api",
                     scope_json=request.scope_json,
                     allowed_sources_json=request.allowed_sources_json,
                     domain=request.domain,
                     sensitivity=request.sensitivity,
                     write_policy=request.write_policy,
+                    actor_type=actor_type,
+                    actor_id=actor_id,
+                    trace_id=request.trace_id or decision.trace_id,
+                    run_id=identity.agent_run_id if identity is not None else None,
+                    agent_identity=identity.to_record() if identity is not None else None,
+                    policy_decision=decision.to_record(),
                 )
             )
     except VNextQueueValidationError:
         return _vnext_public_error_response(status_code=400, detail="vNext queue task request is invalid")
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
 
     return JSONResponse(
         status_code=201,
@@ -6088,10 +6560,24 @@ def get_vnext_artifact(artifact_id: UUID, user_id: UUID) -> JSONResponse:
 @app.post("/v0/vnext/artifacts/{artifact_id}/review")
 def review_vnext_artifact(artifact_id: UUID, request: VNextArtifactReviewRequest) -> JSONResponse:
     settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
 
     try:
         with user_connection(settings.database_url, request.user_id) as conn:
-            payload = VNextQueueService(PostgresVNextStore(conn)).review_artifact(
+            store = PostgresVNextStore(conn)
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="artifact.review",
+                target_type="artifact",
+                target_id=str(artifact_id),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            payload = VNextQueueService(store).review_artifact(
                 artifact_id=str(artifact_id),
                 action=request.action,
             )
@@ -6099,6 +6585,8 @@ def review_vnext_artifact(artifact_id: UUID, request: VNextArtifactReviewRequest
         return _vnext_public_error_response(status_code=404, detail="vNext artifact was not found")
     except VNextQueueValidationError:
         return _vnext_public_error_response(status_code=400, detail="vNext artifact review request is invalid")
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
 
     return JSONResponse(
         status_code=200,
@@ -6199,14 +6687,38 @@ def get_vnext_belief_state(belief_id: str, user_id: UUID) -> JSONResponse:
 @app.post("/v0/vnext/projects/update-candidates")
 def generate_vnext_project_update_candidate(request: VNextProjectAutomationRequest) -> JSONResponse:
     settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
 
     try:
         with user_connection(settings.database_url, request.user_id) as conn:
-            payload = VNextProjectService(PostgresVNextStore(conn)).generate_project_update_candidate(
-                _vnext_project_automation_request(request)
+            store = PostgresVNextStore(conn)
+            requested_domains = _vnext_string_list(request.scope, "domains")
+            requested_sensitivity = _vnext_string_list(request.options, "sensitivity_allowed") or (
+                "public",
+                "internal",
+                "private",
+                "unknown",
+            )
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="artifact.generate",
+                domains=requested_domains,
+                sensitivity_allowed=requested_sensitivity,
+                project_scope=tuple(request.project_scope) or _vnext_string_list(request.scope, "projects"),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            payload = VNextProjectService(store).generate_project_update_candidate(
+                _vnext_project_automation_request(request, identity=identity, decision=decision)
             )
     except VNextProjectValidationError:
         return _vnext_public_error_response(status_code=400, detail="vNext project update request is invalid")
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
 
     return JSONResponse(status_code=201, content=jsonable_encoder(payload))
 
@@ -6244,23 +6756,57 @@ def get_vnext_project_dashboard(project_id: str, user_id: UUID) -> JSONResponse:
 @app.post("/v0/vnext/open-loops")
 def create_vnext_open_loop(request: VNextOpenLoopCreateRequest) -> JSONResponse:
     settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
 
-    with user_connection(settings.database_url, request.user_id) as conn:
-        payload = PostgresVNextStore(conn).create_open_loop(
-            {
-                "title": request.title.strip(),
-                "description": request.description,
-                "due_at": request.due_at,
-                "priority": request.priority,
-                "memory_id": request.memory_id,
-                "project_id": request.project_id,
-                "source_id": request.source_id,
-                "domain": request.domain,
-                "sensitivity": request.sensitivity,
-                "metadata_json": {"created_from": "vnext_workspace"},
-            },
-            actor_type="user",
-        )
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            store = PostgresVNextStore(conn)
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="open_loop.create",
+                domains=(request.domain,),
+                sensitivity_allowed=(request.sensitivity,),
+                project_scope=tuple(request.project_scope),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            actor_type, _actor_id = _vnext_agent_actor(identity, fallback="user")
+            payload = store.create_open_loop(
+                {
+                    "title": request.title.strip(),
+                    "description": request.description,
+                    "due_at": request.due_at,
+                    "priority": request.priority,
+                    "memory_id": request.memory_id,
+                    "project_id": request.project_id,
+                    "source_id": request.source_id,
+                    "domain": request.domain,
+                    "sensitivity": request.sensitivity,
+                    "metadata_json": {
+                        "created_from": "vnext_workspace",
+                        **agent_metadata(identity, decision),
+                    },
+                },
+                actor_type=actor_type,
+            )
+            if identity is not None:
+                append_event(
+                    store,
+                    event_type="agent.open_loop_created",
+                    actor_type="agent",
+                    actor_id=identity.agent_id,
+                    target_type="open_loop",
+                    target_id=str(payload["id"]),
+                    trace_id=request.trace_id or decision.trace_id,
+                    run_id=identity.agent_run_id,
+                    payload={"agent_identity": identity.to_record(), "policy_decision": decision.to_record()},
+                )
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
 
     return JSONResponse(status_code=201, content=jsonable_encoder({"open_loop": payload}))
 
@@ -6297,6 +6843,195 @@ def upsert_vnext_brain_charter(request: VNextBrainCharterUpsertRequest) -> JSONR
         )
 
     return JSONResponse(status_code=200, content=jsonable_encoder({"brain_charter": payload}))
+
+
+@app.get("/v0/vnext/scheduler/status")
+def get_vnext_scheduler_status(user_id: UUID) -> JSONResponse:
+    settings = get_settings()
+
+    with user_connection(settings.database_url, user_id) as conn:
+        payload = VNextSchedulerService(PostgresVNextStore(conn)).status()
+
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.get("/v0/vnext/scheduler/runs")
+def list_vnext_scheduler_runs(user_id: UUID, workflow_type: str | None = None, limit: int = 20) -> JSONResponse:
+    settings = get_settings()
+
+    with user_connection(settings.database_url, user_id) as conn:
+        payload = PostgresVNextStore(conn).list_scheduler_runs(workflow_type=workflow_type, limit=limit)
+
+    return JSONResponse(status_code=200, content=jsonable_encoder({"items": payload, "count": len(payload)}))
+
+
+@app.patch("/v0/vnext/scheduler/workflows/{workflow_type}")
+def patch_vnext_scheduler_workflow(workflow_type: str, request: VNextSchedulerWorkflowPatchRequest) -> JSONResponse:
+    settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+        if request.schedule_json is not None:
+            validate_schedule(workflow_type, request.schedule_json)
+    except (AgentIdentityValidationError, VNextSchedulerValidationError) as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            store = PostgresVNextStore(conn)
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="scheduler.configure",
+                workflow_type=workflow_type,
+                project_scope=tuple(request.project_scope),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            actor_type, _actor_id = _vnext_agent_actor(identity, fallback="user")
+            payload = VNextSchedulerService(store).configure_workflow(
+                workflow_type=workflow_type,
+                enabled=request.enabled,
+                paused=request.paused,
+                schedule_json=request.schedule_json,
+                timezone=request.timezone,
+                actor_type=actor_type,
+            )
+    except VNextSchedulerValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
+
+    return JSONResponse(status_code=200, content=jsonable_encoder({"workflow": payload, "policy_decision": decision.to_record()}))
+
+
+@app.post("/v0/vnext/scheduler/workflows/{workflow_type}/run-now")
+def run_vnext_scheduler_workflow_now(workflow_type: str, request: VNextSchedulerRunNowRequest) -> JSONResponse:
+    settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
+    scope = request.scope
+    options = request.options
+    requested_domains = _vnext_string_list(scope, "domains")
+    requested_sensitivity = _vnext_string_list(options, "sensitivity_allowed") or (
+        "public",
+        "internal",
+        "private",
+        "unknown",
+    )
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            store = PostgresVNextStore(conn)
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="scheduler.run_now",
+                domains=requested_domains,
+                sensitivity_allowed=requested_sensitivity,
+                project_scope=tuple(request.project_scope) or _vnext_string_list(scope, "projects"),
+                workflow_type=workflow_type,
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            triggered_by = "agent" if identity is not None else "user"
+            payload = VNextSchedulerService(store).run_now(
+                SchedulerRunRequest(
+                    workflow_type=workflow_type,
+                    domains=decision.effective_domains,
+                    sensitivity_allowed=decision.effective_sensitivity_allowed,
+                    generated_for=str(options["generated_for"]) if isinstance(options.get("generated_for"), str) else None,
+                    triggered_by=triggered_by,
+                    agent_identity=identity,
+                    policy_decision=decision,
+                    options=options,
+                )
+            )
+    except VNextSchedulerValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
+
+    return JSONResponse(status_code=201, content=jsonable_encoder({**payload, "policy_decision": decision.to_record()}))
+
+
+@app.post("/v0/vnext/scheduler/run-due")
+def run_vnext_scheduler_due(request: VNextSchedulerRunDueRequest) -> JSONResponse:
+    settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            store = PostgresVNextStore(conn)
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action="scheduler.run_due",
+                project_scope=tuple(request.project_scope),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            actor_type, _actor_id = _vnext_agent_actor(identity, fallback="scheduler")
+            payload = VNextSchedulerService(store).run_due_workflows(
+                limit=request.limit,
+                triggered_by=actor_type,
+                agent_identity=identity,
+                policy_decision=decision,
+            )
+    except VNextSchedulerValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
+
+    return JSONResponse(status_code=201, content=jsonable_encoder({**payload, "policy_decision": decision.to_record()}))
+
+
+@app.post("/v0/vnext/scheduler/pause")
+def pause_vnext_scheduler(request: VNextSchedulerControlRequest) -> JSONResponse:
+    return _vnext_scheduler_global_control(request, action="scheduler.pause", pause=True)
+
+
+@app.post("/v0/vnext/scheduler/resume")
+def resume_vnext_scheduler(request: VNextSchedulerControlRequest) -> JSONResponse:
+    return _vnext_scheduler_global_control(request, action="scheduler.resume", pause=False)
+
+
+def _vnext_scheduler_global_control(
+    request: VNextSchedulerControlRequest,
+    *,
+    action: str,
+    pause: bool,
+) -> JSONResponse:
+    settings = get_settings()
+    try:
+        identity = _vnext_agent_identity(request)
+    except AgentIdentityValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
+
+    try:
+        with user_connection(settings.database_url, request.user_id) as conn:
+            store = PostgresVNextStore(conn)
+            decision = _vnext_policy_checked(
+                store=store,
+                identity=identity,
+                action=action,
+                project_scope=tuple(request.project_scope),
+            )
+            if decision.decision == "blocked":
+                return _vnext_permission_response(decision)
+            actor_type, _actor_id = _vnext_agent_actor(identity, fallback="user")
+            service = VNextSchedulerService(store)
+            payload = service.pause_all(actor_type=actor_type) if pause else service.resume_all(actor_type=actor_type)
+    except VNextSchedulerValidationError as exc:
+        return _vnext_public_error_response(status_code=400, detail=str(exc))
+    except AgentPolicyBlockedError as exc:
+        return _vnext_permission_response(exc.decision)
+
+    return JSONResponse(status_code=200, content=jsonable_encoder({**payload, "policy_decision": decision.to_record()}))
 
 
 @app.post("/v0/vnext/open-loops/extract")

--- a/apps/api/src/alicebot_api/mcp_tools.py
+++ b/apps/api/src/alicebot_api/mcp_tools.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from typing import cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from alicebot_api.continuity_capture import (
     ContinuityCaptureValidationError,
@@ -124,11 +124,23 @@ from alicebot_api.task_briefing import (
     compile_and_persist_task_brief,
     get_persisted_task_brief,
 )
+from alicebot_api.vnext_agent_control import (
+    AgentIdentity,
+    AgentIdentityValidationError,
+    PolicyDecision,
+    agent_metadata,
+    append_policy_events,
+    evaluate_agent_policy,
+)
 from alicebot_api.vnext_brain import BrainArtifactRequest, VNextBrainService
+from alicebot_api.vnext_capture import VNextCaptureService
 from alicebot_api.vnext_connections import ConnectionFinderRequest, VNextConnectionService
 from alicebot_api.vnext_contradictions import ContradictionFinderRequest, VNextContradictionService
+from alicebot_api.vnext_event_log import append_event
 from alicebot_api.vnext_projects import ProjectAutomationRequest, VNextProjectService
+from alicebot_api.vnext_queue import QueueTaskRequest, VNextQueueService
 from alicebot_api.vnext_retrieval import VNextRetrievalRequest, VNextRetrievalService
+from alicebot_api.vnext_scheduler import SchedulerRunRequest, VNextSchedulerService
 from alicebot_api.vnext_json import json_safe
 from alicebot_api.vnext_store import PostgresVNextStore
 
@@ -311,6 +323,86 @@ def _parse_string_list(arguments: Mapping[str, object], key: str) -> tuple[str, 
         if normalized:
             output.append(normalized)
     return tuple(output)
+
+
+def _agent_identity_from_arguments(arguments: Mapping[str, object]) -> AgentIdentity | None:
+    try:
+        return AgentIdentity.from_payload(arguments)
+    except AgentIdentityValidationError as exc:
+        raise MCPToolError(str(exc)) from exc
+
+
+def _policy_checked(
+    store: PostgresVNextStore,
+    *,
+    identity: AgentIdentity | None,
+    action: str,
+    domains: tuple[str, ...] = (),
+    sensitivity_allowed: tuple[str, ...] = ("public", "internal", "private", "unknown"),
+    project_scope: tuple[str, ...] = (),
+    workflow_type: str | None = None,
+    write_policy: str | None = None,
+) -> tuple[str, str | None, object]:
+    if identity is not None:
+        store.upsert_agent_identity(
+            {
+                "agent_id": identity.agent_id,
+                "agent_type": identity.agent_type,
+                "permission_profile": identity.permission_profile,
+                "project_scope_json": list(identity.project_scope),
+                "metadata_json": {"last_agent_run_id": identity.agent_run_id, "last_task_id": identity.task_id},
+            },
+            actor_type="agent",
+        )
+    decision = evaluate_agent_policy(
+        identity=identity,
+        action=action,
+        domains=domains,
+        sensitivity_allowed=sensitivity_allowed,
+        project_scope=project_scope,
+        workflow_type=workflow_type,
+        write_policy=write_policy,
+    )
+    append_policy_events(store, identity=identity, decision=decision)
+    return ("agent", identity.agent_id, decision) if identity is not None else ("system", None, decision)
+
+
+def _raise_mcp_policy_blocked(decision: PolicyDecision) -> None:
+    raise MCPToolError(f"agent policy blocked: {', '.join(decision.reasons) or decision.action}")
+
+
+def _mcp_agent_policy_preflight(
+    context: MCPRuntimeContext,
+    arguments: Mapping[str, object],
+    *,
+    action: str,
+    domains: tuple[str, ...] = (),
+    sensitivity_allowed: tuple[str, ...] = ("public", "internal", "private", "unknown"),
+    project_scope: tuple[str, ...] = (),
+    workflow_type: str | None = None,
+    write_policy: str | None = None,
+) -> PolicyDecision:
+    identity = _agent_identity_from_arguments(arguments)
+    blocked_decision: PolicyDecision | None = None
+    decision: PolicyDecision | None = None
+    with _vnext_store_context(context) as store:
+        _actor_type, _actor_id, decision = _policy_checked(
+            store,
+            identity=identity,
+            action=action,
+            domains=domains,
+            sensitivity_allowed=sensitivity_allowed,
+            project_scope=project_scope,
+            workflow_type=workflow_type,
+            write_policy=write_policy,
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if decision is None:
+        raise MCPToolError("agent policy preflight did not complete")
+    return decision
 
 
 def _parse_task_brief_request(arguments: Mapping[str, object], *, mode_key: str = "mode") -> TaskBriefCompileRequestInput:
@@ -1071,6 +1163,15 @@ def _handle_alice_recent_decisions(context: MCPRuntimeContext, arguments: Mappin
         minimum=1,
         maximum=MAX_CONTINUITY_RECALL_LIMIT,
     )
+    _mcp_agent_policy_preflight(
+        context,
+        arguments,
+        action="recent_decisions.lookup",
+        domains=_parse_string_list(arguments, "domains"),
+        sensitivity_allowed=_parse_string_list(arguments, "sensitivity_allowed")
+        or ("public", "internal", "private", "unknown"),
+        project_scope=_parse_string_list(arguments, "project_scope"),
+    )
     return _recent_decisions_payload(context, arguments=arguments, limit=limit)
 
 
@@ -1081,6 +1182,15 @@ def _handle_alice_recent_changes(context: MCPRuntimeContext, arguments: Mapping[
         default=DEFAULT_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
         minimum=0,
         maximum=MAX_CONTINUITY_RESUMPTION_RECENT_CHANGES_LIMIT,
+    )
+    _mcp_agent_policy_preflight(
+        context,
+        arguments,
+        action="recent_changes.lookup",
+        domains=_parse_string_list(arguments, "domains"),
+        sensitivity_allowed=_parse_string_list(arguments, "sensitivity_allowed")
+        or ("public", "internal", "private", "unknown"),
+        project_scope=_parse_string_list(arguments, "project_scope"),
     )
 
     with _store_context(context) as store:
@@ -1484,22 +1594,47 @@ def _handle_alice_vnext_context_pack(context: MCPRuntimeContext, arguments: Mapp
         "private",
         "unknown",
     )
+    identity = _agent_identity_from_arguments(arguments)
 
+    blocked_decision: PolicyDecision | None = None
+    payload: JsonObject | None = None
     with _vnext_store_context(context) as store:
-        return VNextRetrievalService(store).compile_context_pack(
-            VNextRetrievalRequest(
-                query=_parse_required_text(arguments, "query"),
-                domains=_parse_string_list(arguments, "domains"),
-                projects=_parse_string_list(arguments, "projects"),
-                people=_parse_string_list(arguments, "people"),
-                time_window=_parse_optional_text(arguments, "time_window") or "all",
-                sensitivity_allowed=sensitivity_allowed,
-                include_sources=_parse_bool(arguments, key="include_sources", default=True),
-                include_contradictions=_parse_bool(arguments, key="include_contradictions", default=True),
-                max_items=max_items,
-                max_tokens=max_tokens,
-            )
+        actor_type, actor_id, decision = _policy_checked(
+            store,
+            identity=identity,
+            action="context_pack.request",
+            domains=_parse_string_list(arguments, "domains"),
+            sensitivity_allowed=sensitivity_allowed,
+            project_scope=_parse_string_list(arguments, "project_scope") or _parse_string_list(arguments, "projects"),
         )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextRetrievalService(store).compile_context_pack(
+                VNextRetrievalRequest(
+                    query=_parse_required_text(arguments, "query"),
+                    domains=decision.effective_domains,
+                    projects=_parse_string_list(arguments, "projects"),
+                    people=_parse_string_list(arguments, "people"),
+                    time_window=_parse_optional_text(arguments, "time_window") or "all",
+                    sensitivity_allowed=decision.effective_sensitivity_allowed,
+                    include_sources=_parse_bool(arguments, key="include_sources", default=True),
+                    include_contradictions=_parse_bool(arguments, key="include_contradictions", default=True),
+                    max_items=max_items,
+                    max_tokens=max_tokens,
+                    actor_type=actor_type,
+                    actor_id=actor_id,
+                    agent_identity=identity.to_record() if identity is not None else None,
+                    policy_decision=decision.to_record(),
+                    trace_id=_parse_optional_text(arguments, "trace_id") or decision.trace_id,
+                    run_id=identity.agent_run_id if identity is not None else None,
+                )
+            )
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if payload is None:
+        raise MCPToolError("vNext context-pack request did not complete")
+    return payload
 
 
 def _brain_artifact_request_from_arguments(arguments: Mapping[str, object]) -> BrainArtifactRequest:
@@ -1550,8 +1685,24 @@ def _connection_request_from_arguments(arguments: Mapping[str, object]) -> Conne
 
 
 def _handle_alice_generate_connections(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    request = _connection_request_from_arguments(arguments)
+    decision = _mcp_agent_policy_preflight(
+        context,
+        arguments,
+        action="artifact.generate",
+        domains=request.domains,
+        sensitivity_allowed=request.sensitivity_allowed,
+        project_scope=_parse_string_list(arguments, "project_scope") or _parse_string_list(arguments, "projects"),
+    )
+    request = ConnectionFinderRequest(
+        query=request.query,
+        domains=decision.effective_domains,
+        sensitivity_allowed=decision.effective_sensitivity_allowed,
+        max_connections=request.max_connections,
+        auto_accept_threshold=request.auto_accept_threshold,
+    )
     with _vnext_store_context(context) as store:
-        return VNextConnectionService(store).generate_connection_report(_connection_request_from_arguments(arguments))
+        return VNextConnectionService(store).generate_connection_report(request)
 
 
 def _handle_alice_graph_edge_review(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
@@ -1585,10 +1736,23 @@ def _contradiction_request_from_arguments(arguments: Mapping[str, object]) -> Co
 
 
 def _handle_alice_generate_contradictions(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    request = _contradiction_request_from_arguments(arguments)
+    decision = _mcp_agent_policy_preflight(
+        context,
+        arguments,
+        action="artifact.generate",
+        domains=request.domains,
+        sensitivity_allowed=request.sensitivity_allowed,
+        project_scope=_parse_string_list(arguments, "project_scope") or _parse_string_list(arguments, "projects"),
+    )
+    request = ContradictionFinderRequest(
+        query=request.query,
+        domains=decision.effective_domains,
+        sensitivity_allowed=decision.effective_sensitivity_allowed,
+        max_contradictions=request.max_contradictions,
+    )
     with _vnext_store_context(context) as store:
-        return VNextContradictionService(store).generate_contradiction_report(
-            _contradiction_request_from_arguments(arguments)
-        )
+        return VNextContradictionService(store).generate_contradiction_report(request)
 
 
 def _handle_alice_belief_review(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
@@ -1645,10 +1809,17 @@ def _handle_alice_project_dashboard(context: MCPRuntimeContext, arguments: Mappi
         "private",
         "unknown",
     )
+    decision = _mcp_agent_policy_preflight(
+        context,
+        arguments,
+        action="project.dashboard",
+        sensitivity_allowed=sensitivity_allowed,
+        project_scope=_parse_string_list(arguments, "project_scope"),
+    )
     with _vnext_store_context(context) as store:
         return VNextProjectService(store).project_dashboard(
             project_id=_parse_required_text(arguments, "project_id"),
-            sensitivity_allowed=sensitivity_allowed,
+            sensitivity_allowed=decision.effective_sensitivity_allowed,
         )
 
 
@@ -1669,6 +1840,415 @@ def _handle_alice_open_loop_review(context: MCPRuntimeContext, arguments: Mappin
             priority=_parse_optional_text(arguments, "priority"),
             resolution_note=_parse_optional_text(arguments, "resolution_note"),
         )
+
+
+def _handle_alice_vnext_capture(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    identity = _agent_identity_from_arguments(arguments)
+    domain = _parse_optional_text(arguments, "domain") or "unknown"
+    sensitivity = _parse_optional_text(arguments, "sensitivity") or "unknown"
+    blocked_decision: PolicyDecision | None = None
+    payload: JsonObject | None = None
+    with _vnext_store_context(context) as store:
+        actor_type, actor_id, decision = _policy_checked(
+            store,
+            identity=identity,
+            action="source.capture",
+            domains=(domain,),
+            sensitivity_allowed=(sensitivity,),
+            project_scope=_parse_string_list(arguments, "project_scope"),
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextCaptureService(
+                store,
+                actor_type=actor_type,
+                actor_id=actor_id,
+                trace_id=_parse_optional_text(arguments, "trace_id") or decision.trace_id,
+                run_id=identity.agent_run_id if identity is not None else None,
+                agent_identity=identity.to_record() if identity is not None else None,
+                policy_decision=decision.to_record(),
+            ).capture_text(
+                _parse_required_text(arguments, "raw_text"),
+                title=_parse_optional_text(arguments, "title"),
+                domain=domain,
+                sensitivity=sensitivity,
+            ).to_record()
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if payload is None:
+        raise MCPToolError("vNext source capture did not complete")
+    return payload
+
+
+def _handle_alice_vnext_queue_task(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    identity = _agent_identity_from_arguments(arguments)
+    domain = _parse_optional_text(arguments, "domain") or "unknown"
+    sensitivity = _parse_optional_text(arguments, "sensitivity") or "unknown"
+    write_policy = _parse_optional_text(arguments, "write_policy") or "proposal_only"
+    blocked_decision: PolicyDecision | None = None
+    payload: JsonObject | None = None
+    with _vnext_store_context(context) as store:
+        actor_type, actor_id, decision = _policy_checked(
+            store,
+            identity=identity,
+            action="queue_task.create",
+            domains=(domain,),
+            sensitivity_allowed=(sensitivity,),
+            project_scope=_parse_string_list(arguments, "project_scope"),
+            write_policy=write_policy,
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextQueueService(store).enqueue_task(
+                QueueTaskRequest(
+                    title=_parse_required_text(arguments, "title"),
+                    task_type=_parse_required_text(arguments, "task_type"),
+                    instructions=_parse_required_text(arguments, "instructions"),
+                    requested_by=identity.agent_id if identity is not None else "mcp",
+                    domain=domain,
+                    sensitivity=sensitivity,
+                    write_policy=write_policy,
+                    scope_json={"project_scope": list(_parse_string_list(arguments, "project_scope"))},
+                    actor_type=actor_type,
+                    actor_id=actor_id,
+                    trace_id=_parse_optional_text(arguments, "trace_id") or decision.trace_id,
+                    run_id=identity.agent_run_id if identity is not None else None,
+                    agent_identity=identity.to_record() if identity is not None else None,
+                    policy_decision=decision.to_record(),
+                )
+            )
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if payload is None:
+        raise MCPToolError("vNext queue task did not complete")
+    return payload
+
+
+def _handle_alice_vnext_generate_artifact(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    workflow_type = _parse_optional_text(arguments, "workflow_type") or "daily_brief"
+    if workflow_type in {"connection_report", "connections"}:
+        return _handle_alice_generate_connections(context, arguments)
+    if workflow_type in {"contradiction_report", "contradictions"}:
+        return _handle_alice_generate_contradictions(context, arguments)
+    identity = _agent_identity_from_arguments(arguments)
+    sensitivity_allowed = _parse_string_list(arguments, "sensitivity_allowed") or (
+        "public",
+        "internal",
+        "private",
+        "unknown",
+    )
+    blocked_decision: PolicyDecision | None = None
+    payload: JsonObject | None = None
+    with _vnext_store_context(context) as store:
+        actor_type, actor_id, decision = _policy_checked(
+            store,
+            identity=identity,
+            action="artifact.generate",
+            domains=_parse_string_list(arguments, "domains"),
+            sensitivity_allowed=sensitivity_allowed,
+            project_scope=_parse_string_list(arguments, "project_scope") or _parse_string_list(arguments, "projects"),
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            request = BrainArtifactRequest(
+                domains=decision.effective_domains,
+                sensitivity_allowed=decision.effective_sensitivity_allowed,
+                generated_for=_parse_optional_text(arguments, "generated_for"),
+                source_limit=_parse_int(arguments, key="source_limit", default=8, minimum=1, maximum=50),
+                memory_limit=_parse_int(arguments, key="memory_limit", default=8, minimum=1, maximum=50),
+                open_loop_limit=_parse_int(arguments, key="open_loop_limit", default=8, minimum=1, maximum=50),
+                artifact_limit=_parse_int(arguments, key="artifact_limit", default=4, minimum=1, maximum=50),
+                discover_open_loops=_parse_bool(arguments, key="discover_open_loops", default=True),
+                create_candidate_memories=_parse_bool(arguments, key="create_candidate_memories", default=True),
+                generated_by=actor_type,
+                actor_id=actor_id,
+                trace_id=_parse_optional_text(arguments, "trace_id") or decision.trace_id,
+                run_id=identity.agent_run_id if identity is not None else None,
+                agent_identity=identity.to_record() if identity is not None else None,
+                policy_decision=decision.to_record(),
+                metadata_json=agent_metadata(identity, decision),
+            )
+            service = VNextBrainService(store)
+            payload = (
+                service.generate_weekly_synthesis(request)
+                if workflow_type == "weekly_synthesis"
+                else service.generate_daily_brief(request)
+            )
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if payload is None:
+        raise MCPToolError("vNext artifact generation did not complete")
+    return payload
+
+
+def _handle_alice_vnext_open_loops(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    status = _parse_optional_text(arguments, "status") or "open"
+    sensitivity_allowed = _parse_string_list(arguments, "sensitivity_allowed") or (
+        "public",
+        "internal",
+        "private",
+        "unknown",
+    )
+    decision = _mcp_agent_policy_preflight(
+        context,
+        arguments,
+        action="open_loop.lookup",
+        domains=_parse_string_list(arguments, "domains"),
+        sensitivity_allowed=sensitivity_allowed,
+        project_scope=_parse_string_list(arguments, "project_scope"),
+    )
+    with _vnext_store_context(context) as store:
+        loops = store.list_open_loops(
+            status=status if status != "all" else None,
+            domains=list(decision.effective_domains) or None,
+            sensitivity_allowed=list(decision.effective_sensitivity_allowed),
+            limit=_parse_int(arguments, key="limit", default=20, minimum=1, maximum=100),
+        )
+    return {"items": loops, "count": len(loops)}
+
+
+def _handle_alice_vnext_propose_memory(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    identity = _agent_identity_from_arguments(arguments)
+    if identity is None:
+        raise MCPToolError("agent_id is required for alice_vnext_propose_memory")
+    proposal_type = _parse_optional_text(arguments, "proposal_type") or "candidate_memory"
+    canonical_text = _parse_required_text(arguments, "canonical_text")
+    domain = _parse_optional_text(arguments, "domain") or "unknown"
+    sensitivity = _parse_optional_text(arguments, "sensitivity") or "unknown"
+    blocked_decision: PolicyDecision | None = None
+    memory: JsonObject | None = None
+    decision: PolicyDecision | None = None
+    with _vnext_store_context(context) as store:
+        _actor_type, _actor_id, decision = _policy_checked(
+            store,
+            identity=identity,
+            action="memory.propose",
+            domains=(domain,),
+            sensitivity_allowed=(sensitivity,),
+            project_scope=_parse_string_list(arguments, "project_scope"),
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            proposal_id = _parse_optional_text(arguments, "proposal_id") or str(uuid4())
+            memory = store.create_memory(
+                {
+                    "memory_type": {
+                        "decision": "decision",
+                        "project_update": "project_state",
+                        "belief_update": "belief",
+                        "contradiction": "contradiction",
+                        "artifact_summary": "artifact_summary",
+                        "open_loop": "open_loop",
+                    }.get(proposal_type, "semantic"),
+                    "memory_key": f"agent_proposal.{proposal_type}.{proposal_id}",
+                    "value": {"proposal_type": proposal_type, "text": canonical_text},
+                    "status": "candidate",
+                    "confidence": _parse_optional_float(arguments, "confidence") or 0.5,
+                    "title": _parse_optional_text(arguments, "title") or canonical_text[:120],
+                    "canonical_text": canonical_text,
+                    "summary": canonical_text[:280],
+                    "domain": domain,
+                    "sensitivity": sensitivity,
+                    "metadata_json": {
+                        "proposal_type": proposal_type,
+                        "review_required": True,
+                        **agent_metadata(identity, decision),
+                    },
+                },
+                actor_type="agent",
+            )
+            append_event(
+                store,
+                event_type="agent.memory_proposed",
+                actor_type="agent",
+                actor_id=identity.agent_id,
+                target_type="memory",
+                target_id=str(memory["id"]),
+                trace_id=_parse_optional_text(arguments, "trace_id") or decision.trace_id,
+                run_id=identity.agent_run_id,
+                payload={"proposal_type": proposal_type, "agent_identity": identity.to_record()},
+            )
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if memory is None or decision is None:
+        raise MCPToolError("vNext memory proposal did not complete")
+    return {"proposal": memory, "policy_decision": decision.to_record(), "review_required": True}
+
+
+def _handle_alice_vnext_review_items(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    with _vnext_store_context(context) as store:
+        items = [
+            row
+            for row in store.list_memories(status=None)
+            if str(row.get("status")) in {"candidate", "needs_review", "private_only"}
+        ][:_parse_int(arguments, key="limit", default=20, minimum=1, maximum=100)]
+    return {"items": items, "count": len(items)}
+
+
+def _handle_alice_vnext_artifact_get(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    artifact_id = _parse_required_text(arguments, "artifact_id")
+    with _vnext_store_context(context) as store:
+        artifact = store.get_artifact(artifact_id)
+    if artifact is None:
+        raise MCPToolError(f"artifact {artifact_id} was not found")
+    return artifact
+
+
+def _handle_alice_vnext_artifact_review(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    identity = _agent_identity_from_arguments(arguments)
+    artifact_id = _parse_required_text(arguments, "artifact_id")
+    blocked_decision: PolicyDecision | None = None
+    payload: JsonObject | None = None
+    with _vnext_store_context(context) as store:
+        _actor_type, _actor_id, decision = _policy_checked(store, identity=identity, action="artifact.review")
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextQueueService(store).review_artifact(
+                artifact_id=artifact_id,
+                action=_parse_required_text(arguments, "action"),
+            )
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if payload is None:
+        raise MCPToolError("vNext artifact review did not complete")
+    return payload
+
+
+def _handle_alice_vnext_scheduler_status(context: MCPRuntimeContext, _arguments: Mapping[str, object]) -> JsonObject:
+    with _vnext_store_context(context) as store:
+        return VNextSchedulerService(store).status()
+
+
+def _handle_alice_vnext_scheduler_run_now(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    identity = _agent_identity_from_arguments(arguments)
+    workflow_type = _parse_required_text(arguments, "workflow_type")
+    sensitivity_allowed = _parse_string_list(arguments, "sensitivity_allowed") or (
+        "public",
+        "internal",
+        "private",
+        "unknown",
+    )
+    blocked_decision: PolicyDecision | None = None
+    payload: JsonObject | None = None
+    with _vnext_store_context(context) as store:
+        _actor_type, _actor_id, decision = _policy_checked(
+            store,
+            identity=identity,
+            action="scheduler.run_now",
+            domains=_parse_string_list(arguments, "domains"),
+            sensitivity_allowed=sensitivity_allowed,
+            project_scope=_parse_string_list(arguments, "project_scope") or _parse_string_list(arguments, "projects"),
+            workflow_type=workflow_type,
+        )
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextSchedulerService(store).run_now(
+                SchedulerRunRequest(
+                    workflow_type=workflow_type,
+                    domains=decision.effective_domains,
+                    sensitivity_allowed=decision.effective_sensitivity_allowed,
+                    generated_for=_parse_optional_text(arguments, "generated_for"),
+                    triggered_by="agent" if identity is not None else "user",
+                    agent_identity=identity,
+                    policy_decision=decision,
+                )
+            )
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if payload is None:
+        raise MCPToolError("vNext scheduler run-now did not complete")
+    return payload
+
+
+def _handle_alice_vnext_scheduler_run_due(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    identity = _agent_identity_from_arguments(arguments)
+    limit_value = arguments.get("limit", 10)
+    if not isinstance(limit_value, int):
+        raise MCPToolError("limit must be an integer")
+    blocked_decision: PolicyDecision | None = None
+    payload: JsonObject | None = None
+    with _vnext_store_context(context) as store:
+        actor_type, _actor_id, decision = _policy_checked(store, identity=identity, action="scheduler.run_due")
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextSchedulerService(store).run_due_workflows(
+                limit=limit_value,
+                triggered_by=actor_type if identity is not None else "scheduler",
+                agent_identity=identity,
+                policy_decision=decision,
+            )
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if payload is None:
+        raise MCPToolError("vNext scheduler run-due did not complete")
+    return payload
+
+
+def _handle_alice_vnext_scheduler_pause(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    identity = _agent_identity_from_arguments(arguments)
+    blocked_decision: PolicyDecision | None = None
+    payload: JsonObject | None = None
+    with _vnext_store_context(context) as store:
+        actor_type, _actor_id, decision = _policy_checked(store, identity=identity, action="scheduler.pause")
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextSchedulerService(store).pause_all(actor_type=actor_type)
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if payload is None:
+        raise MCPToolError("vNext scheduler pause did not complete")
+    return payload
+
+
+def _handle_alice_vnext_scheduler_resume(context: MCPRuntimeContext, arguments: Mapping[str, object]) -> JsonObject:
+    identity = _agent_identity_from_arguments(arguments)
+    blocked_decision: PolicyDecision | None = None
+    payload: JsonObject | None = None
+    with _vnext_store_context(context) as store:
+        actor_type, _actor_id, decision = _policy_checked(store, identity=identity, action="scheduler.resume")
+        if decision.decision == "blocked":
+            blocked_decision = decision
+        else:
+            payload = VNextSchedulerService(store).resume_all(actor_type=actor_type)
+    if blocked_decision is not None:
+        _raise_mcp_policy_blocked(blocked_decision)
+    if payload is None:
+        raise MCPToolError("vNext scheduler resume did not complete")
+    return payload
+
+
+_VNEXT_AGENT_SCHEMA_PROPERTIES: dict[str, object] = {
+    "agent_id": {"type": "string"},
+    "agent_type": {"type": "string"},
+    "agent_run_id": {"type": "string"},
+    "task_id": {"type": "string"},
+    "project_scope": {"type": "array", "items": {"type": "string"}},
+    "permission_profile": {"type": "string"},
+    "trace_id": {"type": "string"},
+    "domains": {"type": "array", "items": {"type": "string"}},
+    "sensitivity_allowed": {"type": "array", "items": {"type": "string"}},
+}
+
+
+def _vnext_agent_tool_schema(
+    properties: dict[str, object] | None = None,
+    *,
+    required: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": required or [],
+        "properties": {**_VNEXT_AGENT_SCHEMA_PROPERTIES, **(properties or {})},
+    }
 
 
 _TOOL_DEFINITIONS: list[dict[str, object]] = [
@@ -2528,6 +3108,165 @@ _TOOL_DEFINITIONS: list[dict[str, object]] = [
             },
         },
     },
+    {
+        "name": "alice_vnext_capture",
+        "description": "Capture a vNext source with optional agent identity and policy checks.",
+        "inputSchema": _vnext_agent_tool_schema(
+            {
+                "raw_text": {"type": "string"},
+                "title": {"type": "string"},
+                "source_type": {"type": "string"},
+                "domain": {"type": "string"},
+                "sensitivity": {"type": "string"},
+            },
+            required=["raw_text"],
+        ),
+    },
+    {
+        "name": "alice_vnext_queue_task",
+        "description": "Create a vNext queue task with optional agent identity and policy checks.",
+        "inputSchema": _vnext_agent_tool_schema(
+            {
+                "title": {"type": "string"},
+                "task_type": {"type": "string"},
+                "instructions": {"type": "string"},
+                "domain": {"type": "string"},
+                "sensitivity": {"type": "string"},
+                "scheduled_for": {"type": "string"},
+            },
+            required=["title", "task_type", "instructions"],
+        ),
+    },
+    {
+        "name": "alice_vnext_generate_artifact",
+        "description": "Generate a vNext artifact workflow such as daily_brief or weekly_synthesis.",
+        "inputSchema": _vnext_agent_tool_schema(
+            {
+                "artifact_type": {"type": "string"},
+                "workflow_type": {"type": "string"},
+                "generated_for": {"type": "string"},
+                "max_items": {"type": "integer", "minimum": 1, "maximum": 50},
+            },
+        ),
+    },
+    {
+        "name": "alice_vnext_project_dashboard",
+        "description": "Return vNext project dashboard state.",
+        "inputSchema": _vnext_agent_tool_schema({"project_id": {"type": "string"}}, required=["project_id"]),
+    },
+    {
+        "name": "alice_vnext_open_loops",
+        "description": "List vNext open loops with domain and sensitivity filters.",
+        "inputSchema": _vnext_agent_tool_schema(
+            {
+                "title": {"type": "string"},
+                "description": {"type": "string"},
+                "project_id": {"type": "string"},
+                "source_id": {"type": "string"},
+                "status": {"type": "string"},
+                "priority": {"type": "string"},
+                "due_at": {"type": "string"},
+                "domain": {"type": "string"},
+                "sensitivity": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 50},
+            },
+        ),
+    },
+    {
+        "name": "alice_vnext_recent_decisions",
+        "description": "Return recent decision context through the existing continuity lookup.",
+        "inputSchema": _vnext_agent_tool_schema({"limit": {"type": "integer", "minimum": 1, "maximum": 50}}),
+    },
+    {
+        "name": "alice_vnext_recent_changes",
+        "description": "Return recent change context through the existing continuity lookup.",
+        "inputSchema": _vnext_agent_tool_schema({"limit": {"type": "integer", "minimum": 1, "maximum": 50}}),
+    },
+    {
+        "name": "alice_vnext_find_connections",
+        "description": "Generate a vNext connection report.",
+        "inputSchema": _vnext_agent_tool_schema({"max_connections": {"type": "integer", "minimum": 1, "maximum": 50}}),
+    },
+    {
+        "name": "alice_vnext_find_contradictions",
+        "description": "Generate a vNext contradiction report.",
+        "inputSchema": _vnext_agent_tool_schema({"max_contradictions": {"type": "integer", "minimum": 1, "maximum": 50}}),
+    },
+    {
+        "name": "alice_vnext_propose_memory",
+        "description": "Submit an agent memory proposal for human review.",
+        "inputSchema": _vnext_agent_tool_schema(
+            {
+                "proposal_type": {"type": "string"},
+                "title": {"type": "string"},
+                "canonical_text": {"type": "string"},
+                "source_refs": {"type": "array", "items": {"type": "string"}},
+                "domain": {"type": "string"},
+                "sensitivity": {"type": "string"},
+                "confidence": {"type": "number"},
+                "rationale": {"type": "string"},
+            },
+            required=["agent_id", "canonical_text"],
+        ),
+    },
+    {
+        "name": "alice_vnext_review_items",
+        "description": "List pending vNext memory review items.",
+        "inputSchema": _vnext_agent_tool_schema(
+            {
+                "status": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 50},
+            },
+        ),
+    },
+    {
+        "name": "alice_vnext_artifact_get",
+        "description": "Get one vNext generated artifact.",
+        "inputSchema": _vnext_agent_tool_schema({"artifact_id": {"type": "string"}}, required=["artifact_id"]),
+    },
+    {
+        "name": "alice_vnext_artifact_review",
+        "description": "Review a vNext artifact; agent callers are policy checked.",
+        "inputSchema": _vnext_agent_tool_schema(
+            {
+                "artifact_id": {"type": "string"},
+                "action": {"type": "string"},
+                "reason": {"type": "string"},
+            },
+            required=["artifact_id", "action"],
+        ),
+    },
+    {
+        "name": "alice_vnext_scheduler_status",
+        "description": "Return governed local scheduler status.",
+        "inputSchema": _vnext_agent_tool_schema(),
+    },
+    {
+        "name": "alice_vnext_scheduler_run_now",
+        "description": "Run a governed scheduler workflow now with policy checks.",
+        "inputSchema": _vnext_agent_tool_schema(
+            {
+                "workflow_type": {"type": "string"},
+                "generated_for": {"type": "string"},
+            },
+            required=["workflow_type"],
+        ),
+    },
+    {
+        "name": "alice_vnext_scheduler_run_due",
+        "description": "Run enabled governed scheduler workflows whose next_run_at is due.",
+        "inputSchema": _vnext_agent_tool_schema({"limit": {"type": "integer", "minimum": 1, "maximum": 50}}),
+    },
+    {
+        "name": "alice_vnext_scheduler_pause",
+        "description": "Pause all governed scheduler workflows.",
+        "inputSchema": _vnext_agent_tool_schema(),
+    },
+    {
+        "name": "alice_vnext_scheduler_resume",
+        "description": "Resume all governed scheduler workflows.",
+        "inputSchema": _vnext_agent_tool_schema(),
+    },
 ]
 
 _TOOL_HANDLERS = {
@@ -2578,6 +3317,24 @@ _TOOL_HANDLERS = {
     "alice_project_dashboard": _handle_alice_project_dashboard,
     "alice_open_loop_extract": _handle_alice_open_loop_extract,
     "alice_open_loop_review": _handle_alice_open_loop_review,
+    "alice_vnext_capture": _handle_alice_vnext_capture,
+    "alice_vnext_queue_task": _handle_alice_vnext_queue_task,
+    "alice_vnext_generate_artifact": _handle_alice_vnext_generate_artifact,
+    "alice_vnext_project_dashboard": _handle_alice_project_dashboard,
+    "alice_vnext_open_loops": _handle_alice_vnext_open_loops,
+    "alice_vnext_recent_decisions": _handle_alice_recent_decisions,
+    "alice_vnext_recent_changes": _handle_alice_recent_changes,
+    "alice_vnext_find_connections": _handle_alice_generate_connections,
+    "alice_vnext_find_contradictions": _handle_alice_generate_contradictions,
+    "alice_vnext_propose_memory": _handle_alice_vnext_propose_memory,
+    "alice_vnext_review_items": _handle_alice_vnext_review_items,
+    "alice_vnext_artifact_get": _handle_alice_vnext_artifact_get,
+    "alice_vnext_artifact_review": _handle_alice_vnext_artifact_review,
+    "alice_vnext_scheduler_status": _handle_alice_vnext_scheduler_status,
+    "alice_vnext_scheduler_run_now": _handle_alice_vnext_scheduler_run_now,
+    "alice_vnext_scheduler_run_due": _handle_alice_vnext_scheduler_run_due,
+    "alice_vnext_scheduler_pause": _handle_alice_vnext_scheduler_pause,
+    "alice_vnext_scheduler_resume": _handle_alice_vnext_scheduler_resume,
 }
 
 

--- a/apps/api/src/alicebot_api/store.py
+++ b/apps/api/src/alicebot_api/store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import Any, TypedDict, TypeVar, cast
 from uuid import UUID
@@ -1821,17 +1822,30 @@ INSERT_MEMORY_REVISION_SQL = """
                   user_id,
                   memory_id,
                   sequence_no,
+                  revision_number,
+                  revision_type,
                   action,
                   memory_key,
                   previous_value,
                   new_value,
                   source_event_ids,
-                  candidate
+                  candidate,
+                  text_before,
+                  text_after
                 )
                 SELECT
                   app.current_user_id(),
                   %s,
                   next_sequence.sequence_no,
+                  next_sequence.sequence_no,
+                  CASE %s
+                    WHEN 'ADD' THEN 'created'
+                    WHEN 'UPDATE' THEN 'edited'
+                    WHEN 'DELETE' THEN 'archived'
+                    ELSE 'edited'
+                  END,
+                  %s,
+                  %s,
                   %s,
                   %s,
                   %s,
@@ -7096,11 +7110,14 @@ class ContinuityStore:
                 memory_id,
                 memory_id,
                 action,
+                action,
                 memory_key,
                 Jsonb(previous_value),
                 Jsonb(new_value),
                 Jsonb(source_event_ids),
                 Jsonb(candidate),
+                None if previous_value is None else json.dumps(previous_value, sort_keys=True),
+                "{}" if new_value is None else json.dumps(new_value, sort_keys=True),
             ),
         )
 

--- a/apps/api/src/alicebot_api/vnext_agent_control.py
+++ b/apps/api/src/alicebot_api/vnext_agent_control.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+from uuid import uuid4
+
+from alicebot_api.vnext_event_log import append_event
+from alicebot_api.vnext_repositories import JsonObject
+
+
+AGENT_TYPES = (
+    "personal_assistant",
+    "coding_agent",
+    "research_agent",
+    "workflow_agent",
+    "unknown",
+)
+
+PERMISSION_PROFILES = (
+    "read_only_agent",
+    "project_scoped_agent",
+    "trusted_local_agent",
+    "memory_proposal_agent",
+    "admin_agent",
+)
+
+POLICY_DECISIONS = ("allowed", "allowed_with_filtering", "requires_review", "blocked")
+
+RESTRICTED_DOMAINS = frozenset({"family", "health", "spiritual", "legal", "financial"})
+RESTRICTED_SENSITIVITY = frozenset({"confidential", "highly_sensitive", "sacred", "regulated"})
+ALL_SENSITIVITY = ("public", "internal", "private", "confidential", "highly_sensitive", "sacred", "regulated", "unknown")
+DEFAULT_AGENT_SENSITIVITY = ("public", "internal", "private", "unknown")
+
+READ_ACTIONS = {
+    "context_pack.request",
+    "project.dashboard",
+    "open_loop.lookup",
+    "recent_decisions.lookup",
+    "recent_changes.lookup",
+    "connections.find",
+    "contradictions.find",
+    "review_items.lookup",
+    "artifact.lookup",
+    "scheduler.status",
+}
+
+WRITE_ACTIONS = {
+    "source.capture",
+    "queue_task.create",
+    "artifact.generate",
+    "memory.propose",
+    "open_loop.create",
+    "open_loop.update",
+    "artifact.review",
+    "scheduler.run_now",
+    "scheduler.run_due",
+    "scheduler.pause",
+    "scheduler.resume",
+    "scheduler.configure",
+}
+
+
+class AgentIdentityValidationError(ValueError):
+    """Raised when an agent identity payload is malformed."""
+
+
+class AgentPolicyBlockedError(PermissionError):
+    """Raised when a vNext agent policy blocks an operation."""
+
+    def __init__(self, decision: "PolicyDecision") -> None:
+        super().__init__("agent policy blocked this action")
+        self.decision = decision
+
+
+@dataclass(frozen=True, slots=True)
+class AgentIdentity:
+    agent_id: str
+    agent_type: str = "unknown"
+    agent_run_id: str | None = None
+    task_id: str | None = None
+    project_scope: tuple[str, ...] = ()
+    permission_profile: str = "read_only_agent"
+
+    @property
+    def actor_type(self) -> str:
+        return "agent"
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, object]) -> "AgentIdentity | None":
+        nested = payload.get("agent_identity")
+        source: Mapping[str, object]
+        if isinstance(nested, Mapping):
+            source = nested
+        else:
+            source = payload
+
+        agent_id = _optional_text(source.get("agent_id"))
+        if agent_id is None:
+            return None
+
+        agent_type = _optional_text(source.get("agent_type")) or _default_agent_type(agent_id)
+        if agent_type not in AGENT_TYPES:
+            raise AgentIdentityValidationError(f"agent_type must be one of {', '.join(AGENT_TYPES)}")
+
+        permission_profile = _optional_text(source.get("permission_profile")) or _default_permission_profile(agent_id)
+        if permission_profile not in PERMISSION_PROFILES:
+            raise AgentIdentityValidationError(
+                f"permission_profile must be one of {', '.join(PERMISSION_PROFILES)}"
+            )
+
+        return cls(
+            agent_id=agent_id,
+            agent_type=agent_type,
+            agent_run_id=_optional_text(source.get("agent_run_id")),
+            task_id=_optional_text(source.get("task_id")),
+            project_scope=tuple(_string_list(source.get("project_scope"))),
+            permission_profile=permission_profile,
+        )
+
+    def to_record(self) -> JsonObject:
+        return {
+            "agent_id": self.agent_id,
+            "agent_type": self.agent_type,
+            "agent_run_id": self.agent_run_id,
+            "task_id": self.task_id,
+            "project_scope": list(self.project_scope),
+            "permission_profile": self.permission_profile,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDecision:
+    decision: str
+    action: str
+    permission_profile: str
+    reasons: tuple[str, ...] = ()
+    effective_domains: tuple[str, ...] = ()
+    effective_sensitivity_allowed: tuple[str, ...] = DEFAULT_AGENT_SENSITIVITY
+    review_required: bool = False
+    trace_id: str = ""
+
+    def to_record(self) -> JsonObject:
+        return {
+            "decision": self.decision,
+            "action": self.action,
+            "permission_profile": self.permission_profile,
+            "reasons": list(self.reasons),
+            "effective_domains": list(self.effective_domains),
+            "effective_sensitivity_allowed": list(self.effective_sensitivity_allowed),
+            "review_required": self.review_required,
+            "trace_id": self.trace_id,
+        }
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise AgentIdentityValidationError("agent identity fields must be strings")
+    normalized = " ".join(value.split()).strip()
+    return normalized or None
+
+
+def _string_list(value: object) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise AgentIdentityValidationError("project_scope must be a list of strings")
+    values: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise AgentIdentityValidationError("project_scope must be a list of strings")
+        normalized = " ".join(item.split()).strip()
+        if normalized:
+            values.append(normalized)
+    return values
+
+
+def _default_agent_type(agent_id: str) -> str:
+    if agent_id.casefold() == "hermes":
+        return "personal_assistant"
+    if agent_id.casefold() == "openclaw":
+        return "coding_agent"
+    return "unknown"
+
+
+def _default_permission_profile(agent_id: str) -> str:
+    if agent_id.casefold() == "hermes":
+        return "trusted_local_agent"
+    if agent_id.casefold() == "openclaw":
+        return "project_scoped_agent"
+    return "read_only_agent"
+
+
+def _profile_sensitivity(profile: str) -> tuple[str, ...]:
+    if profile == "read_only_agent":
+        return ("public", "internal", "unknown")
+    if profile == "admin_agent":
+        return ALL_SENSITIVITY
+    return DEFAULT_AGENT_SENSITIVITY
+
+
+def _filtered_domains(profile: str, domains: tuple[str, ...]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    if profile in {"trusted_local_agent", "admin_agent"}:
+        return domains, ()
+    blocked = tuple(domain for domain in domains if domain in RESTRICTED_DOMAINS)
+    allowed = tuple(domain for domain in domains if domain not in RESTRICTED_DOMAINS)
+    return allowed, blocked
+
+
+def _filtered_sensitivity(profile: str, sensitivity_allowed: tuple[str, ...]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    profile_allowed = set(_profile_sensitivity(profile))
+    requested = sensitivity_allowed or _profile_sensitivity(profile)
+    allowed = tuple(value for value in requested if value in profile_allowed)
+    filtered = tuple(value for value in requested if value not in profile_allowed)
+    return allowed or tuple(_profile_sensitivity(profile)), filtered
+
+
+def evaluate_agent_policy(
+    *,
+    identity: AgentIdentity | None,
+    action: str,
+    domains: tuple[str, ...] = (),
+    sensitivity_allowed: tuple[str, ...] = DEFAULT_AGENT_SENSITIVITY,
+    project_scope: tuple[str, ...] = (),
+    workflow_type: str | None = None,
+    write_policy: str | None = None,
+) -> PolicyDecision:
+    trace_id = f"policy-{uuid4()}"
+    if identity is None:
+        return PolicyDecision(
+            decision="allowed",
+            action=action,
+            permission_profile="user_or_system",
+            effective_domains=domains,
+            effective_sensitivity_allowed=sensitivity_allowed,
+            trace_id=trace_id,
+        )
+
+    profile = identity.permission_profile
+    reasons: list[str] = []
+    effective_domains, filtered_domains = _filtered_domains(profile, domains)
+    effective_sensitivity, filtered_sensitivity = _filtered_sensitivity(profile, sensitivity_allowed)
+    decision = "allowed"
+    review_required = False
+
+    if filtered_domains:
+        reasons.append("restricted_domain_filtered")
+        decision = "allowed_with_filtering"
+    if filtered_sensitivity:
+        reasons.append("restricted_sensitivity_filtered")
+        decision = "allowed_with_filtering"
+    if domains and not effective_domains and filtered_domains:
+        reasons.append("all_requested_domains_restricted")
+        decision = "blocked"
+
+    if profile == "read_only_agent" and action in WRITE_ACTIONS:
+        reasons.append("read_only_agent_cannot_write")
+        decision = "blocked"
+
+    if action == "memory.propose":
+        if profile not in {"project_scoped_agent", "trusted_local_agent", "memory_proposal_agent", "admin_agent"}:
+            reasons.append("memory_proposal_permission_required")
+            decision = "blocked"
+        else:
+            review_required = True
+            if decision == "allowed":
+                decision = "requires_review"
+
+    if action in {"artifact.review", "memory.review"} and profile != "admin_agent":
+        reasons.append("human_or_admin_review_required")
+        decision = "blocked"
+
+    if write_policy and write_policy != "proposal_only" and profile != "admin_agent":
+        reasons.append("no_auto_promotion")
+        decision = "blocked"
+
+    if profile == "project_scoped_agent":
+        requested_scope = project_scope or identity.project_scope
+        if not requested_scope and action in {"context_pack.request", "artifact.generate", "memory.propose", "scheduler.run_now"}:
+            reasons.append("project_scope_required")
+            decision = "blocked"
+        if action == "scheduler.run_now" and workflow_type not in {"connection_report", "contradiction_report", "project_update_scan"}:
+            reasons.append("project_scoped_agent_cannot_run_global_workflow")
+            decision = "blocked"
+        if action == "scheduler.run_due":
+            reasons.append("project_scoped_agent_cannot_trigger_global_scheduler")
+            decision = "blocked"
+        if action in {"scheduler.pause", "scheduler.resume", "scheduler.configure"}:
+            reasons.append("project_scoped_agent_cannot_control_global_scheduler")
+            decision = "blocked"
+
+    if action == "scheduler.configure" and profile != "admin_agent":
+        reasons.append("admin_agent_required_for_scheduler_configuration")
+        decision = "blocked"
+    if action in {"scheduler.pause", "scheduler.resume"} and profile not in {"trusted_local_agent", "admin_agent"}:
+        reasons.append("trusted_or_admin_agent_required_for_scheduler_control")
+        decision = "blocked"
+    if action == "scheduler.run_now" and profile not in {"project_scoped_agent", "trusted_local_agent", "admin_agent"}:
+        reasons.append("trusted_agent_required_for_scheduler_run")
+        decision = "blocked"
+    if action == "scheduler.run_due" and profile not in {"trusted_local_agent", "admin_agent"}:
+        reasons.append("trusted_or_admin_agent_required_for_scheduler_due_run")
+        decision = "blocked"
+
+    return PolicyDecision(
+        decision=decision,
+        action=action,
+        permission_profile=profile,
+        reasons=tuple(dict.fromkeys(reasons)),
+        effective_domains=effective_domains,
+        effective_sensitivity_allowed=effective_sensitivity,
+        review_required=review_required or decision == "requires_review",
+        trace_id=trace_id,
+    )
+
+
+def ensure_policy_allowed(decision: PolicyDecision) -> None:
+    if decision.decision == "blocked":
+        raise AgentPolicyBlockedError(decision)
+
+
+def append_policy_events(
+    store,
+    *,
+    identity: AgentIdentity | None,
+    decision: PolicyDecision,
+    target_type: str | None = None,
+    target_id: str | None = None,
+) -> None:
+    if identity is None:
+        return
+    payload = {
+        "agent_identity": identity.to_record(),
+        "policy_decision": decision.to_record(),
+    }
+    append_event(
+        store,
+        event_type="policy.decision",
+        actor_type=identity.actor_type,
+        actor_id=identity.agent_id,
+        target_type=target_type,
+        target_id=target_id,
+        trace_id=decision.trace_id,
+        run_id=identity.agent_run_id,
+        payload=payload,
+    )
+    if decision.decision == "blocked":
+        append_event(
+            store,
+            event_type="agent.policy_blocked",
+            actor_type=identity.actor_type,
+            actor_id=identity.agent_id,
+            target_type=target_type,
+            target_id=target_id,
+            trace_id=decision.trace_id,
+            run_id=identity.agent_run_id,
+            payload=payload,
+        )
+    elif decision.decision == "allowed_with_filtering":
+        append_event(
+            store,
+            event_type="agent.policy_filtered",
+            actor_type=identity.actor_type,
+            actor_id=identity.agent_id,
+            target_type=target_type,
+            target_id=target_id,
+            trace_id=decision.trace_id,
+            run_id=identity.agent_run_id,
+            payload=payload,
+        )
+
+
+def agent_metadata(identity: AgentIdentity | None, decision: PolicyDecision | None = None) -> JsonObject:
+    metadata: JsonObject = {}
+    if identity is not None:
+        metadata["generated_by"] = "agent"
+        metadata["agent_id"] = identity.agent_id
+        metadata["agent_run_id"] = identity.agent_run_id
+        metadata["agent_identity"] = identity.to_record()
+    if decision is not None:
+        metadata["policy_decision"] = decision.to_record()
+        metadata["review_required"] = decision.review_required
+    return metadata
+
+
+__all__ = [
+    "AGENT_TYPES",
+    "PERMISSION_PROFILES",
+    "POLICY_DECISIONS",
+    "AgentIdentity",
+    "AgentIdentityValidationError",
+    "AgentPolicyBlockedError",
+    "PolicyDecision",
+    "agent_metadata",
+    "append_policy_events",
+    "ensure_policy_allowed",
+    "evaluate_agent_policy",
+]

--- a/apps/api/src/alicebot_api/vnext_brain.py
+++ b/apps/api/src/alicebot_api/vnext_brain.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 import re
 from typing import Protocol
@@ -32,11 +32,11 @@ class VNextBrainValidationError(ValueError):
 class VNextBrainStore(Protocol):
     def append_event(self, event: JsonObject) -> JsonObject: ...
 
-    def create_artifact(self, artifact: JsonObject) -> JsonObject: ...
+    def create_artifact(self, artifact: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
-    def create_memory(self, memory: JsonObject) -> JsonObject: ...
+    def create_memory(self, memory: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
-    def create_open_loop(self, loop: JsonObject) -> JsonObject: ...
+    def create_open_loop(self, loop: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
     def search_sources(
         self,
@@ -86,6 +86,13 @@ class BrainArtifactRequest:
     artifact_limit: int = DEFAULT_ARTIFACT_LIMIT
     discover_open_loops: bool = True
     create_candidate_memories: bool = True
+    generated_by: str = "system"
+    actor_id: str | None = None
+    trace_id: str | None = None
+    run_id: str | None = None
+    agent_identity: JsonObject | None = None
+    policy_decision: JsonObject | None = None
+    metadata_json: JsonObject = field(default_factory=dict)
 
 
 def _today_iso() -> str:
@@ -251,9 +258,16 @@ class VNextBrainService:
                 "status": "needs_review",
                 "domain": _artifact_domain(request, all_rows),
                 "sensitivity": _highest_sensitivity(all_rows),
-                "generated_by": "vnext_daily_brief",
+                "generated_by": request.generated_by if request.generated_by != "system" else "vnext_daily_brief",
                 "metadata_json": {
                     "workflow": "daily_brief",
+                    "generated_by": request.generated_by,
+                    "agent_identity": request.agent_identity,
+                    "agent_id": request.agent_identity.get("agent_id") if isinstance(request.agent_identity, dict) else None,
+                    "agent_run_id": request.agent_identity.get("agent_run_id") if isinstance(request.agent_identity, dict) else None,
+                    "scheduler_run_id": request.run_id if request.generated_by == "scheduler" else None,
+                    "trace_id": request.trace_id,
+                    "policy_decision": request.policy_decision,
                     "generated_for": day.isoformat(),
                     "input_summary": _input_summary(
                         sources=sources,
@@ -262,22 +276,41 @@ class VNextBrainService:
                         artifacts=artifacts,
                     ),
                     "candidate_open_loop_ids": [str(row.get("id")) for row in candidate_open_loops],
+                    **request.metadata_json,
                 },
-            }
+            },
+            actor_type=request.generated_by,
         )
         append_event(
             self.store,
             event_type="artifact.generated",
-            actor_type="system",
+            actor_type=request.generated_by,
+            actor_id=request.actor_id,
             target_type="artifact",
             target_id=str(artifact["id"]),
+            trace_id=request.trace_id,
+            run_id=request.run_id,
             payload={
                 "workflow": "daily_brief",
                 "generated_for": day.isoformat(),
                 "artifact_type": "daily_brief",
                 "candidate_open_loop_count": len(candidate_open_loops),
+                "agent_identity": request.agent_identity,
+                "policy_decision": request.policy_decision,
             },
         )
+        if request.generated_by == "agent" and request.actor_id is not None:
+            append_event(
+                self.store,
+                event_type="agent.artifact_generated",
+                actor_type="agent",
+                actor_id=request.actor_id,
+                target_type="artifact",
+                target_id=str(artifact["id"]),
+                trace_id=request.trace_id,
+                run_id=request.run_id,
+                payload={"workflow": "daily_brief", "agent_identity": request.agent_identity},
+            )
         return artifact
 
     def generate_weekly_synthesis(self, request: BrainArtifactRequest | None = None) -> JsonObject:
@@ -304,9 +337,16 @@ class VNextBrainService:
                 "status": "needs_review",
                 "domain": _artifact_domain(request, all_rows),
                 "sensitivity": _highest_sensitivity(all_rows),
-                "generated_by": "vnext_weekly_synthesis",
+                "generated_by": request.generated_by if request.generated_by != "system" else "vnext_weekly_synthesis",
                 "metadata_json": {
                     "workflow": "weekly_synthesis",
+                    "generated_by": request.generated_by,
+                    "agent_identity": request.agent_identity,
+                    "agent_id": request.agent_identity.get("agent_id") if isinstance(request.agent_identity, dict) else None,
+                    "agent_run_id": request.agent_identity.get("agent_run_id") if isinstance(request.agent_identity, dict) else None,
+                    "scheduler_run_id": request.run_id if request.generated_by == "scheduler" else None,
+                    "trace_id": request.trace_id,
+                    "policy_decision": request.policy_decision,
                     "generated_for": day.isoformat(),
                     "week": week_label,
                     "input_summary": _input_summary(
@@ -316,23 +356,42 @@ class VNextBrainService:
                         artifacts=artifacts,
                     ),
                     "candidate_memory_ids": [str(row.get("id")) for row in candidate_memories],
+                    **request.metadata_json,
                 },
-            }
+            },
+            actor_type=request.generated_by,
         )
         append_event(
             self.store,
             event_type="artifact.generated",
-            actor_type="system",
+            actor_type=request.generated_by,
+            actor_id=request.actor_id,
             target_type="artifact",
             target_id=str(artifact["id"]),
+            trace_id=request.trace_id,
+            run_id=request.run_id,
             payload={
                 "workflow": "weekly_synthesis",
                 "generated_for": day.isoformat(),
                 "week": week_label,
                 "artifact_type": "weekly_synthesis",
                 "candidate_memory_count": len(candidate_memories),
+                "agent_identity": request.agent_identity,
+                "policy_decision": request.policy_decision,
             },
         )
+        if request.generated_by == "agent" and request.actor_id is not None:
+            append_event(
+                self.store,
+                event_type="agent.artifact_generated",
+                actor_type="agent",
+                actor_id=request.actor_id,
+                target_type="artifact",
+                target_id=str(artifact["id"]),
+                trace_id=request.trace_id,
+                run_id=request.run_id,
+                payload={"workflow": "weekly_synthesis", "agent_identity": request.agent_identity},
+            )
         return artifact
 
     def _load_inputs(
@@ -403,7 +462,8 @@ class VNextBrainService:
                             "discovered_by": "vnext_daily_brief",
                             "source_id": source.get("id"),
                         },
-                    }
+                    },
+                    actor_type=request.generated_by,
                 )
             )
         return created
@@ -433,8 +493,13 @@ class VNextBrainService:
                     "metadata_json": {
                         "candidate": True,
                         "discovered_by": "vnext_weekly_synthesis",
+                        "generated_by": request.generated_by,
+                        "agent_identity": request.agent_identity,
+                        "scheduler_run_id": request.run_id if request.generated_by == "scheduler" else None,
+                        "trace_id": request.trace_id,
                     },
-                }
+                },
+                actor_type=request.generated_by,
             )
         ]
 

--- a/apps/api/src/alicebot_api/vnext_capture.py
+++ b/apps/api/src/alicebot_api/vnext_capture.py
@@ -24,13 +24,13 @@ class VNextCaptureStore(Protocol):
 
     def get_source_by_content_hash(self, content_hash: str) -> JsonObject | None: ...
 
-    def create_source(self, source: JsonObject) -> JsonObject: ...
+    def create_source(self, source: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
-    def create_source_chunk(self, chunk: JsonObject) -> JsonObject: ...
+    def create_source_chunk(self, chunk: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
-    def create_memory(self, memory: JsonObject) -> JsonObject: ...
+    def create_memory(self, memory: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
-    def create_provenance_link(self, link: JsonObject) -> JsonObject: ...
+    def create_provenance_link(self, link: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -323,9 +323,26 @@ def _extract_text_from_json_value(value: object) -> list[str]:
 
 
 class VNextCaptureService:
-    def __init__(self, store: VNextCaptureStore, *, chunk_max_chars: int = DEFAULT_CHUNK_MAX_CHARS) -> None:
+    def __init__(
+        self,
+        store: VNextCaptureStore,
+        *,
+        chunk_max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
+        actor_type: str = "system",
+        actor_id: str | None = None,
+        trace_id: str | None = None,
+        run_id: str | None = None,
+        agent_identity: JsonObject | None = None,
+        policy_decision: JsonObject | None = None,
+    ) -> None:
         self.store = store
         self.chunk_max_chars = chunk_max_chars
+        self.actor_type = actor_type
+        self.actor_id = actor_id
+        self.trace_id = trace_id
+        self.run_id = run_id
+        self.agent_identity = agent_identity
+        self.policy_decision = policy_decision
 
     def _log_event(
         self,
@@ -338,8 +355,15 @@ class VNextCaptureService:
         return append_event(
             self.store,
             event_type=event_type,
-            actor_type="system",
-            payload=payload,
+            actor_type=self.actor_type,
+            actor_id=self.actor_id,
+            trace_id=self.trace_id,
+            run_id=self.run_id,
+            payload={
+                **payload,
+                "agent_identity": self.agent_identity,
+                "policy_decision": self.policy_decision,
+            },
             target_type=target_type,
             target_id=target_id,
         )
@@ -447,10 +471,16 @@ class VNextCaptureService:
                     "sensitivity": source_input.sensitivity,
                     "metadata_json": {
                         **source_input.metadata_json,
+                        "generated_by": self.actor_type,
+                        "agent_identity": self.agent_identity,
+                        "agent_id": self.actor_id if self.actor_type == "agent" else None,
+                        "trace_id": self.trace_id,
+                        "policy_decision": self.policy_decision,
                         "raw_text": normalized_text,
                         "raw_text_sha256": content_hash,
                     },
-                }
+                },
+                actor_type=self.actor_type,
             )
             source_id = str(source["id"])
             self._log_event(
@@ -474,7 +504,8 @@ class VNextCaptureService:
                         "text": chunk,
                         "token_count": len(chunk.split()),
                         "metadata_json": {"content_hash": content_hash},
-                    }
+                    },
+                    actor_type=self.actor_type,
                 )
                 chunk_rows.append(chunk_row)
 
@@ -510,8 +541,14 @@ class VNextCaptureService:
                             "source_chunk_index": candidate.source_chunk_index,
                             "extraction_rule": candidate.extraction_rule,
                             "capture_content_hash": content_hash,
+                            "generated_by": self.actor_type,
+                            "agent_identity": self.agent_identity,
+                            "agent_id": self.actor_id if self.actor_type == "agent" else None,
+                            "trace_id": self.trace_id,
+                            "policy_decision": self.policy_decision,
                         },
-                    }
+                    },
+                    actor_type=self.actor_type,
                 )
                 self.store.create_provenance_link(
                     {
@@ -522,7 +559,8 @@ class VNextCaptureService:
                         "quote": candidate.text,
                         "evidence_role": "quoted_from",
                         "confidence": candidate.confidence,
-                    }
+                    },
+                    actor_type=self.actor_type,
                 )
                 self._log_event(
                     event_type="memory.candidate_created",

--- a/apps/api/src/alicebot_api/vnext_projects.py
+++ b/apps/api/src/alicebot_api/vnext_projects.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import re
 from typing import Protocol
 from uuid import uuid4
@@ -22,17 +22,17 @@ class VNextProjectValidationError(ValueError):
 class VNextProjectStore(Protocol):
     def append_event(self, event: JsonObject) -> JsonObject: ...
 
-    def create_artifact(self, artifact: JsonObject) -> JsonObject: ...
+    def create_artifact(self, artifact: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
     def get_artifact(self, artifact_id: str) -> JsonObject | None: ...
 
-    def update_artifact_status(self, *, artifact_id: str, status: str) -> JsonObject: ...
+    def update_artifact_status(self, *, artifact_id: str, status: str, actor_type: str = "system") -> JsonObject: ...
 
-    def create_memory(self, memory: JsonObject) -> JsonObject: ...
+    def create_memory(self, memory: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
-    def update_memory(self, *, memory_id: str, patch: JsonObject) -> JsonObject: ...
+    def update_memory(self, *, memory_id: str, patch: JsonObject, actor_type: str = "system") -> JsonObject: ...
 
-    def append_revision(self, revision: JsonObject) -> JsonObject: ...
+    def append_revision(self, revision: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
     def get_project(self, project_id: str) -> JsonObject | None: ...
 
@@ -45,9 +45,9 @@ class VNextProjectStore(Protocol):
         limit: int = DEFAULT_PROJECT_LIMIT,
     ) -> list[JsonObject]: ...
 
-    def update_project(self, *, project_id: str, patch: JsonObject) -> JsonObject: ...
+    def update_project(self, *, project_id: str, patch: JsonObject, actor_type: str = "system") -> JsonObject: ...
 
-    def create_open_loop(self, loop: JsonObject) -> JsonObject: ...
+    def create_open_loop(self, loop: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
     def get_open_loop(self, loop_id: str) -> JsonObject | None: ...
 
@@ -62,9 +62,16 @@ class VNextProjectStore(Protocol):
         limit: int = DEFAULT_PROJECT_LIMIT,
     ) -> list[JsonObject]: ...
 
-    def update_open_loop(self, *, loop_id: str, patch: JsonObject) -> JsonObject: ...
+    def update_open_loop(self, *, loop_id: str, patch: JsonObject, actor_type: str = "system") -> JsonObject: ...
 
-    def update_open_loop_status(self, *, loop_id: str, status: str, resolution_note: str | None = None) -> JsonObject: ...
+    def update_open_loop_status(
+        self,
+        *,
+        loop_id: str,
+        status: str,
+        resolution_note: str | None = None,
+        actor_type: str = "system",
+    ) -> JsonObject: ...
 
     def search_sources(
         self,
@@ -101,6 +108,13 @@ class ProjectAutomationRequest:
     project_id: str | None = None
     person_id: str | None = None
     max_items: int = DEFAULT_PROJECT_LIMIT
+    generated_by: str = "system"
+    actor_id: str | None = None
+    trace_id: str | None = None
+    run_id: str | None = None
+    agent_identity: JsonObject | None = None
+    policy_decision: JsonObject | None = None
+    metadata_json: JsonObject = field(default_factory=dict)
 
 
 def _validate_request(request: ProjectAutomationRequest) -> None:
@@ -287,8 +301,15 @@ class VNextProjectService:
                     "project_id": project.get("id"),
                     "source_ids": _source_ids(sources),
                     "memory_ids": _source_ids(memories),
+                    "generated_by": request.generated_by,
+                    "agent_identity": request.agent_identity,
+                    "agent_id": request.actor_id if request.generated_by == "agent" else None,
+                    "trace_id": request.trace_id,
+                    "policy_decision": request.policy_decision,
+                    **request.metadata_json,
                 },
-            }
+            },
+            actor_type=request.generated_by,
         )
         artifact = self.store.create_artifact(
             {
@@ -304,7 +325,7 @@ class VNextProjectService:
                 "status": "needs_review",
                 "domain": project.get("domain", "project"),
                 "sensitivity": _highest_sensitivity([project, *sources, *memories]),
-                "generated_by": "vnext_project_auto_updater",
+                "generated_by": request.generated_by if request.generated_by != "system" else "vnext_project_auto_updater",
                 "metadata_json": {
                     "workflow": "project_auto_update",
                     "project_id": project.get("id"),
@@ -312,19 +333,32 @@ class VNextProjectService:
                     "suggested_current_state": suggested_current_state,
                     "source_ids": _source_ids(sources),
                     "memory_ids": _source_ids(memories),
+                    "generated_by": request.generated_by,
+                    "agent_identity": request.agent_identity,
+                    "agent_id": request.actor_id if request.generated_by == "agent" else None,
+                    "agent_run_id": request.run_id if request.generated_by == "agent" else None,
+                    "trace_id": request.trace_id,
+                    "policy_decision": request.policy_decision,
+                    **request.metadata_json,
                 },
-            }
+            },
+            actor_type=request.generated_by,
         )
         append_event(
             self.store,
             event_type="project.update_candidate_created",
-            actor_type="system",
+            actor_type=request.generated_by,
+            actor_id=request.actor_id,
             target_type="artifact",
             target_id=str(artifact["id"]),
+            trace_id=request.trace_id,
+            run_id=request.run_id,
             payload={
                 "project_id": project.get("id"),
                 "candidate_memory_id": candidate_memory.get("id"),
                 "source_ids": _source_ids(sources),
+                "agent_identity": request.agent_identity,
+                "policy_decision": request.policy_decision,
             },
         )
         return artifact
@@ -346,12 +380,24 @@ class VNextProjectService:
                     candidate["project_id"] = request.project_id
                 if request.person_id is not None:
                     candidate["person_id"] = request.person_id
-                created.append(self.store.create_open_loop(candidate))
+                metadata = candidate.get("metadata_json") if isinstance(candidate.get("metadata_json"), dict) else {}
+                candidate["metadata_json"] = {
+                    **metadata,
+                    "generated_by": request.generated_by,
+                    "agent_identity": request.agent_identity,
+                    "agent_id": request.actor_id if request.generated_by == "agent" else None,
+                    "trace_id": request.trace_id,
+                    "policy_decision": request.policy_decision,
+                }
+                created.append(self.store.create_open_loop(candidate, actor_type=request.generated_by))
         append_event(
             self.store,
             event_type="open_loop.extraction_completed",
-            actor_type="system",
+            actor_type=request.generated_by,
+            actor_id=request.actor_id,
             target_type="open_loop",
+            trace_id=request.trace_id,
+            run_id=request.run_id,
             payload={"created_count": len(created), "source_ids": _source_ids(sources)},
         )
         return created

--- a/apps/api/src/alicebot_api/vnext_queue.py
+++ b/apps/api/src/alicebot_api/vnext_queue.py
@@ -22,7 +22,7 @@ class VNextQueueNotFoundError(VNextQueueValidationError):
 class VNextQueueStore(Protocol):
     def append_event(self, event: JsonObject) -> JsonObject: ...
 
-    def create_task(self, task: JsonObject) -> JsonObject: ...
+    def create_task(self, task: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
     def claim_next_task(self) -> JsonObject | None: ...
 
@@ -48,6 +48,12 @@ class QueueTaskRequest:
     write_policy: str = "proposal_only"
     scheduled_for: str | None = None
     metadata_json: JsonObject = field(default_factory=dict)
+    actor_type: str = "system"
+    actor_id: str | None = None
+    trace_id: str | None = None
+    run_id: str | None = None
+    agent_identity: JsonObject | None = None
+    policy_decision: JsonObject | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -137,17 +143,39 @@ class VNextQueueService:
                 "sensitivity": request.sensitivity,
                 "write_policy": request.write_policy,
                 "scheduled_for": request.scheduled_for,
-                "metadata_json": request.metadata_json,
-            }
+                "metadata_json": {
+                    **request.metadata_json,
+                    "agent_identity": request.agent_identity,
+                    "agent_id": request.actor_id if request.actor_type == "agent" else None,
+                    "policy_decision": request.policy_decision,
+                    "trace_id": request.trace_id,
+                },
+            },
+            actor_type=request.actor_type,
         )
         append_event(
             self.store,
             event_type="queue.task_enqueued",
-            actor_type="system",
+            actor_type=request.actor_type,
+            actor_id=request.actor_id,
             target_type="task",
             target_id=str(task["id"]),
+            trace_id=request.trace_id,
+            run_id=request.run_id,
             payload={"task_type": task_type, "write_policy": request.write_policy},
         )
+        if request.actor_type == "agent" and request.actor_id is not None:
+            append_event(
+                self.store,
+                event_type="agent.task_created",
+                actor_type="agent",
+                actor_id=request.actor_id,
+                target_type="task",
+                target_id=str(task["id"]),
+                trace_id=request.trace_id,
+                run_id=request.run_id,
+                payload={"task_type": task_type, "agent_identity": request.agent_identity},
+            )
         return task
 
     def process_next_task(self) -> QueueProcessResult:

--- a/apps/api/src/alicebot_api/vnext_retrieval.py
+++ b/apps/api/src/alicebot_api/vnext_retrieval.py
@@ -67,6 +67,12 @@ class VNextRetrievalRequest:
     include_contradictions: bool = True
     max_items: int = DEFAULT_CONTEXT_PACK_LIMIT
     max_tokens: int = 8_000
+    actor_type: str = "system"
+    actor_id: str | None = None
+    agent_identity: JsonObject | None = None
+    policy_decision: JsonObject | None = None
+    trace_id: str | None = None
+    run_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -274,7 +280,7 @@ class VNextRetrievalService:
         terms = list(interpretation["terms"])  # type: ignore[arg-type]
         domains = list(interpretation["domains"])  # type: ignore[arg-type]
         sensitivity_allowed = list(interpretation["sensitivity_allowed"])  # type: ignore[arg-type]
-        trace_id = str(uuid4())
+        trace_id = request.trace_id or str(uuid4())
         context_pack_id = str(uuid4())
 
         memory_rows = self.store.search_memories(
@@ -364,22 +370,46 @@ class VNextRetrievalService:
             "warnings": warnings,
             "trace_id": trace_id,
             "trace": trace,
+            "agent_identity": request.agent_identity,
+            "policy_decision": request.policy_decision,
         }
         append_event(
             self.store,
             event_type="retrieval.context_pack_compiled",
-            actor_type="system",
+            actor_type=request.actor_type,
+            actor_id=request.actor_id,
             target_type="context_pack",
             target_id=context_pack_id,
             trace_id=trace_id,
+            run_id=request.run_id,
             payload={
                 "query": request.query,
                 "query_type": interpretation["query_type"],
                 "candidate_count": trace["candidate_count"],
                 "selected_count": trace["selected_count"],
                 "warnings": warnings,
+                "agent_identity": request.agent_identity,
+                "policy_decision": request.policy_decision,
             },
         )
+        if request.actor_type == "agent" and request.actor_id is not None:
+            append_event(
+                self.store,
+                event_type="agent.context_pack_requested",
+                actor_type="agent",
+                actor_id=request.actor_id,
+                target_type="context_pack",
+                target_id=context_pack_id,
+                trace_id=trace_id,
+                run_id=request.run_id,
+                payload={
+                    "query": request.query,
+                    "query_type": interpretation["query_type"],
+                    "selected_count": trace["selected_count"],
+                    "agent_identity": request.agent_identity,
+                    "policy_decision": request.policy_decision,
+                },
+            )
         return pack
 
     def _supporting_evidence(self, memories: list[JsonObject]) -> list[JsonObject]:

--- a/apps/api/src/alicebot_api/vnext_scheduler.py
+++ b/apps/api/src/alicebot_api/vnext_scheduler.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, time, timedelta
+from typing import Protocol
+from uuid import uuid4
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from alicebot_api.vnext_agent_control import AgentIdentity, PolicyDecision
+from alicebot_api.vnext_brain import BrainArtifactRequest, VNextBrainService
+from alicebot_api.vnext_event_log import append_event
+from alicebot_api.vnext_repositories import JsonObject
+
+
+WORKFLOW_TYPES = (
+    "daily_brief",
+    "weekly_synthesis",
+    "connection_report",
+    "contradiction_report",
+    "open_loop_review",
+    "project_update_scan",
+)
+PRIMARY_WORKFLOWS = ("daily_brief", "weekly_synthesis")
+DAY_NAMES = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")
+
+
+class VNextSchedulerValidationError(ValueError):
+    """Raised when scheduler configuration or execution input is invalid."""
+
+
+class VNextSchedulerStore(Protocol):
+    def append_event(self, event: JsonObject) -> JsonObject: ...
+
+    def upsert_scheduler_workflow(self, workflow: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
+
+    def update_scheduler_workflow(
+        self,
+        *,
+        workflow_type: str,
+        patch: JsonObject,
+        actor_type: str = "system",
+    ) -> JsonObject: ...
+
+    def get_scheduler_workflow(self, workflow_type: str) -> JsonObject | None: ...
+
+    def list_scheduler_workflows(self) -> list[JsonObject]: ...
+
+    def create_scheduler_run(self, run: JsonObject, *, actor_type: str = "scheduler") -> JsonObject: ...
+
+    def update_scheduler_run(self, *, run_id: str, patch: JsonObject, actor_type: str = "scheduler") -> JsonObject: ...
+
+    def list_scheduler_runs(self, *, workflow_type: str | None = None, limit: int = 20) -> list[JsonObject]: ...
+
+    def create_artifact(self, artifact: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
+
+    def search_sources(self, **kwargs) -> list[JsonObject]: ...
+
+    def search_memories(self, **kwargs) -> list[JsonObject]: ...
+
+    def list_open_loops(self, **kwargs) -> list[JsonObject]: ...
+
+    def list_artifacts(self, **kwargs) -> list[JsonObject]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerRunRequest:
+    workflow_type: str
+    domains: tuple[str, ...] = ()
+    sensitivity_allowed: tuple[str, ...] = ("public", "internal", "private", "unknown")
+    generated_for: str | None = None
+    triggered_by: str = "user"
+    agent_identity: AgentIdentity | None = None
+    policy_decision: PolicyDecision | None = None
+    options: JsonObject = field(default_factory=dict)
+
+
+def default_schedule(workflow_type: str) -> JsonObject:
+    if workflow_type == "daily_brief":
+        return {"kind": "daily", "time_of_day": "08:00", "days_of_week": list(DAY_NAMES)}
+    if workflow_type == "weekly_synthesis":
+        return {"kind": "weekly", "day_of_week": "monday", "time_of_day": "09:00"}
+    return {"kind": "manual"}
+
+
+def _parse_time_of_day(value: object) -> time:
+    if not isinstance(value, str):
+        raise VNextSchedulerValidationError("time_of_day must be HH:MM")
+    try:
+        hour, minute = value.split(":", 1)
+        return time(hour=int(hour), minute=int(minute))
+    except (TypeError, ValueError) as exc:
+        raise VNextSchedulerValidationError("time_of_day must be HH:MM") from exc
+
+
+def _day_index(value: object) -> int:
+    if isinstance(value, int) and 0 <= value <= 6:
+        return value
+    if isinstance(value, str):
+        normalized = value.casefold().strip()
+        if normalized in DAY_NAMES:
+            return DAY_NAMES.index(normalized)
+    raise VNextSchedulerValidationError("day_of_week must be a weekday name or integer 0-6")
+
+
+def validate_schedule(workflow_type: str, schedule_json: JsonObject) -> JsonObject:
+    if workflow_type not in WORKFLOW_TYPES:
+        raise VNextSchedulerValidationError(f"workflow_type must be one of {', '.join(WORKFLOW_TYPES)}")
+    if not isinstance(schedule_json, dict):
+        raise VNextSchedulerValidationError("schedule_json must be an object")
+
+    kind = schedule_json.get("kind") or ("daily" if workflow_type == "daily_brief" else "weekly" if workflow_type == "weekly_synthesis" else "manual")
+    if kind == "manual":
+        return {"kind": "manual"}
+    if workflow_type == "daily_brief":
+        when = _parse_time_of_day(schedule_json.get("time_of_day", "08:00"))
+        days = schedule_json.get("days_of_week", list(DAY_NAMES))
+        if not isinstance(days, list) or not days:
+            raise VNextSchedulerValidationError("days_of_week must be a non-empty list")
+        day_values = sorted(dict.fromkeys(_day_index(day) for day in days))
+        return {
+            "kind": "daily",
+            "time_of_day": f"{when.hour:02d}:{when.minute:02d}",
+            "days_of_week": [DAY_NAMES[index] for index in day_values],
+        }
+    if workflow_type == "weekly_synthesis":
+        when = _parse_time_of_day(schedule_json.get("time_of_day", "09:00"))
+        day = DAY_NAMES[_day_index(schedule_json.get("day_of_week", "monday"))]
+        return {"kind": "weekly", "day_of_week": day, "time_of_day": f"{when.hour:02d}:{when.minute:02d}"}
+    return {"kind": "manual"}
+
+
+def compute_next_run_at(
+    *,
+    workflow_type: str,
+    enabled: bool,
+    paused: bool,
+    schedule_json: JsonObject,
+    timezone: str,
+    now: datetime | None = None,
+) -> str | None:
+    if not enabled or paused:
+        return None
+    schedule = validate_schedule(workflow_type, schedule_json)
+    if schedule.get("kind") == "manual":
+        return None
+    try:
+        zone = ZoneInfo(timezone)
+    except ZoneInfoNotFoundError as exc:
+        raise VNextSchedulerValidationError("timezone must be a valid IANA timezone") from exc
+    local_now = (now or datetime.now(UTC)).astimezone(zone)
+    run_time = _parse_time_of_day(schedule["time_of_day"])
+    if schedule["kind"] == "daily":
+        allowed_days = {_day_index(day) for day in schedule["days_of_week"]}  # type: ignore[index]
+    else:
+        allowed_days = {_day_index(schedule["day_of_week"])}
+    for offset in range(8):
+        candidate_date = (local_now + timedelta(days=offset)).date()
+        if candidate_date.weekday() not in allowed_days:
+            continue
+        candidate = datetime.combine(candidate_date, run_time, tzinfo=zone)
+        if candidate > local_now:
+            return candidate.astimezone(UTC).isoformat()
+    raise VNextSchedulerValidationError("could not compute next scheduler run")
+
+
+def _coerce_datetime(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise VNextSchedulerValidationError("next_run_at must be an ISO datetime") from exc
+    else:
+        raise VNextSchedulerValidationError("next_run_at must be an ISO datetime")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+class VNextSchedulerService:
+    def __init__(self, store: VNextSchedulerStore) -> None:
+        self.store = store
+
+    def ensure_default_workflows(self) -> list[JsonObject]:
+        existing = {str(row["workflow_type"]): row for row in self.store.list_scheduler_workflows()}
+        workflows: list[JsonObject] = []
+        for workflow_type in WORKFLOW_TYPES:
+            if workflow_type in existing:
+                workflows.append(existing[workflow_type])
+                continue
+            workflows.append(
+                self.store.upsert_scheduler_workflow(
+                    {
+                        "workflow_type": workflow_type,
+                        "enabled": False,
+                        "paused": False,
+                        "schedule_json": default_schedule(workflow_type),
+                        "timezone": "UTC",
+                        "next_run_at": None,
+                        "metadata_json": {"created_by": "vnext_scheduler_defaults"},
+                    }
+                )
+            )
+        return workflows
+
+    def status(self) -> JsonObject:
+        workflows = self.ensure_default_workflows()
+        runs = self.store.list_scheduler_runs(limit=20)
+        return {
+            "mode": "local_governed",
+            "disabled_by_default": True,
+            "workflows": workflows,
+            "recent_runs": runs,
+            "enabled_count": sum(1 for row in workflows if row.get("enabled") is True),
+            "paused_count": sum(1 for row in workflows if row.get("paused") is True),
+            "last_failure": next((run for run in runs if run.get("status") == "failed"), None),
+        }
+
+    def configure_workflow(
+        self,
+        *,
+        workflow_type: str,
+        enabled: bool | None = None,
+        paused: bool | None = None,
+        schedule_json: JsonObject | None = None,
+        timezone: str | None = None,
+        actor_type: str = "user",
+    ) -> JsonObject:
+        current = self._ensure_workflow(workflow_type)
+        next_enabled = bool(current.get("enabled")) if enabled is None else enabled
+        next_paused = bool(current.get("paused")) if paused is None else paused
+        next_schedule = validate_schedule(workflow_type, schedule_json or current.get("schedule_json") or default_schedule(workflow_type))
+        next_timezone = timezone or str(current.get("timezone") or "UTC")
+        next_run_at = compute_next_run_at(
+            workflow_type=workflow_type,
+            enabled=next_enabled,
+            paused=next_paused,
+            schedule_json=next_schedule,
+            timezone=next_timezone,
+        )
+        row = self.store.update_scheduler_workflow(
+            workflow_type=workflow_type,
+            patch={
+                "enabled": next_enabled,
+                "paused": next_paused,
+                "schedule_json": next_schedule,
+                "timezone": next_timezone,
+                "next_run_at": next_run_at,
+                "last_error": None,
+            },
+            actor_type=actor_type,
+        )
+        event_type = "scheduler.workflow_enabled" if next_enabled else "scheduler.workflow_disabled"
+        if paused is True:
+            event_type = "scheduler.workflow_paused"
+        elif paused is False:
+            event_type = "scheduler.workflow_resumed"
+        append_event(
+            self.store,
+            event_type=event_type,
+            actor_type=actor_type,
+            target_type="scheduler_workflow",
+            target_id=str(row["id"]),
+            payload={"workflow_type": workflow_type, "enabled": next_enabled, "paused": next_paused},
+        )
+        return row
+
+    def pause_all(self, *, actor_type: str = "user") -> JsonObject:
+        workflows = [self.configure_workflow(workflow_type=workflow_type, paused=True, actor_type=actor_type) for workflow_type in WORKFLOW_TYPES]
+        return {"workflows": workflows, "paused_count": len(workflows)}
+
+    def resume_all(self, *, actor_type: str = "user") -> JsonObject:
+        workflows = [self.configure_workflow(workflow_type=workflow_type, paused=False, actor_type=actor_type) for workflow_type in WORKFLOW_TYPES]
+        return {"workflows": workflows, "resumed_count": len(workflows)}
+
+    def run_due_workflows(
+        self,
+        *,
+        now: datetime | None = None,
+        limit: int = 10,
+        triggered_by: str = "scheduler",
+        agent_identity: AgentIdentity | None = None,
+        policy_decision: PolicyDecision | None = None,
+    ) -> JsonObject:
+        if limit < 1:
+            raise VNextSchedulerValidationError("limit must be at least 1")
+        checked_at = _coerce_datetime(now or datetime.now(UTC)) or datetime.now(UTC)
+        due_runs: list[JsonObject] = []
+        for workflow in self.ensure_default_workflows():
+            if len(due_runs) >= limit:
+                break
+            if workflow.get("enabled") is not True or workflow.get("paused") is True:
+                continue
+            next_run_at = _coerce_datetime(workflow.get("next_run_at"))
+            if next_run_at is None or next_run_at > checked_at:
+                continue
+            workflow_type = str(workflow["workflow_type"])
+            result = self.run_now(
+                SchedulerRunRequest(
+                    workflow_type=workflow_type,
+                    generated_for=self._generated_for(workflow, checked_at),
+                    triggered_by=triggered_by,
+                    agent_identity=agent_identity,
+                    policy_decision=policy_decision,
+                    options={
+                        "scheduled_for": next_run_at.isoformat(),
+                        "due_scan_checked_at": checked_at.isoformat(),
+                    },
+                )
+            )
+            due_runs.append(
+                {
+                    "workflow_type": workflow_type,
+                    "scheduled_for": next_run_at.isoformat(),
+                    "run": result["run"],
+                    "artifact": result["artifact"],
+                }
+            )
+        append_event(
+            self.store,
+            event_type="scheduler.due_scan",
+            actor_type=triggered_by,
+            payload={"checked_at": checked_at.isoformat(), "due_count": len(due_runs), "limit": limit},
+        )
+        return {"checked_at": checked_at.isoformat(), "due_count": len(due_runs), "runs": due_runs}
+
+    def run_now(self, request: SchedulerRunRequest) -> JsonObject:
+        if request.workflow_type not in WORKFLOW_TYPES:
+            raise VNextSchedulerValidationError(f"workflow_type must be one of {', '.join(WORKFLOW_TYPES)}")
+        workflow = self._ensure_workflow(request.workflow_type)
+        trace_id = str(uuid4())
+        actor_type = request.triggered_by
+        run = self.store.create_scheduler_run(
+            {
+                "workflow_id": workflow.get("id"),
+                "workflow_type": request.workflow_type,
+                "status": "started",
+                "triggered_by": request.triggered_by,
+                "trace_id": trace_id,
+                "policy_decision_json": request.policy_decision.to_record() if request.policy_decision else {},
+                "agent_identity_json": request.agent_identity.to_record() if request.agent_identity else {},
+                "metadata_json": {"manual_run": request.triggered_by != "scheduler"},
+            },
+            actor_type=actor_type,
+        )
+        run_id = str(run["id"])
+        try:
+            artifact = self._run_workflow(request, scheduler_run_id=run_id, trace_id=trace_id)
+            artifact_id = str(artifact["id"])
+            updated_run = self.store.update_scheduler_run(
+                run_id=run_id,
+                patch={"status": "succeeded", "artifact_id": artifact_id, "metadata_json": {"artifact_id": artifact_id}},
+                actor_type=actor_type,
+            )
+            self.store.update_scheduler_workflow(
+                workflow_type=request.workflow_type,
+                patch={
+                    "last_run_id": run_id,
+                    "last_run_at": updated_run.get("finished_at"),
+                    "last_result": "succeeded",
+                    "last_error": None,
+                    "next_run_at": self._next_run_after(workflow),
+                },
+                actor_type=actor_type,
+            )
+            append_event(
+                self.store,
+                event_type="scheduler.artifact_created",
+                actor_type=actor_type,
+                target_type="artifact",
+                target_id=artifact_id,
+                trace_id=trace_id,
+                run_id=run_id,
+                payload={"workflow_type": request.workflow_type, "scheduler_run_id": run_id},
+            )
+            return {"run": updated_run, "artifact": artifact}
+        except Exception as exc:
+            updated_run = self.store.update_scheduler_run(
+                run_id=run_id,
+                patch={"status": "failed", "error_message": str(exc), "metadata_json": {"error_type": type(exc).__name__}},
+                actor_type=actor_type,
+            )
+            self.store.update_scheduler_workflow(
+                workflow_type=request.workflow_type,
+                patch={
+                    "last_run_id": run_id,
+                    "last_run_at": updated_run.get("finished_at"),
+                    "last_result": "failed",
+                    "last_error": str(exc),
+                    "next_run_at": self._next_run_after(workflow),
+                },
+                actor_type=actor_type,
+            )
+            return {"run": updated_run, "artifact": None}
+
+    def _ensure_workflow(self, workflow_type: str) -> JsonObject:
+        if workflow_type not in WORKFLOW_TYPES:
+            raise VNextSchedulerValidationError(f"workflow_type must be one of {', '.join(WORKFLOW_TYPES)}")
+        workflow = self.store.get_scheduler_workflow(workflow_type)
+        if workflow is not None:
+            return workflow
+        return self.store.upsert_scheduler_workflow(
+            {
+                "workflow_type": workflow_type,
+                "enabled": False,
+                "paused": False,
+                "schedule_json": default_schedule(workflow_type),
+                "timezone": "UTC",
+                "next_run_at": None,
+                "metadata_json": {"created_by": "vnext_scheduler_defaults"},
+            }
+        )
+
+    def _run_workflow(self, request: SchedulerRunRequest, *, scheduler_run_id: str, trace_id: str) -> JsonObject:
+        metadata = {
+            "generated_by": "scheduler",
+            "workflow": request.workflow_type,
+            "scheduler_run_id": scheduler_run_id,
+            "trace_id": trace_id,
+            "policy_decision": request.policy_decision.to_record() if request.policy_decision else None,
+            "agent_identity": request.agent_identity.to_record() if request.agent_identity else None,
+        }
+        brain_request = BrainArtifactRequest(
+            domains=request.domains,
+            sensitivity_allowed=request.sensitivity_allowed,
+            generated_for=request.generated_for,
+            discover_open_loops=False,
+            create_candidate_memories=False,
+            generated_by="scheduler",
+            trace_id=trace_id,
+            run_id=scheduler_run_id,
+            metadata_json=metadata,
+        )
+        brain = VNextBrainService(self.store)
+        if request.workflow_type == "daily_brief":
+            return brain.generate_daily_brief(brain_request)
+        if request.workflow_type == "weekly_synthesis":
+            return brain.generate_weekly_synthesis(brain_request)
+        artifact_type = {
+            "connection_report": "connection_report",
+            "contradiction_report": "contradiction_report",
+            "open_loop_review": "open_loop_report",
+            "project_update_scan": "project_update",
+        }.get(request.workflow_type, "system_report")
+        return self.store.create_artifact(
+            {
+                "artifact_type": artifact_type,
+                "title": f"{request.workflow_type.replace('_', ' ').title()} - {datetime.now(UTC).date().isoformat()}",
+                "content_markdown": "\n".join(
+                    [
+                        f"# {request.workflow_type.replace('_', ' ').title()}",
+                        "",
+                        "This governed scheduler workflow is configured but has only a deterministic local scaffold in this sprint.",
+                    ]
+                ),
+                "status": "needs_review",
+                "domain": request.domains[0] if len(request.domains) == 1 else "unknown",
+                "sensitivity": "unknown",
+                "generated_by": "scheduler",
+                "metadata_json": metadata,
+            },
+            actor_type="scheduler",
+        )
+
+    def _next_run_after(self, workflow: JsonObject) -> str | None:
+        workflow_type = str(workflow["workflow_type"])
+        return compute_next_run_at(
+            workflow_type=workflow_type,
+            enabled=bool(workflow.get("enabled")),
+            paused=bool(workflow.get("paused")),
+            schedule_json=workflow.get("schedule_json") or default_schedule(workflow_type),
+            timezone=str(workflow.get("timezone") or "UTC"),
+        )
+
+    def _generated_for(self, workflow: JsonObject, checked_at: datetime) -> str:
+        try:
+            zone = ZoneInfo(str(workflow.get("timezone") or "UTC"))
+        except ZoneInfoNotFoundError:
+            zone = UTC
+        return checked_at.astimezone(zone).date().isoformat()
+
+
+__all__ = [
+    "PRIMARY_WORKFLOWS",
+    "SchedulerRunRequest",
+    "VNextSchedulerService",
+    "VNextSchedulerStore",
+    "VNextSchedulerValidationError",
+    "WORKFLOW_TYPES",
+    "compute_next_run_at",
+    "default_schedule",
+    "validate_schedule",
+]

--- a/apps/api/src/alicebot_api/vnext_store.py
+++ b/apps/api/src/alicebot_api/vnext_store.py
@@ -273,6 +273,54 @@ BRAIN_CHARTER_COLUMNS = """
                   updated_at
                 """
 
+AGENT_IDENTITY_COLUMNS = """
+                  id,
+                  user_id,
+                  agent_id,
+                  agent_type,
+                  permission_profile,
+                  display_name,
+                  project_scope_json,
+                  metadata_json,
+                  created_at,
+                  updated_at
+                """
+
+SCHEDULER_WORKFLOW_COLUMNS = """
+                  id,
+                  user_id,
+                  workflow_type,
+                  enabled,
+                  paused,
+                  schedule_json,
+                  timezone,
+                  next_run_at,
+                  last_run_id,
+                  last_run_at,
+                  last_result,
+                  last_error,
+                  created_at,
+                  updated_at,
+                  metadata_json
+                """
+
+SCHEDULER_RUN_COLUMNS = """
+                  id,
+                  user_id,
+                  workflow_id,
+                  workflow_type,
+                  status,
+                  triggered_by,
+                  trace_id,
+                  started_at,
+                  finished_at,
+                  artifact_id,
+                  error_message,
+                  policy_decision_json,
+                  agent_identity_json,
+                  metadata_json
+                """
+
 
 def _json_object(value: object | None) -> Jsonb:
     if value is None:
@@ -2228,6 +2276,326 @@ class PostgresVNextStore:
                 FROM brain_charters
                 LIMIT 1
                 """
+        )
+
+    def upsert_agent_identity(self, agent: JsonObject, *, actor_type: str = "agent") -> VNextRow:
+        row = self._fetch_one(
+            "upsert_agent_identity",
+            f"""
+                INSERT INTO agent_identities (
+                  id,
+                  user_id,
+                  agent_id,
+                  agent_type,
+                  permission_profile,
+                  display_name,
+                  project_scope_json,
+                  metadata_json
+                )
+                VALUES (
+                  COALESCE(%s::uuid, gen_random_uuid()),
+                  app.current_user_id(),
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s
+                )
+                ON CONFLICT (user_id, agent_id)
+                DO UPDATE SET
+                  agent_type = EXCLUDED.agent_type,
+                  permission_profile = EXCLUDED.permission_profile,
+                  display_name = COALESCE(EXCLUDED.display_name, agent_identities.display_name),
+                  project_scope_json = EXCLUDED.project_scope_json,
+                  metadata_json = agent_identities.metadata_json || EXCLUDED.metadata_json,
+                  updated_at = clock_timestamp()
+                RETURNING {AGENT_IDENTITY_COLUMNS}
+                """,
+            (
+                agent.get("id"),
+                agent["agent_id"],
+                agent.get("agent_type", "unknown"),
+                agent.get("permission_profile", "read_only_agent"),
+                agent.get("display_name"),
+                _json_list(agent.get("project_scope_json") or agent.get("project_scope")),
+                _json_object(agent.get("metadata_json")),
+            ),
+        )
+        self._append_mutation_event(
+            event_type="agent.identity_upserted",
+            actor_type=actor_type,
+            actor_id=str(row["agent_id"]),
+            target_type="agent_identity",
+            target_id=row["id"],
+            payload={"operation": "upsert", "agent_id": str(row["agent_id"])},
+        )
+        return row
+
+    def list_agent_identities(self, *, limit: int = 20) -> list[VNextRow]:
+        return self._fetch_all(
+            f"""
+                SELECT {AGENT_IDENTITY_COLUMNS}
+                FROM agent_identities
+                ORDER BY updated_at DESC, id DESC
+                LIMIT %s
+                """,
+            (limit,),
+        )
+
+    def list_agent_events(self, *, agent_id: str | None = None, limit: int = 50) -> list[VNextRow]:
+        return self._fetch_all(
+            f"""
+                SELECT {EVENT_LOG_COLUMNS}
+                FROM event_log
+                WHERE actor_type = 'agent'
+                  AND (%s::text IS NULL OR actor_id = %s)
+                ORDER BY occurred_at DESC, id DESC
+                LIMIT %s
+                """,
+            (agent_id, agent_id, limit),
+        )
+
+    def upsert_scheduler_workflow(self, workflow: JsonObject, *, actor_type: str = "system") -> VNextRow:
+        row = self._fetch_one(
+            "upsert_scheduler_workflow",
+            f"""
+                INSERT INTO scheduler_workflows (
+                  id,
+                  user_id,
+                  workflow_type,
+                  enabled,
+                  paused,
+                  schedule_json,
+                  timezone,
+                  next_run_at,
+                  metadata_json
+                )
+                VALUES (
+                  COALESCE(%s::uuid, gen_random_uuid()),
+                  app.current_user_id(),
+                  %s,
+                  COALESCE(%s, false),
+                  COALESCE(%s, false),
+                  %s,
+                  COALESCE(%s, 'UTC'),
+                  %s,
+                  %s
+                )
+                ON CONFLICT (user_id, workflow_type)
+                DO UPDATE SET
+                  enabled = EXCLUDED.enabled,
+                  paused = EXCLUDED.paused,
+                  schedule_json = EXCLUDED.schedule_json,
+                  timezone = EXCLUDED.timezone,
+                  next_run_at = EXCLUDED.next_run_at,
+                  metadata_json = scheduler_workflows.metadata_json || EXCLUDED.metadata_json,
+                  updated_at = clock_timestamp()
+                RETURNING {SCHEDULER_WORKFLOW_COLUMNS}
+                """,
+            (
+                workflow.get("id"),
+                workflow["workflow_type"],
+                workflow.get("enabled"),
+                workflow.get("paused"),
+                _json_object(workflow.get("schedule_json")),
+                workflow.get("timezone"),
+                workflow.get("next_run_at"),
+                _json_object(workflow.get("metadata_json")),
+            ),
+        )
+        self._append_mutation_event(
+            event_type="scheduler.workflow_upserted",
+            actor_type=actor_type,
+            target_type="scheduler_workflow",
+            target_id=row["id"],
+            payload={
+                "operation": "upsert",
+                "workflow_type": str(row["workflow_type"]),
+                "enabled": bool(row["enabled"]),
+                "paused": bool(row["paused"]),
+            },
+        )
+        return row
+
+    def update_scheduler_workflow(self, *, workflow_type: str, patch: JsonObject, actor_type: str = "system") -> VNextRow:
+        row = self._fetch_one(
+            "update_scheduler_workflow",
+            f"""
+                UPDATE scheduler_workflows
+                SET enabled = COALESCE(%s, enabled),
+                    paused = COALESCE(%s, paused),
+                    schedule_json = COALESCE(%s, schedule_json),
+                    timezone = COALESCE(%s, timezone),
+                    next_run_at = CASE
+                      WHEN %s THEN %s::timestamptz
+                      ELSE next_run_at
+                    END,
+                    last_run_id = COALESCE(%s::uuid, last_run_id),
+                    last_run_at = COALESCE(%s::timestamptz, last_run_at),
+                    last_result = COALESCE(%s, last_result),
+                    last_error = CASE
+                      WHEN %s THEN %s
+                      ELSE last_error
+                    END,
+                    metadata_json = COALESCE(%s, metadata_json),
+                    updated_at = clock_timestamp()
+                WHERE workflow_type = %s
+                RETURNING {SCHEDULER_WORKFLOW_COLUMNS}
+                """,
+            (
+                patch.get("enabled"),
+                patch.get("paused"),
+                _json_object(patch["schedule_json"]) if "schedule_json" in patch else None,
+                patch.get("timezone"),
+                "next_run_at" in patch,
+                patch.get("next_run_at"),
+                patch.get("last_run_id"),
+                patch.get("last_run_at"),
+                patch.get("last_result"),
+                "last_error" in patch,
+                patch.get("last_error"),
+                _json_object(patch["metadata_json"]) if "metadata_json" in patch else None,
+                workflow_type,
+            ),
+        )
+        self._append_mutation_event(
+            event_type="scheduler.workflow_updated",
+            actor_type=actor_type,
+            target_type="scheduler_workflow",
+            target_id=row["id"],
+            payload={"operation": "update", "workflow_type": workflow_type, "changes": patch},
+        )
+        return row
+
+    def get_scheduler_workflow(self, workflow_type: str) -> VNextRow | None:
+        return self._fetch_optional_one(
+            f"""
+                SELECT {SCHEDULER_WORKFLOW_COLUMNS}
+                FROM scheduler_workflows
+                WHERE workflow_type = %s
+                """,
+            (workflow_type,),
+        )
+
+    def list_scheduler_workflows(self) -> list[VNextRow]:
+        return self._fetch_all(
+            f"""
+                SELECT {SCHEDULER_WORKFLOW_COLUMNS}
+                FROM scheduler_workflows
+                ORDER BY workflow_type ASC
+                """
+        )
+
+    def create_scheduler_run(self, run: JsonObject, *, actor_type: str = "scheduler") -> VNextRow:
+        row = self._fetch_one(
+            "create_scheduler_run",
+            f"""
+                INSERT INTO scheduler_runs (
+                  id,
+                  user_id,
+                  workflow_id,
+                  workflow_type,
+                  status,
+                  triggered_by,
+                  trace_id,
+                  policy_decision_json,
+                  agent_identity_json,
+                  metadata_json
+                )
+                VALUES (
+                  COALESCE(%s::uuid, gen_random_uuid()),
+                  app.current_user_id(),
+                  %s::uuid,
+                  %s,
+                  COALESCE(%s, 'started'),
+                  COALESCE(%s, 'scheduler'),
+                  %s,
+                  %s,
+                  %s,
+                  %s
+                )
+                RETURNING {SCHEDULER_RUN_COLUMNS}
+                """,
+            (
+                run.get("id"),
+                run.get("workflow_id"),
+                run["workflow_type"],
+                run.get("status"),
+                run.get("triggered_by"),
+                run["trace_id"],
+                _json_object(run.get("policy_decision_json")),
+                _json_object(run.get("agent_identity_json")),
+                _json_object(run.get("metadata_json")),
+            ),
+        )
+        self._append_mutation_event(
+            event_type="scheduler.run_started",
+            actor_type=actor_type,
+            target_type="scheduler_run",
+            target_id=row["id"],
+            trace_id=str(row["trace_id"]),
+            run_id=str(row["id"]),
+            payload={"workflow_type": str(row["workflow_type"]), "triggered_by": str(row["triggered_by"])},
+        )
+        return row
+
+    def update_scheduler_run(self, *, run_id: str, patch: JsonObject, actor_type: str = "scheduler") -> VNextRow:
+        row = self._fetch_one(
+            "update_scheduler_run",
+            f"""
+                UPDATE scheduler_runs
+                SET status = COALESCE(%s, status),
+                    finished_at = CASE
+                      WHEN %s IN ('succeeded', 'failed') THEN clock_timestamp()
+                      ELSE finished_at
+                    END,
+                    artifact_id = COALESCE(%s::uuid, artifact_id),
+                    error_message = COALESCE(%s, error_message),
+                    policy_decision_json = COALESCE(%s, policy_decision_json),
+                    agent_identity_json = COALESCE(%s, agent_identity_json),
+                    metadata_json = COALESCE(%s, metadata_json)
+                WHERE id = %s::uuid
+                RETURNING {SCHEDULER_RUN_COLUMNS}
+                """,
+            (
+                patch.get("status"),
+                patch.get("status"),
+                patch.get("artifact_id"),
+                patch.get("error_message"),
+                _json_object(patch["policy_decision_json"]) if "policy_decision_json" in patch else None,
+                _json_object(patch["agent_identity_json"]) if "agent_identity_json" in patch else None,
+                _json_object(patch["metadata_json"]) if "metadata_json" in patch else None,
+                run_id,
+            ),
+        )
+        event_type = "scheduler.run_succeeded" if row["status"] == "succeeded" else "scheduler.run_failed" if row["status"] == "failed" else "scheduler.run_updated"
+        self._append_mutation_event(
+            event_type=event_type,
+            actor_type=actor_type,
+            target_type="scheduler_run",
+            target_id=row["id"],
+            trace_id=str(row["trace_id"]),
+            run_id=str(row["id"]),
+            payload={
+                "workflow_type": str(row["workflow_type"]),
+                "status": str(row["status"]),
+                "artifact_id": str(row["artifact_id"]) if row.get("artifact_id") is not None else None,
+                "error_message": row.get("error_message"),
+            },
+        )
+        return row
+
+    def list_scheduler_runs(self, *, workflow_type: str | None = None, limit: int = 20) -> list[VNextRow]:
+        return self._fetch_all(
+            f"""
+                SELECT {SCHEDULER_RUN_COLUMNS}
+                FROM scheduler_runs
+                WHERE (%s::text IS NULL OR workflow_type = %s)
+                ORDER BY started_at DESC, id DESC
+                LIMIT %s
+                """,
+            (workflow_type, workflow_type, limit),
         )
 
 

--- a/apps/web/app/vnext/page.test.tsx
+++ b/apps/web/app/vnext/page.test.tsx
@@ -23,6 +23,8 @@ const EXPECTED_SURFACES = [
   "People",
   "Beliefs",
   "Open Loops",
+  "Agent Activity",
+  "Schedules",
   "Timeline",
   "Graph",
   "Connectors",
@@ -91,6 +93,8 @@ describe("VNextPage", () => {
     expect(screen.getByText("Evidence-first answer")).toBeInTheDocument();
     expect(screen.getByText("Artifacts with review actions")).toBeInTheDocument();
     expect(screen.getByText("Belief review")).toBeInTheDocument();
+    expect(screen.getByText("Agents and policy posture")).toBeInTheDocument();
+    expect(screen.getByText("Governed scheduler")).toBeInTheDocument();
     expect(screen.getByText("Connection graph")).toBeInTheDocument();
     expect(screen.getByText("Connector settings")).toBeInTheDocument();
     expect(screen.getByText("Brain Charter")).toBeInTheDocument();
@@ -104,6 +108,9 @@ describe("VNextPage", () => {
     expect(screen.getByText("Memory sources used")).toBeInTheDocument();
     expect(screen.getAllByText("Contradictions").length).toBeGreaterThan(0);
     expect(screen.getByText("Why this answer")).toBeInTheDocument();
+    expect(screen.getByText("OpenClaw")).toBeInTheDocument();
+    expect(screen.getByText("Hermes")).toBeInTheDocument();
+    expect(screen.getByText("Recent scheduler runs")).toBeInTheDocument();
   });
 
   it("keeps fixture labels aligned to vNext schema values and connector contracts", () => {
@@ -183,6 +190,24 @@ describe("VNextPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Generate weekly synthesis" }));
     expect(screen.getAllByText("Demo weekly artifact generated.").length).toBeGreaterThan(0);
+  });
+
+  it("updates governed scheduler fixture state", async () => {
+    await renderVNextPage();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Enable" })[0]);
+    expect(screen.getAllByText("Demo scheduler action applied: enable.").length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getAllByLabelText("Time of day")[0], {
+      target: { value: "07:30" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit schedule" })[0]);
+    expect(screen.getAllByText("Demo scheduler action applied: update_schedule.").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Daily at 07:30 UTC/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Run now" })[0]);
+    expect(screen.getAllByText("Demo scheduler action applied: run_now.").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/scheduler-run-demo-1/).length).toBeGreaterThan(0);
   });
 
   it("saves Brain Charter settings and keeps connector settings visible", async () => {

--- a/apps/web/components/vnext-brain-workspace.tsx
+++ b/apps/web/components/vnext-brain-workspace.tsx
@@ -15,6 +15,7 @@ import type {
   VNextPersonRecord,
   VNextProjectDashboard,
   VNextProjectRecord,
+  VNextSchedulerStatus,
   VNextSourceRecord,
   VNextTaskRecord,
   VNextWorkspacePayload,
@@ -28,9 +29,11 @@ import {
   generateVNextProjectUpdate,
   generateVNextWeeklySynthesis,
   getVNextWorkspace,
+  patchVNextSchedulerWorkflow,
   reviewVNextArtifact,
   reviewVNextMemory,
   reviewVNextOpenLoop,
+  runVNextSchedulerWorkflowNow,
   upsertVNextBrainCharter,
 } from "../lib/api";
 import { EmptyState } from "./empty-state";
@@ -114,6 +117,8 @@ type WorkspaceView = {
   beliefs: VNextBeliefRecord[];
   tasks: VNextTaskRecord[];
   recentEvents: VNextEventRecord[];
+  agentActivity: NonNullable<VNextWorkspacePayload["agent_activity"]>;
+  scheduler: VNextSchedulerStatus;
   brainCharter: VNextBrainCharterRecord | null;
 };
 
@@ -136,6 +141,8 @@ const SURFACES = [
   "People",
   "Beliefs",
   "Open Loops",
+  "Agent Activity",
+  "Schedules",
   "Timeline",
   "Graph",
   "Connectors",
@@ -229,11 +236,31 @@ function createSummary(view: Omit<WorkspaceView, "summary">): WorkspaceSummary {
     open_loop_count: view.openLoops.filter((item) => item.status === "open").length,
     project_count: view.projects.length,
     event_count: view.recentEvents.length,
+    agent_count: view.agentActivity.agents.length,
+    scheduler_enabled_count: view.scheduler.enabled_count,
     memory_status_counts: memoryStatusCounts,
     artifact_status_counts: artifactStatusCounts,
     open_loop_status_counts: openLoopStatusCounts,
   };
 }
+
+const EMPTY_AGENT_ACTIVITY: NonNullable<VNextWorkspacePayload["agent_activity"]> = {
+  agents: [],
+  recent_events: [],
+  policy_blocks: [],
+  generated_artifacts: [],
+  pending_review_items: [],
+};
+
+const EMPTY_SCHEDULER: VNextSchedulerStatus = {
+  mode: "local_governed",
+  disabled_by_default: true,
+  workflows: [],
+  recent_runs: [],
+  enabled_count: 0,
+  paused_count: 0,
+  last_failure: null,
+};
 
 const FIXTURE_SOURCES: VNextSourceRecord[] = [
   {
@@ -410,6 +437,84 @@ const FIXTURE_EVENTS: VNextEventRecord[] = [
   },
 ];
 
+const FIXTURE_AGENT_ACTIVITY: NonNullable<VNextWorkspacePayload["agent_activity"]> = {
+  agents: [
+    {
+      id: "agent-fixture-openclaw",
+      agent_id: "openclaw",
+      agent_type: "coding_agent",
+      permission_profile: "project_scoped_agent",
+      project_scope_json: ["Alice"],
+      updated_at: "2026-05-10T08:45:00Z",
+    },
+    {
+      id: "agent-fixture-hermes",
+      agent_id: "hermes",
+      agent_type: "personal_assistant",
+      permission_profile: "trusted_local_agent",
+      project_scope_json: ["Alice"],
+      updated_at: "2026-05-10T08:42:00Z",
+    },
+  ],
+  recent_events: [
+    {
+      id: "agent-event-fixture-1",
+      event_type: "agent.context_pack_requested",
+      actor_type: "agent",
+      actor_id: "openclaw",
+      target_type: "context_pack",
+      target_id: "context-pack-fixture",
+      occurred_at: "2026-05-10T08:45:00Z",
+      payload_json: { query: "Alice project status", selected_count: 3 },
+    },
+  ],
+  policy_blocks: [
+    {
+      id: "agent-event-fixture-2",
+      event_type: "agent.policy_filtered",
+      actor_type: "agent",
+      actor_id: "openclaw",
+      target_type: "context_pack",
+      target_id: "context-pack-fixture-filtered",
+      occurred_at: "2026-05-10T08:46:00Z",
+      payload_json: { reason: "restricted_domain_filtered" },
+    },
+  ],
+  generated_artifacts: FIXTURE_ARTIFACTS,
+  pending_review_items: FIXTURE_REVIEW_ITEMS,
+};
+
+const FIXTURE_SCHEDULER: VNextSchedulerStatus = {
+  mode: "local_governed",
+  disabled_by_default: true,
+  enabled_count: 0,
+  paused_count: 0,
+  last_failure: null,
+  workflows: [
+    {
+      id: "schedule-daily",
+      workflow_type: "daily_brief",
+      enabled: false,
+      paused: false,
+      schedule_json: { kind: "daily", time_of_day: "08:00", days_of_week: ["monday", "tuesday", "wednesday", "thursday", "friday"] },
+      timezone: "UTC",
+      next_run_at: null,
+      last_result: null,
+    },
+    {
+      id: "schedule-weekly",
+      workflow_type: "weekly_synthesis",
+      enabled: false,
+      paused: false,
+      schedule_json: { kind: "weekly", day_of_week: "monday", time_of_day: "09:00" },
+      timezone: "UTC",
+      next_run_at: null,
+      last_result: null,
+    },
+  ],
+  recent_runs: [],
+};
+
 export const INITIAL_CONNECTORS: ConnectorSetting[] = [
   {
     id: "telegram",
@@ -521,6 +626,8 @@ function fixtureWorkspace(): WorkspaceView {
     beliefs: FIXTURE_BELIEFS,
     tasks: [],
     recentEvents: FIXTURE_EVENTS,
+    agentActivity: FIXTURE_AGENT_ACTIVITY,
+    scheduler: FIXTURE_SCHEDULER,
     brainCharter: {
       id: "brain-charter-fixture",
       content_markdown: "# ALICE.md\n\nKeep generated artifacts reviewable before promotion.",
@@ -542,6 +649,8 @@ function emptyWorkspace(): WorkspaceView {
     beliefs: [],
     tasks: [],
     recentEvents: [],
+    agentActivity: EMPTY_AGENT_ACTIVITY,
+    scheduler: EMPTY_SCHEDULER,
     brainCharter: null,
   };
   return { ...view, summary: createSummary(view) };
@@ -560,6 +669,8 @@ function workspaceFromPayload(payload: VNextWorkspacePayload): WorkspaceView {
     beliefs: payload.beliefs,
     tasks: payload.tasks,
     recentEvents: payload.recent_events,
+    agentActivity: payload.agent_activity ?? EMPTY_AGENT_ACTIVITY,
+    scheduler: payload.scheduler ?? EMPTY_SCHEDULER,
     brainCharter: payload.brain_charter,
   };
 }
@@ -634,6 +745,35 @@ function latestArtifact(artifacts: VNextArtifactRecord[], artifactType: string) 
   return artifacts.find((artifact) => artifact.artifact_type === artifactType) ?? null;
 }
 
+function scheduleValue(workflow: VNextSchedulerStatus["workflows"][number], key: string, fallback: string) {
+  const schedule = asRecord(workflow.schedule_json);
+  const value = schedule[key];
+  return typeof value === "string" ? value : fallback;
+}
+
+function scheduleSummary(workflow: VNextSchedulerStatus["workflows"][number]) {
+  const schedule = asRecord(workflow.schedule_json);
+  const kind = textValue(schedule.kind) || "manual";
+  if (kind === "daily") {
+    const days = Array.isArray(schedule.days_of_week) ? schedule.days_of_week.join(", ") : "configured days";
+    return `Daily at ${scheduleValue(workflow, "time_of_day", "08:00")} ${workflow.timezone} on ${days}`;
+  }
+  if (kind === "weekly") {
+    return `Weekly on ${scheduleValue(workflow, "day_of_week", "monday")} at ${scheduleValue(workflow, "time_of_day", "09:00")} ${workflow.timezone}`;
+  }
+  return "Manual only";
+}
+
+function agentDisplayName(agentId: string) {
+  if (agentId.toLowerCase() === "openclaw") {
+    return "OpenClaw";
+  }
+  if (agentId.toLowerCase() === "hermes") {
+    return "Hermes";
+  }
+  return agentId;
+}
+
 export function VNextBrainWorkspace({
   apiBaseUrl,
   userId,
@@ -698,6 +838,9 @@ export function VNextBrainWorkspace({
 
   const [charterText, setCharterText] = useState("# ALICE.md\n\nKeep generated artifacts reviewable before promotion.");
   const [charterSensitivity, setCharterSensitivity] = useState<Sensitivity>("private");
+  const [schedulerDrafts, setSchedulerDrafts] = useState<
+    Record<string, { timeOfDay: string; dayOfWeek: string; timezone: string }>
+  >({});
 
   const dailyArtifact = latestArtifact(workspace.artifacts, "daily_brief");
   const weeklyArtifact = latestArtifact(workspace.artifacts, "weekly_synthesis");
@@ -1118,6 +1261,127 @@ export function VNextBrainWorkspace({
     );
   }
 
+  async function handleSchedulerAction(
+    workflow: VNextSchedulerStatus["workflows"][number],
+    action: "enable" | "disable" | "pause" | "resume" | "run_now" | "update_schedule",
+  ) {
+    const draft = schedulerDrafts[workflow.workflow_type] ?? {
+      timeOfDay: scheduleValue(workflow, "time_of_day", workflow.workflow_type === "weekly_synthesis" ? "09:00" : "08:00"),
+      dayOfWeek: scheduleValue(workflow, "day_of_week", "monday"),
+      timezone: workflow.timezone || "UTC",
+    };
+    const scheduleJson =
+      workflow.workflow_type === "daily_brief"
+        ? { kind: "daily", time_of_day: draft.timeOfDay, days_of_week: ["monday", "tuesday", "wednesday", "thursday", "friday"] }
+        : workflow.workflow_type === "weekly_synthesis"
+          ? { kind: "weekly", day_of_week: draft.dayOfWeek, time_of_day: draft.timeOfDay }
+          : { kind: "manual" };
+
+    if (!liveModeReady || !apiBaseUrl || !userId) {
+      updateFixtureWorkspace(
+        (previous) => {
+          const now = new Date().toISOString();
+          const runId = `scheduler-run-demo-${previous.scheduler.recent_runs.length + 1}`;
+          const nextArtifact: VNextArtifactRecord | null =
+            action === "run_now"
+              ? {
+                  id: `artifact-scheduler-demo-${previous.artifacts.length + 1}`,
+                  artifact_type: workflow.workflow_type,
+                  title: `${workflow.workflow_type.replace(/_/g, " ")} - scheduler demo`,
+                  content_markdown: `# ${workflow.workflow_type}\n\nGenerated by the governed scheduler demo path.`,
+                  status: "needs_review",
+                  domain: defaultDomain,
+                  sensitivity: defaultSensitivity,
+                  generated_by: "scheduler",
+                  metadata_json: {
+                    workflow: workflow.workflow_type,
+                    scheduler_run_id: runId,
+                    trace_id: `trace-${runId}`,
+                    generated_by: "scheduler",
+                  },
+                }
+              : null;
+          const nextRun =
+            action === "run_now"
+              ? {
+                  id: runId,
+                  workflow_type: workflow.workflow_type,
+                  status: "succeeded",
+                  triggered_by: "user",
+                  trace_id: `trace-${runId}`,
+                  started_at: now,
+                  finished_at: now,
+                  artifact_id: nextArtifact?.id ?? null,
+                  metadata_json: { demo: true },
+                }
+              : null;
+          const workflows = previous.scheduler.workflows.map((item) =>
+            item.id === workflow.id
+              ? {
+                  ...item,
+                  enabled: action === "enable" ? true : action === "disable" ? false : item.enabled,
+                  paused: action === "pause" ? true : action === "resume" ? false : item.paused,
+                  schedule_json: action === "update_schedule" ? scheduleJson : item.schedule_json,
+                  timezone: action === "update_schedule" ? draft.timezone : item.timezone,
+                  last_run_id: nextRun?.id ?? item.last_run_id,
+                  last_run_at: nextRun?.finished_at ?? item.last_run_at,
+                  last_result: nextRun ? "succeeded" : item.last_result,
+                  last_error: nextRun ? null : item.last_error,
+                }
+              : item,
+          );
+          const scheduler = {
+            ...previous.scheduler,
+            workflows,
+            recent_runs: nextRun ? [nextRun, ...previous.scheduler.recent_runs] : previous.scheduler.recent_runs,
+            enabled_count: workflows.filter((item) => item.enabled).length,
+            paused_count: workflows.filter((item) => item.paused).length,
+          };
+          const event: VNextEventRecord = {
+            id: `scheduler-event-demo-${previous.recentEvents.length + 1}`,
+            event_type: action === "run_now" ? "scheduler.run_succeeded" : `scheduler.workflow_${action}`,
+            actor_type: "user",
+            target_type: "scheduler_workflow",
+            target_id: workflow.id,
+            occurred_at: now,
+            payload_json: { workflow_type: workflow.workflow_type },
+          };
+          const view = {
+            ...previous,
+            scheduler,
+            artifacts: nextArtifact ? [nextArtifact, ...previous.artifacts] : previous.artifacts,
+            recentEvents: [event, ...previous.recentEvents],
+          };
+          return { ...view, summary: createSummary(view) };
+        },
+        `Demo scheduler action applied: ${action}.`,
+      );
+      return;
+    }
+
+    await runLiveAction(
+      `Applying scheduler action: ${action}...`,
+      async () => {
+        if (action === "run_now") {
+          await runVNextSchedulerWorkflowNow(apiBaseUrl, workflow.workflow_type, {
+            user_id: userId,
+            scope: { domains: [defaultDomain] },
+            options: { sensitivity_allowed: ["public", "internal", "private", "unknown"] },
+          });
+          return;
+        }
+        await patchVNextSchedulerWorkflow(apiBaseUrl, workflow.workflow_type, {
+          user_id: userId,
+          enabled: action === "enable" ? true : action === "disable" ? false : undefined,
+          paused: action === "pause" ? true : action === "resume" ? false : undefined,
+          schedule_json: action === "update_schedule" ? scheduleJson : undefined,
+          timezone: action === "update_schedule" ? draft.timezone : undefined,
+        });
+      },
+      `Scheduler action applied: ${action}.`,
+    );
+  }
+
   async function handleArtifactAction(artifact: VNextArtifactRecord, action: "review" | "accept" | "reject" | "promote" | "archive") {
     if (!liveModeReady || !apiBaseUrl || !userId) {
       const statusMap = {
@@ -1293,6 +1557,16 @@ export function VNextBrainWorkspace({
           <div className="metric-value">{workspace.summary.project_count}</div>
           <div className="metric-label">Projects</div>
           <p className="metric-detail">Live project dashboards and update candidates.</p>
+        </SectionCard>
+        <SectionCard className="section-card--metric">
+          <div className="metric-value">{workspace.summary.agent_count ?? workspace.agentActivity.agents.length}</div>
+          <div className="metric-label">Agents</div>
+          <p className="metric-detail">Known agent identities with policy-scoped activity.</p>
+        </SectionCard>
+        <SectionCard className="section-card--metric">
+          <div className="metric-value">{workspace.summary.scheduler_enabled_count ?? workspace.scheduler.enabled_count}</div>
+          <div className="metric-label">Schedules on</div>
+          <p className="metric-detail">Governed workflows enabled for local runs.</p>
         </SectionCard>
       </section>
 
@@ -1856,6 +2130,271 @@ export function VNextBrainWorkspace({
                 </div>
               </div>
             ) : null}
+          </div>
+        </SectionCard>
+      </div>
+
+      <div id="vnext-agent-activity" className="content-grid content-grid--wide">
+        <SectionCard
+          eyebrow="Agent Activity"
+          title="Agents and policy posture"
+          description="Agent-originated requests keep identity, scope, permission profile, and policy outcomes visible to the operator."
+        >
+          <div className="list-rows">
+            {workspace.agentActivity.agents.length ? (
+              workspace.agentActivity.agents.map((agent) => (
+                <article key={agent.id} className="list-row">
+                  <div className="list-row__topline">
+                    <div>
+                      <span className="list-row__eyebrow mono">{agent.agent_type}</span>
+                      <h3 className="list-row__title">{agentDisplayName(agent.agent_id)}</h3>
+                    </div>
+                    <StatusBadge status={agent.permission_profile} />
+                  </div>
+                  <div className="list-row__meta">
+                    <span className="meta-pill mono">{agent.agent_id}</span>
+                    <span className="meta-pill">Scope: {Array.isArray(agent.project_scope_json) && agent.project_scope_json.length ? agent.project_scope_json.join(", ") : "none"}</span>
+                    <span className="meta-pill">Updated: {agent.updated_at ?? "unknown"}</span>
+                  </div>
+                </article>
+              ))
+            ) : (
+              <EmptyState title="No agent identities yet" description="Agent identities appear after MCP, API, or CLI calls include agent metadata." />
+            )}
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          eyebrow="Agent Activity"
+          title="Recent agent events"
+          description="Context packs, artifacts, tasks, memory proposals, open loops, project updates, and policy decisions are auditable here."
+        >
+          <div className="list-rows">
+            {workspace.agentActivity.recent_events.length ? (
+              workspace.agentActivity.recent_events.slice(0, 8).map((event) => (
+                <article key={event.id} className="list-row">
+                  <div className="list-row__topline">
+                    <div>
+                      <span className="list-row__eyebrow mono">{event.occurred_at}</span>
+                      <h3 className="list-row__title">{event.event_type}</h3>
+                    </div>
+                    <StatusBadge status={event.actor_id ?? event.actor_type} />
+                  </div>
+                  <div className="list-row__meta">
+                    <span className="meta-pill">Target: {event.target_type ? `${event.target_type}:${event.target_id}` : "workspace"}</span>
+                    {event.trace_id ? <span className="meta-pill mono">Trace {event.trace_id}</span> : null}
+                    {event.run_id ? <span className="meta-pill mono">Run {event.run_id}</span> : null}
+                  </div>
+                </article>
+              ))
+            ) : (
+              <EmptyState title="No agent events" description="Agent context packs, proposals, generated artifacts, and queue activity will appear here." />
+            )}
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          eyebrow="Agent Activity"
+          title="Policy blocks and filters"
+          description="Blocked and filtered agent requests remain visible for privacy and safety review."
+        >
+          <div className="list-rows">
+            {workspace.agentActivity.policy_blocks.length ? (
+              workspace.agentActivity.policy_blocks.map((event) => (
+                <article key={event.id} className="list-row">
+                  <div className="list-row__topline">
+                    <h3 className="list-row__title">{event.event_type}</h3>
+                    <StatusBadge status={event.actor_id ?? "agent"} />
+                  </div>
+                  <p>{JSON.stringify(event.payload_json ?? {})}</p>
+                  <div className="list-row__meta">
+                    <span className="meta-pill mono">{event.occurred_at}</span>
+                    <span className="meta-pill">Target: {event.target_type ?? "policy"}</span>
+                  </div>
+                </article>
+              ))
+            ) : (
+              <EmptyState title="No policy blocks" description="Restricted or filtered agent requests will be logged here." />
+            )}
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          eyebrow="Agent Activity"
+          title="Generated and proposed work"
+          description="Agent-generated artifacts and pending review items stay in human review lanes."
+        >
+          <div className="key-value-grid key-value-grid--compact">
+            <div>
+              <dt>Generated artifacts</dt>
+              <dd>{workspace.agentActivity.generated_artifacts.length}</dd>
+            </div>
+            <div>
+              <dt>Pending review items</dt>
+              <dd>{workspace.agentActivity.pending_review_items.length}</dd>
+            </div>
+          </div>
+          <div className="list-rows">
+            {[...workspace.agentActivity.generated_artifacts.slice(0, 3), ...workspace.agentActivity.pending_review_items.slice(0, 3)].map((item) => (
+              <article key={`agent-work-${item.id}`} className="list-row">
+                <div className="list-row__topline">
+                  <h3 className="list-row__title">{"artifact_type" in item ? item.title : memoryText(item)}</h3>
+                  <StatusBadge status={item.status ?? "needs_review"} />
+                </div>
+                <div className="list-row__meta">
+                  <span className="meta-pill">Domain: {domainLabel(asDomain(item.domain))}</span>
+                  <span className="meta-pill">Sensitivity: {sensitivityLabel(asSensitivity(item.sensitivity))}</span>
+                </div>
+              </article>
+            ))}
+          </div>
+        </SectionCard>
+      </div>
+
+      <div id="vnext-schedules" className="content-grid content-grid--wide">
+        <SectionCard
+          eyebrow="Schedules"
+          title="Governed scheduler"
+          description="Local workflows are disabled by default, policy-checked, pausable, auditable, and produce reviewable artifacts only."
+        >
+          <div className="cluster">
+            <StatusBadge status={workspace.scheduler.disabled_by_default ? "requires_review" : "active"} label={workspace.scheduler.disabled_by_default ? "Disabled by default" : "Configured"} />
+            <span className="meta-pill">Mode: {workspace.scheduler.mode}</span>
+            <span className="meta-pill">Enabled: {workspace.scheduler.enabled_count}</span>
+            <span className="meta-pill">Paused: {workspace.scheduler.paused_count}</span>
+          </div>
+          {workspace.scheduler.last_failure ? (
+            <article className="list-row">
+              <div className="list-row__topline">
+                <h3 className="list-row__title">Last scheduler failure</h3>
+                <StatusBadge status="failed" />
+              </div>
+              <p>{workspace.scheduler.last_failure.error_message ?? "No error message recorded."}</p>
+            </article>
+          ) : null}
+          <div className="list-rows">
+            {workspace.scheduler.workflows.length ? (
+              workspace.scheduler.workflows.map((workflow) => {
+                const draft = schedulerDrafts[workflow.workflow_type] ?? {
+                  timeOfDay: scheduleValue(workflow, "time_of_day", workflow.workflow_type === "weekly_synthesis" ? "09:00" : "08:00"),
+                  dayOfWeek: scheduleValue(workflow, "day_of_week", "monday"),
+                  timezone: workflow.timezone || "UTC",
+                };
+                return (
+                  <article key={workflow.id} className="list-row">
+                    <div className="list-row__topline">
+                      <div>
+                        <span className="list-row__eyebrow mono">{workflow.workflow_type}</span>
+                        <h3 className="list-row__title">{workflow.workflow_type.replace(/_/g, " ")}</h3>
+                      </div>
+                      <StatusBadge status={workflow.paused ? "paused" : workflow.enabled ? "active" : "disabled"} />
+                    </div>
+                    <p>{scheduleSummary(workflow)}</p>
+                    <div className="list-row__meta">
+                      <span className="meta-pill">Next: {workflow.next_run_at ?? "manual or disabled"}</span>
+                      <span className="meta-pill">Last: {workflow.last_run_at ?? "never"}</span>
+                      <span className="meta-pill">Result: {workflow.last_result ?? "none"}</span>
+                      {workflow.last_error ? <span className="meta-pill">Error: {workflow.last_error}</span> : null}
+                    </div>
+                    {workflow.workflow_type === "daily_brief" || workflow.workflow_type === "weekly_synthesis" ? (
+                      <div className="form-field-group form-field-group--two-up">
+                        <div className="form-field">
+                          <label htmlFor={`vnext-schedule-time-${workflow.workflow_type}`}>Time of day</label>
+                          <input
+                            id={`vnext-schedule-time-${workflow.workflow_type}`}
+                            value={draft.timeOfDay}
+                            onChange={(event) =>
+                              setSchedulerDrafts((previous) => ({
+                                ...previous,
+                                [workflow.workflow_type]: { ...draft, timeOfDay: event.target.value },
+                              }))
+                            }
+                            placeholder="08:00"
+                          />
+                        </div>
+                        {workflow.workflow_type === "weekly_synthesis" ? (
+                          <div className="form-field">
+                            <label htmlFor="vnext-schedule-weekly-day">Weekly day</label>
+                            <select
+                              id="vnext-schedule-weekly-day"
+                              value={draft.dayOfWeek}
+                              onChange={(event) =>
+                                setSchedulerDrafts((previous) => ({
+                                  ...previous,
+                                  [workflow.workflow_type]: { ...draft, dayOfWeek: event.target.value },
+                                }))
+                              }
+                            >
+                              {["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"].map((day) => (
+                                <option key={day} value={day}>{day}</option>
+                              ))}
+                            </select>
+                          </div>
+                        ) : null}
+                        <div className="form-field">
+                          <label htmlFor={`vnext-schedule-zone-${workflow.workflow_type}`}>Timezone</label>
+                          <input
+                            id={`vnext-schedule-zone-${workflow.workflow_type}`}
+                            value={draft.timezone}
+                            onChange={(event) =>
+                              setSchedulerDrafts((previous) => ({
+                                ...previous,
+                                [workflow.workflow_type]: { ...draft, timezone: event.target.value },
+                              }))
+                            }
+                            placeholder="UTC"
+                          />
+                        </div>
+                      </div>
+                    ) : null}
+                    <div className="vnext-review-actions">
+                      <button type="button" className="button-secondary" onClick={() => void handleSchedulerAction(workflow, workflow.enabled ? "disable" : "enable")} disabled={Boolean(pendingAction)}>
+                        {workflow.enabled ? "Disable" : "Enable"}
+                      </button>
+                      <button type="button" className="button-secondary" onClick={() => void handleSchedulerAction(workflow, workflow.paused ? "resume" : "pause")} disabled={Boolean(pendingAction)}>
+                        {workflow.paused ? "Resume" : "Pause"}
+                      </button>
+                      <button type="button" className="button-secondary" onClick={() => void handleSchedulerAction(workflow, "update_schedule")} disabled={Boolean(pendingAction)}>
+                        Edit schedule
+                      </button>
+                      <button type="button" className="button" onClick={() => void handleSchedulerAction(workflow, "run_now")} disabled={Boolean(pendingAction)}>
+                        Run now
+                      </button>
+                    </div>
+                  </article>
+                );
+              })
+            ) : (
+              <EmptyState title="No scheduler workflows" description="The local API will create disabled workflow defaults when live scheduler status is loaded." />
+            )}
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          eyebrow="Schedules"
+          title="Recent scheduler runs"
+          description="Run history records workflow, status, run ID, trace ID, output artifact, and failures."
+        >
+          <div className="timeline-list">
+            {workspace.scheduler.recent_runs.length ? (
+              workspace.scheduler.recent_runs.map((run) => (
+                <article key={run.id} className="timeline-item">
+                  <div className="timeline-item__topline">
+                    <span className="list-row__eyebrow mono">{run.started_at}</span>
+                    <h3 className="list-row__title">{run.workflow_type}</h3>
+                  </div>
+                  <div className="list-row__meta">
+                    <span className="meta-pill">Status: {run.status}</span>
+                    <span className="meta-pill mono">Run {run.id}</span>
+                    <span className="meta-pill mono">Trace {run.trace_id}</span>
+                    <span className="meta-pill">Artifact: {run.artifact_id ?? "none"}</span>
+                  </div>
+                  {run.error_message ? <p>{run.error_message}</p> : null}
+                </article>
+              ))
+            ) : (
+              <EmptyState title="No scheduler runs" description="Manual or scheduled workflow runs will appear here." />
+            )}
           </div>
         </SectionCard>
       </div>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -267,10 +267,13 @@ export type VNextTaskRecord = VNextRow & {
 export type VNextEventRecord = VNextRow & {
   event_type: string;
   actor_type: string;
+  actor_id?: string | null;
   target_type?: string | null;
   target_id?: string | null;
   occurred_at: string;
   payload_json?: JsonObject;
+  trace_id?: string | null;
+  run_id?: string | null;
 };
 
 export type VNextBrainCharterRecord = VNextRow & {
@@ -298,6 +301,72 @@ export type VNextProjectDashboard = {
   };
 };
 
+export type VNextAgentIdentityRecord = VNextRow & {
+  agent_id: string;
+  agent_type: string;
+  permission_profile: string;
+  display_name?: string | null;
+  project_scope_json?: unknown[];
+  metadata_json?: JsonObject;
+};
+
+export type VNextPolicyDecisionRecord = {
+  decision: string;
+  action: string;
+  permission_profile: string;
+  reasons: string[];
+  effective_domains: string[];
+  effective_sensitivity_allowed: string[];
+  review_required: boolean;
+  trace_id: string;
+};
+
+export type VNextSchedulerWorkflowRecord = VNextRow & {
+  workflow_type: string;
+  enabled: boolean;
+  paused: boolean;
+  schedule_json?: JsonObject;
+  timezone: string;
+  next_run_at?: string | null;
+  last_run_id?: string | null;
+  last_run_at?: string | null;
+  last_result?: string | null;
+  last_error?: string | null;
+  metadata_json?: JsonObject;
+};
+
+export type VNextSchedulerRunRecord = VNextRow & {
+  workflow_type: string;
+  status: string;
+  triggered_by: string;
+  trace_id: string;
+  started_at: string;
+  finished_at?: string | null;
+  artifact_id?: string | null;
+  error_message?: string | null;
+  policy_decision_json?: JsonObject;
+  agent_identity_json?: JsonObject;
+  metadata_json?: JsonObject;
+};
+
+export type VNextSchedulerStatus = {
+  mode: string;
+  disabled_by_default: boolean;
+  workflows: VNextSchedulerWorkflowRecord[];
+  recent_runs: VNextSchedulerRunRecord[];
+  enabled_count: number;
+  paused_count: number;
+  last_failure: VNextSchedulerRunRecord | null;
+};
+
+export type VNextAgentActivity = {
+  agents: VNextAgentIdentityRecord[];
+  recent_events: VNextEventRecord[];
+  policy_blocks: VNextEventRecord[];
+  generated_artifacts: VNextArtifactRecord[];
+  pending_review_items: VNextMemoryRecord[];
+};
+
 export type VNextWorkspacePayload = {
   mode: "live";
   summary: {
@@ -308,6 +377,8 @@ export type VNextWorkspacePayload = {
     open_loop_count: number;
     project_count: number;
     event_count: number;
+    agent_count?: number;
+    scheduler_enabled_count?: number;
     memory_status_counts: Record<string, number>;
     artifact_status_counts: Record<string, number>;
     open_loop_status_counts: Record<string, number>;
@@ -322,6 +393,8 @@ export type VNextWorkspacePayload = {
   beliefs: VNextBeliefRecord[];
   tasks: VNextTaskRecord[];
   recent_events: VNextEventRecord[];
+  agent_activity?: VNextAgentActivity;
+  scheduler?: VNextSchedulerStatus;
   brain_charter: VNextBrainCharterRecord | null;
 };
 
@@ -3968,4 +4041,49 @@ export function upsertVNextBrainCharter(
       body: JSON.stringify(payload),
     },
   );
+}
+
+export function getVNextSchedulerStatus(apiBaseUrl: string, userId: string) {
+  return requestJson<VNextSchedulerStatus>(
+    apiBaseUrl,
+    "/v0/vnext/scheduler/status",
+    undefined,
+    { user_id: userId },
+  );
+}
+
+export function patchVNextSchedulerWorkflow(
+  apiBaseUrl: string,
+  workflowType: string,
+  payload: {
+    user_id: string;
+    enabled?: boolean;
+    paused?: boolean;
+    schedule_json?: JsonObject;
+    timezone?: string;
+  },
+) {
+  return requestJson<{ workflow: VNextSchedulerWorkflowRecord; policy_decision: VNextPolicyDecisionRecord }>(
+    apiBaseUrl,
+    `/v0/vnext/scheduler/workflows/${workflowType}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export function runVNextSchedulerWorkflowNow(
+  apiBaseUrl: string,
+  workflowType: string,
+  payload: { user_id: string; scope?: JsonObject; options?: JsonObject },
+) {
+  return requestJson<{
+    run: VNextSchedulerRunRecord;
+    artifact: VNextArtifactRecord | null;
+    policy_decision: VNextPolicyDecisionRecord;
+  }>(apiBaseUrl, `/v0/vnext/scheduler/workflows/${workflowType}/run-now`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
 }

--- a/docs/agentic_control_plane_sprint
+++ b/docs/agentic_control_plane_sprint
@@ -1,0 +1,565 @@
+
+Alice vNext Sprint Prompt: Agentic Control Plane + Governed Scheduler
+
+Project Scope
+
+Build the next Alice vNext sprint focused on making Alice agent-native, scheduled, auditable, and safe by default.
+
+Alice already has a live-backed /vnext workspace, source capture, candidate memories, provenance, context packs, generated artifacts, open loops, projects, Brain Charter settings, and review flows.
+
+This sprint should add two connected capabilities:
+
+1. Agentic Control Plane
+    Hermes, OpenClaw, and future agents must be able to safely interact with Alice through MCP/API/CLI using scoped identities, permissions, context packs, task submission, artifact generation, memory proposals, and review queues.
+2. Governed Scheduler
+    Alice must be able to run daily/weekly/proactive workflows on a governed local schedule, producing reviewable generated artifacts without automatically promoting anything into trusted memory.
+
+The /vnext UI should remain the human operator console: review, auditability, agent activity, schedule settings, artifact inspection, and memory governance.
+
+⸻
+
+Product Principle
+
+Alice is not primarily a second-brain notes app.
+
+Alice is:
+
+An agent-native memory and continuity substrate for humans and agents,
+with a human review and governance cockpit.
+
+Hermes/OpenClaw should interact through Alice MCP/API/CLI. /vnext should expose what happened, what was retrieved, what was generated, what was proposed, what was blocked, and what needs review.
+
+⸻
+
+Core Build Requirements
+
+1. Agent Identity Model
+
+Add a first-class agent identity model for API/MCP/CLI initiated actions.
+
+Each agent-originated call should be able to include:
+
+{
+  "agent_id": "hermes",
+  "agent_type": "personal_assistant | coding_agent | research_agent | workflow_agent | unknown",
+  "agent_run_id": "...",
+  "task_id": "...",
+  "project_scope": ["Alice"],
+  "permission_profile": "trusted_local_agent"
+}
+
+Persist agent identity in event logs, generated artifacts, memory proposals, task queue records, context pack traces, scheduler-triggered runs where applicable, and policy decisions.
+
+Supported initial permission profiles:
+
+read_only_agent
+project_scoped_agent
+trusted_local_agent
+memory_proposal_agent
+admin_agent
+
+Default behavior:
+
+Hermes:
+- broad personal assistant context where allowed by policy
+- can create open loops
+- can create task queue items
+- can generate artifacts
+- can propose memories
+- cannot auto-promote sensitive memories
+OpenClaw:
+- project-scoped by default
+- can request project/sprint/code context
+- can create artifacts
+- can propose project updates and open loops
+- cannot access family, health, spiritual, legal, financial, or highly sensitive domains unless explicitly allowed
+
+Do not hardcode only Hermes/OpenClaw. Make this generic enough for future agents.
+
+⸻
+
+2. Agent Permission and Policy Enforcement
+
+Implement a policy layer that checks:
+
+agent identity
+permission profile
+requested action
+project scope
+domain scope
+sensitivity scope
+write policy
+
+The policy layer must decide whether the action is:
+
+allowed
+allowed_with_filtering
+requires_review
+blocked
+
+Blocked and filtered actions must be logged.
+
+Agents must not be able to bypass:
+
+domain/sensitivity restrictions
+no-auto-promotion rule
+review-required workflows
+raw evidence deletion restrictions
+Brain Charter constraints
+
+⸻
+
+3. MCP/API/CLI Parity for Agentic Workflows
+
+Ensure the following capabilities are available through MCP/API/CLI, not only UI:
+
+context pack request
+source capture
+queue task creation
+artifact generation
+project dashboard lookup
+open-loop lookup/create/update
+recent decisions lookup
+recent changes lookup
+connection report generation
+contradiction report generation
+memory proposal creation
+review item lookup
+artifact lookup
+artifact review action
+scheduler status
+scheduler run now
+scheduler pause/resume
+
+Prioritize MCP and API. CLI can be thinner but must support essential status/run/test flows.
+
+Required MCP tools or equivalent existing tool expansion:
+
+alice_vnext_context_pack
+alice_vnext_capture
+alice_vnext_queue_task
+alice_vnext_generate_artifact
+alice_vnext_project_dashboard
+alice_vnext_open_loops
+alice_vnext_recent_decisions
+alice_vnext_recent_changes
+alice_vnext_find_connections
+alice_vnext_find_contradictions
+alice_vnext_propose_memory
+alice_vnext_review_items
+alice_vnext_artifact_get
+alice_vnext_artifact_review
+alice_vnext_scheduler_status
+alice_vnext_scheduler_run_now
+alice_vnext_scheduler_pause
+alice_vnext_scheduler_resume
+
+If some already exist, extend them to include agent identity, policy checks, trace IDs, and event logging.
+
+⸻
+
+4. Agent Memory Proposal Flow
+
+Agents must be able to propose memory updates without directly promoting them into trusted memory.
+
+Supported proposal types:
+
+candidate_memory
+project_update
+open_loop
+belief_update
+contradiction
+graph_edge
+artifact_summary
+decision
+recent_change
+
+Flow:
+
+agent proposes
+→ Alice applies policy
+→ proposal is stored as candidate/review item/generated artifact
+→ event log records proposal
+→ /vnext review cockpit displays it
+→ human or trusted review flow accepts/edits/rejects
+→ accepted proposal creates memory revision/event log
+
+Required fields for memory proposals:
+
+{
+  "proposal_type": "candidate_memory",
+  "title": "...",
+  "canonical_text": "...",
+  "source_refs": [],
+  "project_scope": ["Alice"],
+  "domain": "professional",
+  "sensitivity": "private",
+  "confidence": 0.72,
+  "agent_id": "openclaw",
+  "agent_run_id": "...",
+  "rationale": "...",
+  "review_required": true
+}
+
+No agent proposal should become trusted memory automatically unless an explicit future policy allows it. For this sprint, keep review required.
+
+⸻
+
+5. Agent Activity View in /vnext
+
+Add an Agent Activity surface in /vnext.
+
+It should show:
+
+agent name/id
+permission profile
+recent context packs requested
+artifacts generated
+tasks created
+memory proposals submitted
+open loops created
+project updates proposed
+policy blocks/filtering events
+last run IDs
+timestamps
+status
+
+Minimum viable UI:
+
+Agent Activity page/tab
+Agent detail panel
+Recent events list
+Policy blocks list
+Generated artifacts by agent
+Pending review items by agent
+
+This does not need to be beautiful yet, but it must be useful for auditability.
+
+⸻
+
+6. Governed Scheduler
+
+Add a local governed scheduler for Alice Brain workflows.
+
+Initial scheduled workflows:
+
+daily_brief
+weekly_synthesis
+connection_report
+contradiction_report
+open_loop_review
+project_update_scan
+
+Required scheduler behavior:
+
+local-first
+disabled by default unless configured
+user-configurable
+agent-addressable with permission checks
+pausable
+auditable
+restart-persistent
+safe by default
+produces generated artifacts only
+does not auto-promote artifacts into memory
+logs start/success/failure
+records run IDs and trace IDs
+
+Daily and weekly workflows should be the primary supported workflows. Others may be opt-in but should have the schema and control path ready.
+
+⸻
+
+7. Scheduler Settings UI
+
+Add scheduler controls to /vnext.
+
+Can be under Settings or a dedicated Schedules tab.
+
+For each workflow, show:
+
+enabled/disabled
+schedule expression or simple schedule fields
+timezone
+next run
+last run
+last result
+last error
+run now
+pause/resume
+edit schedule
+
+Minimum supported schedule config:
+
+Daily Brief:
+- enabled
+- time of day
+- timezone
+- days of week
+Weekly Synthesis:
+- enabled
+- day of week
+- time of day
+- timezone
+
+Scheduler events must also appear in Timeline/event log.
+
+⸻
+
+8. Scheduler API/MCP/CLI
+
+Add or extend endpoints/tools for:
+
+get scheduler status
+list scheduled workflows
+enable workflow
+disable workflow
+pause all
+resume all
+run workflow now
+get workflow run history
+get last failure
+
+Agent-triggered scheduler actions must go through policy checks.
+
+Example rule:
+
+read_only_agent:
+- can view scheduler status
+- cannot run/pause/resume
+project_scoped_agent:
+- can run project-scoped reports if allowed
+- cannot pause global scheduler
+trusted_local_agent:
+- can run now
+- can create project-scoped scheduled tasks if allowed
+- cannot enable broad personal sensitive workflows without review
+admin_agent:
+- can configure schedules
+
+⸻
+
+9. Generated Artifact Metadata
+
+All generated artifacts must include:
+
+generated_by: user | agent | scheduler | system
+agent_id if applicable
+agent_run_id if applicable
+scheduler_run_id if applicable
+workflow type
+source refs
+domain
+sensitivity
+policy decision
+review status
+trace ID
+created_at
+
+Generated artifacts must remain reviewable.
+
+No scheduled or agent-generated artifact may auto-promote to trusted memory.
+
+⸻
+
+10. Event Log Expansion
+
+Every meaningful action must create an event-log entry.
+
+Required new/expanded event types:
+
+agent.context_pack_requested
+agent.task_created
+agent.artifact_generated
+agent.memory_proposed
+agent.policy_blocked
+agent.policy_filtered
+scheduler.workflow_enabled
+scheduler.workflow_disabled
+scheduler.workflow_paused
+scheduler.workflow_resumed
+scheduler.run_started
+scheduler.run_succeeded
+scheduler.run_failed
+scheduler.artifact_created
+policy.decision
+review.item_created
+review.item_accepted
+review.item_rejected
+review.item_edited
+
+Event payloads must include agent identity, scheduler run ID, workflow, target IDs, policy decision, and trace ID where applicable.
+
+⸻
+
+11. Local Alpha Hardening
+
+Include hardening as part of this sprint.
+
+Required hardening:
+
+all new write paths audited
+all new agent paths policy-checked
+scheduler state survives restart
+scheduler failures do not crash app
+bad agent input fails safely
+bad schedule config fails validation
+permission-denied responses are clear
+UI handles loading/empty/error states
+Postgres smoke tests cover main paths
+existing tests stay green
+
+Do not add live OAuth connectors in this sprint.
+
+Do not add production cloud deployment.
+
+Do not add automatic memory promotion.
+
+⸻
+
+Explicit Deferrals
+
+Do not build these in this sprint:
+
+live Gmail OAuth
+live Calendar OAuth
+live Telegram polling
+browser extension runtime actions
+OCR model execution
+voice transcription model execution
+cloud deployment
+hosted accounts
+mobile app
+full notification system
+automatic memory promotion
+human-rated eval scoring
+major graph visualization overhaul
+consumer onboarding polish
+
+A small local notification stub or UI badge is acceptable only if it does not distract from scheduler/agent-control work.
+
+⸻
+
+Required End-to-End Flows
+
+Flow 1: OpenClaw requests project context
+
+OpenClaw calls Alice MCP/API with agent identity.
+Alice policy checks project scope.
+Alice creates context pack for project Alice.
+Context pack includes relevant memories, sources, open loops, recent changes, contradictions, and decisions.
+Event log records request.
+Agent Activity page shows the request.
+
+Flow 2: OpenClaw proposes a memory
+
+OpenClaw proposes a project memory.
+Alice policy checks permission.
+Alice stores proposal as review item/candidate memory.
+No auto-promotion occurs.
+Memory Review page shows pending proposal.
+User accepts/rejects/edits.
+Event log records all actions.
+
+Flow 3: Hermes creates an open loop
+
+Hermes submits open-loop proposal.
+Alice policy checks scope.
+Open loop is created or queued for review depending on sensitivity.
+Open loop appears in /vnext.
+Event log records action.
+
+Flow 4: Scheduler generates daily brief
+
+Daily Brief schedule triggers locally.
+Run creates scheduler run ID and trace ID.
+Alice retrieves scoped context.
+Alice generates daily brief artifact.
+Artifact is not auto-promoted.
+Event log records start/success/artifact creation.
+Generated page shows artifact.
+Timeline shows scheduled run.
+
+Flow 5: Agent tries restricted access
+
+OpenClaw requests family/health/spiritual memory without permission.
+Policy blocks or filters restricted content.
+Context pack excludes restricted memories.
+Event log records policy decision.
+Agent Activity shows policy block/filter.
+
+⸻
+
+Acceptance Criteria
+
+The sprint is complete only when all of the following pass:
+
+Agent identity model exists and is persisted in relevant events/artifacts/tasks/proposals.
+Permission profiles exist and are enforced on API/MCP/CLI paths.
+Agent context-pack requests support project/domain/sensitivity scoping.
+Agent memory proposals can be created and appear in review flow.
+Agent proposals cannot auto-promote to trusted memory.
+Agent Activity page exists in /vnext and shows recent agent actions, generated artifacts, proposals, and policy blocks.
+Governed scheduler exists with persistent workflow configuration.
+Daily Brief schedule can be enabled, disabled, paused, resumed, and manually run.
+Weekly Synthesis schedule can be enabled, disabled, paused, resumed, and manually run.
+Scheduled runs create generated artifacts with correct metadata.
+Scheduled runs create event-log entries for start, success, failure, and artifact creation.
+Scheduler state survives restart.
+Scheduler failures are visible in /vnext and do not crash the app.
+Scheduler/API/MCP/CLI controls are policy-checked.
+No generated artifact is auto-promoted into trusted memory.
+No new live connector OAuth/polling is introduced.
+Postgres-backed integration smoke covers:
+- agent context pack request
+- agent memory proposal
+- restricted policy block/filter
+- scheduler daily brief run
+- scheduler weekly synthesis run
+- artifact review
+- event log verification
+Unit/integration tests pass.
+Web tests pass.
+Web build passes.
+Web lint passes.
+git diff --check passes.
+Existing public preview functionality remains intact.
+
+⸻
+
+Validation Commands
+
+Run the project’s standard validation suite plus new scheduler/agentic smoke tests.
+
+At minimum:
+
+pytest tests/unit -q
+pytest tests/integration -q
+pnpm --dir apps/web test
+pnpm --dir apps/web lint
+pnpm --dir apps/web build
+git diff --check
+alicebot eval run --suite all
+
+Also add and run a dedicated Postgres-backed smoke test for this sprint:
+
+alicebot vnext smoke agentic-scheduler
+
+If that exact command does not exist, create the equivalent script/pytest target and document it.
+
+⸻
+
+Final Deliverable
+
+At the end of the sprint, provide a CTO summary with:
+
+what was built
+new API/MCP/CLI surfaces
+new UI surfaces
+agent permission model
+scheduler behavior
+guardrails preserved
+tests and validation results
+known limitations
+recommended next phase
+PR number
+merge commit

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -33,6 +33,21 @@ alice brief --brief-type general --query local-first
 
 `brief` is the default external-agent continuity entrypoint. It assembles relevant facts, recent changes, open loops, conflicts, timeline highlights, provenance, trust posture, and a next suggested action in one call.
 
+## vNext Agentic Commands
+
+```bash
+alicebot context-pack "Alice sprint context" --domain project
+alicebot vnext agents propose-memory --agent-id openclaw --permission-profile project_scoped_agent --project-scope Alice --title "Candidate memory" --canonical-text "Alice should keep agent proposals review-only." --domain project --sensitivity private
+alicebot vnext scheduler status
+alicebot vnext scheduler run-now daily_brief --agent-id hermes --permission-profile trusted_local_agent --project-scope Alice --domain project
+alicebot vnext scheduler run-due --agent-id hermes --permission-profile trusted_local_agent
+alicebot vnext scheduler pause --agent-id hermes --permission-profile trusted_local_agent
+alicebot vnext scheduler resume --agent-id hermes --permission-profile trusted_local_agent
+alicebot vnext smoke agentic-scheduler
+```
+
+The vNext agent arguments are `--agent-id`, `--agent-type`, `--agent-run-id`, `--agent-task-id`, `--project-scope`, and `--permission-profile`. Agent-originated scheduler and memory-proposal commands are policy checked, logged, and kept review-only where they create memory or generated artifacts.
+
 ## Temporal History Commands
 
 - `state-at` reconstructs entity facts plus effective edges at a prior time
@@ -52,6 +67,7 @@ alice brief --brief-type general --query local-first
 - output format is deterministic for stable automated validation
 - provenance snippets remain visible in recall/resume responses
 - correction flow updates future recall/resume results
+- vNext scheduler smoke output is JSON and fails nonzero if any agent/scheduler gate fails
 
 See tests:
 

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -41,12 +41,33 @@ MCP uses the same local runtime scope as CLI:
 - `alice_memory_correct` (legacy alias)
 - `alice_explain`
 - `alice_context_pack`
+- `alice_vnext_context_pack`
+- `alice_vnext_capture`
+- `alice_vnext_queue_task`
+- `alice_vnext_generate_artifact`
+- `alice_vnext_project_dashboard`
+- `alice_vnext_open_loops`
+- `alice_vnext_recent_decisions`
+- `alice_vnext_recent_changes`
+- `alice_vnext_find_connections`
+- `alice_vnext_find_contradictions`
+- `alice_vnext_propose_memory`
+- `alice_vnext_review_items`
+- `alice_vnext_artifact_get`
+- `alice_vnext_artifact_review`
+- `alice_vnext_scheduler_status`
+- `alice_vnext_scheduler_run_now`
+- `alice_vnext_scheduler_run_due`
+- `alice_vnext_scheduler_pause`
+- `alice_vnext_scheduler_resume`
 
 `alice_brief` is the default external-agent continuity lookup. It returns one continuity bundle with relevant facts, recent changes, open loops, conflicts, timeline highlights, provenance, trust posture, and a next suggested action.
 `alice_explain` now accepts either `continuity_object_id` for evidence-chain inspection or `entity_id` plus optional `at` for temporal explain output.
 `alice_prefetch_context` provides an automation-oriented pre-turn context assembly surface using the same continuity resumption semantics shipped for `alice_resume`.
 `alice_capture_candidates` and `alice_commit_captures` provide the B2 bridge auto-capture pipeline over user/assistant turns with `manual`/`assist`/`auto` commit policy support.
 `alice_review_queue` and `alice_review_apply` provide B3 review operations (`approve`, `edit-and-approve`, `reject`, `supersede-existing`) with deterministic recall/resume effects after approved actions.
+
+The `alice_vnext_*` tools carry the agentic control-plane contract. Agent callers can include `agent_id`, `agent_type`, `agent_run_id`, `task_id`, `project_scope`, `permission_profile`, domain filters, and sensitivity filters. Policy decisions are logged, restricted requests are filtered or blocked, memory writes stay proposal/review-only, and scheduler actions create governed run records with trace IDs.
 
 ## Example: Claude Desktop MCP Config
 
@@ -92,6 +113,7 @@ One-command bridge demo:
 - tool output is deterministic for parity testing
 - MCP does not widen core product semantics beyond the shipped Phase 13 baseline and Bridge `B1` through `B4`
 - `alice_brief` is the preferred first call for external runtimes that need continuity in one request
+- vNext agent tools preserve the no-auto-promotion rule and require review for agent-proposed memory
 
 See tests:
 

--- a/docs/vnext-agentic-control-plane-cto-summary.md
+++ b/docs/vnext-agentic-control-plane-cto-summary.md
@@ -1,0 +1,129 @@
+# Alice vNext Agentic Control Plane: CTO Summary
+
+Date: 2026-05-11
+Audience: CTO / technical leadership
+Phase artifact: vNext agentic control plane and governed local scheduler
+Branch: `codex/agentic-control-plane-scheduler`
+PR: https://github.com/samrusani/AliceBot/pull/199
+Merge commit: pending until squash merge
+
+## Executive Summary
+
+This phase turns Alice vNext from a human-operated second-brain preview into an agent-operable control plane. Agents can now identify themselves, request context, propose memory, trigger governed workflows, and inspect scheduler state through CLI, API, and MCP without receiving direct write access to trusted memory.
+
+The important architectural shift is that agent activity is now explicit, policy checked, and auditable. Alice records who acted, what permission profile was used, which filters were applied, which actions were blocked, and which generated artifacts require review. The scheduler is local and governed: workflows are disabled by default, can be enabled/configured by policy, run into reviewable artifacts, and can be triggered either manually or by local due scans when `next_run_at` arrives.
+
+## What We Built
+
+### Agent Control Plane
+
+- Added agent identities with `agent_id`, `agent_type`, `agent_run_id`, `task_id`, `project_scope`, and `permission_profile`.
+- Added permission profiles: `read_only_agent`, `project_scoped_agent`, `trusted_local_agent`, `memory_proposal_agent`, and `admin_agent`.
+- Added policy decisions: `allowed`, `allowed_with_filtering`, `requires_review`, and `blocked`.
+- Added policy event logging for decisions, filtering, and blocked actions.
+- Preserved no-auto-promotion: agents can propose memory and generate artifacts, but trusted memory changes still require review.
+
+### Governed Scheduler
+
+- Added persistent scheduler workflow and run state in Postgres.
+- Added disabled-by-default workflows for `daily_brief`, `weekly_synthesis`, `connection_report`, `contradiction_report`, `open_loop_review`, and `project_update_scan`.
+- Added schedule validation, timezone-aware `next_run_at`, run history, trace IDs, failure capture, and last-result state.
+- Added local due scans that run enabled, unpaused workflows when `next_run_at` is due, then advance or clear the next run timestamp.
+- Kept scheduler outputs reviewable. Daily and weekly workflows produce generated artifacts; other workflow types have deterministic report scaffolds for this sprint.
+
+### API Surface
+
+- Added agent memory proposal support through `POST /v0/vnext/memory-proposals`.
+- Added scheduler status and run history:
+  - `GET /v0/vnext/scheduler/status`
+  - `GET /v0/vnext/scheduler/runs`
+- Added scheduler configuration and execution:
+  - `PATCH /v0/vnext/scheduler/workflows/{workflow_type}`
+  - `POST /v0/vnext/scheduler/workflows/{workflow_type}/run-now`
+  - `POST /v0/vnext/scheduler/run-due`
+  - `POST /v0/vnext/scheduler/pause`
+  - `POST /v0/vnext/scheduler/resume`
+- Updated the vNext workspace payload with agent activity and scheduler state.
+
+### MCP Surface
+
+- Added agent-native vNext tools for capture, queueing, artifact generation, project dashboards, open loops, recent decisions/changes, connection and contradiction discovery, memory proposals, review item lookup, artifact lookup/review, and scheduler control.
+- Added scheduler MCP tools:
+  - `alice_vnext_scheduler_status`
+  - `alice_vnext_scheduler_run_now`
+  - `alice_vnext_scheduler_run_due`
+  - `alice_vnext_scheduler_pause`
+  - `alice_vnext_scheduler_resume`
+- Ensured blocked MCP policy decisions are logged before the tool returns a permission error.
+
+### CLI Surface
+
+- Added shared vNext agent arguments: `--agent-id`, `--agent-type`, `--agent-run-id`, `--agent-task-id`, `--project-scope`, and `--permission-profile`.
+- Added `alicebot vnext agents propose-memory`.
+- Added scheduler commands:
+  - `alicebot vnext scheduler status`
+  - `alicebot vnext scheduler run-now`
+  - `alicebot vnext scheduler run-due`
+  - `alicebot vnext scheduler pause`
+  - `alicebot vnext scheduler resume`
+- Added `alicebot vnext smoke agentic-scheduler`, a Postgres-backed sprint smoke that verifies defaults, proposal-only memory writes, scheduler runs, due scans, policy blocks, pause/resume, and run history.
+
+### Web Workspace
+
+- Added `/vnext` Agent Activity and Schedules views.
+- Exposed agent identities, permission posture, recent agent events, policy blocks/filters, generated/proposed work, workflow state, enable/disable controls, pause/resume, run-now, schedule editing, and recent scheduler runs.
+- Aligned fixture values with schema-backed vNext enums.
+- Completed the Sprint 11 connector fixture list: Telegram, browser, PDF, DOCX, CSV, screenshot OCR, and voice.
+
+### Review Fixes And Hardening
+
+- Normalized UUID and datetime values before JSON serialization and event hashing.
+- Fixed explicit CLI sensitivity filters so public-only requests do not accidentally include private/internal rows.
+- JSON-encoded vNext CLI/MCP result payloads before dumping.
+- Included `memory_key` in project update revisions.
+- Persisted closed open loops using the database-valid resolved state.
+- Fixed generic retrieval so missing domain scope does not become `unknown`-only.
+- Fixed scheduler `next_run_at` clearing so pause/disable/manual workflows do not retain stale due timestamps.
+- Fixed legacy memory revision inserts after the vNext revision migration made revision fields required.
+- Stabilized integration tests around Telegram rate-limit backend state and Node 20 TypeScript example execution.
+
+## Guardrails Preserved
+
+- No generated artifact or agent proposal is auto-promoted into trusted memory.
+- Restricted domains and high-sensitivity classes are filtered or blocked by policy.
+- Read-only agents cannot write.
+- Project-scoped agents cannot control the global scheduler and can only run limited project workflows.
+- Scheduler configuration requires admin permission.
+- Pause/resume and due-run control require trusted local or admin permission.
+- All agent and scheduler activity is traceable through event logs and run records.
+
+## Validation Evidence
+
+Current local validation performed during this phase:
+
+- Python compile checks for the new scheduler, policy, store, CLI, API, and MCP modules: passed.
+- Focused control-plane unit tests: `40 passed`.
+- Full unit suite: `1069 passed`.
+- Full integration suite: `370 passed`.
+- Web tests: `207 passed`.
+- Web lint: passed.
+- Web build: passed and built `/vnext`.
+- `alicebot eval run --suite all`: `170/170` passed, with `0` critical privacy leaks and `0` prompt-injection tool writes.
+- `alicebot vnext smoke agentic-scheduler`: passed, including the due-scan execution gate.
+- `git diff --check`: passed.
+
+## Known Limitations
+
+- This is still local-governed scheduling, not a hosted production scheduler service.
+- Daily Brief and Weekly Synthesis are the primary fully runnable scheduler workflows; other scheduled workflow types currently emit deterministic reviewable report scaffolds.
+- The `/vnext` workspace includes fixture-backed preview data in addition to live API-backed scheduler/agent surfaces.
+- Connectors remain deterministic payload normalizers; live OAuth, polling, OCR execution, and transcription execution are separate integration work.
+- Agent writes remain proposal/review-only by design.
+
+## Recommended Next Phase
+
+- Add a small local scheduler daemon or launchd/systemd recipe around `alicebot vnext scheduler run-due`.
+- Convert the remaining scheduler workflow scaffolds into full deterministic report generators.
+- Expand `/vnext` from mixed fixture/live data to fully live-backed workspace data.
+- Add hosted scheduler readiness checks only after local scheduler behavior is stable.
+- Add design-partner telemetry around which agent policies block, filter, or require review most often.

--- a/docs/vnext/README.md
+++ b/docs/vnext/README.md
@@ -1,6 +1,6 @@
 # Alice vNext Public Preview
 
-Alice vNext is the next public wedge for Alice as a true second brain: a local-first memory kernel, reviewable generated briefs, connector-backed evidence capture, and agent-facing context packs.
+Alice vNext is the next public wedge for Alice as an agent-native second brain: a local-first memory kernel, reviewable generated briefs, connector-backed evidence capture, agent-facing context packs, governed agent proposals, and local scheduler workflows.
 
 This preview is not a hosted launch. It is a repo-local, deterministic public preview built around the vNext memory-kernel schema and the fixture-safe workflows shipped under `v0.5.1-vnext-preview`.
 
@@ -10,15 +10,17 @@ Alice vNext has three layers:
 
 - **Alice Core**: the local-first persistence, provenance, policy, and event-log substrate. Core owns sources, chunks, memories, revisions, graph edges, projects, open loops, artifacts, evals, and connector evidence.
 - **Alice Brain**: the user-facing second-brain workflows on top of Core. Brain generates daily briefs, weekly syntheses, context packs, contradiction reports, connection reports, project updates, and reviewable artifacts.
-- **Alice Agent Memory**: the agent integration layer. Agent Memory exposes continuity through CLI, API, and MCP so external agents can capture, retrieve, resume, explain, and generate context without owning the memory database.
+- **Alice Agent Memory**: the agent integration layer. Agent Memory exposes continuity through CLI, API, and MCP so external agents can capture, retrieve, resume, explain, generate context, propose memory, and trigger governed scheduler workflows without owning the memory database.
 
 ## Preview Surfaces
 
 - Source capture: manual text, local text/Markdown files, Markdown folders, ChatGPT exports.
 - Retrieval: deterministic context packs with domain/sensitivity filters and provenance.
 - Brain workflows: daily brief, weekly synthesis, connection report, contradiction report, project update, open-loop review.
+- Agentic control plane: scoped agent identities, permission profiles, policy decisions, memory proposals, and Agent Activity audit surface.
+- Governed scheduler: disabled-by-default daily/weekly/proactive workflow controls with local due scans, run history, trace IDs, failures, and reviewable artifacts.
 - Connectors: deterministic Telegram, browser clipper, PDF, DOCX, CSV, screenshot OCR, and voice transcript payload ingestion.
-- UI: fixture-backed `/vnext` workspace for review, Ask Alice, briefs, queue, projects, beliefs, graph, connectors, and privacy settings.
+- UI: live/fixture-backed `/vnext` workspace for review, Ask Alice, briefs, queue, projects, Agent Activity, Schedules, beliefs, graph, connectors, and privacy settings.
 - Evals: synthetic corpus and baseline metrics for recall, temporal reasoning, contradictions, provenance, privacy, open loops, and prompt injection.
 
 ## Start Here
@@ -30,6 +32,7 @@ Alice vNext has three layers:
 5. Use [demo script](demo-video-script.md) for a short walkthrough.
 6. Use [release checklist](../release/vnext-public-release-checklist.md) before publishing or tagging.
 7. Review [preview release notes](../release/v0.5.1-vnext-preview-release-notes.md) and [tag plan](../release/v0.5.1-vnext-preview-tag-plan.md).
+8. Review the [agentic control plane CTO summary](../vnext-agentic-control-plane-cto-summary.md) for the current sprint closeout.
 
 ## Launch Boundary
 

--- a/docs/vnext/architecture.md
+++ b/docs/vnext/architecture.md
@@ -14,6 +14,7 @@ Core owns durable state and policy boundaries:
 - `provenance_links` connect memories, artifacts, graph edges, projects, and open loops back to source chunks.
 - `event_log` records append-only system events for mutation, connector sync, artifact generation, and review.
 - `brain_charters` store the user-editable operating agreement for a brain.
+- `agent_identities`, `scheduler_workflows`, and `scheduler_runs` persist governed agent and schedule state across restarts.
 
 ### Alice Brain
 
@@ -38,8 +39,10 @@ Agent Memory exposes Alice to external tools without letting those tools own Ali
 - API endpoints for product surfaces
 - MCP tools for agent environments
 - connector payload ingestion for source evidence
+- scoped agent identities and permission profiles
+- governed scheduler controls for local proactive workflows
 
-Agents can request context and propose writes, but durable mutation still passes through Core policies, review state, provenance, and event logging.
+Agents can request context, submit tasks, generate artifacts, propose memory, and run allowed scheduler workflows, but durable mutation still passes through Core policies, review state, provenance, and event logging.
 
 ## Data Flow
 
@@ -49,6 +52,36 @@ Agents can request context and propose writes, but durable mutation still passes
 4. Brain workflows retrieve allowed evidence and generate reviewable artifacts.
 5. Review actions accept, edit, reject, supersede, close, snooze, or promote.
 6. Event log records write paths for audit and replay.
+7. Agent and scheduler actions add agent identity, policy decision, run ID, trace ID, target ID, and workflow metadata where applicable.
+
+## Agentic Control Plane
+
+Agent-originated API, CLI, and MCP calls can carry `agent_id`, `agent_type`, `agent_run_id`, `task_id`, `project_scope`, and `permission_profile`.
+
+Initial permission profiles are:
+
+- `read_only_agent`
+- `project_scoped_agent`
+- `trusted_local_agent`
+- `memory_proposal_agent`
+- `admin_agent`
+
+The policy layer evaluates the requested action, project scope, domain scope, sensitivity scope, workflow type, and write policy. Decisions are `allowed`, `allowed_with_filtering`, `requires_review`, or `blocked`; filtered and blocked outcomes are logged.
+
+Agent proposals remain candidate/review items. This sprint does not allow agent or scheduler output to auto-promote into trusted memory.
+
+## Governed Scheduler
+
+The local scheduler owns disabled-by-default workflow configuration for:
+
+- `daily_brief`
+- `weekly_synthesis`
+- `connection_report`
+- `contradiction_report`
+- `open_loop_review`
+- `project_update_scan`
+
+Daily Brief and Weekly Synthesis are the primary runnable workflows. Local due scans run enabled, unpaused workflows whose `next_run_at` has arrived, then advance the next run timestamp. Other workflow types have persistent configuration, policy-checked control paths, run history, and generated report artifacts. Scheduler runs record status, trace ID, triggering actor, policy decision, agent identity when present, output artifact ID, and failure details.
 
 ## Connector Boundary
 
@@ -71,7 +104,8 @@ Each connector preserves raw evidence in source metadata, applies conservative d
 - Prompt-injection eval cases are quarantined and cannot trigger tool writes.
 - Sensitive domains and sensitivities are filtered before context-pack assembly.
 - Generated artifacts inherit the highest selected source sensitivity.
+- Agents cannot bypass domain/sensitivity filters, review-required workflows, scheduler policy checks, Brain Charter constraints, or the no-auto-promotion rule.
 
 ## Current Production Gap
 
-Before a public vNext tag, decide whether connector cursors and secrets move from event-log seeding into a dedicated connector settings table or encrypted local secret store. Live connector polling, OAuth, browser extension packaging, OCR execution, and transcription execution remain outside this preview.
+Before a public vNext tag, decide whether connector cursors and secrets move from event-log seeding into a dedicated connector settings table or encrypted local secret store. Live connector polling, OAuth, browser extension packaging, OCR execution, transcription execution, hosted scheduling, and automatic memory promotion remain outside this preview.

--- a/scripts/run_reference_agent_examples_demo.py
+++ b/scripts/run_reference_agent_examples_demo.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import socket
 import subprocess
 import sys
+import tempfile
 import threading
 from typing import Any
 
@@ -18,6 +19,7 @@ TYPESCRIPT_EXAMPLE = REPO_ROOT / "docs" / "examples" / "generic_typescript_agent
 CANONICAL_BRIEF_FIXTURE = (
     REPO_ROOT / "fixtures" / "reference_integrations" / "continuity_brief_agent_handoff_v1.json"
 )
+TYPESCRIPT_PACKAGE = REPO_ROOT / "apps" / "web" / "node_modules" / "typescript"
 
 
 def _brief_payload() -> dict[str, Any]:
@@ -102,6 +104,65 @@ def _run_step(*, name: str, command: list[str], env: dict[str, str]) -> dict[str
     }
 
 
+def _node_supports_strip_types(env: dict[str, str]) -> bool:
+    completed = subprocess.run(
+        ["node", "--experimental-strip-types", "--version"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return completed.returncode == 0
+
+
+def _run_typescript_step(env: dict[str, str]) -> dict[str, Any]:
+    if _node_supports_strip_types(env):
+        return _run_step(
+            name="typescript_example",
+            command=["node", "--experimental-strip-types", str(TYPESCRIPT_EXAMPLE)],
+            env=env,
+        )
+
+    with tempfile.TemporaryDirectory(prefix="alice-reference-agent-ts-") as temp_dir:
+        compiled_path = Path(temp_dir) / "generic_typescript_agent.js"
+        transpile_script = """
+const fs = require("fs");
+const ts = require(process.argv[1]);
+const sourcePath = process.argv[2];
+const outputPath = process.argv[3];
+const source = fs.readFileSync(sourcePath, "utf8");
+const output = ts.transpileModule(source, {
+  compilerOptions: {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.CommonJS,
+  },
+});
+fs.writeFileSync(outputPath, output.outputText);
+"""
+        transpile = subprocess.run(
+            ["node", "-e", transpile_script, str(TYPESCRIPT_PACKAGE), str(TYPESCRIPT_EXAMPLE), str(compiled_path)],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if transpile.returncode != 0:
+            return {
+                "name": "typescript_example",
+                "command": ["node", "--experimental-strip-types", str(TYPESCRIPT_EXAMPLE)],
+                "returncode": transpile.returncode,
+                "stdout": None,
+                "stderr": transpile.stderr.strip(),
+            }
+        return _run_step(
+            name="typescript_example",
+            command=["node", str(compiled_path)],
+            env=env,
+        )
+
+
 def main() -> int:
     server, thread, base_url = _start_demo_server()
     env = os.environ.copy()
@@ -120,11 +181,7 @@ def main() -> int:
             command=[sys.executable, str(PYTHON_EXAMPLE)],
             env=env,
         )
-        typescript_step = _run_step(
-            name="typescript_example",
-            command=["node", "--experimental-strip-types", str(TYPESCRIPT_EXAMPLE)],
-            env=env,
-        )
+        typescript_step = _run_typescript_step(env)
     finally:
         server.shutdown()
         thread.join(timeout=5)

--- a/tests/integration/test_phase10_telegram_transport_api.py
+++ b/tests/integration/test_phase10_telegram_transport_api.py
@@ -617,6 +617,7 @@ def test_phase10_telegram_webhook_rate_limit_enforced(
     migrated_database_urls,
     monkeypatch,
 ) -> None:
+    main_module.entrypoint_rate_limiter.reset()
     monkeypatch.setattr(
         main_module,
         "get_settings",
@@ -624,11 +625,12 @@ def test_phase10_telegram_webhook_rate_limit_enforced(
             database_url=migrated_database_urls["app"],
             telegram_webhook_secret="",
             telegram_bot_token="",
-            telegram_bot_username="alicebot",
-            telegram_webhook_rate_limit_max_requests=1,
-            telegram_webhook_rate_limit_window_seconds=60,
-        ),
-    )
+                telegram_bot_username="alicebot",
+                telegram_webhook_rate_limit_max_requests=1,
+                telegram_webhook_rate_limit_window_seconds=60,
+                entrypoint_rate_limit_backend="memory",
+            ),
+        )
 
     first_webhook_status, _first_webhook_payload = invoke_request(
         "POST",

--- a/tests/integration/test_vnext_live_workspace_api.py
+++ b/tests/integration/test_vnext_live_workspace_api.py
@@ -200,11 +200,80 @@ def test_vnext_live_workspace_happy_path_writes_reviewable_postgres_state(
     assert "supporting_evidence" in pack_payload
     assert "contradicting_evidence" in pack_payload
 
+    openclaw_identity = {
+        "agent_id": "openclaw",
+        "agent_type": "coding_agent",
+        "agent_run_id": "openclaw-smoke-run-1",
+        "task_id": "openclaw-task-1",
+        "project_scope": ["Alice"],
+        "permission_profile": "project_scoped_agent",
+    }
+    openclaw_pack_status, openclaw_pack_payload = invoke_request(
+        "POST",
+        "/v0/vnext/context-packs",
+        payload={
+            "user_id": user_id_text,
+            "agent_identity": openclaw_identity,
+            "project_scope": ["Alice"],
+            "query": "Alice Live UI uses Postgres",
+            "scope": {"domains": ["project"]},
+            "options": {"sensitivity_allowed": ["public", "internal", "private", "unknown"], "max_items": 6},
+        },
+    )
+    assert openclaw_pack_status == 201
+    assert openclaw_pack_payload["agent_identity"]["agent_id"] == "openclaw"
+    assert openclaw_pack_payload["policy_decision"]["decision"] == "allowed"
+    assert openclaw_pack_payload["trace"]["selected_count"] >= 1
+
+    proposal_status, proposal_payload = invoke_request(
+        "POST",
+        "/v0/vnext/memory-proposals",
+        payload={
+            "user_id": user_id_text,
+            "agent_identity": openclaw_identity,
+            "proposal_type": "candidate_memory",
+            "title": "OpenClaw project memory proposal",
+            "canonical_text": "OpenClaw should use Alice project context through governed memory proposals.",
+            "source_refs": [source_id],
+            "project_scope": ["Alice"],
+            "domain": "project",
+            "sensitivity": "private",
+            "confidence": 0.72,
+            "rationale": "Agentic scheduler smoke proposal.",
+        },
+    )
+    assert proposal_status == 201
+    assert proposal_payload["proposal"]["status"] == "candidate"
+    assert proposal_payload["proposal"]["metadata_json"]["review_required"] is True
+    assert proposal_payload["review_required"] is True
+
+    restricted_status, restricted_payload = invoke_request(
+        "POST",
+        "/v0/vnext/context-packs",
+        payload={
+            "user_id": user_id_text,
+            "agent_identity": openclaw_identity,
+            "query": "restricted family and health context",
+            "scope": {"domains": ["family", "health"], "projects": ["Alice"]},
+            "options": {"sensitivity_allowed": ["private", "highly_sensitive"], "max_items": 6},
+        },
+    )
+    assert restricted_status == 403
+    assert restricted_payload["policy_decision"]["decision"] == "blocked"
+    assert "all_requested_domains_restricted" in restricted_payload["policy_decision"]["reasons"]
+
     open_loop_status, open_loop_payload = invoke_request(
         "POST",
         "/v0/vnext/open-loops",
         payload={
             "user_id": user_id_text,
+            "agent_identity": {
+                "agent_id": "hermes",
+                "agent_type": "personal_assistant",
+                "agent_run_id": "hermes-smoke-run-1",
+                "project_scope": ["Alice"],
+                "permission_profile": "trusted_local_agent",
+            },
             "title": "Confirm project dashboard updates before release",
             "description": "Created from the live /vnext workspace smoke.",
             "priority": "high",
@@ -217,6 +286,7 @@ def test_vnext_live_workspace_happy_path_writes_reviewable_postgres_state(
     )
     assert open_loop_status == 201
     loop_id = open_loop_payload["open_loop"]["id"]
+    assert open_loop_payload["open_loop"]["metadata_json"]["agent_id"] == "hermes"
 
     edit_loop_status, edit_loop_payload = invoke_request(
         "POST",
@@ -297,6 +367,95 @@ def test_vnext_live_workspace_happy_path_writes_reviewable_postgres_state(
     assert weekly_review_status == 200
     assert weekly_review_payload["status"] == "accepted"
 
+    scheduler_status, scheduler_payload = invoke_request(
+        "GET",
+        "/v0/vnext/scheduler/status",
+        query_params={"user_id": user_id_text},
+    )
+    assert scheduler_status == 200
+    assert scheduler_payload["disabled_by_default"] is True
+    assert {workflow["workflow_type"] for workflow in scheduler_payload["workflows"]} >= {
+        "daily_brief",
+        "weekly_synthesis",
+    }
+
+    daily_enable_status, daily_enable_payload = invoke_request(
+        "PATCH",
+        "/v0/vnext/scheduler/workflows/daily_brief",
+        payload={
+            "user_id": user_id_text,
+            "enabled": True,
+            "schedule_json": {"kind": "daily", "time_of_day": "08:00", "days_of_week": ["monday"]},
+            "timezone": "UTC",
+        },
+    )
+    assert daily_enable_status == 200
+    assert daily_enable_payload["workflow"]["enabled"] is True
+
+    weekly_enable_status, weekly_enable_payload = invoke_request(
+        "PATCH",
+        "/v0/vnext/scheduler/workflows/weekly_synthesis",
+        payload={
+            "user_id": user_id_text,
+            "enabled": True,
+            "schedule_json": {"kind": "weekly", "day_of_week": "monday", "time_of_day": "09:00"},
+            "timezone": "UTC",
+        },
+    )
+    assert weekly_enable_status == 200
+    assert weekly_enable_payload["workflow"]["enabled"] is True
+
+    pause_status, pause_payload = invoke_request(
+        "POST",
+        "/v0/vnext/scheduler/pause",
+        payload={"user_id": user_id_text},
+    )
+    assert pause_status == 200
+    assert pause_payload["paused_count"] >= 2
+
+    resume_status, resume_payload = invoke_request(
+        "POST",
+        "/v0/vnext/scheduler/resume",
+        payload={"user_id": user_id_text},
+    )
+    assert resume_status == 200
+    assert resume_payload["resumed_count"] >= 2
+
+    scheduler_daily_status, scheduler_daily_payload = invoke_request(
+        "POST",
+        "/v0/vnext/scheduler/workflows/daily_brief/run-now",
+        payload={
+            "user_id": user_id_text,
+            "scope": {"domains": ["project"]},
+            "options": {"generated_for": "2026-05-11", "sensitivity_allowed": ["public", "internal", "private", "unknown"]},
+        },
+    )
+    assert scheduler_daily_status == 201
+    assert scheduler_daily_payload["run"]["status"] == "succeeded"
+    assert scheduler_daily_payload["artifact"]["generated_by"] == "scheduler"
+    assert scheduler_daily_payload["artifact"]["metadata_json"]["scheduler_run_id"] == scheduler_daily_payload["run"]["id"]
+
+    scheduler_weekly_status, scheduler_weekly_payload = invoke_request(
+        "POST",
+        "/v0/vnext/scheduler/workflows/weekly_synthesis/run-now",
+        payload={
+            "user_id": user_id_text,
+            "scope": {"domains": ["project"]},
+            "options": {"generated_for": "2026-05-11", "sensitivity_allowed": ["public", "internal", "private", "unknown"]},
+        },
+    )
+    assert scheduler_weekly_status == 201
+    assert scheduler_weekly_payload["run"]["status"] == "succeeded"
+    assert scheduler_weekly_payload["artifact"]["metadata_json"]["generated_by"] == "scheduler"
+
+    scheduler_review_status, scheduler_review_payload = invoke_request(
+        "POST",
+        f"/v0/vnext/artifacts/{scheduler_daily_payload['artifact']['id']}/review",
+        payload={"user_id": user_id_text, "action": "archive"},
+    )
+    assert scheduler_review_status == 200
+    assert scheduler_review_payload["status"] == "archived"
+
     project_update_status, project_update_payload = invoke_request(
         "POST",
         "/v0/vnext/projects/update-candidates",
@@ -355,9 +514,14 @@ def test_vnext_live_workspace_happy_path_writes_reviewable_postgres_state(
     )
     assert final_workspace_status == 200
     assert final_workspace_payload["summary"]["artifact_count"] >= 3
+    assert final_workspace_payload["summary"]["agent_count"] >= 2
+    assert final_workspace_payload["summary"]["scheduler_enabled_count"] >= 2
     assert final_workspace_payload["project_dashboards"][0]["counts"]["open_loops"] >= 1
     assert final_workspace_payload["brain_charter"]["id"] == charter_payload["brain_charter"]["id"]
     assert final_workspace_payload["recent_events"]
+    assert final_workspace_payload["agent_activity"]["agents"]
+    assert final_workspace_payload["agent_activity"]["policy_blocks"]
+    assert final_workspace_payload["scheduler"]["recent_runs"]
 
     with user_connection(migrated_database_urls["app"], user_id) as conn:
         with conn.cursor() as cur:
@@ -373,11 +537,35 @@ def test_vnext_live_workspace_happy_path_writes_reviewable_postgres_state(
                 """
             )
             active_artifact_summary_count = cur.fetchone()["count"]
+            cur.execute(
+                """
+                SELECT COUNT(*) AS count
+                FROM memories
+                WHERE status = 'candidate'
+                  AND metadata_json ->> 'proposal_type' = 'candidate_memory'
+                  AND metadata_json ->> 'agent_id' = 'openclaw'
+                """
+            )
+            openclaw_candidate_count = cur.fetchone()["count"]
+            cur.execute(
+                """
+                SELECT COUNT(*) AS count
+                FROM scheduler_runs
+                WHERE status = 'succeeded'
+                  AND workflow_type IN ('daily_brief', 'weekly_synthesis')
+                """
+            )
+            scheduler_success_count = cur.fetchone()["count"]
 
     assert {
         "project.created",
         "source.created",
         "source.captured",
+        "policy.decision",
+        "agent.context_pack_requested",
+        "agent.memory_proposed",
+        "agent.policy_blocked",
+        "review.item_created",
         "memory.updated",
         "memory_revision.created",
         "graph_edge.created",
@@ -387,6 +575,14 @@ def test_vnext_live_workspace_happy_path_writes_reviewable_postgres_state(
         "artifact.generated",
         "artifact.reviewed",
         "project.update_candidate_created",
+        "scheduler.workflow_enabled",
+        "scheduler.workflow_paused",
+        "scheduler.workflow_resumed",
+        "scheduler.run_started",
+        "scheduler.run_succeeded",
+        "scheduler.artifact_created",
         "brain_charter.upserted",
     }.issubset(event_types)
     assert active_artifact_summary_count == 0
+    assert openclaw_candidate_count == 1
+    assert scheduler_success_count >= 2

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -47,6 +47,16 @@ def test_parser_routes_required_commands() -> None:
         (["vnext", "projects", "dashboard", "project-1"], "_run_vnext_project_dashboard"),
         (["vnext", "open-loops", "extract"], "_run_vnext_open_loops_extract"),
         (["vnext", "open-loops", "review", "loop-1", "--action", "close"], "_run_vnext_open_loop_review"),
+        (
+            ["vnext", "agents", "propose-memory", "--agent-id", "hermes", "--title", "T", "--canonical-text", "Fact"],
+            "_run_vnext_agent_propose_memory",
+        ),
+        (["vnext", "scheduler", "status"], "_run_vnext_scheduler_status"),
+        (["vnext", "scheduler", "run-now", "daily_brief"], "_run_vnext_scheduler_run_now"),
+        (["vnext", "scheduler", "run-due"], "_run_vnext_scheduler_run_due"),
+        (["vnext", "scheduler", "pause"], "_run_vnext_scheduler_pause"),
+        (["vnext", "scheduler", "resume"], "_run_vnext_scheduler_resume"),
+        (["vnext", "smoke", "agentic-scheduler"], "_run_vnext_smoke_agentic_scheduler"),
         (["mutations", "generate"], "_run_mutation_generate"),
         (["mutations", "candidates"], "_run_mutation_candidates"),
         (["mutations", "commit"], "_run_mutation_commit"),
@@ -123,46 +133,58 @@ class FakeVNextCliStore:
         self.beliefs: dict[str, dict[str, object]] = {}
         self.projects: dict[str, dict[str, object]] = {}
         self.revisions: list[dict[str, object]] = []
+        self.agent_identities: dict[str, dict[str, object]] = {}
+        self.scheduler_workflows: dict[str, dict[str, object]] = {}
+        self.scheduler_runs: list[dict[str, object]] = []
 
     def append_event(self, event: dict[str, object]) -> dict[str, object]:
         self.events.append(event)
         return event
 
+    def upsert_agent_identity(self, identity: dict[str, object], **_kwargs) -> dict[str, object]:
+        row = {
+            **identity,
+            "id": self.agent_identities.get(str(identity["agent_id"]), {}).get("id")
+            or f"agent-{len(self.agent_identities) + 1}",
+        }
+        self.agent_identities[str(identity["agent_id"])] = row
+        return row
+
     def get_source_by_content_hash(self, content_hash: str) -> dict[str, object] | None:
         return self.source_by_hash.get(content_hash)
 
-    def create_source(self, source: dict[str, object]) -> dict[str, object]:
+    def create_source(self, source: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**source, "id": f"source-{len(self.sources) + 1}"}
         self.sources.append(row)
         self.source_by_hash[str(source["content_hash"])] = row
         return row
 
-    def create_source_chunk(self, chunk: dict[str, object]) -> dict[str, object]:
+    def create_source_chunk(self, chunk: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**chunk, "id": f"chunk-{len(self.chunks) + 1}"}
         self.chunks.append(row)
         return row
 
-    def create_memory(self, memory: dict[str, object]) -> dict[str, object]:
+    def create_memory(self, memory: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**memory, "id": f"memory-{len(self.memories) + 1}"}
         self.memories.append(row)
         return row
 
-    def update_memory(self, *, memory_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_memory(self, *, memory_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         for memory in self.memories:
             if memory["id"] == memory_id:
                 memory.update(patch)
                 return memory
         raise AssertionError(memory_id)
 
-    def append_revision(self, revision: dict[str, object]) -> dict[str, object]:
+    def append_revision(self, revision: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**revision, "id": f"revision-{len(self.revisions) + 1}"}
         self.revisions.append(row)
         return row
 
-    def create_provenance_link(self, link: dict[str, object]) -> dict[str, object]:
+    def create_provenance_link(self, link: dict[str, object], **_kwargs) -> dict[str, object]:
         return {**link, "id": "provenance-1"}
 
-    def create_open_loop(self, loop: dict[str, object]) -> dict[str, object]:
+    def create_open_loop(self, loop: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**loop, "id": f"loop-{len(self.open_loops) + 1}", "status": loop.get("status", "open")}
         self.open_loops.append(row)
         return row
@@ -215,7 +237,7 @@ class FakeVNextCliStore:
                 return loop
         return None
 
-    def update_open_loop(self, *, loop_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_open_loop(self, *, loop_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         loop = self.get_open_loop(loop_id)
         if loop is None:
             raise AssertionError(loop_id)
@@ -228,6 +250,7 @@ class FakeVNextCliStore:
         loop_id: str,
         status: str,
         resolution_note: str | None = None,
+        **_kwargs,
     ) -> dict[str, object]:
         loop = self.update_open_loop(loop_id=loop_id, patch={"status": status})
         if resolution_note is not None:
@@ -238,12 +261,12 @@ class FakeVNextCliStore:
         del target_type, target_id
         return []
 
-    def create_edge(self, edge: dict[str, object]) -> dict[str, object]:
+    def create_edge(self, edge: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**edge, "id": f"edge-{len(self.edges) + 1}"}
         self.edges[str(row["id"])] = row
         return row
 
-    def update_edge_status(self, *, edge_id: str, status: str) -> dict[str, object]:
+    def update_edge_status(self, *, edge_id: str, status: str, **_kwargs) -> dict[str, object]:
         edge = self.edges[edge_id]
         metadata = edge.get("metadata_json")
         if not isinstance(metadata, dict):
@@ -263,7 +286,7 @@ class FakeVNextCliStore:
             and edge.get("valid_to") is None
         ]
 
-    def create_belief(self, belief: dict[str, object]) -> dict[str, object]:
+    def create_belief(self, belief: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**belief, "id": f"belief-{len(self.beliefs) + 1}"}
         self.beliefs[str(row["id"])] = row
         return row
@@ -290,6 +313,7 @@ class FakeVNextCliStore:
         status: str,
         confidence: float | None = None,
         superseded_by: str | None = None,
+        **_kwargs,
     ) -> dict[str, object]:
         belief = self.beliefs[belief_id]
         belief["status"] = status
@@ -315,7 +339,7 @@ class FakeVNextCliStore:
             and (target_id is None or event.get("target_id") == target_id)
         ]
 
-    def create_task(self, task: dict[str, object]) -> dict[str, object]:
+    def create_task(self, task: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**task, "id": f"task-{len(self.tasks) + 1}", "status": "pending"}
         self.tasks.append(row)
         return row
@@ -333,6 +357,7 @@ class FakeVNextCliStore:
         task_id: str,
         status: str,
         details: dict[str, object] | None = None,
+        **_kwargs,
     ) -> dict[str, object]:
         for task in self.tasks:
             if task["id"] == task_id:
@@ -342,7 +367,7 @@ class FakeVNextCliStore:
                 return task
         raise AssertionError(task_id)
 
-    def create_artifact(self, artifact: dict[str, object]) -> dict[str, object]:
+    def create_artifact(self, artifact: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**artifact, "id": f"artifact-{len(self.artifacts) + 1}"}
         self.artifacts[str(row["id"])] = row
         return row
@@ -381,15 +406,102 @@ class FakeVNextCliStore:
         rows = [row for row in self.projects.values() if status is None or row.get("status") == status]
         return rows[:limit]
 
-    def update_project(self, *, project_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_project(self, *, project_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         project = self.projects[project_id]
         project.update(patch)
         return project
 
-    def update_artifact_status(self, *, artifact_id: str, status: str) -> dict[str, object]:
+    def update_artifact_status(self, *, artifact_id: str, status: str, **_kwargs) -> dict[str, object]:
         artifact = self.artifacts[artifact_id]
         artifact["status"] = status
         return artifact
+
+    def upsert_scheduler_workflow(self, workflow: dict[str, object], **_kwargs) -> dict[str, object]:
+        workflow_type = str(workflow["workflow_type"])
+        existing = self.scheduler_workflows.get(workflow_type, {})
+        row = {
+            **existing,
+            **workflow,
+            "id": existing.get("id") or f"workflow-{len(self.scheduler_workflows) + 1}",
+        }
+        self.scheduler_workflows[workflow_type] = row
+        return row
+
+    def update_scheduler_workflow(
+        self,
+        *,
+        workflow_type: str,
+        patch: dict[str, object],
+        **_kwargs,
+    ) -> dict[str, object]:
+        workflow = self.get_scheduler_workflow(workflow_type)
+        if workflow is None:
+            workflow = self.upsert_scheduler_workflow(
+                {
+                    "workflow_type": workflow_type,
+                    "enabled": False,
+                    "paused": False,
+                    "schedule_json": {"kind": "manual"},
+                    "timezone": "UTC",
+                    "next_run_at": None,
+                    "metadata_json": {},
+                }
+            )
+        workflow.update(patch)
+        return workflow
+
+    def get_scheduler_workflow(self, workflow_type: str) -> dict[str, object] | None:
+        return self.scheduler_workflows.get(workflow_type)
+
+    def list_scheduler_workflows(self) -> list[dict[str, object]]:
+        return list(self.scheduler_workflows.values())
+
+    def create_scheduler_run(self, run: dict[str, object], **_kwargs) -> dict[str, object]:
+        row = {
+            **run,
+            "id": f"scheduler-run-{len(self.scheduler_runs) + 1}",
+            "started_at": datetime.now(UTC).isoformat(),
+        }
+        self.scheduler_runs.append(row)
+        self.append_event(
+            {
+                "event_type": "scheduler.run_started",
+                "target_type": "scheduler_run",
+                "target_id": row["id"],
+                "payload_json": {"workflow_type": row["workflow_type"]},
+            }
+        )
+        return row
+
+    def update_scheduler_run(
+        self,
+        *,
+        run_id: str,
+        patch: dict[str, object],
+        **_kwargs,
+    ) -> dict[str, object]:
+        for run in self.scheduler_runs:
+            if run["id"] == run_id:
+                run.update(patch)
+                run["finished_at"] = datetime.now(UTC).isoformat()
+                self.append_event(
+                    {
+                        "event_type": "scheduler.run_succeeded" if run.get("status") == "succeeded" else "scheduler.run_failed",
+                        "target_type": "scheduler_run",
+                        "target_id": run_id,
+                        "payload_json": {"workflow_type": run["workflow_type"]},
+                    }
+                )
+                return run
+        raise AssertionError(run_id)
+
+    def list_scheduler_runs(self, *, workflow_type: str | None = None, limit: int = 20) -> list[dict[str, object]]:
+        rows = [
+            run
+            for run in reversed(self.scheduler_runs)
+            if workflow_type is None or run.get("workflow_type") == workflow_type
+        ]
+        return rows[:limit]
 
 
 def test_vnext_capture_text_cli_uses_vnext_capture_service(monkeypatch) -> None:
@@ -594,6 +706,33 @@ def test_vnext_brain_cli_generates_daily_and_weekly_artifacts(monkeypatch) -> No
     assert weekly_payload["artifact_type"] == "weekly_synthesis"
     assert weekly_payload["metadata_json"]["candidate_memory_ids"] == ["memory-2"]
     assert store.events[-1]["event_type"] == "artifact.generated"
+
+
+def test_vnext_agentic_scheduler_smoke_cli_runs_required_gates(monkeypatch) -> None:
+    store = FakeVNextCliStore()
+
+    @contextmanager
+    def fake_vnext_store_context(_ctx):
+        yield store
+
+    monkeypatch.setattr(cli_module, "_vnext_store_context", fake_vnext_store_context)
+    ctx = cli_module.CLIContext(
+        settings=Settings(database_url="postgresql://db"),
+        database_url="postgresql://db",
+        user_id=uuid4(),
+    )
+    args = cli_module.build_parser().parse_args(["vnext", "smoke", "agentic-scheduler"])
+
+    output = args.handler(ctx, args)
+
+    payload = json.loads(output)
+    assert payload["status"] == "passed"
+    assert all(payload["gates"].values())
+    assert payload["policy_decisions"]["blocked"]["decision"] == "blocked"
+    assert store.memories[-1]["status"] == "candidate"
+    assert len(store.scheduler_runs) == 3
+    assert {run["status"] for run in store.scheduler_runs} == {"succeeded"}
+    assert any(event["event_type"] == "agent.policy_blocked" for event in store.events)
 
 
 def test_vnext_connection_cli_generates_reviews_and_lists_neighborhood(monkeypatch) -> None:

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -64,6 +64,24 @@ def test_mcp_tool_surface_is_adr_aligned_and_deterministic() -> None:
         "alice_project_dashboard",
         "alice_open_loop_extract",
         "alice_open_loop_review",
+        "alice_vnext_capture",
+        "alice_vnext_queue_task",
+        "alice_vnext_generate_artifact",
+        "alice_vnext_project_dashboard",
+        "alice_vnext_open_loops",
+        "alice_vnext_recent_decisions",
+        "alice_vnext_recent_changes",
+        "alice_vnext_find_connections",
+        "alice_vnext_find_contradictions",
+        "alice_vnext_propose_memory",
+        "alice_vnext_review_items",
+        "alice_vnext_artifact_get",
+        "alice_vnext_artifact_review",
+        "alice_vnext_scheduler_status",
+        "alice_vnext_scheduler_run_now",
+        "alice_vnext_scheduler_run_due",
+        "alice_vnext_scheduler_pause",
+        "alice_vnext_scheduler_resume",
     ]
 
     for tool in tools:
@@ -126,7 +144,7 @@ class FakeVNextMCPStore:
         self.events.append(event)
         return event
 
-    def create_artifact(self, artifact: dict[str, object]) -> dict[str, object]:
+    def create_artifact(self, artifact: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**artifact, "id": f"artifact-{len(self.artifacts) + 1}"}
         self.artifacts[str(row["id"])] = row
         return row
@@ -134,39 +152,39 @@ class FakeVNextMCPStore:
     def get_artifact(self, artifact_id: str) -> dict[str, object] | None:
         return self.artifacts.get(artifact_id)
 
-    def update_artifact_status(self, *, artifact_id: str, status: str) -> dict[str, object]:
+    def update_artifact_status(self, *, artifact_id: str, status: str, **_kwargs) -> dict[str, object]:
         artifact = self.artifacts[artifact_id]
         artifact["status"] = status
         return artifact
 
-    def create_memory(self, memory: dict[str, object]) -> dict[str, object]:
+    def create_memory(self, memory: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**memory, "id": f"memory-{len(self.memories) + 2}"}
         self.memories.append(row)
         return row
 
-    def update_memory(self, *, memory_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_memory(self, *, memory_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         for memory in self.memories:
             if memory["id"] == memory_id:
                 memory.update(patch)
                 return memory
         raise AssertionError(memory_id)
 
-    def append_revision(self, revision: dict[str, object]) -> dict[str, object]:
+    def append_revision(self, revision: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**revision, "id": f"revision-{len(self.revisions) + 1}"}
         self.revisions.append(row)
         return row
 
-    def create_open_loop(self, loop: dict[str, object]) -> dict[str, object]:
+    def create_open_loop(self, loop: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**loop, "id": f"loop-{len(self.open_loops) + 1}", "status": loop.get("status", "open")}
         self.open_loops.append(row)
         return row
 
-    def create_edge(self, edge: dict[str, object]) -> dict[str, object]:
+    def create_edge(self, edge: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**edge, "id": f"edge-{len(self.edges) + 1}"}
         self.edges[str(row["id"])] = row
         return row
 
-    def update_edge_status(self, *, edge_id: str, status: str) -> dict[str, object]:
+    def update_edge_status(self, *, edge_id: str, status: str, **_kwargs) -> dict[str, object]:
         edge = self.edges[edge_id]
         metadata = edge.get("metadata_json")
         if not isinstance(metadata, dict):
@@ -227,7 +245,7 @@ class FakeVNextMCPStore:
                 return loop
         return None
 
-    def update_open_loop(self, *, loop_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_open_loop(self, *, loop_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         loop = self.get_open_loop(loop_id)
         if loop is None:
             raise AssertionError(loop_id)
@@ -240,6 +258,7 @@ class FakeVNextMCPStore:
         loop_id: str,
         status: str,
         resolution_note: str | None = None,
+        **_kwargs,
     ) -> dict[str, object]:
         loop = self.update_open_loop(loop_id=loop_id, patch={"status": status})
         if resolution_note is not None:
@@ -257,7 +276,7 @@ class FakeVNextMCPStore:
         limit = kwargs.get("limit", 8)
         return [row for row in self.projects.values() if status is None or row.get("status") == status][:limit]
 
-    def update_project(self, *, project_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_project(self, *, project_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         project = self.projects[project_id]
         project.update(patch)
         return project
@@ -287,6 +306,7 @@ class FakeVNextMCPStore:
         status: str,
         confidence: float | None = None,
         superseded_by: str | None = None,
+        **_kwargs,
     ) -> dict[str, object]:
         belief = self.beliefs[belief_id]
         belief["status"] = status

--- a/tests/unit/test_memory_store.py
+++ b/tests/unit/test_memory_store.py
@@ -178,20 +178,23 @@ def test_memory_methods_use_expected_queries_and_payload_serialization() -> None
     append_revision_query, append_revision_params = cursor.executed[3]
     assert "INSERT INTO memory_revisions" in append_revision_query
     assert append_revision_params is not None
-    assert append_revision_params[:4] == (
+    assert append_revision_params[:5] == (
         memory_id,
         memory_id,
         "ADD",
+        "ADD",
         "user.preference.coffee",
     )
-    assert isinstance(append_revision_params[4], Jsonb)
-    assert append_revision_params[4].obj is None
     assert isinstance(append_revision_params[5], Jsonb)
-    assert append_revision_params[5].obj == {"likes": "black"}
+    assert append_revision_params[5].obj is None
     assert isinstance(append_revision_params[6], Jsonb)
-    assert append_revision_params[6].obj == [str(event_id)]
+    assert append_revision_params[6].obj == {"likes": "black"}
     assert isinstance(append_revision_params[7], Jsonb)
-    assert append_revision_params[7].obj == {"memory_key": "user.preference.coffee"}
+    assert append_revision_params[7].obj == [str(event_id)]
+    assert isinstance(append_revision_params[8], Jsonb)
+    assert append_revision_params[8].obj == {"memory_key": "user.preference.coffee"}
+    assert append_revision_params[9] is None
+    assert append_revision_params[10] == '{"likes": "black"}'
     assert cursor.executed[6] == (
         """
                 SELECT

--- a/tests/unit/test_vnext_agent_control.py
+++ b/tests/unit/test_vnext_agent_control.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+
+from alicebot_api.vnext_agent_control import (
+    AgentIdentity,
+    AgentPolicyBlockedError,
+    append_policy_events,
+    ensure_policy_allowed,
+    evaluate_agent_policy,
+)
+
+
+class EventStore:
+    def __init__(self) -> None:
+        self.events: list[dict[str, object]] = []
+
+    def append_event(self, event: dict[str, object]) -> dict[str, object]:
+        self.events.append(event)
+        return event
+
+
+def test_agent_identity_defaults_known_agents_without_hardcoding_only_them() -> None:
+    hermes = AgentIdentity.from_payload({"agent_id": "hermes"})
+    openclaw = AgentIdentity.from_payload({"agent_id": "openclaw", "project_scope": ["Alice"]})
+    future_agent = AgentIdentity.from_payload({"agent_id": "research-bot", "permission_profile": "memory_proposal_agent"})
+
+    assert hermes is not None
+    assert hermes.agent_type == "personal_assistant"
+    assert hermes.permission_profile == "trusted_local_agent"
+    assert openclaw is not None
+    assert openclaw.agent_type == "coding_agent"
+    assert openclaw.permission_profile == "project_scoped_agent"
+    assert openclaw.project_scope == ("Alice",)
+    assert future_agent is not None
+    assert future_agent.agent_type == "unknown"
+    assert future_agent.permission_profile == "memory_proposal_agent"
+
+
+def test_policy_filters_or_blocks_restricted_project_scoped_agent_access() -> None:
+    openclaw = AgentIdentity.from_payload({"agent_id": "openclaw", "project_scope": ["Alice"]})
+    assert openclaw is not None
+
+    filtered = evaluate_agent_policy(
+        identity=openclaw,
+        action="context_pack.request",
+        domains=("project", "health"),
+        sensitivity_allowed=("public", "private", "highly_sensitive"),
+        project_scope=("Alice",),
+    )
+    blocked = evaluate_agent_policy(
+        identity=openclaw,
+        action="context_pack.request",
+        domains=("family", "health"),
+        sensitivity_allowed=("private",),
+        project_scope=("Alice",),
+    )
+
+    assert filtered.decision == "allowed_with_filtering"
+    assert filtered.effective_domains == ("project",)
+    assert filtered.effective_sensitivity_allowed == ("public", "private")
+    assert "restricted_domain_filtered" in filtered.reasons
+    assert "restricted_sensitivity_filtered" in filtered.reasons
+    assert blocked.decision == "blocked"
+    assert "all_requested_domains_restricted" in blocked.reasons
+
+
+def test_policy_requires_review_for_agent_memory_proposals_and_blocks_auto_promotion() -> None:
+    agent = AgentIdentity.from_payload(
+        {
+            "agent_id": "memory-bot",
+            "permission_profile": "memory_proposal_agent",
+            "project_scope": ["Alice"],
+        }
+    )
+    assert agent is not None
+
+    proposal = evaluate_agent_policy(
+        identity=agent,
+        action="memory.propose",
+        domains=("project",),
+        sensitivity_allowed=("private",),
+        project_scope=("Alice",),
+    )
+    auto_promotion = evaluate_agent_policy(
+        identity=agent,
+        action="memory.propose",
+        domains=("project",),
+        sensitivity_allowed=("private",),
+        project_scope=("Alice",),
+        write_policy="trusted_write",
+    )
+
+    assert proposal.decision == "requires_review"
+    assert proposal.review_required is True
+    assert auto_promotion.decision == "blocked"
+    assert "no_auto_promotion" in auto_promotion.reasons
+    with pytest.raises(AgentPolicyBlockedError):
+        ensure_policy_allowed(auto_promotion)
+
+
+def test_scheduler_policy_distinguishes_project_scoped_trusted_and_admin_agents() -> None:
+    openclaw = AgentIdentity.from_payload({"agent_id": "openclaw", "project_scope": ["Alice"]})
+    hermes = AgentIdentity.from_payload({"agent_id": "hermes"})
+    admin = AgentIdentity.from_payload({"agent_id": "ops", "permission_profile": "admin_agent"})
+    assert openclaw is not None and hermes is not None and admin is not None
+
+    project_report = evaluate_agent_policy(
+        identity=openclaw,
+        action="scheduler.run_now",
+        domains=("project",),
+        project_scope=("Alice",),
+        workflow_type="project_update_scan",
+    )
+    daily = evaluate_agent_policy(
+        identity=openclaw,
+        action="scheduler.run_now",
+        domains=("project",),
+        project_scope=("Alice",),
+        workflow_type="daily_brief",
+    )
+    project_due = evaluate_agent_policy(
+        identity=openclaw,
+        action="scheduler.run_due",
+        domains=("project",),
+        project_scope=("Alice",),
+    )
+    pause = evaluate_agent_policy(identity=hermes, action="scheduler.pause")
+    run_due = evaluate_agent_policy(identity=hermes, action="scheduler.run_due")
+    configure = evaluate_agent_policy(identity=admin, action="scheduler.configure")
+
+    assert project_report.decision == "allowed"
+    assert daily.decision == "blocked"
+    assert "project_scoped_agent_cannot_run_global_workflow" in daily.reasons
+    assert project_due.decision == "blocked"
+    assert "project_scoped_agent_cannot_trigger_global_scheduler" in project_due.reasons
+    assert pause.decision == "allowed"
+    assert run_due.decision == "allowed"
+    assert configure.decision == "allowed"
+
+
+def test_policy_events_log_decision_and_filtered_or_blocked_outcomes() -> None:
+    store = EventStore()
+    agent = AgentIdentity.from_payload({"agent_id": "openclaw", "project_scope": ["Alice"]})
+    assert agent is not None
+    decision = evaluate_agent_policy(
+        identity=agent,
+        action="context_pack.request",
+        domains=("project", "family"),
+        project_scope=("Alice",),
+    )
+
+    append_policy_events(store, identity=agent, decision=decision, target_type="context_pack", target_id="pack-1")
+
+    event_types = [event["event_type"] for event in store.events]
+    assert event_types == ["policy.decision", "agent.policy_filtered"]
+    assert store.events[0]["actor_id"] == "openclaw"
+    assert store.events[0]["trace_id"] == decision.trace_id

--- a/tests/unit/test_vnext_brain.py
+++ b/tests/unit/test_vnext_brain.py
@@ -17,17 +17,17 @@ class InMemoryVNextBrainStore:
         self.events.append(event)
         return event
 
-    def create_artifact(self, artifact: dict[str, object]) -> dict[str, object]:
+    def create_artifact(self, artifact: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**artifact, "id": f"artifact-{len(self.artifacts) + 1}"}
         self.artifacts[str(row["id"])] = row
         return row
 
-    def create_memory(self, memory: dict[str, object]) -> dict[str, object]:
+    def create_memory(self, memory: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**memory, "id": f"memory-{len(self.memories) + 1}"}
         self.memories.append(row)
         return row
 
-    def create_open_loop(self, loop: dict[str, object]) -> dict[str, object]:
+    def create_open_loop(self, loop: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**loop, "id": f"loop-{len(self.open_loops) + 1}"}
         self.open_loops.append(row)
         return row

--- a/tests/unit/test_vnext_capture.py
+++ b/tests/unit/test_vnext_capture.py
@@ -37,7 +37,7 @@ class InMemoryVNextCaptureStore:
         self.calls.append("get_source_by_content_hash")
         return self._source_by_hash.get(content_hash)
 
-    def create_source(self, source: dict[str, object]) -> dict[str, object]:
+    def create_source(self, source: dict[str, object], **_kwargs) -> dict[str, object]:
         self.calls.append("create_source")
         row = {
             **source,
@@ -48,7 +48,7 @@ class InMemoryVNextCaptureStore:
         self._source_by_hash[str(source["content_hash"])] = row
         return row
 
-    def create_source_chunk(self, chunk: dict[str, object]) -> dict[str, object]:
+    def create_source_chunk(self, chunk: dict[str, object], **_kwargs) -> dict[str, object]:
         self.calls.append("create_source_chunk")
         row = {
             **chunk,
@@ -58,7 +58,7 @@ class InMemoryVNextCaptureStore:
         self.chunks.append(row)
         return row
 
-    def create_memory(self, memory: dict[str, object]) -> dict[str, object]:
+    def create_memory(self, memory: dict[str, object], **_kwargs) -> dict[str, object]:
         self.calls.append("create_memory")
         row = {
             **memory,
@@ -68,7 +68,7 @@ class InMemoryVNextCaptureStore:
         self.memories.append(row)
         return row
 
-    def create_provenance_link(self, link: dict[str, object]) -> dict[str, object]:
+    def create_provenance_link(self, link: dict[str, object], **_kwargs) -> dict[str, object]:
         self.calls.append("create_provenance_link")
         row = {
             **link,

--- a/tests/unit/test_vnext_connectors.py
+++ b/tests/unit/test_vnext_connectors.py
@@ -37,23 +37,23 @@ class InMemoryVNextConnectorStore:
     def get_source_by_content_hash(self, content_hash: str) -> dict[str, object] | None:
         return self._source_by_hash.get(content_hash)
 
-    def create_source(self, source: dict[str, object]) -> dict[str, object]:
+    def create_source(self, source: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**source, "id": f"source-{len(self.sources) + 1}"}
         self.sources.append(row)
         self._source_by_hash[str(source["content_hash"])] = row
         return row
 
-    def create_source_chunk(self, chunk: dict[str, object]) -> dict[str, object]:
+    def create_source_chunk(self, chunk: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**chunk, "id": f"chunk-{len(self.chunks) + 1}"}
         self.chunks.append(row)
         return row
 
-    def create_memory(self, memory: dict[str, object]) -> dict[str, object]:
+    def create_memory(self, memory: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**memory, "id": f"memory-{len(self.memories) + 1}"}
         self.memories.append(row)
         return row
 
-    def create_provenance_link(self, link: dict[str, object]) -> dict[str, object]:
+    def create_provenance_link(self, link: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**link, "id": f"provenance-{len(self.provenance_links) + 1}"}
         self.provenance_links.append(row)
         return row

--- a/tests/unit/test_vnext_main.py
+++ b/tests/unit/test_vnext_main.py
@@ -32,7 +32,7 @@ class FakeVNextStore:
     def get_source_by_content_hash(self, content_hash: str) -> dict[str, object] | None:
         return self.source_by_hash.get(content_hash)
 
-    def create_source(self, source: dict[str, object]) -> dict[str, object]:
+    def create_source(self, source: dict[str, object], **_kwargs) -> dict[str, object]:
         source_id = str(uuid4())
         row = {**source, "id": source_id}
         self.sources[source_id] = row
@@ -45,39 +45,39 @@ class FakeVNextStore:
             return source
         return None
 
-    def delete_source(self, *, source_id: str) -> dict[str, object]:
+    def delete_source(self, *, source_id: str, **_kwargs) -> dict[str, object]:
         source = self.sources[source_id]
         source["deleted_at"] = "now"
         return source
 
-    def create_source_chunk(self, chunk: dict[str, object]) -> dict[str, object]:
+    def create_source_chunk(self, chunk: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**chunk, "id": f"chunk-{len(self.chunks) + 1}"}
         self.chunks.append(row)
         return row
 
-    def create_memory(self, memory: dict[str, object]) -> dict[str, object]:
+    def create_memory(self, memory: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**memory, "id": f"memory-{len(self.memories) + 1}"}
         self.memories.append(row)
         return row
 
-    def update_memory(self, *, memory_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_memory(self, *, memory_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         for memory in self.memories:
             if memory["id"] == memory_id:
                 memory.update(patch)
                 return memory
         raise AssertionError(memory_id)
 
-    def append_revision(self, revision: dict[str, object]) -> dict[str, object]:
+    def append_revision(self, revision: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**revision, "id": f"revision-{len(self.revisions) + 1}"}
         self.revisions.append(row)
         return row
 
-    def create_provenance_link(self, link: dict[str, object]) -> dict[str, object]:
+    def create_provenance_link(self, link: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**link, "id": f"provenance-{len(self.provenance_links) + 1}"}
         self.provenance_links.append(row)
         return row
 
-    def create_open_loop(self, loop: dict[str, object]) -> dict[str, object]:
+    def create_open_loop(self, loop: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**loop, "id": f"loop-{len(self.open_loops) + 1}", "status": loop.get("status", "open")}
         self.open_loops.append(row)
         return row
@@ -130,7 +130,7 @@ class FakeVNextStore:
                 return loop
         return None
 
-    def update_open_loop(self, *, loop_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_open_loop(self, *, loop_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         loop = self.get_open_loop(loop_id)
         if loop is None:
             raise AssertionError(loop_id)
@@ -143,6 +143,7 @@ class FakeVNextStore:
         loop_id: str,
         status: str,
         resolution_note: str | None = None,
+        **_kwargs,
     ) -> dict[str, object]:
         loop = self.update_open_loop(loop_id=loop_id, patch={"status": status})
         if resolution_note is not None:
@@ -156,7 +157,7 @@ class FakeVNextStore:
             if link.get("target_type") == target_type and link.get("target_id") == target_id
         ]
 
-    def create_task(self, task: dict[str, object]) -> dict[str, object]:
+    def create_task(self, task: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**task, "id": str(uuid4()), "status": task.get("status", "pending")}
         self.tasks.append(row)
         return row
@@ -174,6 +175,7 @@ class FakeVNextStore:
         task_id: str,
         status: str,
         details: dict[str, object] | None = None,
+        **_kwargs,
     ) -> dict[str, object]:
         for task in self.tasks:
             if task.get("id") == task_id:
@@ -183,7 +185,7 @@ class FakeVNextStore:
                 return task
         raise AssertionError(task_id)
 
-    def create_artifact(self, artifact: dict[str, object]) -> dict[str, object]:
+    def create_artifact(self, artifact: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**artifact, "id": str(uuid4())}
         self.artifacts[str(row["id"])] = row
         return row
@@ -207,7 +209,7 @@ class FakeVNextStore:
         ]
         return rows[:limit]
 
-    def update_artifact_status(self, *, artifact_id: str, status: str) -> dict[str, object]:
+    def update_artifact_status(self, *, artifact_id: str, status: str, **_kwargs) -> dict[str, object]:
         artifact = self.artifacts[artifact_id]
         artifact["status"] = status
         return artifact
@@ -227,7 +229,7 @@ class FakeVNextStore:
         rows = [row for row in self.projects.values() if status is None or row.get("status") == status]
         return rows[:limit]
 
-    def update_project(self, *, project_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_project(self, *, project_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         project = self.projects[project_id]
         project.update(patch)
         return project

--- a/tests/unit/test_vnext_projects.py
+++ b/tests/unit/test_vnext_projects.py
@@ -19,7 +19,7 @@ class InMemoryVNextProjectStore:
         self.events.append(event)
         return event
 
-    def create_artifact(self, artifact: dict[str, object]) -> dict[str, object]:
+    def create_artifact(self, artifact: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**artifact, "id": f"artifact-{len(self.artifacts) + 1}"}
         self.artifacts[str(row["id"])] = row
         return row
@@ -27,22 +27,22 @@ class InMemoryVNextProjectStore:
     def get_artifact(self, artifact_id: str) -> dict[str, object] | None:
         return self.artifacts.get(artifact_id)
 
-    def update_artifact_status(self, *, artifact_id: str, status: str) -> dict[str, object]:
+    def update_artifact_status(self, *, artifact_id: str, status: str, **_kwargs) -> dict[str, object]:
         artifact = self.artifacts[artifact_id]
         artifact["status"] = status
         return artifact
 
-    def create_memory(self, memory: dict[str, object]) -> dict[str, object]:
+    def create_memory(self, memory: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**memory, "id": f"memory-{len(self.memories) + 1}"}
         self.memories[str(row["id"])] = row
         return row
 
-    def update_memory(self, *, memory_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_memory(self, *, memory_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         memory = self.memories[memory_id]
         memory.update(patch)
         return memory
 
-    def append_revision(self, revision: dict[str, object]) -> dict[str, object]:
+    def append_revision(self, revision: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**revision, "id": f"revision-{len(self.revisions) + 1}"}
         self.revisions.append(row)
         return row
@@ -61,12 +61,12 @@ class InMemoryVNextProjectStore:
         rows = [row for row in self.projects.values() if status is None or row.get("status") == status]
         return _filter_rows(rows, domains=domains, sensitivity_allowed=sensitivity_allowed)[:limit]
 
-    def update_project(self, *, project_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_project(self, *, project_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         project = self.projects[project_id]
         project.update(patch)
         return project
 
-    def create_open_loop(self, loop: dict[str, object]) -> dict[str, object]:
+    def create_open_loop(self, loop: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**loop, "id": f"loop-{len(self.open_loops) + 1}", "status": loop.get("status", "open")}
         self.open_loops[str(row["id"])] = row
         return row
@@ -93,7 +93,7 @@ class InMemoryVNextProjectStore:
         ]
         return _filter_rows(rows, domains=domains, sensitivity_allowed=sensitivity_allowed)[:limit]
 
-    def update_open_loop(self, *, loop_id: str, patch: dict[str, object]) -> dict[str, object]:
+    def update_open_loop(self, *, loop_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
         loop = self.open_loops[loop_id]
         loop.update(patch)
         return loop
@@ -104,6 +104,7 @@ class InMemoryVNextProjectStore:
         loop_id: str,
         status: str,
         resolution_note: str | None = None,
+        **_kwargs,
     ) -> dict[str, object]:
         loop = self.open_loops[loop_id]
         loop["status"] = status

--- a/tests/unit/test_vnext_queue.py
+++ b/tests/unit/test_vnext_queue.py
@@ -18,7 +18,7 @@ class InMemoryVNextQueueStore:
         self.events.append(event)
         return event
 
-    def create_task(self, task: dict[str, object]) -> dict[str, object]:
+    def create_task(self, task: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {
             **task,
             "id": f"task-{len(self.tasks) + 1}",
@@ -40,6 +40,7 @@ class InMemoryVNextQueueStore:
         task_id: str,
         status: str,
         details: dict[str, object] | None = None,
+        **_kwargs,
     ) -> dict[str, object]:
         for task in self.tasks:
             if task["id"] != task_id:
@@ -50,7 +51,7 @@ class InMemoryVNextQueueStore:
             return task
         raise AssertionError(f"missing task {task_id}")
 
-    def create_artifact(self, artifact: dict[str, object]) -> dict[str, object]:
+    def create_artifact(self, artifact: dict[str, object], **_kwargs) -> dict[str, object]:
         if self.fail_artifact_create:
             raise RuntimeError("artifact renderer failed")
         row = {
@@ -63,7 +64,7 @@ class InMemoryVNextQueueStore:
     def get_artifact(self, artifact_id: str) -> dict[str, object] | None:
         return self.artifacts.get(artifact_id)
 
-    def update_artifact_status(self, *, artifact_id: str, status: str) -> dict[str, object]:
+    def update_artifact_status(self, *, artifact_id: str, status: str, **_kwargs) -> dict[str, object]:
         artifact = self.artifacts[artifact_id]
         artifact["status"] = status
         return artifact

--- a/tests/unit/test_vnext_scheduler.py
+++ b/tests/unit/test_vnext_scheduler.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from alicebot_api.vnext_scheduler import (
+    SchedulerRunRequest,
+    VNextSchedulerService,
+    VNextSchedulerValidationError,
+    compute_next_run_at,
+    validate_schedule,
+)
+
+
+class InMemorySchedulerStore:
+    def __init__(self, *, fail_artifact_create: bool = False) -> None:
+        self.fail_artifact_create = fail_artifact_create
+        self.events: list[dict[str, object]] = []
+        self.workflows: dict[str, dict[str, object]] = {}
+        self.runs: dict[str, dict[str, object]] = {}
+        self.artifacts: dict[str, dict[str, object]] = {}
+        self.sources: list[dict[str, object]] = [
+            {
+                "id": "source-1",
+                "source_type": "manual_text",
+                "title": "Daily scheduler note",
+                "domain": "project",
+                "sensitivity": "private",
+                "captured_at": "2026-05-10T08:00:00Z",
+                "metadata_json": {"raw_text": "TODO: review scheduled daily brief"},
+            }
+        ]
+        self.memories: list[dict[str, object]] = [
+            {
+                "id": "memory-1",
+                "memory_type": "project_state",
+                "canonical_text": "Scheduler generated artifacts stay reviewable.",
+                "status": "active",
+                "domain": "project",
+                "sensitivity": "private",
+            }
+        ]
+        self.open_loops: list[dict[str, object]] = []
+
+    def append_event(self, event: dict[str, object]) -> dict[str, object]:
+        self.events.append(event)
+        return event
+
+    def upsert_scheduler_workflow(self, workflow: dict[str, object], *, actor_type: str = "system") -> dict[str, object]:
+        workflow_type = str(workflow["workflow_type"])
+        row = {
+            "id": f"workflow-{workflow_type}",
+            "workflow_type": workflow_type,
+            "enabled": bool(workflow.get("enabled", False)),
+            "paused": bool(workflow.get("paused", False)),
+            "schedule_json": workflow.get("schedule_json", {"kind": "manual"}),
+            "timezone": workflow.get("timezone", "UTC"),
+            "next_run_at": workflow.get("next_run_at"),
+            "metadata_json": workflow.get("metadata_json", {}),
+            "last_run_id": None,
+            "last_run_at": None,
+            "last_result": None,
+            "last_error": None,
+        }
+        self.workflows[workflow_type] = row
+        self.append_event({"event_type": "scheduler.workflow_upserted", "actor_type": actor_type})
+        return row
+
+    def update_scheduler_workflow(
+        self,
+        *,
+        workflow_type: str,
+        patch: dict[str, object],
+        actor_type: str = "system",
+    ) -> dict[str, object]:
+        row = self.workflows[workflow_type]
+        row.update(
+            {
+                key: value
+                for key, value in patch.items()
+                if value is not None or key in {"last_error", "next_run_at"}
+            }
+        )
+        self.append_event({"event_type": "scheduler.workflow_updated", "actor_type": actor_type})
+        return row
+
+    def get_scheduler_workflow(self, workflow_type: str) -> dict[str, object] | None:
+        return self.workflows.get(workflow_type)
+
+    def list_scheduler_workflows(self) -> list[dict[str, object]]:
+        return list(self.workflows.values())
+
+    def create_scheduler_run(self, run: dict[str, object], *, actor_type: str = "scheduler") -> dict[str, object]:
+        row = {
+            **run,
+            "id": f"run-{len(self.runs) + 1}",
+            "started_at": "2026-05-10T08:00:00Z",
+            "finished_at": None,
+            "artifact_id": None,
+            "error_message": None,
+        }
+        self.runs[str(row["id"])] = row
+        self.append_event(
+            {
+                "event_type": "scheduler.run_started",
+                "actor_type": actor_type,
+                "run_id": row["id"],
+                "trace_id": row["trace_id"],
+            }
+        )
+        return row
+
+    def update_scheduler_run(
+        self,
+        *,
+        run_id: str,
+        patch: dict[str, object],
+        actor_type: str = "scheduler",
+    ) -> dict[str, object]:
+        row = self.runs[run_id]
+        row.update(patch)
+        if row["status"] in {"succeeded", "failed"}:
+            row["finished_at"] = "2026-05-10T08:01:00Z"
+        event_type = "scheduler.run_succeeded" if row["status"] == "succeeded" else "scheduler.run_failed"
+        self.append_event(
+            {
+                "event_type": event_type,
+                "actor_type": actor_type,
+                "run_id": row["id"],
+                "trace_id": row["trace_id"],
+            }
+        )
+        return row
+
+    def list_scheduler_runs(self, *, workflow_type: str | None = None, limit: int = 20) -> list[dict[str, object]]:
+        rows = [
+            row
+            for row in self.runs.values()
+            if workflow_type is None or row["workflow_type"] == workflow_type
+        ]
+        return rows[:limit]
+
+    def create_artifact(self, artifact: dict[str, object], *, actor_type: str = "system") -> dict[str, object]:
+        if self.fail_artifact_create:
+            raise RuntimeError("artifact store unavailable")
+        row = {**artifact, "id": f"artifact-{len(self.artifacts) + 1}"}
+        self.artifacts[str(row["id"])] = row
+        self.append_event({"event_type": "artifact.created", "actor_type": actor_type, "target_id": row["id"]})
+        return row
+
+    def search_sources(self, **kwargs) -> list[dict[str, object]]:
+        return self.sources[: kwargs.get("limit", 8)]
+
+    def search_memories(self, **kwargs) -> list[dict[str, object]]:
+        return self.memories[: kwargs.get("limit", 8)]
+
+    def list_open_loops(self, **_kwargs) -> list[dict[str, object]]:
+        return list(self.open_loops)
+
+    def list_artifacts(self, **kwargs) -> list[dict[str, object]]:
+        return list(self.artifacts.values())[: kwargs.get("limit", 8)]
+
+
+def test_schedule_validation_and_next_run_are_deterministic() -> None:
+    schedule = validate_schedule(
+        "daily_brief",
+        {"kind": "daily", "time_of_day": "08:30", "days_of_week": ["monday", "wednesday"]},
+    )
+    next_run = compute_next_run_at(
+        workflow_type="daily_brief",
+        enabled=True,
+        paused=False,
+        schedule_json=schedule,
+        timezone="UTC",
+        now=datetime(2026, 5, 11, 8, 0, tzinfo=UTC),
+    )
+
+    assert schedule == {"kind": "daily", "time_of_day": "08:30", "days_of_week": ["monday", "wednesday"]}
+    assert next_run == "2026-05-11T08:30:00+00:00"
+    with pytest.raises(VNextSchedulerValidationError, match="time_of_day"):
+        validate_schedule("daily_brief", {"kind": "daily", "time_of_day": "bad"})
+
+
+def test_scheduler_defaults_are_disabled_and_run_now_creates_reviewable_artifact_only() -> None:
+    store = InMemorySchedulerStore()
+    service = VNextSchedulerService(store)
+
+    status = service.status()
+    configured = service.configure_workflow(
+        workflow_type="daily_brief",
+        enabled=True,
+        schedule_json={"kind": "daily", "time_of_day": "08:00", "days_of_week": ["monday"]},
+        timezone="UTC",
+    )
+    result = service.run_now(
+        SchedulerRunRequest(
+            workflow_type="daily_brief",
+            domains=("project",),
+            sensitivity_allowed=("public", "private"),
+            generated_for="2026-05-11",
+        )
+    )
+
+    assert status["disabled_by_default"] is True
+    assert status["enabled_count"] == 0
+    assert configured["enabled"] is True
+    assert result["run"]["status"] == "succeeded"
+    assert result["artifact"]["status"] == "needs_review"
+    assert result["artifact"]["generated_by"] == "scheduler"
+    assert result["artifact"]["metadata_json"]["scheduler_run_id"] == result["run"]["id"]
+    assert [memory["status"] for memory in store.memories] == ["active"]
+    assert "scheduler.run_started" in [event["event_type"] for event in store.events]
+    assert "scheduler.run_succeeded" in [event["event_type"] for event in store.events]
+    assert "scheduler.artifact_created" in [event["event_type"] for event in store.events]
+
+
+def test_scheduler_run_due_executes_due_enabled_workflows_and_advances_next_run() -> None:
+    store = InMemorySchedulerStore()
+    service = VNextSchedulerService(store)
+    service.configure_workflow(
+        workflow_type="daily_brief",
+        enabled=True,
+        schedule_json={"kind": "daily", "time_of_day": "08:00", "days_of_week": ["monday"]},
+        timezone="UTC",
+    )
+    store.workflows["daily_brief"]["next_run_at"] = "2026-05-11T08:00:00+00:00"
+
+    result = service.run_due_workflows(now=datetime(2026, 5, 11, 8, 5, tzinfo=UTC))
+
+    assert result["due_count"] == 1
+    assert result["runs"][0]["workflow_type"] == "daily_brief"
+    assert result["runs"][0]["run"]["status"] == "succeeded"
+    assert result["runs"][0]["artifact"]["status"] == "needs_review"
+    assert store.workflows["daily_brief"]["next_run_at"] != "2026-05-11T08:00:00+00:00"
+    assert "scheduler.due_scan" in [event["event_type"] for event in store.events]
+
+
+def test_scheduler_pause_clears_stale_next_run() -> None:
+    store = InMemorySchedulerStore()
+    service = VNextSchedulerService(store)
+    service.configure_workflow(
+        workflow_type="daily_brief",
+        enabled=True,
+        schedule_json={"kind": "daily", "time_of_day": "08:00", "days_of_week": ["monday"]},
+        timezone="UTC",
+    )
+
+    paused = service.configure_workflow(workflow_type="daily_brief", paused=True)
+
+    assert paused["paused"] is True
+    assert paused["next_run_at"] is None
+
+
+def test_scheduler_failure_marks_run_failed_without_raising() -> None:
+    store = InMemorySchedulerStore(fail_artifact_create=True)
+    service = VNextSchedulerService(store)
+
+    result = service.run_now(SchedulerRunRequest(workflow_type="project_update_scan", domains=("project",)))
+
+    assert result["artifact"] is None
+    assert result["run"]["status"] == "failed"
+    assert result["run"]["error_message"] == "artifact store unavailable"
+    assert store.workflows["project_update_scan"]["last_result"] == "failed"
+    assert store.workflows["project_update_scan"]["last_error"] == "artifact store unavailable"


### PR DESCRIPTION
## Summary
- Adds vNext agent identities, permission profiles, policy decisions, and audit events across API, CLI, and MCP.
- Adds the governed local scheduler with persisted workflow/run state, run-now, run-due, pause/resume, and reviewable generated artifacts.
- Expands the /vnext workspace with Agent Activity and Schedules surfaces, plus docs including the CTO summary.

## Upgrade Overview
### Protected Areas
- [x] memory schema
- [x] continuity APIs
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic

### Compatibility Impact
Adds new vNext tables and endpoints while preserving existing stable v0.5.1 behavior. Existing vNext callers keep their current context-pack, project, review, and artifact paths; new agent and scheduler fields are additive.

### Migration / Rollout
Alembic revision 20260511_0068 creates agent identity and scheduler tables with RLS policies and grants. Rollout is the standard migration path through ./scripts/migrate.sh before enabling scheduler workflows.

### Operator Action
Operators should run migrations, review the new /vnext Agent Activity and Schedules views, and explicitly enable any scheduler workflows they want. Scheduler defaults remain disabled, and generated output remains review-only.

### Validation
Validated with py_compile, full unit tests, full integration tests, web test/lint/build, eval suite, agentic scheduler smoke, migration check, and git diff --check.

### Rollback
Disable or pause scheduler workflows first. If rollback is required before use, revert this PR and run the Alembic downgrade for revision 20260511_0068 to drop the new scheduler and agent identity tables.

## Validation
- ./.venv/bin/python -m py_compile apps/api/src/alicebot_api/vnext_agent_control.py apps/api/src/alicebot_api/vnext_scheduler.py apps/api/src/alicebot_api/vnext_store.py apps/api/src/alicebot_api/cli.py apps/api/src/alicebot_api/main.py apps/api/src/alicebot_api/mcp_tools.py
- ./.venv/bin/pytest tests/unit -q
- ./.venv/bin/pytest tests/integration -q
- pnpm --dir apps/web test
- pnpm --dir apps/web lint
- pnpm --dir apps/web build
- ./.venv/bin/alicebot eval run --suite all
- ./.venv/bin/alicebot vnext smoke agentic-scheduler
- ./scripts/migrate.sh
- git diff --check

## Notes
- This is one coherent sprint, so this PR carries the whole phase.
- Scheduler output remains review-only; no agent or scheduler path auto-promotes trusted memory.