### PR TITLE
[codex] Build vNext local runtime scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ Alice vNext is the next release candidate for the true second-brain product. It 
 - **Alice Brain**: user-facing second-brain workflows such as daily briefs, weekly syntheses, context packs, contradiction reports, project updates, open loops, and reviewable artifacts.
 - **Alice Agent Memory**: CLI, API, and MCP surfaces that let agents capture, retrieve, resume, explain, generate context, propose memory, and trigger governed workflows without owning the memory store.
 
-The vNext preview currently includes deterministic source capture, retrieval/context packs, queue/artifact workflows, daily and weekly brain artifacts, connection/contradiction/project/open-loop workflows, synthetic evals, deterministic connector payload ingestion, agent identity/policy auditing, a governed local scheduler with due scans, and a live/fixture-backed `/vnext` operator workspace.
+The vNext preview currently includes deterministic source capture, retrieval/context packs, queue/artifact workflows, daily and weekly brain artifacts, connection/contradiction/project/open-loop workflows, synthetic evals, deterministic connector payload ingestion, agent identity/policy auditing, a governed local scheduler with due scans, a local scheduler daemon, policy telemetry, and a live/fixture-backed `/vnext` operator workspace.
 
 Start with:
 
 - [vNext overview](docs/vnext/README.md)
 - [vNext quickstart](docs/vnext/quickstart.md)
 - [vNext architecture](docs/vnext/architecture.md)
+- [vNext local runtime](docs/vnext/local-runtime.md)
 - [vNext security and privacy](docs/vnext/security-privacy.md)
 - [Example ALICE.md](docs/vnext/ALICE.example.md)
 - [vNext demo video script](docs/vnext/demo-video-script.md)
@@ -53,6 +54,7 @@ Start with:
 - [vNext preview release notes](docs/release/v0.5.1-vnext-preview-release-notes.md)
 - [vNext preview tag plan](docs/release/v0.5.1-vnext-preview-tag-plan.md)
 - [Agentic control plane CTO summary](docs/vnext-agentic-control-plane-cto-summary.md)
+- [Local runtime CTO summary](docs/vnext-local-runtime-cto-summary.md)
 
 ## Release Boundary (`v0.5.1`)
 
@@ -392,8 +394,10 @@ Deferred beyond `v0.5.1`:
 - [vNext Preview](docs/vnext/README.md)
 - [vNext Quickstart](docs/vnext/quickstart.md)
 - [vNext Architecture](docs/vnext/architecture.md)
+- [vNext Local Runtime](docs/vnext/local-runtime.md)
 - [vNext Security and Privacy](docs/vnext/security-privacy.md)
 - [Agentic Control Plane CTO Summary](docs/vnext-agentic-control-plane-cto-summary.md)
+- [Local Runtime CTO Summary](docs/vnext-local-runtime-cto-summary.md)
 - [Quickstart](docs/quickstart/local-setup-and-first-result.md)
 - [Architecture](ARCHITECTURE.md)
 - [MCP](docs/integrations/mcp.md)

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -9,6 +9,7 @@ import json
 import os
 from pathlib import Path
 import sys
+import tempfile
 from uuid import UUID, uuid4
 
 import psycopg
@@ -193,6 +194,7 @@ from alicebot_api.vnext_agent_control import (
     append_policy_events,
     ensure_policy_allowed,
     evaluate_agent_policy,
+    summarize_agent_policy_telemetry,
 )
 from alicebot_api.vnext_capture import VNextCaptureService, VNextCaptureValidationError
 from alicebot_api.vnext_brain import BrainArtifactRequest, VNextBrainService, VNextBrainValidationError
@@ -220,7 +222,17 @@ from alicebot_api.vnext_evals import (
 from alicebot_api.vnext_projects import ProjectAutomationRequest, VNextProjectService, VNextProjectValidationError
 from alicebot_api.vnext_queue import QueueTaskRequest, VNextQueueService, VNextQueueValidationError
 from alicebot_api.vnext_retrieval import VNextRetrievalRequest, VNextRetrievalService, VNextRetrievalValidationError
-from alicebot_api.vnext_scheduler import SchedulerRunRequest, VNextSchedulerService, VNextSchedulerValidationError
+from alicebot_api.vnext_scheduler import SchedulerRunRequest, VNextSchedulerService, VNextSchedulerValidationError, WORKFLOW_TYPES, default_schedule
+from alicebot_api.vnext_scheduler_runtime import (
+    DEFAULT_LOG_FILE,
+    DEFAULT_PID_FILE,
+    DEFAULT_STATUS_FILE,
+    SchedulerRuntimeConfig,
+    daemon_status,
+    run_foreground_daemon,
+    start_background_daemon,
+    stop_daemon,
+)
 from alicebot_api.vnext_event_log import append_event
 from alicebot_api.vnext_json import json_safe
 from alicebot_api.vnext_store import PostgresVNextStore
@@ -731,10 +743,42 @@ def _run_vnext_agent_propose_memory(ctx: CLIContext, args: argparse.Namespace) -
     return _json_dumps({"proposal": memory, "policy_decision": decision.to_record(), "review_required": True})
 
 
+def _run_vnext_agent_policy_telemetry(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _vnext_store_context(ctx) as store:
+        events = store.list_agent_events(agent_id=args.agent_id, limit=args.limit)
+        artifacts = store.list_artifacts(limit=args.limit)
+        memories = store.list_memories(status=None)
+    return _json_dumps(
+        {
+            "summary": summarize_agent_policy_telemetry(
+                agent_events=events,
+                artifacts=artifacts,
+                memories=memories,
+            )
+        }
+    )
+
+
 def _run_vnext_scheduler_status(ctx: CLIContext, _args: argparse.Namespace) -> str:
     with _vnext_store_context(ctx) as store:
         payload = VNextSchedulerService(store).status()
     return _json_dumps(payload)
+
+
+def _run_vnext_scheduler_runs(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _vnext_store_context(ctx) as store:
+        runs = store.list_scheduler_runs(workflow_type=args.workflow_type, limit=args.limit)
+    return _json_dumps({"items": runs, "count": len(runs)})
+
+
+def _run_vnext_scheduler_failures(ctx: CLIContext, args: argparse.Namespace) -> str:
+    with _vnext_store_context(ctx) as store:
+        runs = [
+            run
+            for run in store.list_scheduler_runs(workflow_type=args.workflow_type, limit=max(args.limit * 4, args.limit))
+            if run.get("status") == "failed"
+        ][: args.limit]
+    return _json_dumps({"items": runs, "count": len(runs)})
 
 
 def _run_vnext_scheduler_run_now(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -794,6 +838,34 @@ def _run_vnext_scheduler_run_due(ctx: CLIContext, args: argparse.Namespace) -> s
     if payload is None or decision is None:
         raise RuntimeError("scheduler run-due did not complete")
     return _json_dumps({**payload, "policy_decision": decision.to_record()})
+
+
+def _scheduler_runtime_config(ctx: CLIContext, args: argparse.Namespace) -> SchedulerRuntimeConfig:
+    return SchedulerRuntimeConfig(
+        database_url=ctx.database_url,
+        user_id=ctx.user_id,
+        interval_seconds=args.interval_seconds,
+        limit=args.limit,
+        pid_file=Path(args.pid_file),
+        status_file=Path(args.status_file),
+        log_file=Path(args.log_file),
+        once=getattr(args, "once", False),
+    )
+
+
+def _run_vnext_scheduler_daemon_start(ctx: CLIContext, args: argparse.Namespace) -> str:
+    config = _scheduler_runtime_config(ctx, args)
+    if args.foreground:
+        return _json_dumps(run_foreground_daemon(config))
+    return _json_dumps(start_background_daemon(config))
+
+
+def _run_vnext_scheduler_daemon_status(_ctx: CLIContext, args: argparse.Namespace) -> str:
+    return _json_dumps(daemon_status(pid_file=Path(args.pid_file), status_file=Path(args.status_file)))
+
+
+def _run_vnext_scheduler_daemon_stop(_ctx: CLIContext, args: argparse.Namespace) -> str:
+    return _json_dumps(stop_daemon(pid_file=Path(args.pid_file), status_file=Path(args.status_file)))
 
 
 def _run_vnext_scheduler_pause(ctx: CLIContext, args: argparse.Namespace) -> str:
@@ -1021,6 +1093,173 @@ def _run_vnext_smoke_agentic_scheduler(ctx: CLIContext, _args: argparse.Namespac
             "due_run": due_decision.to_record(),
             "blocked": blocked_decision.to_record(),
         },
+    }
+    if payload["status"] != "passed":
+        raise RuntimeError(_json_dumps(payload))
+    return _json_dumps(payload)
+
+
+def _seed_local_runtime_smoke_inputs(store, smoke_id: str) -> None:
+    source = store.create_source(
+        {
+            "source_type": "manual_text",
+            "title": f"Local runtime smoke source {smoke_id}",
+            "content_hash": f"sha256:local-runtime-smoke-{smoke_id}",
+            "domain": "project",
+            "sensitivity": "private",
+            "metadata_json": {
+                "raw_text": (
+                    "Decision: Local runtime smoke should keep scheduled artifacts reviewable. "
+                    "TODO: inspect scheduler failures and policy telemetry after daemon scans."
+                ),
+                "smoke": "local-runtime",
+            },
+        },
+        actor_type="system",
+    )
+    memory = store.create_memory(
+        {
+            "memory_type": "project_state",
+            "memory_key": f"local_runtime_smoke.{smoke_id}",
+            "value": {"text": "The local runtime daemon runs governed scheduler workflows into reviewable artifacts."},
+            "status": "active",
+            "confidence": 0.8,
+            "title": "Local runtime smoke state",
+            "canonical_text": "The local runtime daemon runs governed scheduler workflows into reviewable artifacts.",
+            "summary": "Local runtime daemon smoke state.",
+            "domain": "project",
+            "sensitivity": "private",
+            "metadata_json": {"source_id": str(source["id"]), "smoke": "local-runtime"},
+        },
+        actor_type="system",
+    )
+    project = store.create_project(
+        {
+            "name": f"Local Runtime Smoke {smoke_id[:8]}",
+            "slug": f"local-runtime-smoke-{smoke_id[:8]}",
+            "status": "active",
+            "description": "Project used by the vNext local runtime smoke.",
+            "current_state": "Needs scheduled project update scan validation.",
+            "domain": "project",
+            "sensitivity": "private",
+            "metadata_json": {"smoke": "local-runtime"},
+        },
+        actor_type="system",
+    )
+    store.create_open_loop(
+        {
+            "memory_id": str(memory["id"]),
+            "title": "Inspect local runtime smoke output",
+            "status": "open",
+            "description": "Confirm daemon due scans appear in scheduler history and event logs.",
+            "priority": "normal",
+            "project_id": str(project["id"]),
+            "source_id": str(source["id"]),
+            "domain": "project",
+            "sensitivity": "private",
+            "metadata_json": {"smoke": "local-runtime"},
+        },
+        actor_type="system",
+    )
+
+
+def _run_vnext_smoke_local_runtime(ctx: CLIContext, _args: argparse.Namespace) -> str:
+    smoke_id = str(uuid4())
+    due_at = "2000-01-01T00:00:00+00:00"
+    with tempfile.TemporaryDirectory(prefix="alicebot-vnext-scheduler-") as tmpdir:
+        runtime_dir = Path(tmpdir)
+        with _vnext_store_context(ctx) as store:
+            service = VNextSchedulerService(store)
+            service.ensure_default_workflows()
+            _seed_local_runtime_smoke_inputs(store, smoke_id)
+            for workflow_type in WORKFLOW_TYPES:
+                store.update_scheduler_workflow(
+                    workflow_type=workflow_type,
+                    patch={
+                        "enabled": True,
+                        "paused": False,
+                        "schedule_json": default_schedule(workflow_type),
+                        "timezone": "UTC",
+                        "next_run_at": due_at,
+                        "last_error": None,
+                    },
+                    actor_type="system",
+                )
+
+        daemon_payload = run_foreground_daemon(
+            SchedulerRuntimeConfig(
+                database_url=ctx.database_url,
+                user_id=ctx.user_id,
+                interval_seconds=0.1,
+                limit=len(WORKFLOW_TYPES),
+                pid_file=runtime_dir / "scheduler.pid",
+                status_file=runtime_dir / "scheduler-status.json",
+                log_file=runtime_dir / "scheduler.log",
+                once=True,
+            )
+        )
+
+    last_due_scan = daemon_payload.get("last_due_scan") if isinstance(daemon_payload.get("last_due_scan"), dict) else {}
+    due_runs = last_due_scan.get("runs") if isinstance(last_due_scan, dict) and isinstance(last_due_scan.get("runs"), list) else []
+    artifacts = [run.get("artifact") for run in due_runs if isinstance(run, dict) and isinstance(run.get("artifact"), dict)]
+    required_metadata = {"workflow_type", "scheduler_run_id", "trace_id", "source_refs", "generated_by", "review_status"}
+    observed_workflows = {str(run.get("workflow_type")) for run in due_runs if isinstance(run, dict)}
+    metadata_complete = all(
+        artifact.get("generated_by") == "scheduler"
+        and artifact.get("status") == "needs_review"
+        and artifact.get("domain") is not None
+        and artifact.get("sensitivity") is not None
+        and required_metadata.issubset(set((artifact.get("metadata_json") or {}).keys()))
+        for artifact in artifacts
+        if isinstance(artifact, dict)
+    )
+    gates = {
+        "daemon_once_completed": daemon_payload.get("running") is False and daemon_payload.get("last_error") is None,
+        "due_scan_executed_all_workflows": observed_workflows == set(WORKFLOW_TYPES),
+        "daily_brief_scheduled": "daily_brief" in observed_workflows,
+        "weekly_synthesis_scheduled": "weekly_synthesis" in observed_workflows,
+        "connection_report_scheduled": "connection_report" in observed_workflows,
+        "contradiction_report_scheduled": "contradiction_report" in observed_workflows,
+        "open_loop_review_scheduled": "open_loop_review" in observed_workflows,
+        "project_update_scan_scheduled": "project_update_scan" in observed_workflows,
+        "scheduled_artifacts_reviewable": len(artifacts) == len(WORKFLOW_TYPES)
+        and all(isinstance(artifact, dict) and artifact.get("status") == "needs_review" for artifact in artifacts),
+        "scheduled_artifact_metadata_complete": metadata_complete,
+    }
+    daemon_summary = {
+        key: daemon_payload.get(key)
+        for key in (
+            "configured",
+            "running",
+            "mode",
+            "pid",
+            "started_at",
+            "stopped_at",
+            "last_heartbeat_at",
+            "last_due_scan_at",
+            "last_due_count",
+            "last_error",
+            "last_error_type",
+        )
+        if key in daemon_payload
+    }
+    run_summaries = [
+        {
+            "workflow_type": run.get("workflow_type"),
+            "run_id": ((run.get("run") or {}).get("id") if isinstance(run.get("run"), dict) else None),
+            "status": ((run.get("run") or {}).get("status") if isinstance(run.get("run"), dict) else None),
+            "artifact_id": ((run.get("artifact") or {}).get("id") if isinstance(run.get("artifact"), dict) else None),
+            "artifact_type": ((run.get("artifact") or {}).get("artifact_type") if isinstance(run.get("artifact"), dict) else None),
+        }
+        for run in due_runs
+        if isinstance(run, dict)
+    ]
+    payload = {
+        "status": "passed" if all(gates.values()) else "failed",
+        "smoke": "local-runtime",
+        "gates": gates,
+        "daemon": daemon_summary,
+        "runs": run_summaries,
     }
     if payload["status"] != "passed":
         raise RuntimeError(_json_dumps(payload))
@@ -2327,11 +2566,26 @@ def build_parser() -> argparse.ArgumentParser:
     vnext_agent_propose_parser.add_argument("--confidence", type=float, default=0.5, help="Proposal confidence.")
     vnext_agent_propose_parser.add_argument("--rationale", default=None, help="Proposal rationale.")
     vnext_agent_propose_parser.set_defaults(handler=_run_vnext_agent_propose_memory)
+    vnext_agent_telemetry_parser = vnext_agents_subparsers.add_parser(
+        "policy-telemetry",
+        help="Summarize vNext agent policy blocks, filters, reviews, workflows, and proposals.",
+    )
+    vnext_agent_telemetry_parser.add_argument("--agent-id", default=None, help="Optional agent id filter.")
+    vnext_agent_telemetry_parser.add_argument("--limit", type=int, default=200, help="Maximum agent events to summarize.")
+    vnext_agent_telemetry_parser.set_defaults(handler=_run_vnext_agent_policy_telemetry)
 
     vnext_scheduler_parser = vnext_subparsers.add_parser("scheduler", help="Governed local vNext scheduler controls.")
     vnext_scheduler_subparsers = vnext_scheduler_parser.add_subparsers(dest="vnext_scheduler_command", required=True)
     vnext_scheduler_status_parser = vnext_scheduler_subparsers.add_parser("status", help="Show scheduler status.")
     vnext_scheduler_status_parser.set_defaults(handler=_run_vnext_scheduler_status)
+    vnext_scheduler_runs_parser = vnext_scheduler_subparsers.add_parser("runs", help="List scheduler run history.")
+    vnext_scheduler_runs_parser.add_argument("--workflow-type", default=None, help="Optional workflow type filter.")
+    vnext_scheduler_runs_parser.add_argument("--limit", type=int, default=20, help="Maximum runs to return.")
+    vnext_scheduler_runs_parser.set_defaults(handler=_run_vnext_scheduler_runs)
+    vnext_scheduler_failures_parser = vnext_scheduler_subparsers.add_parser("failures", help="List failed scheduler runs.")
+    vnext_scheduler_failures_parser.add_argument("--workflow-type", default=None, help="Optional workflow type filter.")
+    vnext_scheduler_failures_parser.add_argument("--limit", type=int, default=20, help="Maximum failed runs to return.")
+    vnext_scheduler_failures_parser.set_defaults(handler=_run_vnext_scheduler_failures)
     vnext_scheduler_run_parser = vnext_scheduler_subparsers.add_parser("run-now", help="Run a workflow now.")
     _add_vnext_agent_arguments(vnext_scheduler_run_parser)
     vnext_scheduler_run_parser.add_argument("workflow_type", help="Workflow type, such as daily_brief.")
@@ -2354,6 +2608,25 @@ def build_parser() -> argparse.ArgumentParser:
     vnext_scheduler_resume_parser = vnext_scheduler_subparsers.add_parser("resume", help="Resume all scheduler workflows.")
     _add_vnext_agent_arguments(vnext_scheduler_resume_parser)
     vnext_scheduler_resume_parser.set_defaults(handler=_run_vnext_scheduler_resume)
+    vnext_scheduler_daemon_parser = vnext_scheduler_subparsers.add_parser("daemon", help="Run or inspect the local scheduler daemon.")
+    vnext_scheduler_daemon_subparsers = vnext_scheduler_daemon_parser.add_subparsers(dest="vnext_scheduler_daemon_command", required=True)
+    vnext_scheduler_daemon_start_parser = vnext_scheduler_daemon_subparsers.add_parser("start", help="Start the local scheduler daemon.")
+    vnext_scheduler_daemon_start_parser.add_argument("--foreground", action="store_true", help="Run in the foreground instead of spawning a background process.")
+    vnext_scheduler_daemon_start_parser.add_argument("--once", action="store_true", help="Run one due scan, then exit. Useful for local smoke tests.")
+    vnext_scheduler_daemon_start_parser.add_argument("--interval-seconds", type=float, default=60.0, help="Due-scan polling interval.")
+    vnext_scheduler_daemon_start_parser.add_argument("--limit", type=int, default=10, help="Maximum due workflows per scan.")
+    vnext_scheduler_daemon_start_parser.add_argument("--pid-file", default=str(DEFAULT_PID_FILE), help="Daemon pid file.")
+    vnext_scheduler_daemon_start_parser.add_argument("--status-file", default=str(DEFAULT_STATUS_FILE), help="Daemon status JSON file.")
+    vnext_scheduler_daemon_start_parser.add_argument("--log-file", default=str(DEFAULT_LOG_FILE), help="Daemon log file.")
+    vnext_scheduler_daemon_start_parser.set_defaults(handler=_run_vnext_scheduler_daemon_start)
+    vnext_scheduler_daemon_status_parser = vnext_scheduler_daemon_subparsers.add_parser("status", help="Show local scheduler daemon process status.")
+    vnext_scheduler_daemon_status_parser.add_argument("--pid-file", default=str(DEFAULT_PID_FILE), help="Daemon pid file.")
+    vnext_scheduler_daemon_status_parser.add_argument("--status-file", default=str(DEFAULT_STATUS_FILE), help="Daemon status JSON file.")
+    vnext_scheduler_daemon_status_parser.set_defaults(handler=_run_vnext_scheduler_daemon_status)
+    vnext_scheduler_daemon_stop_parser = vnext_scheduler_daemon_subparsers.add_parser("stop", help="Stop the local scheduler daemon process.")
+    vnext_scheduler_daemon_stop_parser.add_argument("--pid-file", default=str(DEFAULT_PID_FILE), help="Daemon pid file.")
+    vnext_scheduler_daemon_stop_parser.add_argument("--status-file", default=str(DEFAULT_STATUS_FILE), help="Daemon status JSON file.")
+    vnext_scheduler_daemon_stop_parser.set_defaults(handler=_run_vnext_scheduler_daemon_stop)
 
     vnext_smoke_parser = vnext_subparsers.add_parser("smoke", help="Run vNext smoke checks.")
     vnext_smoke_subparsers = vnext_smoke_parser.add_subparsers(dest="vnext_smoke_command", required=True)
@@ -2362,6 +2635,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run the agentic control-plane and governed scheduler smoke.",
     )
     vnext_smoke_agentic_scheduler_parser.set_defaults(handler=_run_vnext_smoke_agentic_scheduler)
+    vnext_smoke_local_runtime_parser = vnext_smoke_subparsers.add_parser(
+        "local-runtime",
+        help="Run the local scheduler daemon and due-workflow smoke.",
+    )
+    vnext_smoke_local_runtime_parser.set_defaults(handler=_run_vnext_smoke_local_runtime)
 
     mutations_parser = subparsers.add_parser("mutations", help="Generate, inspect, and apply memory operations.")
     mutations_subparsers = mutations_parser.add_subparsers(dest="mutations_command", required=True)

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -470,6 +470,7 @@ from alicebot_api.vnext_agent_control import (
     agent_metadata,
     append_policy_events,
     evaluate_agent_policy,
+    summarize_agent_policy_telemetry,
 )
 from alicebot_api.vnext_brain import BrainArtifactRequest, VNextBrainService, VNextBrainValidationError
 from alicebot_api.vnext_capture import VNextCaptureService, VNextCaptureValidationError
@@ -505,6 +506,7 @@ from alicebot_api.vnext_scheduler import (
     default_schedule,
     validate_schedule,
 )
+from alicebot_api.vnext_scheduler_runtime import daemon_status
 from alicebot_api.vnext_store import PostgresVNextStore
 from alicebot_api.continuity_lifecycle import (
     ContinuityLifecycleNotFoundError,
@@ -1538,6 +1540,12 @@ def _vnext_workspace_payload(store: PostgresVNextStore) -> dict[str, object]:
     agent_identities = store.list_agent_identities(limit=20)
     agent_events = store.list_agent_events(limit=50)
     scheduler_status = VNextSchedulerService(store).status()
+    scheduler_status = {**scheduler_status, "daemon": daemon_status()}
+    policy_telemetry = summarize_agent_policy_telemetry(
+        agent_events=agent_events,
+        artifacts=artifacts,
+        memories=review_memories,
+    )
     project_service = VNextProjectService(store)
     project_dashboards: list[dict[str, object]] = []
     for project in projects[:5]:
@@ -1592,6 +1600,7 @@ def _vnext_workspace_payload(store: PostgresVNextStore) -> dict[str, object]:
                 and memory["metadata_json"].get("agent_id") is not None
             ],
         },
+        "policy_telemetry": policy_telemetry,
         "scheduler": scheduler_status,
         "brain_charter": store.get_brain_charter(),
     }
@@ -6851,6 +6860,7 @@ def get_vnext_scheduler_status(user_id: UUID) -> JSONResponse:
 
     with user_connection(settings.database_url, user_id) as conn:
         payload = VNextSchedulerService(PostgresVNextStore(conn)).status()
+    payload = {**payload, "daemon": daemon_status()}
 
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
@@ -6863,6 +6873,38 @@ def list_vnext_scheduler_runs(user_id: UUID, workflow_type: str | None = None, l
         payload = PostgresVNextStore(conn).list_scheduler_runs(workflow_type=workflow_type, limit=limit)
 
     return JSONResponse(status_code=200, content=jsonable_encoder({"items": payload, "count": len(payload)}))
+
+
+@app.get("/v0/vnext/scheduler/failures")
+def list_vnext_scheduler_failures(user_id: UUID, workflow_type: str | None = None, limit: int = 20) -> JSONResponse:
+    settings = get_settings()
+
+    with user_connection(settings.database_url, user_id) as conn:
+        runs = [
+            run
+            for run in PostgresVNextStore(conn).list_scheduler_runs(
+                workflow_type=workflow_type,
+                limit=max(limit * 4, limit),
+            )
+            if run.get("status") == "failed"
+        ][:limit]
+
+    return JSONResponse(status_code=200, content=jsonable_encoder({"items": runs, "count": len(runs)}))
+
+
+@app.get("/v0/vnext/agents/policy-telemetry")
+def get_vnext_agent_policy_telemetry(user_id: UUID, agent_id: str | None = None, limit: int = 200) -> JSONResponse:
+    settings = get_settings()
+
+    with user_connection(settings.database_url, user_id) as conn:
+        store = PostgresVNextStore(conn)
+        payload = summarize_agent_policy_telemetry(
+            agent_events=store.list_agent_events(agent_id=agent_id, limit=limit),
+            artifacts=store.list_artifacts(limit=min(limit, 200)),
+            memories=store.list_memories(status=None),
+        )
+
+    return JSONResponse(status_code=200, content=jsonable_encoder({"summary": payload}))
 
 
 @app.patch("/v0/vnext/scheduler/workflows/{workflow_type}")

--- a/apps/api/src/alicebot_api/vnext_agent_control.py
+++ b/apps/api/src/alicebot_api/vnext_agent_control.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections import Counter, defaultdict
 from dataclasses import dataclass
-from typing import Mapping
+from typing import Iterable, Mapping
 from uuid import uuid4
 
 from alicebot_api.vnext_event_log import append_event
@@ -134,10 +135,13 @@ class PolicyDecision:
     action: str
     permission_profile: str
     reasons: tuple[str, ...] = ()
+    requested_domains: tuple[str, ...] = ()
     effective_domains: tuple[str, ...] = ()
+    requested_sensitivity_allowed: tuple[str, ...] = DEFAULT_AGENT_SENSITIVITY
     effective_sensitivity_allowed: tuple[str, ...] = DEFAULT_AGENT_SENSITIVITY
     review_required: bool = False
     trace_id: str = ""
+    workflow_type: str | None = None
 
     def to_record(self) -> JsonObject:
         return {
@@ -145,10 +149,13 @@ class PolicyDecision:
             "action": self.action,
             "permission_profile": self.permission_profile,
             "reasons": list(self.reasons),
+            "requested_domains": list(self.requested_domains),
             "effective_domains": list(self.effective_domains),
+            "requested_sensitivity_allowed": list(self.requested_sensitivity_allowed),
             "effective_sensitivity_allowed": list(self.effective_sensitivity_allowed),
             "review_required": self.review_required,
             "trace_id": self.trace_id,
+            "workflow_type": self.workflow_type,
         }
 
 
@@ -232,9 +239,12 @@ def evaluate_agent_policy(
             decision="allowed",
             action=action,
             permission_profile="user_or_system",
+            requested_domains=domains,
             effective_domains=domains,
+            requested_sensitivity_allowed=sensitivity_allowed,
             effective_sensitivity_allowed=sensitivity_allowed,
             trace_id=trace_id,
+            workflow_type=workflow_type,
         )
 
     profile = identity.permission_profile
@@ -308,11 +318,170 @@ def evaluate_agent_policy(
         action=action,
         permission_profile=profile,
         reasons=tuple(dict.fromkeys(reasons)),
+        requested_domains=domains,
         effective_domains=effective_domains,
+        requested_sensitivity_allowed=sensitivity_allowed,
         effective_sensitivity_allowed=effective_sensitivity,
         review_required=review_required or decision == "requires_review",
         trace_id=trace_id,
+        workflow_type=workflow_type,
     )
+
+
+def _event_payload(event: Mapping[str, object]) -> Mapping[str, object]:
+    payload = event.get("payload_json")
+    if isinstance(payload, Mapping):
+        return payload
+    payload = event.get("payload")
+    if isinstance(payload, Mapping):
+        return payload
+    return {}
+
+
+def _policy_decision_from_event(event: Mapping[str, object]) -> Mapping[str, object] | None:
+    payload = _event_payload(event)
+    decision = payload.get("policy_decision")
+    return decision if isinstance(decision, Mapping) else None
+
+
+def _agent_id_for_event(event: Mapping[str, object]) -> str:
+    actor_id = event.get("actor_id")
+    if isinstance(actor_id, str) and actor_id:
+        return actor_id
+    payload = _event_payload(event)
+    identity = payload.get("agent_identity")
+    if isinstance(identity, Mapping) and isinstance(identity.get("agent_id"), str):
+        return str(identity["agent_id"])
+    return "unknown"
+
+
+def _counter_rows(counter: Counter[str], *, key_name: str) -> list[JsonObject]:
+    return [
+        {key_name: key, "count": count}
+        for key, count in counter.most_common()
+    ]
+
+
+def _nested_counter_rows(counter: Mapping[str, Counter[str]], *, key_name: str, nested_key: str) -> list[JsonObject]:
+    rows: list[JsonObject] = []
+    for key in sorted(counter):
+        nested = counter[key]
+        rows.append(
+            {
+                key_name: key,
+                "count": sum(nested.values()),
+                nested_key: dict(nested.most_common()),
+            }
+        )
+    return sorted(rows, key=lambda row: (-int(row["count"]), str(row[key_name])))
+
+
+def summarize_agent_policy_telemetry(
+    *,
+    agent_events: Iterable[Mapping[str, object]],
+    artifacts: Iterable[Mapping[str, object]] = (),
+    memories: Iterable[Mapping[str, object]] = (),
+) -> JsonObject:
+    """Build a compact operator summary from append-only agent events."""
+
+    blocks_by_agent: defaultdict[str, Counter[str]] = defaultdict(Counter)
+    filters_by_agent: defaultdict[str, Counter[str]] = defaultdict(Counter)
+    review_by_agent: defaultdict[str, Counter[str]] = defaultdict(Counter)
+    restricted_domains = Counter()
+    workflows = Counter()
+    workflow_agents: defaultdict[str, Counter[str]] = defaultdict(Counter)
+    memory_proposals = Counter()
+    artifact_generation = Counter()
+    total_policy_decisions = 0
+    total_agent_events = 0
+    seen_policy_traces: set[str] = set()
+    memory_proposal_ids: set[str] = set()
+    artifact_generation_ids: set[str] = set()
+
+    for event in agent_events:
+        total_agent_events += 1
+        agent_id = _agent_id_for_event(event)
+        event_type = str(event.get("event_type") or "")
+        payload = _event_payload(event)
+        decision = _policy_decision_from_event(event)
+        if decision is not None:
+            trace_id = str(decision.get("trace_id") or event.get("trace_id") or "")
+            if trace_id and trace_id in seen_policy_traces:
+                decision = None
+            elif trace_id:
+                seen_policy_traces.add(trace_id)
+        if decision is not None:
+            total_policy_decisions += 1
+            action = str(decision.get("action") or "unknown")
+            decision_value = str(decision.get("decision") or "")
+            if decision_value == "blocked":
+                blocks_by_agent[agent_id][action] += 1
+            if decision_value == "allowed_with_filtering":
+                filters_by_agent[agent_id][action] += 1
+            if decision.get("review_required") is True or decision_value == "requires_review":
+                review_by_agent[agent_id][action] += 1
+            requested_domains = decision.get("requested_domains")
+            effective_domains = set(decision.get("effective_domains") or []) if isinstance(decision.get("effective_domains"), list) else set()
+            if isinstance(requested_domains, list):
+                for domain in requested_domains:
+                    if isinstance(domain, str) and domain not in effective_domains:
+                        restricted_domains[domain] += 1
+            elif "restricted_domain_filtered" in set(decision.get("reasons") or []):
+                restricted_domains["restricted_domain_filtered"] += 1
+            workflow_type = decision.get("workflow_type")
+            if action == "scheduler.run_now" and isinstance(workflow_type, str) and workflow_type:
+                workflows[workflow_type] += 1
+                workflow_agents[workflow_type][agent_id] += 1
+
+        if event_type == "agent.memory_proposed":
+            if isinstance(event.get("target_id"), str):
+                memory_proposal_ids.add(str(event["target_id"]))
+            memory_proposals[agent_id] += 1
+        if event_type in {"agent.artifact_generated", "artifact.generated"}:
+            if isinstance(event.get("target_id"), str):
+                artifact_generation_ids.add(str(event["target_id"]))
+            artifact_generation[agent_id] += 1
+        if event_type.startswith("scheduler.") and agent_id != "unknown":
+            workflow_type = payload.get("workflow_type")
+            if isinstance(workflow_type, str) and workflow_type:
+                workflows[workflow_type] += 1
+                workflow_agents[workflow_type][agent_id] += 1
+
+    for memory in memories:
+        metadata = memory.get("metadata_json")
+        memory_id = str(memory.get("id")) if memory.get("id") is not None else ""
+        if (
+            isinstance(metadata, Mapping)
+            and isinstance(metadata.get("agent_id"), str)
+            and memory_id not in memory_proposal_ids
+        ):
+            memory_proposals[str(metadata["agent_id"])] += 1
+
+    for artifact in artifacts:
+        metadata = artifact.get("metadata_json")
+        artifact_id = str(artifact.get("id")) if artifact.get("id") is not None else ""
+        if isinstance(metadata, Mapping) and metadata.get("generated_by") == "agent" and artifact_id not in artifact_generation_ids:
+            agent_id = metadata.get("agent_id")
+            artifact_generation[str(agent_id) if isinstance(agent_id, str) and agent_id else "unknown"] += 1
+
+    return {
+        "total_agent_events": total_agent_events,
+        "total_policy_decisions": total_policy_decisions,
+        "policy_blocks_by_agent": _nested_counter_rows(blocks_by_agent, key_name="agent_id", nested_key="actions"),
+        "policy_filters_by_agent": _nested_counter_rows(filters_by_agent, key_name="agent_id", nested_key="actions"),
+        "requires_review_by_agent": _nested_counter_rows(review_by_agent, key_name="agent_id", nested_key="actions"),
+        "restricted_domains_requested": _counter_rows(restricted_domains, key_name="domain"),
+        "workflows_triggered_by_agents": [
+            {
+                "workflow_type": workflow_type,
+                "count": count,
+                "agents": dict(workflow_agents[workflow_type].most_common()),
+            }
+            for workflow_type, count in workflows.most_common()
+        ],
+        "memory_proposals_by_agent": _counter_rows(memory_proposals, key_name="agent_id"),
+        "artifact_generation_by_agent": _counter_rows(artifact_generation, key_name="agent_id"),
+    }
 
 
 def ensure_policy_allowed(decision: PolicyDecision) -> None:
@@ -396,4 +565,5 @@ __all__ = [
     "append_policy_events",
     "ensure_policy_allowed",
     "evaluate_agent_policy",
+    "summarize_agent_policy_telemetry",
 ]

--- a/apps/api/src/alicebot_api/vnext_brain.py
+++ b/apps/api/src/alicebot_api/vnext_brain.py
@@ -218,6 +218,11 @@ def _input_summary(
     }
 
 
+def _source_refs(rows: list[JsonObject]) -> list[str]:
+    refs = [f"source:{row.get('id')}" for row in rows if row.get("id") is not None]
+    return list(dict.fromkeys(refs))
+
+
 def _candidate_open_loop_titles(sources: list[JsonObject]) -> list[tuple[str, JsonObject]]:
     candidates: list[tuple[str, JsonObject]] = []
     pattern = re.compile(r"^\s*(?:todo|follow up|waiting on|question|ask)\s*:?\s*(.+)$", re.IGNORECASE)
@@ -269,6 +274,7 @@ class VNextBrainService:
                     "trace_id": request.trace_id,
                     "policy_decision": request.policy_decision,
                     "generated_for": day.isoformat(),
+                    "source_refs": _source_refs(sources),
                     "input_summary": _input_summary(
                         sources=sources,
                         memories=memories,
@@ -349,6 +355,7 @@ class VNextBrainService:
                     "policy_decision": request.policy_decision,
                     "generated_for": day.isoformat(),
                     "week": week_label,
+                    "source_refs": _source_refs(sources),
                     "input_summary": _input_summary(
                         sources=sources,
                         memories=memories,

--- a/apps/api/src/alicebot_api/vnext_connections.py
+++ b/apps/api/src/alicebot_api/vnext_connections.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import re
 from typing import Protocol
 
@@ -92,6 +92,13 @@ class ConnectionFinderRequest:
     sensitivity_allowed: tuple[str, ...] = DEFAULT_SENSITIVITY_ALLOWED
     max_connections: int = DEFAULT_CONNECTION_LIMIT
     auto_accept_threshold: float | None = None
+    generated_by: str = "system"
+    actor_id: str | None = None
+    trace_id: str | None = None
+    run_id: str | None = None
+    agent_identity: JsonObject | None = None
+    policy_decision: JsonObject | None = None
+    metadata_json: JsonObject = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -323,6 +330,10 @@ class VNextConnectionService:
                         "status": status,
                         "connection": candidate.to_record(),
                         "candidate": status == "candidate",
+                        "generated_by": request.generated_by,
+                        "scheduler_run_id": request.run_id if request.generated_by == "scheduler" else None,
+                        "trace_id": request.trace_id,
+                        "policy_decision": request.policy_decision,
                     },
                 }
             )
@@ -332,17 +343,23 @@ class VNextConnectionService:
             append_event(
                 self.store,
                 event_type="connection.candidate_edge_logged",
-                actor_type="system",
+                actor_type=request.generated_by,
+                actor_id=request.actor_id,
                 target_type="graph_edge",
                 target_id=edge_id,
+                trace_id=request.trace_id,
+                run_id=request.run_id,
                 payload={
                     "connection_type": candidate.connection_type,
                     "edge_type": CONNECTION_TO_EDGE_TYPE[candidate.connection_type],
                     "confidence": candidate.confidence,
                     "status": status,
+                    "policy_decision": request.policy_decision,
                 },
             )
 
+        source_ids = [str(source.get("id")) for source in sources if source.get("id") is not None]
+        memory_ids = [str(memory.get("id")) for memory in memories if memory.get("id") is not None]
         artifact = self.store.create_artifact(
             {
                 "artifact_type": "connection_report",
@@ -351,25 +368,43 @@ class VNextConnectionService:
                 "status": "needs_review",
                 "domain": request.domains[0] if len(request.domains) == 1 else "unknown",
                 "sensitivity": self._highest_sensitivity([*sources, *memories]),
-                "generated_by": "vnext_connection_finder",
+                "generated_by": request.generated_by if request.generated_by != "system" else "vnext_connection_finder",
                 "metadata_json": {
                     "workflow": "connection_finder",
+                    "workflow_type": "connection_report",
                     "candidate_edge_ids": edge_ids,
                     "connections": connection_records,
+                    "source_ids": source_ids,
+                    "memory_ids": memory_ids,
+                    "source_refs": [f"source:{source_id}" for source_id in source_ids],
                     "input_counts": {"sources": len(sources), "memories": len(memories)},
+                    "generated_by": request.generated_by,
+                    "agent_identity": request.agent_identity,
+                    "agent_id": request.actor_id if request.generated_by == "agent" else None,
+                    "agent_run_id": request.run_id if request.generated_by == "agent" else None,
+                    "scheduler_run_id": request.run_id if request.generated_by == "scheduler" else None,
+                    "trace_id": request.trace_id,
+                    "policy_decision": request.policy_decision,
+                    "review_status": "needs_review",
+                    **request.metadata_json,
                 },
             }
         )
         append_event(
             self.store,
             event_type="artifact.generated",
-            actor_type="system",
+            actor_type=request.generated_by,
+            actor_id=request.actor_id,
             target_type="artifact",
             target_id=str(artifact["id"]),
+            trace_id=request.trace_id,
+            run_id=request.run_id,
             payload={
                 "workflow": "connection_finder",
+                "workflow_type": "connection_report",
                 "artifact_type": "connection_report",
                 "candidate_edge_count": len(edge_ids),
+                "policy_decision": request.policy_decision,
             },
         )
         return artifact

--- a/apps/api/src/alicebot_api/vnext_contradictions.py
+++ b/apps/api/src/alicebot_api/vnext_contradictions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import re
 from typing import Protocol
 
@@ -109,6 +109,13 @@ class ContradictionFinderRequest:
     domains: tuple[str, ...] = ()
     sensitivity_allowed: tuple[str, ...] = DEFAULT_SENSITIVITY_ALLOWED
     max_contradictions: int = DEFAULT_CONTRADICTION_LIMIT
+    generated_by: str = "system"
+    actor_id: str | None = None
+    trace_id: str | None = None
+    run_id: str | None = None
+    agent_identity: JsonObject | None = None
+    policy_decision: JsonObject | None = None
+    metadata_json: JsonObject = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -319,6 +326,10 @@ class VNextContradictionService:
                         "status": "candidate",
                         "candidate": True,
                         "contradiction": record,
+                        "generated_by": request.generated_by,
+                        "scheduler_run_id": request.run_id if request.generated_by == "scheduler" else None,
+                        "trace_id": request.trace_id,
+                        "policy_decision": request.policy_decision,
                     },
                 }
             )
@@ -328,17 +339,24 @@ class VNextContradictionService:
             append_event(
                 self.store,
                 event_type="contradiction.candidate_edge_logged",
-                actor_type="system",
+                actor_type=request.generated_by,
+                actor_id=request.actor_id,
                 target_type="graph_edge",
                 target_id=edge_id,
+                trace_id=request.trace_id,
+                run_id=request.run_id,
                 payload={
                     "contradiction_type": candidate.contradiction_type,
                     "belief_id": str(candidate.belief.get("id")),
                     "confidence": candidate.confidence,
                     "recommended_action": candidate.recommended_action,
+                    "policy_decision": request.policy_decision,
                 },
             )
 
+        source_ids = [str(source.get("id")) for source in sources if source.get("id") is not None]
+        memory_ids = [str(memory.get("id")) for memory in memories if memory.get("id") is not None]
+        belief_ids = [str(belief.get("id")) for belief in beliefs if belief.get("id") is not None]
         artifact = self.store.create_artifact(
             {
                 "artifact_type": "contradiction_report",
@@ -347,29 +365,48 @@ class VNextContradictionService:
                 "status": "needs_review",
                 "domain": request.domains[0] if len(request.domains) == 1 else "unknown",
                 "sensitivity": self._highest_sensitivity([*sources, *memories, *beliefs]),
-                "generated_by": "vnext_contradiction_finder",
+                "generated_by": request.generated_by if request.generated_by != "system" else "vnext_contradiction_finder",
                 "metadata_json": {
                     "workflow": "contradiction_finder",
+                    "workflow_type": "contradiction_report",
                     "candidate_edge_ids": edge_ids,
                     "contradictions": records,
+                    "source_ids": source_ids,
+                    "memory_ids": memory_ids,
+                    "belief_ids": belief_ids,
+                    "source_refs": [f"source:{source_id}" for source_id in source_ids],
                     "input_counts": {
                         "sources": len(sources),
                         "memories": len(memories),
                         "beliefs": len(beliefs),
                     },
+                    "generated_by": request.generated_by,
+                    "agent_identity": request.agent_identity,
+                    "agent_id": request.actor_id if request.generated_by == "agent" else None,
+                    "agent_run_id": request.run_id if request.generated_by == "agent" else None,
+                    "scheduler_run_id": request.run_id if request.generated_by == "scheduler" else None,
+                    "trace_id": request.trace_id,
+                    "policy_decision": request.policy_decision,
+                    "review_status": "needs_review",
+                    **request.metadata_json,
                 },
             }
         )
         append_event(
             self.store,
             event_type="artifact.generated",
-            actor_type="system",
+            actor_type=request.generated_by,
+            actor_id=request.actor_id,
             target_type="artifact",
             target_id=str(artifact["id"]),
+            trace_id=request.trace_id,
+            run_id=request.run_id,
             payload={
                 "workflow": "contradiction_finder",
+                "workflow_type": "contradiction_report",
                 "artifact_type": "contradiction_report",
                 "candidate_edge_count": len(edge_ids),
+                "policy_decision": request.policy_decision,
             },
         )
         return artifact

--- a/apps/api/src/alicebot_api/vnext_projects.py
+++ b/apps/api/src/alicebot_api/vnext_projects.py
@@ -332,6 +332,7 @@ class VNextProjectService:
                     "candidate_memory_id": candidate_memory.get("id"),
                     "suggested_current_state": suggested_current_state,
                     "source_ids": _source_ids(sources),
+                    "source_refs": [f"source:{source_id}" for source_id in _source_ids(sources)],
                     "memory_ids": _source_ids(memories),
                     "generated_by": request.generated_by,
                     "agent_identity": request.agent_identity,

--- a/apps/api/src/alicebot_api/vnext_scheduler.py
+++ b/apps/api/src/alicebot_api/vnext_scheduler.py
@@ -8,7 +8,10 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from alicebot_api.vnext_agent_control import AgentIdentity, PolicyDecision
 from alicebot_api.vnext_brain import BrainArtifactRequest, VNextBrainService
+from alicebot_api.vnext_connections import ConnectionFinderRequest, VNextConnectionService
+from alicebot_api.vnext_contradictions import ContradictionFinderRequest, VNextContradictionService
 from alicebot_api.vnext_event_log import append_event
+from alicebot_api.vnext_projects import ProjectAutomationRequest, VNextProjectService, VNextProjectValidationError
 from alicebot_api.vnext_repositories import JsonObject
 
 
@@ -51,6 +54,8 @@ class VNextSchedulerStore(Protocol):
 
     def list_scheduler_runs(self, *, workflow_type: str | None = None, limit: int = 20) -> list[JsonObject]: ...
 
+    def try_scheduler_workflow_lock(self, workflow_type: str) -> bool: ...
+
     def create_artifact(self, artifact: JsonObject, *, actor_type: str = "system") -> JsonObject: ...
 
     def search_sources(self, **kwargs) -> list[JsonObject]: ...
@@ -60,6 +65,10 @@ class VNextSchedulerStore(Protocol):
     def list_open_loops(self, **kwargs) -> list[JsonObject]: ...
 
     def list_artifacts(self, **kwargs) -> list[JsonObject]: ...
+
+    def list_projects(self, **kwargs) -> list[JsonObject]: ...
+
+    def list_events(self, **kwargs) -> list[JsonObject]: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -208,15 +217,39 @@ class VNextSchedulerService:
 
     def status(self) -> JsonObject:
         workflows = self.ensure_default_workflows()
-        runs = self.store.list_scheduler_runs(limit=20)
+        runs = self.store.list_scheduler_runs(limit=100)
+        recent_events = self.store.list_events(limit=100)
+        due_scan_events = [event for event in recent_events if event.get("event_type") == "scheduler.due_scan"]
+        failures = [run for run in runs if run.get("status") == "failed"]
+        successes = [run for run in runs if run.get("status") == "succeeded"]
+        running = next((run for run in runs if run.get("status") == "started"), None)
+        next_due_workflow = min(
+            (
+                workflow
+                for workflow in workflows
+                if workflow.get("enabled") is True
+                and workflow.get("paused") is not True
+                and workflow.get("next_run_at") is not None
+            ),
+            key=lambda workflow: str(workflow.get("next_run_at")),
+            default=None,
+        )
         return {
             "mode": "local_governed",
             "disabled_by_default": True,
             "workflows": workflows,
-            "recent_runs": runs,
+            "recent_runs": runs[:20],
             "enabled_count": sum(1 for row in workflows if row.get("enabled") is True),
             "paused_count": sum(1 for row in workflows if row.get("paused") is True),
-            "last_failure": next((run for run in runs if run.get("status") == "failed"), None),
+            "last_failure": failures[0] if failures else None,
+            "recent_failures": failures[:10],
+            "last_due_scan": due_scan_events[0] if due_scan_events else None,
+            "next_due_workflow": next_due_workflow,
+            "currently_running_workflow": running,
+            "last_success_by_workflow": {
+                workflow_type: next((run for run in successes if run.get("workflow_type") == workflow_type), None)
+                for workflow_type in WORKFLOW_TYPES
+            },
         }
 
     def configure_workflow(
@@ -298,6 +331,16 @@ class VNextSchedulerService:
             if next_run_at is None or next_run_at > checked_at:
                 continue
             workflow_type = str(workflow["workflow_type"])
+            if not self.store.try_scheduler_workflow_lock(workflow_type):
+                append_event(
+                    self.store,
+                    event_type="scheduler.workflow_lock_skipped",
+                    actor_type=triggered_by,
+                    target_type="scheduler_workflow",
+                    target_id=str(workflow.get("id")) if workflow.get("id") is not None else None,
+                    payload={"workflow_type": workflow_type, "scheduled_for": next_run_at.isoformat()},
+                )
+                continue
             result = self.run_now(
                 SchedulerRunRequest(
                     workflow_type=workflow_type,
@@ -418,10 +461,12 @@ class VNextSchedulerService:
         metadata = {
             "generated_by": "scheduler",
             "workflow": request.workflow_type,
+            "workflow_type": request.workflow_type,
             "scheduler_run_id": scheduler_run_id,
             "trace_id": trace_id,
             "policy_decision": request.policy_decision.to_record() if request.policy_decision else None,
             "agent_identity": request.agent_identity.to_record() if request.agent_identity else None,
+            "review_status": "needs_review",
         }
         brain_request = BrainArtifactRequest(
             domains=request.domains,
@@ -439,12 +484,37 @@ class VNextSchedulerService:
             return brain.generate_daily_brief(brain_request)
         if request.workflow_type == "weekly_synthesis":
             return brain.generate_weekly_synthesis(brain_request)
-        artifact_type = {
-            "connection_report": "connection_report",
-            "contradiction_report": "contradiction_report",
-            "open_loop_review": "open_loop_report",
-            "project_update_scan": "project_update",
-        }.get(request.workflow_type, "system_report")
+        if request.workflow_type == "connection_report":
+            return VNextConnectionService(self.store).generate_connection_report(
+                ConnectionFinderRequest(
+                    domains=request.domains,
+                    sensitivity_allowed=request.sensitivity_allowed,
+                    generated_by="scheduler",
+                    trace_id=trace_id,
+                    run_id=scheduler_run_id,
+                    agent_identity=request.agent_identity.to_record() if request.agent_identity else None,
+                    policy_decision=request.policy_decision.to_record() if request.policy_decision else None,
+                    metadata_json=metadata,
+                )
+            )
+        if request.workflow_type == "contradiction_report":
+            return VNextContradictionService(self.store).generate_contradiction_report(
+                ContradictionFinderRequest(
+                    domains=request.domains,
+                    sensitivity_allowed=request.sensitivity_allowed,
+                    generated_by="scheduler",
+                    trace_id=trace_id,
+                    run_id=scheduler_run_id,
+                    agent_identity=request.agent_identity.to_record() if request.agent_identity else None,
+                    policy_decision=request.policy_decision.to_record() if request.policy_decision else None,
+                    metadata_json=metadata,
+                )
+            )
+        if request.workflow_type == "open_loop_review":
+            return self._generate_open_loop_review_artifact(request, metadata=metadata)
+        if request.workflow_type == "project_update_scan":
+            return self._generate_project_update_scan_artifact(request, metadata=metadata)
+        artifact_type = "system_report"
         return self.store.create_artifact(
             {
                 "artifact_type": artifact_type,
@@ -465,6 +535,114 @@ class VNextSchedulerService:
             actor_type="scheduler",
         )
 
+    def _generate_open_loop_review_artifact(self, request: SchedulerRunRequest, *, metadata: JsonObject) -> JsonObject:
+        domains = list(request.domains) if request.domains else None
+        loops = self.store.list_open_loops(
+            status="open",
+            domains=domains,
+            sensitivity_allowed=list(request.sensitivity_allowed),
+            limit=20,
+        )
+        source_refs = [
+            f"source:{loop.get('source_id')}"
+            for loop in loops
+            if loop.get("source_id") is not None
+        ]
+        loop_lines = [
+            "\n".join(
+                [
+                    f"### {index}. {loop.get('title', 'Open loop')}",
+                    f"- Open loop: open_loop:{loop.get('id')}",
+                    f"- Priority: {loop.get('priority', 'normal')}",
+                    f"- Due: {loop.get('due_at') or 'not set'}",
+                    f"- Source: source:{loop.get('source_id')}" if loop.get("source_id") is not None else "- Source: not linked",
+                    f"- Description: {loop.get('description') or 'No description recorded.'}",
+                ]
+            )
+            for index, loop in enumerate(loops, start=1)
+        ] or ["- No open loops matched this scheduler scope."]
+        content = "\n\n".join(
+            [
+                f"# Open Loop Review - {request.generated_for or datetime.now(UTC).date().isoformat()}",
+                "## Open Items",
+                *loop_lines,
+                "## Review Policy",
+                "- This artifact is review-only and does not close, snooze, or promote any open loop automatically.",
+            ]
+        )
+        enriched_metadata = {
+            **metadata,
+            "workflow": "open_loop_review",
+            "open_loop_ids": [str(loop.get("id")) for loop in loops if loop.get("id") is not None],
+            "source_refs": source_refs,
+            "input_counts": {"open_loops": len(loops)},
+        }
+        return self.store.create_artifact(
+            {
+                "artifact_type": "open_loop_report",
+                "title": f"Open Loop Review - {request.generated_for or datetime.now(UTC).date().isoformat()}",
+                "content_markdown": content,
+                "status": "needs_review",
+                "domain": request.domains[0] if len(request.domains) == 1 else "unknown",
+                "sensitivity": self._highest_sensitivity(loops),
+                "generated_by": "scheduler",
+                "metadata_json": enriched_metadata,
+            },
+            actor_type="scheduler",
+        )
+
+    def _generate_project_update_scan_artifact(self, request: SchedulerRunRequest, *, metadata: JsonObject) -> JsonObject:
+        projects = self.store.list_projects(
+            status="active",
+            domains=list(request.domains) if request.domains else None,
+            sensitivity_allowed=list(request.sensitivity_allowed),
+            limit=1,
+        )
+        if projects:
+            try:
+                return VNextProjectService(self.store).generate_project_update_candidate(
+                    ProjectAutomationRequest(
+                        domains=request.domains,
+                        sensitivity_allowed=request.sensitivity_allowed,
+                        project_id=str(projects[0]["id"]),
+                        generated_by="scheduler",
+                        trace_id=str(metadata.get("trace_id")) if metadata.get("trace_id") is not None else None,
+                        run_id=str(metadata.get("scheduler_run_id")) if metadata.get("scheduler_run_id") is not None else None,
+                        policy_decision=metadata.get("policy_decision") if isinstance(metadata.get("policy_decision"), dict) else None,
+                        metadata_json={**metadata, "workflow_type": "project_update_scan", "review_status": "needs_review"},
+                    )
+                )
+            except VNextProjectValidationError:
+                pass
+        content = "\n".join(
+            [
+                f"# Project Update Scan - {request.generated_for or datetime.now(UTC).date().isoformat()}",
+                "",
+                "No active project matched this scheduler scope.",
+                "",
+                "This review artifact records the scan without creating or promoting trusted memory.",
+            ]
+        )
+        return self.store.create_artifact(
+            {
+                "artifact_type": "project_update",
+                "title": f"Project Update Scan - {request.generated_for or datetime.now(UTC).date().isoformat()}",
+                "content_markdown": content,
+                "status": "needs_review",
+                "domain": request.domains[0] if len(request.domains) == 1 else "project",
+                "sensitivity": "unknown",
+                "generated_by": "scheduler",
+                "metadata_json": {
+                    **metadata,
+                    "workflow": "project_update_scan",
+                    "source_refs": [],
+                    "project_ids": [],
+                    "input_counts": {"projects": 0},
+                },
+            },
+            actor_type="scheduler",
+        )
+
     def _next_run_after(self, workflow: JsonObject) -> str | None:
         workflow_type = str(workflow["workflow_type"])
         return compute_next_run_at(
@@ -481,6 +659,23 @@ class VNextSchedulerService:
         except ZoneInfoNotFoundError:
             zone = UTC
         return checked_at.astimezone(zone).date().isoformat()
+
+    @staticmethod
+    def _highest_sensitivity(rows: list[JsonObject]) -> str:
+        rank = {
+            "public": 1,
+            "internal": 2,
+            "unknown": 2,
+            "private": 3,
+            "confidential": 4,
+            "highly_sensitive": 5,
+            "sacred": 6,
+            "regulated": 6,
+        }
+        sensitivities = [str(row.get("sensitivity", "unknown")) for row in rows]
+        if not sensitivities:
+            return "unknown"
+        return max(sensitivities, key=lambda value: rank.get(value, rank["unknown"]))
 
 
 __all__ = [

--- a/apps/api/src/alicebot_api/vnext_scheduler_runtime.py
+++ b/apps/api/src/alicebot_api/vnext_scheduler_runtime.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+from typing import Callable
+from uuid import UUID
+
+from alicebot_api.db import user_connection
+from alicebot_api.vnext_repositories import JsonObject
+from alicebot_api.vnext_scheduler import VNextSchedulerService
+from alicebot_api.vnext_store import PostgresVNextStore
+
+
+DEFAULT_RUNTIME_DIR = Path("~/.alicebot/vnext-scheduler").expanduser()
+DEFAULT_PID_FILE = DEFAULT_RUNTIME_DIR / "scheduler.pid"
+DEFAULT_STATUS_FILE = DEFAULT_RUNTIME_DIR / "scheduler-status.json"
+DEFAULT_LOG_FILE = DEFAULT_RUNTIME_DIR / "scheduler.log"
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerRuntimeConfig:
+    database_url: str
+    user_id: UUID
+    interval_seconds: float = 60.0
+    limit: int = 10
+    pid_file: Path = DEFAULT_PID_FILE
+    status_file: Path = DEFAULT_STATUS_FILE
+    log_file: Path = DEFAULT_LOG_FILE
+    once: bool = False
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _json_safe(value: object) -> object:
+    if isinstance(value, dict):
+        return {str(key): _json_safe(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(child) for child in value]
+    if isinstance(value, tuple):
+        return [_json_safe(child) for child in value]
+    if isinstance(value, (datetime, Path, UUID)):
+        return str(value)
+    return value
+
+
+def _write_json(path: Path, payload: JsonObject) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_json_safe(payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> JsonObject | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _pid_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def daemon_status(*, pid_file: Path = DEFAULT_PID_FILE, status_file: Path = DEFAULT_STATUS_FILE) -> JsonObject:
+    status = _read_json(status_file) or {}
+    pid = status.get("pid")
+    if not isinstance(pid, int):
+        try:
+            pid = int(pid_file.read_text(encoding="utf-8").strip())
+        except (FileNotFoundError, ValueError):
+            pid = None
+    running = False if status.get("running") is False else _pid_running(pid) if isinstance(pid, int) else False
+    return {
+        "configured": status != {} or pid is not None,
+        "running": running,
+        "pid": pid,
+        "pid_file": str(pid_file),
+        "status_file": str(status_file),
+        **status,
+        "running": running,
+    }
+
+
+def stop_daemon(*, pid_file: Path = DEFAULT_PID_FILE, status_file: Path = DEFAULT_STATUS_FILE, timeout_seconds: float = 10.0) -> JsonObject:
+    status = daemon_status(pid_file=pid_file, status_file=status_file)
+    pid = status.get("pid")
+    if not isinstance(pid, int):
+        return {**status, "stopped": False, "message": "No scheduler daemon pid file found."}
+    if not _pid_running(pid):
+        return {**status, "stopped": True, "message": "Scheduler daemon was already stopped."}
+    os.kill(pid, signal.SIGTERM)
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if not _pid_running(pid):
+            return {**daemon_status(pid_file=pid_file, status_file=status_file), "stopped": True}
+        time.sleep(0.2)
+    return {**daemon_status(pid_file=pid_file, status_file=status_file), "stopped": False, "message": "Scheduler daemon did not stop before timeout."}
+
+
+def start_background_daemon(config: SchedulerRuntimeConfig) -> JsonObject:
+    current = daemon_status(pid_file=config.pid_file, status_file=config.status_file)
+    if current.get("running") is True:
+        return {**current, "started": False, "message": "Scheduler daemon is already running."}
+    config.pid_file.parent.mkdir(parents=True, exist_ok=True)
+    config.log_file.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        "-m",
+        "alicebot_api",
+        "--database-url",
+        config.database_url,
+        "--user-id",
+        str(config.user_id),
+        "vnext",
+        "scheduler",
+        "daemon",
+        "start",
+        "--foreground",
+        "--interval-seconds",
+        str(config.interval_seconds),
+        "--limit",
+        str(config.limit),
+        "--pid-file",
+        str(config.pid_file),
+        "--status-file",
+        str(config.status_file),
+        "--log-file",
+        str(config.log_file),
+    ]
+    log_handle = config.log_file.open("ab")
+    process = subprocess.Popen(command, stdout=log_handle, stderr=subprocess.STDOUT, start_new_session=True)
+    log_handle.close()
+    config.pid_file.write_text(str(process.pid), encoding="utf-8")
+    _write_json(
+        config.status_file,
+        {
+            "pid": process.pid,
+            "running": True,
+            "started_at": _now_iso(),
+            "last_heartbeat_at": _now_iso(),
+            "interval_seconds": config.interval_seconds,
+            "limit": config.limit,
+            "mode": "background",
+            "log_file": str(config.log_file),
+        },
+    )
+    return daemon_status(pid_file=config.pid_file, status_file=config.status_file) | {"started": True}
+
+
+def run_foreground_daemon(
+    config: SchedulerRuntimeConfig,
+    *,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> JsonObject:
+    stop_requested = False
+
+    def _request_stop(_signum, _frame) -> None:
+        nonlocal stop_requested
+        stop_requested = True
+
+    previous_sigterm = signal.signal(signal.SIGTERM, _request_stop)
+    previous_sigint = signal.signal(signal.SIGINT, _request_stop)
+    config.pid_file.parent.mkdir(parents=True, exist_ok=True)
+    config.pid_file.write_text(str(os.getpid()), encoding="utf-8")
+    started_at = _now_iso()
+    last_payload: JsonObject = {
+        "pid": os.getpid(),
+        "running": True,
+        "started_at": started_at,
+        "last_heartbeat_at": started_at,
+        "interval_seconds": config.interval_seconds,
+        "limit": config.limit,
+        "mode": "foreground",
+        "last_due_scan": None,
+        "last_error": None,
+    }
+    try:
+        while not stop_requested:
+            try:
+                with user_connection(config.database_url, config.user_id) as conn:
+                    result = VNextSchedulerService(PostgresVNextStore(conn)).run_due_workflows(limit=config.limit)
+                last_payload = {
+                    **last_payload,
+                    "running": True,
+                    "last_heartbeat_at": _now_iso(),
+                    "last_due_scan": result,
+                    "last_due_scan_at": result.get("checked_at"),
+                    "last_due_count": result.get("due_count", 0),
+                    "last_error": None,
+                }
+            except Exception as exc:  # pragma: no cover - exercised through CLI smoke paths
+                last_payload = {
+                    **last_payload,
+                    "running": True,
+                    "last_heartbeat_at": _now_iso(),
+                    "last_error": str(exc),
+                    "last_error_type": type(exc).__name__,
+                }
+            _write_json(config.status_file, last_payload)
+            if config.once:
+                break
+            sleep_fn(max(config.interval_seconds, 0.1))
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
+        signal.signal(signal.SIGINT, previous_sigint)
+        stopped_payload = {**last_payload, "running": False, "stopped_at": _now_iso()}
+        _write_json(config.status_file, stopped_payload)
+    return daemon_status(pid_file=config.pid_file, status_file=config.status_file)
+
+
+__all__ = [
+    "DEFAULT_LOG_FILE",
+    "DEFAULT_PID_FILE",
+    "DEFAULT_RUNTIME_DIR",
+    "DEFAULT_STATUS_FILE",
+    "SchedulerRuntimeConfig",
+    "daemon_status",
+    "run_foreground_daemon",
+    "start_background_daemon",
+    "stop_daemon",
+]

--- a/apps/api/src/alicebot_api/vnext_store.py
+++ b/apps/api/src/alicebot_api/vnext_store.py
@@ -2598,6 +2598,16 @@ class PostgresVNextStore:
             (workflow_type, workflow_type, limit),
         )
 
+    def try_scheduler_workflow_lock(self, workflow_type: str) -> bool:
+        row = self._fetch_one(
+            "try_scheduler_workflow_lock",
+            """
+                SELECT pg_try_advisory_xact_lock(hashtextextended(%s::text, 17)) AS acquired
+                """,
+            (f"vnext_scheduler:{workflow_type}",),
+        )
+        return bool(row.get("acquired"))
+
 
 __all__ = [
     "PostgresVNextStore",

--- a/apps/web/components/vnext-brain-workspace.tsx
+++ b/apps/web/components/vnext-brain-workspace.tsx
@@ -13,6 +13,7 @@ import type {
   VNextMemoryRecord,
   VNextOpenLoopRecord,
   VNextPersonRecord,
+  VNextPolicyTelemetrySummary,
   VNextProjectDashboard,
   VNextProjectRecord,
   VNextSchedulerStatus,
@@ -33,6 +34,7 @@ import {
   reviewVNextArtifact,
   reviewVNextMemory,
   reviewVNextOpenLoop,
+  runVNextSchedulerDue,
   runVNextSchedulerWorkflowNow,
   upsertVNextBrainCharter,
 } from "../lib/api";
@@ -118,6 +120,7 @@ type WorkspaceView = {
   tasks: VNextTaskRecord[];
   recentEvents: VNextEventRecord[];
   agentActivity: NonNullable<VNextWorkspacePayload["agent_activity"]>;
+  policyTelemetry: VNextPolicyTelemetrySummary;
   scheduler: VNextSchedulerStatus;
   brainCharter: VNextBrainCharterRecord | null;
 };
@@ -252,6 +255,18 @@ const EMPTY_AGENT_ACTIVITY: NonNullable<VNextWorkspacePayload["agent_activity"]>
   pending_review_items: [],
 };
 
+const EMPTY_POLICY_TELEMETRY: VNextPolicyTelemetrySummary = {
+  total_agent_events: 0,
+  total_policy_decisions: 0,
+  policy_blocks_by_agent: [],
+  policy_filters_by_agent: [],
+  requires_review_by_agent: [],
+  restricted_domains_requested: [],
+  workflows_triggered_by_agents: [],
+  memory_proposals_by_agent: [],
+  artifact_generation_by_agent: [],
+};
+
 const EMPTY_SCHEDULER: VNextSchedulerStatus = {
   mode: "local_governed",
   disabled_by_default: true,
@@ -260,6 +275,12 @@ const EMPTY_SCHEDULER: VNextSchedulerStatus = {
   enabled_count: 0,
   paused_count: 0,
   last_failure: null,
+  recent_failures: [],
+  last_due_scan: null,
+  next_due_workflow: null,
+  currently_running_workflow: null,
+  last_success_by_workflow: {},
+  daemon: { configured: false, running: false },
 };
 
 const FIXTURE_SOURCES: VNextSourceRecord[] = [
@@ -484,12 +505,36 @@ const FIXTURE_AGENT_ACTIVITY: NonNullable<VNextWorkspacePayload["agent_activity"
   pending_review_items: FIXTURE_REVIEW_ITEMS,
 };
 
+const FIXTURE_POLICY_TELEMETRY: VNextPolicyTelemetrySummary = {
+  total_agent_events: 2,
+  total_policy_decisions: 2,
+  policy_blocks_by_agent: [],
+  policy_filters_by_agent: [{ agent_id: "openclaw", count: 1, actions: { "context_pack.request": 1 } }],
+  requires_review_by_agent: [{ agent_id: "hermes", count: 1, actions: { "memory.propose": 1 } }],
+  restricted_domains_requested: [{ domain: "financial", count: 1 }],
+  workflows_triggered_by_agents: [{ workflow_type: "project_update_scan", count: 1, agents: { hermes: 1 } }],
+  memory_proposals_by_agent: [{ agent_id: "hermes", count: 1 }],
+  artifact_generation_by_agent: [{ agent_id: "hermes", count: 1 }],
+};
+
 const FIXTURE_SCHEDULER: VNextSchedulerStatus = {
   mode: "local_governed",
   disabled_by_default: true,
   enabled_count: 0,
   paused_count: 0,
   last_failure: null,
+  recent_failures: [],
+  last_due_scan: null,
+  next_due_workflow: null,
+  currently_running_workflow: null,
+  last_success_by_workflow: {},
+  daemon: {
+    configured: true,
+    running: false,
+    pid: null,
+    mode: "background",
+    last_due_count: 0,
+  },
   workflows: [
     {
       id: "schedule-daily",
@@ -627,6 +672,7 @@ function fixtureWorkspace(): WorkspaceView {
     tasks: [],
     recentEvents: FIXTURE_EVENTS,
     agentActivity: FIXTURE_AGENT_ACTIVITY,
+    policyTelemetry: FIXTURE_POLICY_TELEMETRY,
     scheduler: FIXTURE_SCHEDULER,
     brainCharter: {
       id: "brain-charter-fixture",
@@ -650,6 +696,7 @@ function emptyWorkspace(): WorkspaceView {
     tasks: [],
     recentEvents: [],
     agentActivity: EMPTY_AGENT_ACTIVITY,
+    policyTelemetry: EMPTY_POLICY_TELEMETRY,
     scheduler: EMPTY_SCHEDULER,
     brainCharter: null,
   };
@@ -670,6 +717,7 @@ function workspaceFromPayload(payload: VNextWorkspacePayload): WorkspaceView {
     tasks: payload.tasks,
     recentEvents: payload.recent_events,
     agentActivity: payload.agent_activity ?? EMPTY_AGENT_ACTIVITY,
+    policyTelemetry: payload.policy_telemetry ?? EMPTY_POLICY_TELEMETRY,
     scheduler: payload.scheduler ?? EMPTY_SCHEDULER,
     brainCharter: payload.brain_charter,
   };
@@ -1295,9 +1343,12 @@ export function VNextBrainWorkspace({
                   generated_by: "scheduler",
                   metadata_json: {
                     workflow: workflow.workflow_type,
+                    workflow_type: workflow.workflow_type,
                     scheduler_run_id: runId,
                     trace_id: `trace-${runId}`,
                     generated_by: "scheduler",
+                    source_refs: [],
+                    review_status: "needs_review",
                   },
                 }
               : null;
@@ -1379,6 +1430,62 @@ export function VNextBrainWorkspace({
         });
       },
       `Scheduler action applied: ${action}.`,
+    );
+  }
+
+  async function handleSchedulerRunDue() {
+    if (!liveModeReady || !apiBaseUrl || !userId) {
+      updateFixtureWorkspace(
+        (previous) => {
+          const now = new Date().toISOString();
+          const dueWorkflows = previous.scheduler.workflows.filter((workflow) => workflow.enabled && !workflow.paused);
+          const runs = dueWorkflows.map((workflow, index) => ({
+            id: `scheduler-due-demo-${previous.scheduler.recent_runs.length + index + 1}`,
+            workflow_type: workflow.workflow_type,
+            status: "succeeded",
+            triggered_by: "scheduler",
+            trace_id: `trace-due-demo-${index + 1}`,
+            started_at: now,
+            finished_at: now,
+            artifact_id: `artifact-due-demo-${index + 1}`,
+            metadata_json: { demo: true },
+          }));
+          const workflows = previous.scheduler.workflows.map((workflow) =>
+            runs.some((run) => run.workflow_type === workflow.workflow_type)
+              ? { ...workflow, last_run_at: now, last_result: "succeeded", next_run_at: null }
+              : workflow,
+          );
+          const event: VNextEventRecord = {
+            id: `scheduler-due-event-demo-${previous.recentEvents.length + 1}`,
+            event_type: "scheduler.due_scan",
+            actor_type: "scheduler",
+            occurred_at: now,
+            payload_json: { checked_at: now, due_count: runs.length },
+          };
+          const view = {
+            ...previous,
+            scheduler: {
+              ...previous.scheduler,
+              workflows,
+              recent_runs: [...runs, ...previous.scheduler.recent_runs],
+              last_due_scan: event,
+              daemon: { ...previous.scheduler.daemon, configured: true, running: false, last_due_scan_at: now, last_due_count: runs.length },
+            },
+            recentEvents: [event, ...previous.recentEvents],
+          };
+          return { ...view, summary: createSummary(view) };
+        },
+        "Demo due scan applied.",
+      );
+      return;
+    }
+
+    await runLiveAction(
+      "Running due scheduler workflows...",
+      async () => {
+        await runVNextSchedulerDue(apiBaseUrl, { user_id: userId, limit: 10 });
+      },
+      "Due scheduler workflows completed.",
     );
   }
 
@@ -2221,6 +2328,49 @@ export function VNextBrainWorkspace({
 
         <SectionCard
           eyebrow="Agent Activity"
+          title="Policy telemetry"
+          description="Aggregated agent policy outcomes show blocks, filters, review gates, workflow triggers, proposals, and artifact generation."
+        >
+          <div className="key-value-grid key-value-grid--compact">
+            <div>
+              <dt>Agent events</dt>
+              <dd>{workspace.policyTelemetry.total_agent_events}</dd>
+            </div>
+            <div>
+              <dt>Policy decisions</dt>
+              <dd>{workspace.policyTelemetry.total_policy_decisions}</dd>
+            </div>
+            <div>
+              <dt>Filtered agents</dt>
+              <dd>{workspace.policyTelemetry.policy_filters_by_agent.length}</dd>
+            </div>
+            <div>
+              <dt>Review-gated agents</dt>
+              <dd>{workspace.policyTelemetry.requires_review_by_agent.length}</dd>
+            </div>
+          </div>
+          <div className="list-rows">
+            {workspace.policyTelemetry.restricted_domains_requested.slice(0, 3).map((row) => (
+              <article key={`restricted-${textValue(row.domain)}`} className="list-row">
+                <div className="list-row__topline">
+                  <h3 className="list-row__title">{textValue(row.domain) || "restricted domain"}</h3>
+                  <StatusBadge status={`${row.count} requests`} />
+                </div>
+              </article>
+            ))}
+            {workspace.policyTelemetry.workflows_triggered_by_agents.slice(0, 3).map((row) => (
+              <article key={`workflow-telemetry-${textValue(row.workflow_type)}`} className="list-row">
+                <div className="list-row__topline">
+                  <h3 className="list-row__title">{textValue(row.workflow_type) || "workflow"}</h3>
+                  <StatusBadge status={`${row.count} agent runs`} />
+                </div>
+              </article>
+            ))}
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          eyebrow="Agent Activity"
           title="Generated and proposed work"
           description="Agent-generated artifacts and pending review items stay in human review lanes."
         >
@@ -2262,6 +2412,30 @@ export function VNextBrainWorkspace({
             <span className="meta-pill">Mode: {workspace.scheduler.mode}</span>
             <span className="meta-pill">Enabled: {workspace.scheduler.enabled_count}</span>
             <span className="meta-pill">Paused: {workspace.scheduler.paused_count}</span>
+            <span className="meta-pill">Daemon: {workspace.scheduler.daemon?.running ? "running" : workspace.scheduler.daemon?.configured ? "stopped" : "not configured"}</span>
+          </div>
+          <div className="key-value-grid key-value-grid--compact">
+            <div>
+              <dt>Last due scan</dt>
+              <dd>{workspace.scheduler.daemon?.last_due_scan_at ?? workspace.scheduler.last_due_scan?.occurred_at ?? "never"}</dd>
+            </div>
+            <div>
+              <dt>Last due count</dt>
+              <dd>{workspace.scheduler.daemon?.last_due_count ?? (textValue(asRecord(workspace.scheduler.last_due_scan?.payload_json).due_count) || "0")}</dd>
+            </div>
+            <div>
+              <dt>Next due workflow</dt>
+              <dd>{workspace.scheduler.next_due_workflow?.workflow_type ?? "none"}</dd>
+            </div>
+            <div>
+              <dt>Running workflow</dt>
+              <dd>{workspace.scheduler.currently_running_workflow?.workflow_type ?? "none"}</dd>
+            </div>
+          </div>
+          <div className="vnext-review-actions">
+            <button type="button" className="button" onClick={() => void handleSchedulerRunDue()} disabled={Boolean(pendingAction)}>
+              Run due
+            </button>
           </div>
           {workspace.scheduler.last_failure ? (
             <article className="list-row">
@@ -2271,6 +2445,19 @@ export function VNextBrainWorkspace({
               </div>
               <p>{workspace.scheduler.last_failure.error_message ?? "No error message recorded."}</p>
             </article>
+          ) : null}
+          {workspace.scheduler.recent_failures?.length ? (
+            <div className="list-rows">
+              {workspace.scheduler.recent_failures.slice(0, 3).map((run) => (
+                <article key={`scheduler-failure-${run.id}`} className="list-row">
+                  <div className="list-row__topline">
+                    <h3 className="list-row__title">{run.workflow_type}</h3>
+                    <StatusBadge status="failed" />
+                  </div>
+                  <p>{run.error_message ?? "No error message recorded."}</p>
+                </article>
+              ))}
+            </div>
           ) : null}
           <div className="list-rows">
             {workspace.scheduler.workflows.length ? (
@@ -2293,6 +2480,7 @@ export function VNextBrainWorkspace({
                     <div className="list-row__meta">
                       <span className="meta-pill">Next: {workflow.next_run_at ?? "manual or disabled"}</span>
                       <span className="meta-pill">Last: {workflow.last_run_at ?? "never"}</span>
+                      <span className="meta-pill">Last success: {workspace.scheduler.last_success_by_workflow?.[workflow.workflow_type]?.finished_at ?? "never"}</span>
                       <span className="meta-pill">Result: {workflow.last_result ?? "none"}</span>
                       {workflow.last_error ? <span className="meta-pill">Error: {workflow.last_error}</span> : null}
                     </div>

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -35,6 +35,8 @@ import {
   getMemoryRevisions,
   getTaskSteps,
   getVNextBrainCharter,
+  getVNextPolicyTelemetry,
+  getVNextSchedulerFailures,
   getVNextWorkspace,
   getThreadDetail,
   getThreadEvents,
@@ -79,6 +81,8 @@ import {
   reviewVNextArtifact,
   reviewVNextMemory,
   reviewVNextOpenLoop,
+  runVNextSchedulerDue,
+  runVNextSchedulerWorkflowNow,
   shouldExpectThreadExecutionReview,
   submitAssistantResponse,
   submitApprovalRequest,
@@ -3677,6 +3681,14 @@ describe("api helpers", () => {
       content_markdown: "# ALICE.md",
       sensitivity: "private",
     });
+    await getVNextSchedulerFailures("https://api.example.com", "user-1", 5);
+    await runVNextSchedulerWorkflowNow("https://api.example.com", "daily_brief", {
+      user_id: "user-1",
+      scope: { domains: ["project"] },
+      options: { sensitivity_allowed: ["public", "private"] },
+    });
+    await runVNextSchedulerDue("https://api.example.com", { user_id: "user-1", limit: 10 });
+    await getVNextPolicyTelemetry("https://api.example.com", "user-1");
 
     expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
       "https://api.example.com/v0/vnext/workspace?user_id=user-1",
@@ -3692,12 +3704,22 @@ describe("api helpers", () => {
       "https://api.example.com/v0/vnext/open-loops/loop-1/review",
       "https://api.example.com/v0/vnext/settings/brain-charter?user_id=user-1",
       "https://api.example.com/v0/vnext/settings/brain-charter",
+      "https://api.example.com/v0/vnext/scheduler/failures?user_id=user-1&limit=5",
+      "https://api.example.com/v0/vnext/scheduler/workflows/daily_brief/run-now",
+      "https://api.example.com/v0/vnext/scheduler/run-due",
+      "https://api.example.com/v0/vnext/agents/policy-telemetry?user_id=user-1",
     ]);
     expect(fetchMock.mock.calls[1]?.[1]).toEqual(
       expect.objectContaining({ method: "POST" }),
     );
     expect(fetchMock.mock.calls[12]?.[1]).toEqual(
       expect.objectContaining({ method: "PUT" }),
+    );
+    expect(fetchMock.mock.calls[14]?.[1]).toEqual(
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock.mock.calls[15]?.[1]).toEqual(
+      expect.objectContaining({ method: "POST" }),
     );
     expect(JSON.parse(String(fetchMock.mock.calls[6]?.[1]?.body))).toEqual({
       user_id: "user-1",

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -349,6 +349,21 @@ export type VNextSchedulerRunRecord = VNextRow & {
   metadata_json?: JsonObject;
 };
 
+export type VNextSchedulerDaemonStatus = {
+  configured?: boolean;
+  running?: boolean;
+  pid?: number | null;
+  pid_file?: string;
+  status_file?: string;
+  started_at?: string;
+  stopped_at?: string;
+  last_heartbeat_at?: string;
+  last_due_scan_at?: string;
+  last_due_count?: number;
+  last_error?: string | null;
+  mode?: string;
+};
+
 export type VNextSchedulerStatus = {
   mode: string;
   disabled_by_default: boolean;
@@ -357,6 +372,12 @@ export type VNextSchedulerStatus = {
   enabled_count: number;
   paused_count: number;
   last_failure: VNextSchedulerRunRecord | null;
+  recent_failures?: VNextSchedulerRunRecord[];
+  last_due_scan?: VNextEventRecord | null;
+  next_due_workflow?: VNextSchedulerWorkflowRecord | null;
+  currently_running_workflow?: VNextSchedulerRunRecord | null;
+  last_success_by_workflow?: Record<string, VNextSchedulerRunRecord | null>;
+  daemon?: VNextSchedulerDaemonStatus;
 };
 
 export type VNextAgentActivity = {
@@ -365,6 +386,23 @@ export type VNextAgentActivity = {
   policy_blocks: VNextEventRecord[];
   generated_artifacts: VNextArtifactRecord[];
   pending_review_items: VNextMemoryRecord[];
+};
+
+export type VNextTelemetryCounter = {
+  count: number;
+  [key: string]: unknown;
+};
+
+export type VNextPolicyTelemetrySummary = {
+  total_agent_events: number;
+  total_policy_decisions: number;
+  policy_blocks_by_agent: VNextTelemetryCounter[];
+  policy_filters_by_agent: VNextTelemetryCounter[];
+  requires_review_by_agent: VNextTelemetryCounter[];
+  restricted_domains_requested: VNextTelemetryCounter[];
+  workflows_triggered_by_agents: VNextTelemetryCounter[];
+  memory_proposals_by_agent: VNextTelemetryCounter[];
+  artifact_generation_by_agent: VNextTelemetryCounter[];
 };
 
 export type VNextWorkspacePayload = {
@@ -394,6 +432,7 @@ export type VNextWorkspacePayload = {
   tasks: VNextTaskRecord[];
   recent_events: VNextEventRecord[];
   agent_activity?: VNextAgentActivity;
+  policy_telemetry?: VNextPolicyTelemetrySummary;
   scheduler?: VNextSchedulerStatus;
   brain_charter: VNextBrainCharterRecord | null;
 };
@@ -4052,6 +4091,24 @@ export function getVNextSchedulerStatus(apiBaseUrl: string, userId: string) {
   );
 }
 
+export function getVNextSchedulerFailures(apiBaseUrl: string, userId: string, limit = 20) {
+  return requestJson<{ items: VNextSchedulerRunRecord[]; count: number }>(
+    apiBaseUrl,
+    "/v0/vnext/scheduler/failures",
+    undefined,
+    { user_id: userId, limit: String(limit) },
+  );
+}
+
+export function getVNextPolicyTelemetry(apiBaseUrl: string, userId: string) {
+  return requestJson<{ summary: VNextPolicyTelemetrySummary }>(
+    apiBaseUrl,
+    "/v0/vnext/agents/policy-telemetry",
+    undefined,
+    { user_id: userId },
+  );
+}
+
 export function patchVNextSchedulerWorkflow(
   apiBaseUrl: string,
   workflowType: string,
@@ -4083,6 +4140,21 @@ export function runVNextSchedulerWorkflowNow(
     artifact: VNextArtifactRecord | null;
     policy_decision: VNextPolicyDecisionRecord;
   }>(apiBaseUrl, `/v0/vnext/scheduler/workflows/${workflowType}/run-now`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function runVNextSchedulerDue(
+  apiBaseUrl: string,
+  payload: { user_id: string; limit?: number },
+) {
+  return requestJson<{
+    checked_at: string;
+    due_count: number;
+    runs: { workflow_type: string; scheduled_for: string; run: VNextSchedulerRunRecord; artifact: VNextArtifactRecord | null }[];
+    policy_decision: VNextPolicyDecisionRecord;
+  }>(apiBaseUrl, "/v0/vnext/scheduler/run-due", {
     method: "POST",
     body: JSON.stringify(payload),
   });

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -39,11 +39,18 @@ alice brief --brief-type general --query local-first
 alicebot context-pack "Alice sprint context" --domain project
 alicebot vnext agents propose-memory --agent-id openclaw --permission-profile project_scoped_agent --project-scope Alice --title "Candidate memory" --canonical-text "Alice should keep agent proposals review-only." --domain project --sensitivity private
 alicebot vnext scheduler status
+alicebot vnext scheduler daemon start --foreground
+alicebot vnext scheduler daemon status
+alicebot vnext scheduler daemon stop
 alicebot vnext scheduler run-now daily_brief --agent-id hermes --permission-profile trusted_local_agent --project-scope Alice --domain project
 alicebot vnext scheduler run-due --agent-id hermes --permission-profile trusted_local_agent
+alicebot vnext scheduler runs
+alicebot vnext scheduler failures
 alicebot vnext scheduler pause --agent-id hermes --permission-profile trusted_local_agent
 alicebot vnext scheduler resume --agent-id hermes --permission-profile trusted_local_agent
+alicebot vnext agents policy-telemetry
 alicebot vnext smoke agentic-scheduler
+alicebot vnext smoke local-runtime
 ```
 
 The vNext agent arguments are `--agent-id`, `--agent-type`, `--agent-run-id`, `--agent-task-id`, `--project-scope`, and `--permission-profile`. Agent-originated scheduler and memory-proposal commands are policy checked, logged, and kept review-only where they create memory or generated artifacts.
@@ -67,7 +74,7 @@ The vNext agent arguments are `--agent-id`, `--agent-type`, `--agent-run-id`, `-
 - output format is deterministic for stable automated validation
 - provenance snippets remain visible in recall/resume responses
 - correction flow updates future recall/resume results
-- vNext scheduler smoke output is JSON and fails nonzero if any agent/scheduler gate fails
+- vNext scheduler smoke output is JSON and fails nonzero if any agent/scheduler/local-runtime gate fails
 
 See tests:
 

--- a/docs/localruntime.md
+++ b/docs/localruntime.md
@@ -1,0 +1,216 @@
+⸻
+
+Next Sprint Scope
+
+Objective
+
+Turn the current governed scheduler into a reliable local runtime that can run Alice Brain workflows automatically, complete the remaining scheduled workflow generators, and reduce /vnext fixture dependency.
+
+By the end of the sprint, Alice should be able to run locally in the background, execute due workflows safely, generate reviewable artifacts, show all runs in /vnext, and preserve agent/policy/audit controls.
+
+⸻
+
+Core deliverables
+
+1. Local scheduler daemon / service runner
+2. launchd/systemd recipes
+3. Full deterministic generators for remaining scheduler workflows
+4. Fully live-backed scheduler and agent activity surfaces
+5. Reduced /vnext fixture dependency
+6. Scheduler failure/recovery hardening
+7. Agent policy telemetry summary
+8. Updated local alpha docs
+
+⸻
+
+Build requirements
+
+1. Local scheduler daemon
+
+Add a lightweight local runtime around:
+
+alicebot vnext scheduler run-due
+
+Supported modes:
+
+foreground dev mode
+background local daemon mode
+systemd recipe for Linux
+launchd recipe for macOS
+Docker/local process option if already compatible
+
+The daemon should:
+
+poll due workflows on a configurable interval
+respect pause/resume state
+not run disabled workflows
+avoid duplicate concurrent runs
+log start/success/failure
+recover cleanly after restart
+persist last run and next run state
+
+No hosted scheduler yet.
+
+⸻
+
+2. Complete remaining scheduled workflow generators
+
+Daily Brief and Weekly Synthesis are already primary runnable workflows.
+
+Now complete deterministic artifact generation for:
+
+connection_report
+contradiction_report
+open_loop_review
+project_update_scan
+
+Each should produce a reviewable generated artifact with:
+
+artifact_type
+workflow_type
+scheduler_run_id
+trace_id
+generated_by = scheduler
+source refs
+domain
+sensitivity
+policy decision
+review status
+created_at
+
+No workflow may auto-promote anything into trusted memory.
+
+⸻
+
+3. Live-backed /vnext cleanup
+
+Reduce fixture dependency in the existing workspace.
+
+Prioritize making these fully live-backed:
+
+Agent Activity
+Schedules
+Timeline/Event Log
+Generated Artifacts
+Memory Review
+Projects
+Open Loops
+
+Fixture/demo mode can remain, but live mode should be clearly default when API config exists.
+
+⸻
+
+4. Scheduler observability
+
+Add better operator visibility.
+
+The UI should show:
+
+daemon status if available
+last due scan
+next due workflow
+currently running workflow
+recent failures
+last successful run per workflow
+workflow run history
+blocked/filtered policy decisions
+
+CLI should expose:
+
+alicebot vnext scheduler daemon start
+alicebot vnext scheduler daemon status
+alicebot vnext scheduler daemon stop
+alicebot vnext scheduler runs
+alicebot vnext scheduler failures
+
+If stop/status are not practical cross-platform yet, document the local process approach clearly.
+
+⸻
+
+5. Agent policy telemetry
+
+Add a simple summary view/report showing:
+
+policy blocks by agent
+policy filters by agent
+requires-review decisions by agent
+most common restricted domains requested
+most common workflows triggered by agents
+memory proposals by agent
+artifact generation by agent
+
+This is important because Alice is agentic-first. We need to see how Hermes/OpenClaw actually interact with the system.
+
+⸻
+
+Acceptance criteria
+
+Local scheduler daemon or service runner exists.
+Daemon can run due workflows without manual CLI invocation.
+macOS launchd recipe exists.
+Linux systemd recipe exists.
+Scheduler does not run disabled workflows.
+Scheduler respects global pause/resume.
+Scheduler prevents duplicate concurrent runs for the same workflow.
+Daily Brief scheduled run still works.
+Weekly Synthesis scheduled run still works.
+Connection Report scheduled run produces a real reviewable artifact.
+Contradiction Report scheduled run produces a real reviewable artifact.
+Open Loop Review scheduled run produces a real reviewable artifact.
+Project Update Scan scheduled run produces a real reviewable artifact.
+All scheduled artifacts include generated_by, workflow_type, scheduler_run_id, trace_id, source refs, domain, sensitivity, and review status.
+No scheduled workflow auto-promotes artifacts into trusted memory.
+Scheduler failures are captured and visible in /vnext.
+Timeline/Event Log shows scheduler run lifecycle events.
+Agent Activity and Schedules pages are live-backed.
+Generated Artifacts, Memory Review, Projects, and Open Loops are live-backed or substantially more live-backed than the previous phase.
+Demo fixture mode remains available.
+Postgres-backed smoke test covers daemon/due-run behavior.
+Policy telemetry summary exists through CLI/API and visible minimally in /vnext.
+Existing agent permission rules remain enforced.
+Existing no-auto-promotion, privacy, and prompt-injection evals still pass.
+Python tests pass.
+Integration tests pass.
+Web tests pass.
+Web lint passes.
+Web build passes.
+git diff --check passes.
+
+⸻
+
+Explicit deferrals
+
+Still defer:
+
+live Gmail OAuth
+live Calendar OAuth
+live Telegram polling
+browser extension runtime actions
+OCR execution
+voice transcription execution
+hosted scheduler service
+cloud deployment
+mobile app
+automatic memory promotion
+human-rated eval scoring
+major UI redesign
+
+After this sprint, the system will be ready for either:
+
+Model-Backed Intelligence
+
+or:
+
+Live Connector Auth/Polling
+
+But I would only choose between those after seeing whether the local runtime loop feels useful in dogfooding.
+
+Bottom line
+
+This PR is a major step. Alice now has the right agentic control model.
+
+The next milestone is operational:
+
+Alice should run locally in the background, execute governed workflows on schedule, generate useful reviewable artifacts, and show exactly what happened.
+
+Once that is stable, then we make the intelligence stronger.

--- a/docs/runbooks/vnext-local-scheduler.launchd.plist
+++ b/docs/runbooks/vnext-local-scheduler.launchd.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.alicebot.vnext-scheduler</string>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/YOUR_USER/path/to/AliceBot</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>ALICE_DATABASE_URL</key>
+    <string>postgresql://alice:alice@localhost:5432/alicebot</string>
+    <key>ALICE_USER_ID</key>
+    <string>00000000-0000-0000-0000-000000000000</string>
+  </dict>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/YOUR_USER/path/to/AliceBot/.venv/bin/python</string>
+    <string>-m</string>
+    <string>alicebot_api</string>
+    <string>--database-url</string>
+    <string>postgresql://alice:alice@localhost:5432/alicebot</string>
+    <string>--user-id</string>
+    <string>00000000-0000-0000-0000-000000000000</string>
+    <string>vnext</string>
+    <string>scheduler</string>
+    <string>daemon</string>
+    <string>start</string>
+    <string>--foreground</string>
+    <string>--interval-seconds</string>
+    <string>60</string>
+    <string>--limit</string>
+    <string>10</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/Users/YOUR_USER/.alicebot/vnext-scheduler/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/YOUR_USER/.alicebot/vnext-scheduler/launchd.err.log</string>
+</dict>
+</plist>

--- a/docs/runbooks/vnext-local-scheduler.service
+++ b/docs/runbooks/vnext-local-scheduler.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Alice vNext local scheduler daemon
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/YOUR_USER/path/to/AliceBot
+Environment=ALICE_DATABASE_URL=postgresql://alice:alice@localhost:5432/alicebot
+Environment=ALICE_USER_ID=00000000-0000-0000-0000-000000000000
+ExecStart=/home/YOUR_USER/path/to/AliceBot/.venv/bin/python -m alicebot_api --database-url ${ALICE_DATABASE_URL} --user-id ${ALICE_USER_ID} vnext scheduler daemon start --foreground --interval-seconds 60 --limit 10
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/docs/vnext-local-runtime-cto-summary.md
+++ b/docs/vnext-local-runtime-cto-summary.md
@@ -1,0 +1,110 @@
+# Alice vNext Local Runtime: CTO Summary
+
+Date: 2026-05-11
+Audience: CTO / technical leadership
+Phase artifact: vNext local runtime scheduler
+Branch: `codex/local-runtime-scheduler`
+
+## Executive Summary
+
+This phase turns the governed vNext scheduler into an operational local runtime. Alice can now run in the background, poll for due Brain workflows, avoid duplicate concurrent runs, produce reviewable artifacts for all scheduled workflow types, and expose scheduler and agent-policy telemetry in the `/vnext` operator workspace.
+
+The important product shift is that Alice vNext is no longer only a manually triggered preview. It now has the local process model needed for dogfooding: the scheduler can run due work on its own, recover across restarts through persisted workflow/run state, show failures and run history, and preserve the no-auto-promotion and policy-audit controls from the agentic control plane.
+
+## What We Built
+
+### Local Scheduler Runtime
+
+- Added a local daemon module for foreground, one-shot, and background scheduler operation.
+- Added pid, status, heartbeat, due-scan, error, and log-file handling under `~/.alicebot/vnext-scheduler` by default.
+- Added CLI controls:
+  - `alicebot vnext scheduler daemon start`
+  - `alicebot vnext scheduler daemon start --foreground`
+  - `alicebot vnext scheduler daemon start --foreground --once`
+  - `alicebot vnext scheduler daemon status`
+  - `alicebot vnext scheduler daemon stop`
+- Added `alicebot vnext scheduler runs` and `alicebot vnext scheduler failures`.
+- Added macOS launchd and Linux systemd templates for local service installation.
+
+### Scheduler Hardening
+
+- Added a per-workflow Postgres advisory lock so concurrent due scans skip a workflow already being run.
+- Preserved disabled-by-default behavior.
+- Preserved pause/resume behavior.
+- Preserved disabled workflow exclusion.
+- Added richer scheduler status: last due scan, next due workflow, currently running workflow, recent failures, last successful run per workflow, and expanded recent run history.
+- Added failure capture that records failed run state and workflow `last_error` without crashing the scheduler loop.
+
+### Full Scheduled Workflow Coverage
+
+Daily Brief and Weekly Synthesis remained scheduled, reviewable workflows.
+
+This phase completed deterministic scheduled artifacts for the remaining workflow types:
+
+- `connection_report`
+- `contradiction_report`
+- `open_loop_review`
+- `project_update_scan`
+
+Every scheduled artifact is review-only and carries scheduler metadata: `generated_by`, `workflow_type`, `scheduler_run_id`, `trace_id`, `source_refs`, `domain`, `sensitivity`, and `review_status`.
+
+### Agent Policy Telemetry
+
+- Added policy decision records that retain requested domains and sensitivity filters as well as effective filters.
+- Added a telemetry summary for:
+  - policy blocks by agent
+  - policy filters by agent
+  - requires-review decisions by agent
+  - restricted domains requested
+  - workflows triggered by agents
+  - memory proposals by agent
+  - artifact generation by agent
+- Exposed telemetry through:
+  - `alicebot vnext agents policy-telemetry`
+  - `GET /v0/vnext/agents/policy-telemetry`
+  - the `/vnext` Agent Activity surface
+
+### Live Operator Workspace
+
+- Extended `/vnext` Schedules with daemon state, last due scan, last due count, next due workflow, current run, recent failures, last successful run per workflow, run-due control, and run history.
+- Extended `/vnext` Agent Activity with aggregated policy telemetry.
+- Kept demo/fixture mode available while making live workspace payloads the source for scheduler, agent activity, timeline, generated artifacts, memory review, projects, and open loops when API configuration exists.
+
+### Local Runtime Smoke
+
+- Added `alicebot vnext smoke local-runtime`.
+- The smoke seeds a small Postgres-backed local-runtime fixture, marks all six workflows due, runs the foreground daemon once, and verifies that every scheduled workflow produces a reviewable artifact with scheduler metadata.
+
+## Guardrails Preserved
+
+- No scheduled workflow auto-promotes artifacts into trusted memory.
+- Agent memory writes remain proposal/review-only.
+- Existing agent permission rules remain enforced.
+- Restricted domains and high-sensitivity scopes remain filtered or blocked by policy.
+- Scheduler configuration and global controls remain policy checked.
+- The local daemon is explicitly not a hosted scheduler service.
+
+## Operator Takeaways
+
+- Alice can now run locally in the background and execute governed work without manual CLI invocation.
+- The scheduler has enough visibility for dogfooding: status, history, failure state, daemon heartbeat, and event-log traces.
+- All proactive Brain workflows now produce concrete reviewable outputs instead of placeholder scheduler scaffolding.
+- Agent telemetry gives us the first useful view into how Hermes/OpenClaw-style callers interact with policy gates.
+- The next product decision should be based on dogfooding signal: either deepen model-backed intelligence or move into live connector auth/polling.
+
+## Validation Evidence
+
+Current local validation performed during this phase:
+
+- Python compile checks for scheduler runtime, scheduler service, CLI, API, store, Brain workflows, and project/connection/contradiction services: passed.
+- Focused local-runtime unit tests: `35 passed`.
+- Full Python unit suite: `1076 passed`.
+- Full Python integration suite: `370 passed`.
+- Web test suite: `207 passed`.
+- Web lint: passed.
+- Web production build: passed and built `/vnext`.
+- `alicebot vnext smoke agentic-scheduler`: passed.
+- `alicebot vnext smoke local-runtime`: passed, including all six scheduled workflows and daemon one-shot due scan.
+- Live Postgres advisory-lock probe: passed, confirming duplicate same-workflow due runs are skipped while another transaction holds the workflow lock.
+- `alicebot eval run --suite all`: `170/170` passed, with `0` critical privacy leaks and `0` prompt-injection tool writes.
+- `git diff --check`: passed.

--- a/docs/vnext/README.md
+++ b/docs/vnext/README.md
@@ -1,6 +1,6 @@
 # Alice vNext Public Preview
 
-Alice vNext is the next public wedge for Alice as an agent-native second brain: a local-first memory kernel, reviewable generated briefs, connector-backed evidence capture, agent-facing context packs, governed agent proposals, and local scheduler workflows.
+Alice vNext is the next public wedge for Alice as an agent-native second brain: a local-first memory kernel, reviewable generated briefs, connector-backed evidence capture, agent-facing context packs, governed agent proposals, and a local scheduler runtime.
 
 This preview is not a hosted launch. It is a repo-local, deterministic public preview built around the vNext memory-kernel schema and the fixture-safe workflows shipped under `v0.5.1-vnext-preview`.
 
@@ -18,7 +18,7 @@ Alice vNext has three layers:
 - Retrieval: deterministic context packs with domain/sensitivity filters and provenance.
 - Brain workflows: daily brief, weekly synthesis, connection report, contradiction report, project update, open-loop review.
 - Agentic control plane: scoped agent identities, permission profiles, policy decisions, memory proposals, and Agent Activity audit surface.
-- Governed scheduler: disabled-by-default daily/weekly/proactive workflow controls with local due scans, run history, trace IDs, failures, and reviewable artifacts.
+- Governed scheduler: disabled-by-default workflow controls, a local daemon runner, due scans, run history, trace IDs, failures, duplicate-run locks, and reviewable artifacts.
 - Connectors: deterministic Telegram, browser clipper, PDF, DOCX, CSV, screenshot OCR, and voice transcript payload ingestion.
 - UI: live/fixture-backed `/vnext` workspace for review, Ask Alice, briefs, queue, projects, Agent Activity, Schedules, beliefs, graph, connectors, and privacy settings.
 - Evals: synthetic corpus and baseline metrics for recall, temporal reasoning, contradictions, provenance, privacy, open loops, and prompt injection.
@@ -28,11 +28,12 @@ Alice vNext has three layers:
 1. Follow [vNext quickstart](quickstart.md).
 2. Review [architecture](architecture.md).
 3. Review [security and privacy](security-privacy.md).
-4. Use [example ALICE.md](ALICE.example.md) as the first Brain Charter.
-5. Use [demo script](demo-video-script.md) for a short walkthrough.
-6. Use [release checklist](../release/vnext-public-release-checklist.md) before publishing or tagging.
-7. Review [preview release notes](../release/v0.5.1-vnext-preview-release-notes.md) and [tag plan](../release/v0.5.1-vnext-preview-tag-plan.md).
-8. Review the [agentic control plane CTO summary](../vnext-agentic-control-plane-cto-summary.md) for the current sprint closeout.
+4. Review [local runtime](local-runtime.md) before running scheduler workflows in the background.
+5. Use [example ALICE.md](ALICE.example.md) as the first Brain Charter.
+6. Use [demo script](demo-video-script.md) for a short walkthrough.
+7. Use [release checklist](../release/vnext-public-release-checklist.md) before publishing or tagging.
+8. Review [preview release notes](../release/v0.5.1-vnext-preview-release-notes.md) and [tag plan](../release/v0.5.1-vnext-preview-tag-plan.md).
+9. Review the [agentic control plane CTO summary](../vnext-agentic-control-plane-cto-summary.md) and [local runtime CTO summary](../vnext-local-runtime-cto-summary.md) for sprint closeouts.
 
 ## Launch Boundary
 

--- a/docs/vnext/local-runtime.md
+++ b/docs/vnext/local-runtime.md
@@ -1,0 +1,89 @@
+# Alice vNext Local Runtime
+
+Alice vNext now includes a local scheduler runtime for running governed Alice Brain workflows in the background. This is a local alpha runtime, not a hosted scheduler service.
+
+## What It Runs
+
+The daemon wraps:
+
+```bash
+alicebot vnext scheduler daemon start
+```
+
+In foreground mode, it polls `alicebot vnext scheduler run-due` behavior on an interval and persists status to `~/.alicebot/vnext-scheduler/scheduler-status.json`. In background mode, it spawns the same foreground worker as a local process and records a pid file, status file, and log file.
+
+## Commands
+
+```bash
+alicebot vnext scheduler daemon start
+alicebot vnext scheduler daemon start --foreground
+alicebot vnext scheduler daemon start --foreground --once
+alicebot vnext scheduler daemon status
+alicebot vnext scheduler daemon stop
+alicebot vnext scheduler runs
+alicebot vnext scheduler failures
+alicebot vnext agents policy-telemetry
+alicebot vnext smoke local-runtime
+```
+
+Useful options:
+
+- `--interval-seconds`: due-scan polling interval. Default: `60`.
+- `--limit`: maximum due workflows per scan. Default: `10`.
+- `--pid-file`: daemon pid path. Default: `~/.alicebot/vnext-scheduler/scheduler.pid`.
+- `--status-file`: daemon status JSON path. Default: `~/.alicebot/vnext-scheduler/scheduler-status.json`.
+- `--log-file`: daemon log path. Default: `~/.alicebot/vnext-scheduler/scheduler.log`.
+
+## Scheduler Guarantees
+
+- Workflows remain disabled by default.
+- Disabled workflows are not run.
+- Paused workflows are not run.
+- Due scans use a per-workflow Postgres advisory lock to avoid duplicate concurrent runs for the same workflow.
+- Daily Brief and Weekly Synthesis scheduled runs still produce reviewable generated artifacts.
+- Connection Report, Contradiction Report, Open Loop Review, and Project Update Scan now produce deterministic reviewable artifacts from scheduled runs.
+- Scheduled artifacts include scheduler trace metadata: `generated_by`, `workflow_type`, `scheduler_run_id`, `trace_id`, `source_refs`, `domain`, `sensitivity`, and `review_status`.
+- Generated artifacts and agent proposals are not auto-promoted into trusted memory.
+
+## Operator Visibility
+
+The `/vnext` Schedules surface shows daemon posture, last due scan, next due workflow, currently running workflow, recent failures, last successful run per workflow, and run history. The Timeline surface remains backed by the append-only event log. Agent Activity includes policy blocks, filters, review-gated decisions, workflow triggers, memory proposals, and artifact generation telemetry.
+
+The API exposes the same local runtime posture through:
+
+- `GET /v0/vnext/scheduler/status`
+- `GET /v0/vnext/scheduler/runs`
+- `GET /v0/vnext/scheduler/failures`
+- `POST /v0/vnext/scheduler/run-due`
+- `GET /v0/vnext/agents/policy-telemetry`
+
+## macOS launchd
+
+Use [docs/runbooks/vnext-local-scheduler.launchd.plist](../runbooks/vnext-local-scheduler.launchd.plist) as the template. Replace the paths, `ALICE_DATABASE_URL`, and `ALICE_USER_ID` values before loading it.
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.alicebot.vnext-scheduler.plist
+launchctl kickstart -k gui/$(id -u)/com.alicebot.vnext-scheduler
+launchctl bootout gui/$(id -u)/com.alicebot.vnext-scheduler
+```
+
+## Linux systemd
+
+Use [docs/runbooks/vnext-local-scheduler.service](../runbooks/vnext-local-scheduler.service) as the template. Replace the working directory, environment variables, user, and venv path before enabling it.
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now alicebot-vnext-scheduler.service
+systemctl --user status alicebot-vnext-scheduler.service
+systemctl --user stop alicebot-vnext-scheduler.service
+```
+
+## Validation
+
+The local runtime smoke is Postgres-backed:
+
+```bash
+alicebot vnext smoke local-runtime
+```
+
+It seeds a small local-runtime fixture, marks all six scheduler workflows due, runs the foreground daemon once, and checks that each workflow produces a reviewable artifact with scheduler metadata.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -331,13 +331,32 @@ class FakeVNextCliStore:
         )
         return belief
 
-    def list_events(self, *, target_type: str | None = None, target_id: str | None = None) -> list[dict[str, object]]:
-        return [
+    def list_events(
+        self,
+        *,
+        target_type: str | None = None,
+        target_id: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, object]]:
+        rows = [
             event
             for event in self.events
             if (target_type is None or event.get("target_type") == target_type)
             and (target_id is None or event.get("target_id") == target_id)
         ]
+        rows = list(reversed(rows))
+        return rows[:limit] if limit is not None else rows
+
+    def list_agent_events(self, *, agent_id: str | None = None, limit: int = 50) -> list[dict[str, object]]:
+        rows = [
+            event
+            for event in reversed(self.events)
+            if event.get("actor_type") == "agent" and (agent_id is None or event.get("actor_id") == agent_id)
+        ]
+        return rows[:limit]
+
+    def list_memories(self, *, status: str | None = None) -> list[dict[str, object]]:
+        return [memory for memory in self.memories if status is None or memory.get("status") == status]
 
     def create_task(self, task: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**task, "id": f"task-{len(self.tasks) + 1}", "status": "pending"}
@@ -502,6 +521,10 @@ class FakeVNextCliStore:
             if workflow_type is None or run.get("workflow_type") == workflow_type
         ]
         return rows[:limit]
+
+    def try_scheduler_workflow_lock(self, workflow_type: str) -> bool:
+        del workflow_type
+        return True
 
 
 def test_vnext_capture_text_cli_uses_vnext_capture_service(monkeypatch) -> None:

--- a/tests/unit/test_vnext_agent_control.py
+++ b/tests/unit/test_vnext_agent_control.py
@@ -8,6 +8,7 @@ from alicebot_api.vnext_agent_control import (
     append_policy_events,
     ensure_policy_allowed,
     evaluate_agent_policy,
+    summarize_agent_policy_telemetry,
 )
 
 
@@ -156,3 +157,49 @@ def test_policy_events_log_decision_and_filtered_or_blocked_outcomes() -> None:
     assert event_types == ["policy.decision", "agent.policy_filtered"]
     assert store.events[0]["actor_id"] == "openclaw"
     assert store.events[0]["trace_id"] == decision.trace_id
+    assert store.events[0]["payload_json"]["policy_decision"]["requested_domains"] == ["project", "family"]
+
+
+def test_policy_telemetry_summarizes_agent_outcomes() -> None:
+    store = EventStore()
+    openclaw = AgentIdentity.from_payload({"agent_id": "openclaw", "project_scope": ["Alice"]})
+    memory_bot = AgentIdentity.from_payload({"agent_id": "memory-bot", "permission_profile": "memory_proposal_agent"})
+    assert openclaw is not None and memory_bot is not None
+    filtered = evaluate_agent_policy(
+        identity=openclaw,
+        action="context_pack.request",
+        domains=("project", "family"),
+        project_scope=("Alice",),
+    )
+    proposal = evaluate_agent_policy(
+        identity=memory_bot,
+        action="memory.propose",
+        domains=("project",),
+        sensitivity_allowed=("private",),
+    )
+    append_policy_events(store, identity=openclaw, decision=filtered)
+    append_policy_events(store, identity=memory_bot, decision=proposal)
+    store.append_event(
+        {
+            "event_type": "agent.memory_proposed",
+            "actor_type": "agent",
+            "actor_id": "memory-bot",
+            "payload_json": {},
+        }
+    )
+    store.append_event(
+        {
+            "event_type": "scheduler.run_started",
+            "actor_type": "agent",
+            "actor_id": "openclaw",
+            "payload_json": {"workflow_type": "project_update_scan"},
+        }
+    )
+
+    summary = summarize_agent_policy_telemetry(agent_events=store.events)
+
+    assert summary["policy_filters_by_agent"][0]["agent_id"] == "openclaw"
+    assert summary["requires_review_by_agent"][0]["agent_id"] == "memory-bot"
+    assert summary["restricted_domains_requested"] == [{"domain": "family", "count": 1}]
+    assert summary["workflows_triggered_by_agents"][0]["workflow_type"] == "project_update_scan"
+    assert summary["memory_proposals_by_agent"] == [{"agent_id": "memory-bot", "count": 1}]

--- a/tests/unit/test_vnext_scheduler.py
+++ b/tests/unit/test_vnext_scheduler.py
@@ -42,6 +42,8 @@ class InMemorySchedulerStore:
             }
         ]
         self.open_loops: list[dict[str, object]] = []
+        self.projects: list[dict[str, object]] = []
+        self.locked_workflows: set[str] = set()
 
     def append_event(self, event: dict[str, object]) -> dict[str, object]:
         self.events.append(event)
@@ -141,6 +143,9 @@ class InMemorySchedulerStore:
         ]
         return rows[:limit]
 
+    def try_scheduler_workflow_lock(self, workflow_type: str) -> bool:
+        return workflow_type not in self.locked_workflows
+
     def create_artifact(self, artifact: dict[str, object], *, actor_type: str = "system") -> dict[str, object]:
         if self.fail_artifact_create:
             raise RuntimeError("artifact store unavailable")
@@ -160,6 +165,17 @@ class InMemorySchedulerStore:
 
     def list_artifacts(self, **kwargs) -> list[dict[str, object]]:
         return list(self.artifacts.values())[: kwargs.get("limit", 8)]
+
+    def list_projects(self, **kwargs) -> list[dict[str, object]]:
+        return self.projects[: kwargs.get("limit", 8)]
+
+    def list_beliefs(self, **kwargs) -> list[dict[str, object]]:
+        return [] if kwargs else []
+
+    def list_events(self, **kwargs) -> list[dict[str, object]]:
+        limit = kwargs.get("limit")
+        rows = list(reversed(self.events))
+        return rows[:limit] if isinstance(limit, int) else rows
 
 
 def test_schedule_validation_and_next_run_are_deterministic() -> None:
@@ -234,6 +250,71 @@ def test_scheduler_run_due_executes_due_enabled_workflows_and_advances_next_run(
     assert result["runs"][0]["artifact"]["status"] == "needs_review"
     assert store.workflows["daily_brief"]["next_run_at"] != "2026-05-11T08:00:00+00:00"
     assert "scheduler.due_scan" in [event["event_type"] for event in store.events]
+
+
+def test_scheduler_run_due_skips_workflow_when_lock_is_not_acquired() -> None:
+    store = InMemorySchedulerStore()
+    store.locked_workflows.add("daily_brief")
+    service = VNextSchedulerService(store)
+    service.configure_workflow(
+        workflow_type="daily_brief",
+        enabled=True,
+        schedule_json={"kind": "daily", "time_of_day": "08:00", "days_of_week": ["monday"]},
+        timezone="UTC",
+    )
+    store.workflows["daily_brief"]["next_run_at"] = "2026-05-11T08:00:00+00:00"
+
+    result = service.run_due_workflows(now=datetime(2026, 5, 11, 8, 5, tzinfo=UTC))
+
+    assert result["due_count"] == 0
+    assert not store.runs
+    assert "scheduler.workflow_lock_skipped" in [event["event_type"] for event in store.events]
+
+
+@pytest.mark.parametrize(
+    ("workflow_type", "artifact_type"),
+    [
+        ("connection_report", "connection_report"),
+        ("contradiction_report", "contradiction_report"),
+        ("open_loop_review", "open_loop_report"),
+        ("project_update_scan", "project_update"),
+    ],
+)
+def test_remaining_scheduler_workflows_create_reviewable_artifacts(workflow_type: str, artifact_type: str) -> None:
+    store = InMemorySchedulerStore()
+    store.open_loops.append(
+        {
+            "id": "loop-1",
+            "title": "Review scheduler output",
+            "status": "open",
+            "description": "Confirm non-primary workflows produce reviewable artifacts.",
+            "source_id": "source-1",
+            "domain": "project",
+            "sensitivity": "private",
+        }
+    )
+    service = VNextSchedulerService(store)
+
+    result = service.run_now(
+        SchedulerRunRequest(
+            workflow_type=workflow_type,
+            domains=("project",),
+            sensitivity_allowed=("public", "private"),
+            generated_for="2026-05-11",
+        )
+    )
+
+    artifact = result["artifact"]
+    metadata = artifact["metadata_json"]
+    assert result["run"]["status"] == "succeeded"
+    assert artifact["artifact_type"] == artifact_type
+    assert artifact["status"] == "needs_review"
+    assert artifact["generated_by"] == "scheduler"
+    assert metadata["workflow_type"] == workflow_type
+    assert metadata["scheduler_run_id"] == result["run"]["id"]
+    assert metadata["trace_id"] == result["run"]["trace_id"]
+    assert "source_refs" in metadata
+    assert metadata["review_status"] == "needs_review"
 
 
 def test_scheduler_pause_clears_stale_next_run() -> None:

--- a/tests/unit/test_vnext_scheduler_runtime.py
+++ b/tests/unit/test_vnext_scheduler_runtime.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from alicebot_api.vnext_scheduler_runtime import daemon_status
+
+
+def test_daemon_status_preserves_explicit_stopped_state_for_foreground_once(tmp_path: Path) -> None:
+    pid_file = tmp_path / "scheduler.pid"
+    status_file = tmp_path / "scheduler-status.json"
+    pid_file.write_text(str(os.getpid()), encoding="utf-8")
+    status_file.write_text(
+        json.dumps({"pid": os.getpid(), "running": False, "mode": "foreground"}),
+        encoding="utf-8",
+    )
+
+    status = daemon_status(pid_file=pid_file, status_file=status_file)
+
+    assert status["pid"] == os.getpid()
+    assert status["running"] is False


### PR DESCRIPTION
## Summary
- add the vNext local scheduler runtime with foreground, background, and one-shot daemon modes
- complete scheduled generators for connection reports, contradiction reports, open loop reviews, and project update scans
- expose scheduler observability, run/failure history, daemon status, and agent policy telemetry through CLI, API, and /vnext
- add launchd/systemd templates, local runtime docs, and a CTO summary

## Validation
- ./.venv/bin/python -m py_compile apps/api/src/alicebot_api/vnext_scheduler_runtime.py apps/api/src/alicebot_api/vnext_scheduler.py apps/api/src/alicebot_api/cli.py apps/api/src/alicebot_api/main.py apps/api/src/alicebot_api/vnext_store.py apps/api/src/alicebot_api/vnext_agent_control.py apps/api/src/alicebot_api/vnext_brain.py apps/api/src/alicebot_api/vnext_connections.py apps/api/src/alicebot_api/vnext_contradictions.py apps/api/src/alicebot_api/vnext_projects.py
- ./.venv/bin/python -m pytest tests/unit -q: 1076 passed
- ./.venv/bin/python -m pytest tests/integration -q: 370 passed
- pnpm -C apps/web test: 207 passed
- pnpm -C apps/web lint
- pnpm -C apps/web build
- alicebot vnext smoke local-runtime: passed, all six workflows produced reviewable scheduler artifacts
- alicebot vnext smoke agentic-scheduler: passed
- alicebot eval run --suite all: 170/170 passed, 0 critical privacy leaks, 0 prompt-injection tool writes
- live Postgres advisory-lock probe passed
- git diff --check and git diff --cached --check