### PR TITLE
[codex] Fix local scheduler daemon stop latency

### DIFF
--- a/apps/api/src/alicebot_api/vnext_scheduler_runtime.py
+++ b/apps/api/src/alicebot_api/vnext_scheduler_runtime.py
@@ -77,6 +77,19 @@ def _pid_running(pid: int) -> bool:
     return True
 
 
+def _sleep_interruptibly(
+    interval_seconds: float,
+    *,
+    should_stop: Callable[[], bool],
+    sleep_fn: Callable[[float], None],
+) -> None:
+    remaining = max(interval_seconds, 0.1)
+    while remaining > 0 and not should_stop():
+        step = min(remaining, 0.5)
+        sleep_fn(step)
+        remaining -= step
+
+
 def daemon_status(*, pid_file: Path = DEFAULT_PID_FILE, status_file: Path = DEFAULT_STATUS_FILE) -> JsonObject:
     status = _read_json(status_file) or {}
     pid = status.get("pid")
@@ -215,7 +228,11 @@ def run_foreground_daemon(
             _write_json(config.status_file, last_payload)
             if config.once:
                 break
-            sleep_fn(max(config.interval_seconds, 0.1))
+            _sleep_interruptibly(
+                config.interval_seconds,
+                should_stop=lambda: stop_requested,
+                sleep_fn=sleep_fn,
+            )
     finally:
         signal.signal(signal.SIGTERM, previous_sigterm)
         signal.signal(signal.SIGINT, previous_sigint)

--- a/docs/vnext-local-runtime-cto-summary.md
+++ b/docs/vnext-local-runtime-cto-summary.md
@@ -97,14 +97,15 @@ Every scheduled artifact is review-only and carries scheduler metadata: `generat
 Current local validation performed during this phase:
 
 - Python compile checks for scheduler runtime, scheduler service, CLI, API, store, Brain workflows, and project/connection/contradiction services: passed.
-- Focused local-runtime unit tests: `35 passed`.
-- Full Python unit suite: `1076 passed`.
+- Focused local-runtime unit tests: `37 passed`.
+- Full Python unit suite: `1077 passed`.
 - Full Python integration suite: `370 passed`.
 - Web test suite: `207 passed`.
 - Web lint: passed.
 - Web production build: passed and built `/vnext`.
 - `alicebot vnext smoke agentic-scheduler`: passed.
 - `alicebot vnext smoke local-runtime`: passed, including all six scheduled workflows and daemon one-shot due scan.
+- Background daemon start/status/stop probe: passed with temporary pid/status/log paths and a long polling interval.
 - Live Postgres advisory-lock probe: passed, confirming duplicate same-workflow due runs are skipped while another transaction holds the workflow lock.
 - `alicebot eval run --suite all`: `170/170` passed, with `0` critical privacy leaks and `0` prompt-injection tool writes.
 - `git diff --check`: passed.

--- a/tests/unit/test_vnext_scheduler_runtime.py
+++ b/tests/unit/test_vnext_scheduler_runtime.py
@@ -4,7 +4,7 @@ import json
 import os
 from pathlib import Path
 
-from alicebot_api.vnext_scheduler_runtime import daemon_status
+from alicebot_api.vnext_scheduler_runtime import _sleep_interruptibly, daemon_status
 
 
 def test_daemon_status_preserves_explicit_stopped_state_for_foreground_once(tmp_path: Path) -> None:
@@ -20,3 +20,14 @@ def test_daemon_status_preserves_explicit_stopped_state_for_foreground_once(tmp_
 
     assert status["pid"] == os.getpid()
     assert status["running"] is False
+
+
+def test_sleep_interruptibly_uses_short_slices_and_stops_early() -> None:
+    calls: list[float] = []
+
+    def sleep_fn(seconds: float) -> None:
+        calls.append(seconds)
+
+    _sleep_interruptibly(60, should_stop=lambda: len(calls) >= 2, sleep_fn=sleep_fn)
+
+    assert calls == [0.5, 0.5]


### PR DESCRIPTION
## Summary
- fix the local scheduler daemon so SIGTERM is observed during long polling intervals instead of waiting for the full sleep
- add a focused unit test for interruptible sleep slices
- update the CTO validation summary with the hotfix pass counts and background daemon start/status/stop probe

## Why
The final background daemon probe found that `scheduler daemon stop` could time out while the worker was sleeping for a long interval. The daemon now sleeps in short slices and checks the stop flag between slices.

## Validation
- ./.venv/bin/python -m py_compile apps/api/src/alicebot_api/vnext_scheduler_runtime.py
- ./.venv/bin/python -m pytest tests/unit/test_vnext_scheduler_runtime.py -q: 2 passed
- background daemon start/status/stop probe with temporary pid/status/log paths: passed, `stopped: true`
- ./.venv/bin/python -m pytest tests/unit/test_vnext_scheduler.py tests/unit/test_vnext_agent_control.py tests/unit/test_cli.py tests/unit/test_vnext_scheduler_runtime.py -q: 37 passed
- ./.venv/bin/python -m pytest tests/unit -q: 1077 passed
- ./.venv/bin/python -m pytest tests/integration -q: 370 passed
- pnpm -C apps/web test: 207 passed
- pnpm -C apps/web lint
- pnpm -C apps/web build
- alicebot vnext smoke local-runtime: passed
- alicebot vnext smoke agentic-scheduler: passed
- alicebot eval run --suite all: 170/170 passed, 0 critical privacy leaks, 0 prompt-injection tool writes
- git diff --check and git diff --cached --check