### PR TITLE
[codex] Add vNext live-backed operator console

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Alice vNext is the next release candidate for the true second-brain product. It 
 - **Alice Brain**: user-facing second-brain workflows such as daily briefs, weekly syntheses, context packs, contradiction reports, project updates, open loops, and reviewable artifacts.
 - **Alice Agent Memory**: CLI, API, and MCP surfaces that let agents capture, retrieve, resume, explain, generate context, propose memory, and trigger governed workflows without owning the memory store.
 
-The vNext preview currently includes deterministic source capture, retrieval/context packs, queue/artifact workflows, daily and weekly brain artifacts, connection/contradiction/project/open-loop workflows, model-backed source-grounded synthesis, human artifact quality ratings, deterministic-vs-model comparison controls, synthetic evals, live local capture connectors for Telegram, local folders/Obsidian notes, browser clips, and Hermes/OpenClaw-style agent outputs, dedicated connector settings/state storage, encrypted local secret references, deterministic document connector payload ingestion, agent identity/policy auditing, a governed local scheduler with due scans, a local scheduler daemon, policy telemetry, dogfooding readiness telemetry, health checks, and a live/fixture-backed `/vnext` operator workspace.
+The vNext preview currently includes deterministic source capture, retrieval/context packs, queue/artifact workflows, daily and weekly brain artifacts, connection/contradiction/project/open-loop workflows, model-backed source-grounded synthesis, human artifact quality ratings, deterministic-vs-model comparison controls, synthetic evals, live local capture connectors for Telegram, local folders/Obsidian notes, browser clips, and Hermes/OpenClaw-style agent outputs, dedicated connector settings/state storage, encrypted local secret references, deterministic document connector payload ingestion, agent identity/policy auditing, a governed local scheduler with due scans, a local scheduler daemon, policy telemetry, dogfooding readiness telemetry, doctor/readiness checks, capture-to-brief traceability, and a live/fixture-backed `/vnext` operator workspace with source review, memory review, artifact review, project, open-loop, scheduler, connector, and doctor controls.
 
 Start with:
 
@@ -58,6 +58,7 @@ Start with:
 - [Model-backed intelligence CTO summary](docs/vnext-model-backed-intelligence-cto-summary.md)
 - [Live capture connectors CTO summary](docs/vnext-live-capture-connectors-cto-summary.md)
 - [Dogfood hardening CTO summary](docs/vnext-dogfood-hardening-cto-summary.md)
+- [Live-backed operator console CTO summary](docs/vnext-live-backed-operator-console-cto-summary.md)
 - [Dogfood daily checklist](docs/runbooks/vnext-dogfood-daily-checklist.md)
 
 ## Release Boundary (`v0.5.1`)
@@ -403,6 +404,7 @@ Deferred beyond `v0.5.1`:
 - [Agentic Control Plane CTO Summary](docs/vnext-agentic-control-plane-cto-summary.md)
 - [Local Runtime CTO Summary](docs/vnext-local-runtime-cto-summary.md)
 - [Model-Backed Intelligence CTO Summary](docs/vnext-model-backed-intelligence-cto-summary.md)
+- [Live-Backed Operator Console CTO Summary](docs/vnext-live-backed-operator-console-cto-summary.md)
 - [Quickstart](docs/quickstart/local-setup-and-first-result.md)
 - [Architecture](ARCHITECTURE.md)
 - [MCP](docs/integrations/mcp.md)

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -1809,6 +1809,196 @@ def _run_vnext_smoke_capture_to_brief(ctx: CLIContext, _args: argparse.Namespace
     return _json_dumps(payload)
 
 
+def _run_vnext_smoke_operator_console(ctx: CLIContext, _args: argparse.Namespace) -> str:
+    smoke_id = str(uuid4())
+    browser_capture_token = f"operator-console-smoke-{smoke_id}"
+    secrets = InMemorySecretProvider(
+        {
+            "browser.capture_token.operator_console": browser_capture_token,
+            "telegram.bot_token.default": "operator-console-smoke-telegram",
+        }
+    )
+    with _vnext_store_context(ctx) as store:
+        connector_service = VNextConnectorService(store, secret_provider=secrets)
+        connector_service.ensure_default_settings()
+        connector_service.update_config("telegram", enabled=False, secret_ref="telegram.bot_token.default")
+        connector_service.update_config("browser_clipper", enabled=True, secret_ref="browser.capture_token.operator_console")
+        capture = connector_service.capture_browser_clip(
+            {
+                "url": f"https://example.test/operator-console/{smoke_id}",
+                "title": "Operator console smoke source",
+                "selected_text": f"Fact: operator console smoke {smoke_id} should be traceable from capture to brief.",
+                "user_note": "TODO: review the operator console trace.",
+                "capture_token": browser_capture_token,
+            },
+            default_domain="project",
+            default_sensitivity="private",
+        )
+        source_id = capture.source_ids[0] if capture.source_ids else None
+        if source_id is None:
+            raise RuntimeError("operator console smoke failed to capture source")
+
+        source = store.get_source(source_id)
+        source_metadata = source.get("metadata_json") if isinstance(source, dict) and isinstance(source.get("metadata_json"), dict) else {}
+        reviewed_source = store.update_source(
+            source_id=source_id,
+            patch={
+                "metadata_json": {
+                    **source_metadata,
+                    "review_status": "reviewed",
+                    "reviewed_at": datetime.now(UTC).isoformat(),
+                    "review_note": "Reviewed by operator-console smoke.",
+                }
+            },
+            actor_type="user",
+        )
+        append_event(
+            store,
+            event_type="source.reviewed",
+            actor_type="user",
+            target_type="source",
+            target_id=source_id,
+            payload={"smoke": "operator-console"},
+        )
+
+        project = store.create_project(
+            {
+                "name": f"Operator console smoke {smoke_id[:8]}",
+                "slug": f"operator-console-{smoke_id[:8]}",
+                "status": "active",
+                "current_state": "Smoke project created for operator console traceability.",
+                "domain": "project",
+                "sensitivity": "private",
+                "metadata_json": {"smoke": "operator-console"},
+            },
+            actor_type="user",
+        )
+        candidate_memory = next(
+            (
+                memory
+                for memory in store.list_memories(status="candidate")
+                if isinstance(memory.get("metadata_json"), dict)
+                and str(memory["metadata_json"].get("source_id")) == source_id
+            ),
+            None,
+        )
+        if candidate_memory is None:
+            raise RuntimeError("operator console smoke did not create a candidate memory")
+        memory_metadata = candidate_memory.get("metadata_json") if isinstance(candidate_memory.get("metadata_json"), dict) else {}
+        reviewed_memory = store.update_memory(
+            memory_id=str(candidate_memory["id"]),
+            patch={
+                "status": "active",
+                "metadata_json": {**memory_metadata, "project_id": str(project["id"]), "reviewed_by": "operator-console-smoke"},
+                "last_reviewed_at": datetime.now(UTC).isoformat(),
+            },
+            actor_type="user",
+        )
+        store.append_revision(
+            {
+                "memory_id": str(reviewed_memory["id"]),
+                "memory_key": str(reviewed_memory["memory_key"]),
+                "previous_value": candidate_memory.get("value"),
+                "new_value": reviewed_memory.get("value"),
+                "revision_type": "promoted",
+                "action": "operator_console_smoke_memory_review",
+                "text_before": candidate_memory.get("canonical_text"),
+                "text_after": reviewed_memory.get("canonical_text"),
+                "reason": "Operator console smoke accepted candidate memory.",
+                "actor_type": "user",
+                "metadata_json": {"smoke": "operator-console", "source_id": source_id},
+            },
+            actor_type="user",
+        )
+        loop = store.create_open_loop(
+            {
+                "title": f"Review operator console smoke {smoke_id[:8]}",
+                "description": "Source-backed open loop from operator console smoke.",
+                "priority": "normal",
+                "source_id": source_id,
+                "memory_id": str(reviewed_memory["id"]),
+                "project_id": str(project["id"]),
+                "domain": "project",
+                "sensitivity": "private",
+                "metadata_json": {"smoke": "operator-console"},
+            },
+            actor_type="user",
+        )
+        artifact = VNextBrainService(store).generate_daily_brief(
+            BrainArtifactRequest(
+                domains=("project",),
+                sensitivity_allowed=("private", "unknown"),
+                generated_for="2026-05-12",
+                discover_open_loops=True,
+                create_candidate_memories=False,
+            )
+        )
+        reviewed_artifact = VNextQueueService(store).review_artifact(artifact_id=str(artifact["id"]), action="review")
+        rating = store.create_artifact_quality_rating(
+            {
+                "artifact_id": str(artifact["id"]),
+                "reviewer_id": "operator-console-smoke",
+                "usefulness": 5,
+                "accuracy": 5,
+                "source_grounding": 5,
+                "novel_connections": 3,
+                "actionability": 4,
+                "hallucination_risk": 1,
+                "verbosity": "right_sized",
+                "metadata_json": {"smoke": "operator-console", "source_id": source_id},
+            },
+            actor_type="user",
+        )
+        scheduler = VNextSchedulerService(store)
+        scheduler.configure_workflow(
+            workflow_type="daily_brief",
+            enabled=True,
+            paused=False,
+            schedule_json=default_schedule("daily_brief"),
+            timezone="UTC",
+            actor_type="user",
+        )
+        scheduled = scheduler.run_now(
+            SchedulerRunRequest(
+                workflow_type="daily_brief",
+                domains=("project",),
+                sensitivity_allowed=("private", "unknown"),
+                generated_for="2026-05-12",
+                triggered_by="user",
+                options={"generation_mode": "deterministic"},
+            )
+        )
+        pack = VNextRetrievalService(store).compile_context_pack(
+            VNextRetrievalRequest(query=smoke_id, domains=("project",), sensitivity_allowed=("private", "unknown"))
+        )
+        health = connector_service.connector_health_all()
+        doctor = VNextDoctorService(store, secret_provider=secrets).run(fix_safe=True, ci=True)
+        events = store.list_events(limit=100)
+
+    health_items = {str(item["connector_name"]): item for item in health.get("items", []) if isinstance(item, dict)}
+    pack_source_ids = [str(source.get("id")) for source in pack.get("sources", []) if isinstance(source, dict)]
+    artifact_refs = artifact.get("metadata_json", {}).get("source_refs") if isinstance(artifact.get("metadata_json"), dict) else []
+    serialized_refs = _json_dumps(artifact_refs)
+    gates = {
+        "source_review_action_persisted": isinstance(reviewed_source.get("metadata_json"), dict)
+        and reviewed_source["metadata_json"].get("review_status") == "reviewed",
+        "memory_review_action_persisted": reviewed_memory.get("status") == "active",
+        "artifact_review_and_rating_persisted": reviewed_artifact.get("status") == "reviewed"
+        and str(rating.get("artifact_id")) == str(artifact["id"]),
+        "open_loop_created_from_source": str(loop.get("source_id")) == source_id and loop.get("status") == "open",
+        "scheduler_run_now_created_artifact": scheduled.get("artifact") is not None
+        and scheduled.get("run", {}).get("status") == "succeeded",
+        "connector_health_visible": "browser_clipper" in health_items,
+        "doctor_readiness_available": doctor.get("status") in {"pass", "warn"} and doctor.get("blocking_failure_count") == 0,
+        "capture_to_brief_trace_exists": source_id in pack_source_ids or source_id in serialized_refs,
+        "event_log_records_actions": any(event.get("event_type") == "source.reviewed" for event in events),
+    }
+    payload = {"status": "passed" if all(gates.values()) else "failed", "smoke": "operator-console", "gates": gates}
+    if payload["status"] != "passed":
+        raise RuntimeError(_json_dumps(payload))
+    return _json_dumps(payload)
+
+
 def _run_vnext_smoke_connector_hardening(ctx: CLIContext, _args: argparse.Namespace) -> str:
     smoke_id = str(uuid4())
     telegram_update_id = int(time.time() * 1000)
@@ -3633,6 +3823,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run vNext dogfood doctor smoke.",
     )
     vnext_smoke_dogfood_doctor_parser.set_defaults(handler=_run_vnext_smoke_dogfood_doctor)
+    vnext_smoke_operator_console_parser = vnext_smoke_subparsers.add_parser(
+        "operator-console",
+        help="Run the live-backed /vnext operator console smoke.",
+    )
+    vnext_smoke_operator_console_parser.set_defaults(handler=_run_vnext_smoke_operator_console)
 
     mutations_parser = subparsers.add_parser("mutations", help="Generate, inspect, and apply memory operations.")
     mutations_subparsers = mutations_parser.add_subparsers(dest="mutations_command", required=True)

--- a/apps/api/src/alicebot_api/main.py
+++ b/apps/api/src/alicebot_api/main.py
@@ -490,6 +490,7 @@ from alicebot_api.vnext_contradictions import (
     VNextContradictionValidationError,
 )
 from alicebot_api.vnext_dogfooding import VNextDogfoodingService
+from alicebot_api.vnext_doctor import VNextDoctorService
 from alicebot_api.vnext_event_log import append_event
 from alicebot_api.vnext_projects import ProjectAutomationRequest, VNextProjectService, VNextProjectValidationError
 from alicebot_api.vnext_queue import (
@@ -1222,6 +1223,16 @@ class VNextSourceCaptureRequest(VNextAgentRequest):
     sensitivity: str = Field(default="unknown", min_length=1, max_length=80)
 
 
+class VNextSourceReviewRequest(VNextAgentRequest):
+    user_id: UUID
+    action: str = Field(min_length=1, max_length=40)
+    title: str | None = Field(default=None, min_length=1, max_length=280)
+    domain: str | None = Field(default=None, min_length=1, max_length=80)
+    sensitivity: str | None = Field(default=None, min_length=1, max_length=80)
+    project_id: str | None = Field(default=None, min_length=1, max_length=120)
+    review_note: str | None = Field(default=None, min_length=1, max_length=4000)
+
+
 class VNextConnectorSyncRequest(VNextAgentRequest):
     user_id: UUID
     items: list[dict[str, object]] = Field(default_factory=list)
@@ -1484,6 +1495,12 @@ class VNextSchedulerControlRequest(VNextAgentRequest):
     user_id: UUID
 
 
+class VNextDoctorRunRequest(BaseModel):
+    user_id: UUID
+    fix_safe: bool = False
+    ci: bool = True
+
+
 def _vnext_public_error_response(*, status_code: int, detail: str) -> JSONResponse:
     return JSONResponse(status_code=status_code, content={"detail": detail})
 
@@ -1554,6 +1571,170 @@ def _vnext_status_counts(rows: list[dict[str, object]], *, field: str = "status"
         status = str(row.get(field, "unknown"))
         counts[status] = counts.get(status, 0) + 1
     return counts
+
+
+def _vnext_metadata(row: dict[str, object] | None) -> dict[str, object]:
+    if row is None:
+        return {}
+    value = row.get("metadata_json")
+    return value if isinstance(value, dict) else {}
+
+
+def _vnext_payload(row: dict[str, object]) -> dict[str, object]:
+    value = row.get("payload_json")
+    return value if isinstance(value, dict) else {}
+
+
+def _vnext_ref_values(value: object) -> list[str]:
+    refs: list[str] = []
+    if isinstance(value, str):
+        if value.strip():
+            refs.append(value.strip())
+    elif isinstance(value, dict):
+        for key in ("source_id", "id", "ref", "source_ref"):
+            candidate = value.get(key)
+            if isinstance(candidate, (str, int)):
+                refs.append(str(candidate))
+        for nested_key in ("source_ids", "source_refs", "sources"):
+            refs.extend(_vnext_ref_values(value.get(nested_key)))
+    elif isinstance(value, list):
+        for item in value:
+            refs.extend(_vnext_ref_values(item))
+    return refs
+
+
+def _vnext_ref_matches_source(value: object, source_id: str) -> bool:
+    normalized = str(source_id)
+    return any(ref == normalized or ref == f"source:{normalized}" for ref in _vnext_ref_values(value))
+
+
+def _vnext_row_references_source(row: dict[str, object], source_id: str) -> bool:
+    if str(row.get("source_id") or "") == str(source_id):
+        return True
+    metadata = _vnext_metadata(row)
+    for key in ("source_id", "source_ids", "source_ref", "source_refs", "source_references", "selected_source_ids"):
+        if _vnext_ref_matches_source(metadata.get(key), source_id):
+            return True
+    return _vnext_ref_matches_source(row.get("source_event_ids"), source_id)
+
+
+def _vnext_event_references(
+    event: dict[str, object],
+    *,
+    source_id: str,
+    memory_ids: set[str],
+    artifact_ids: set[str],
+    open_loop_ids: set[str],
+) -> bool:
+    target_type = str(event.get("target_type") or "")
+    target_id = str(event.get("target_id") or "")
+    if target_type == "source" and target_id == source_id:
+        return True
+    if target_type == "memory" and target_id in memory_ids:
+        return True
+    if target_type == "artifact" and target_id in artifact_ids:
+        return True
+    if target_type == "open_loop" and target_id in open_loop_ids:
+        return True
+    payload = _vnext_payload(event)
+    return any(
+        _vnext_ref_matches_source(payload.get(key), source_id)
+        for key in ("source_id", "source_ids", "source_ref", "source_refs", "source_references", "selected_source_ids")
+    )
+
+
+def _vnext_source_chunks(store: PostgresVNextStore, source_id: str) -> list[dict[str, object]]:
+    if not hasattr(store, "list_source_chunks"):
+        return []
+    return list(store.list_source_chunks(source_id))
+
+
+def _vnext_source_trace(
+    *,
+    store: PostgresVNextStore,
+    source: dict[str, object],
+    memories: list[dict[str, object]],
+    artifacts: list[dict[str, object]],
+    open_loops: list[dict[str, object]],
+    events: list[dict[str, object]],
+) -> dict[str, object]:
+    source_id = str(source["id"])
+    related_memories = [memory for memory in memories if _vnext_row_references_source(memory, source_id)]
+    related_artifacts = [artifact for artifact in artifacts if _vnext_row_references_source(artifact, source_id)]
+    related_open_loops = [loop for loop in open_loops if _vnext_row_references_source(loop, source_id)]
+    memory_ids = {str(memory["id"]) for memory in related_memories}
+    artifact_ids = {str(artifact["id"]) for artifact in related_artifacts}
+    open_loop_ids = {str(loop["id"]) for loop in related_open_loops}
+    related_events = [
+        event
+        for event in events
+        if _vnext_event_references(
+            event,
+            source_id=source_id,
+            memory_ids=memory_ids,
+            artifact_ids=artifact_ids,
+            open_loop_ids=open_loop_ids,
+        )
+    ]
+    trace_id = next((str(event.get("trace_id")) for event in related_events if event.get("trace_id")), None)
+    chunks = _vnext_source_chunks(store, source_id)
+    return {
+        "trace_id": trace_id or f"source:{source_id}",
+        "trace_kind": "capture_to_brief",
+        "source": source,
+        "chunks": chunks,
+        "candidate_memories": related_memories,
+        "artifacts": related_artifacts,
+        "open_loops": related_open_loops,
+        "events": related_events,
+        "summary": {
+            "source_id": source_id,
+            "chunk_count": len(chunks),
+            "candidate_memory_count": len(related_memories),
+            "artifact_count": len(related_artifacts),
+            "open_loop_count": len(related_open_loops),
+            "event_count": len(related_events),
+        },
+    }
+
+
+def _vnext_artifact_trace(
+    *,
+    artifact: dict[str, object],
+    sources: list[dict[str, object]],
+    quality_evals: list[dict[str, object]],
+    events: list[dict[str, object]],
+) -> dict[str, object]:
+    artifact_id = str(artifact["id"])
+    metadata = _vnext_metadata(artifact)
+    source_refs = _vnext_ref_values(metadata.get("source_refs")) + _vnext_ref_values(metadata.get("source_ids"))
+    related_sources = [
+        source
+        for source in sources
+        if str(source.get("id")) in source_refs or f"source:{source.get('id')}" in source_refs
+    ]
+    related_evals = [rating for rating in quality_evals if str(rating.get("artifact_id")) == artifact_id]
+    related_events = [
+        event
+        for event in events
+        if str(event.get("target_type") or "") == "artifact" and str(event.get("target_id") or "") == artifact_id
+    ]
+    return {
+        "trace_id": metadata.get("trace_id") or metadata.get("scheduler_run_id") or f"artifact:{artifact_id}",
+        "trace_kind": "artifact_review",
+        "artifact": artifact,
+        "sources": related_sources,
+        "quality_evals": related_evals,
+        "events": related_events,
+        "summary": {
+            "artifact_id": artifact_id,
+            "source_count": len(related_sources),
+            "quality_eval_count": len(related_evals),
+            "event_count": len(related_events),
+            "scheduler_run_id": metadata.get("scheduler_run_id"),
+            "agent_run_id": metadata.get("agent_run_id"),
+        },
+    }
 
 
 def _vnext_agent_identity(request: VNextAgentRequest) -> AgentIdentity | None:
@@ -1647,6 +1828,7 @@ def _vnext_workspace_payload(store: PostgresVNextStore) -> dict[str, object]:
     scheduler_status = {**scheduler_status, "daemon": daemon_status()}
     connector_health = VNextConnectorService(store).connector_health_all()
     dogfooding = VNextDogfoodingService(store).dashboard()
+    doctor = VNextDoctorService(store).run(ci=True)
     policy_telemetry = summarize_agent_policy_telemetry(
         agent_events=agent_events,
         artifacts=artifacts,
@@ -1659,6 +1841,17 @@ def _vnext_workspace_payload(store: PostgresVNextStore) -> dict[str, object]:
             project_dashboards.append(project_service.project_dashboard(project_id=str(project["id"])))
         except VNextProjectValidationError:
             continue
+    trace_items = [
+        _vnext_source_trace(
+            store=store,
+            source=source,
+            memories=memories,
+            artifacts=artifacts,
+            open_loops=open_loops,
+            events=recent_events,
+        )
+        for source in sources[:8]
+    ]
     return {
         "mode": "live",
         "summary": {
@@ -1682,6 +1875,12 @@ def _vnext_workspace_payload(store: PostgresVNextStore) -> dict[str, object]:
         "quality_evals": quality_evals,
         "connector_health": connector_health,
         "dogfooding": dogfooding,
+        "doctor": doctor,
+        "traceability": {
+            "items": trace_items,
+            "count": len(trace_items),
+            "order": [str(trace.get("trace_id")) for trace in trace_items],
+        },
         "projects": projects,
         "project_dashboards": project_dashboards,
         "open_loops": open_loops,
@@ -6330,6 +6529,22 @@ def get_vnext_dogfooding_dashboard(user_id: UUID) -> JSONResponse:
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
 
+@app.get("/v0/vnext/doctor")
+def get_vnext_doctor(user_id: UUID, ci: bool = True) -> JSONResponse:
+    settings = get_settings()
+    with user_connection(settings.database_url, user_id) as conn:
+        payload = VNextDoctorService(PostgresVNextStore(conn)).run(ci=ci)
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.post("/v0/vnext/doctor/run")
+def run_vnext_doctor(request: VNextDoctorRunRequest) -> JSONResponse:
+    settings = get_settings()
+    with user_connection(settings.database_url, request.user_id) as conn:
+        payload = VNextDoctorService(PostgresVNextStore(conn)).run(fix_safe=request.fix_safe, ci=request.ci)
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
 @app.post("/v0/vnext/artifacts/{artifact_id}/insight-feedback")
 def record_vnext_artifact_insight_feedback(
     artifact_id: UUID,
@@ -6369,6 +6584,133 @@ def get_vnext_source(source_id: UUID, user_id: UUID) -> JSONResponse:
         status_code=200,
         content=jsonable_encoder(payload),
     )
+
+
+@app.post("/v0/vnext/sources/{source_id}/review")
+def review_vnext_source(source_id: UUID, request: VNextSourceReviewRequest) -> JSONResponse:
+    settings = get_settings()
+    action = request.action.strip().casefold()
+    if action not in {"review", "update", "assign_project", "archive"}:
+        return _vnext_public_error_response(status_code=400, detail="vNext source review action is invalid")
+
+    with user_connection(settings.database_url, request.user_id) as conn:
+        store = PostgresVNextStore(conn)
+        existing = store.get_source(str(source_id))
+        if existing is None:
+            return _vnext_public_error_response(status_code=404, detail="vNext source was not found")
+        if action == "archive":
+            archived = store.delete_source(source_id=str(source_id), actor_type="user")
+            append_event(
+                store,
+                event_type="source.archived",
+                actor_type="user",
+                target_type="source",
+                target_id=str(source_id),
+                payload={"action": action, "review_note": request.review_note},
+            )
+            trace = _vnext_source_trace(
+                store=store,
+                source=archived,
+                memories=store.list_memories(status=None),
+                artifacts=store.list_artifacts(limit=100),
+                open_loops=store.list_open_loops(status=None, limit=100),
+                events=store.list_events(limit=100),
+            )
+            return JSONResponse(status_code=200, content=jsonable_encoder({"source": archived, "archived": True, "trace": trace}))
+
+        if action == "assign_project" and request.project_id is None:
+            return _vnext_public_error_response(status_code=400, detail="project_id is required")
+
+        metadata = {
+            **_vnext_metadata(existing),
+            "review_status": "reviewed" if action == "review" else "updated",
+            "reviewed_at": datetime.now(UTC).isoformat(),
+            "review_note": request.review_note,
+            "updated_from": "vnext_workspace",
+        }
+        if request.project_id is not None:
+            metadata["project_id"] = request.project_id
+        patch: dict[str, object] = {"metadata_json": metadata}
+        if request.title is not None:
+            patch["title"] = request.title
+        if request.domain is not None:
+            patch["domain"] = request.domain
+        if request.sensitivity is not None:
+            patch["sensitivity"] = request.sensitivity
+        updated = store.update_source(source_id=str(source_id), patch=patch, actor_type="user")
+        if action == "assign_project":
+            store.create_edge(
+                {
+                    "from_type": "source",
+                    "from_id": str(source_id),
+                    "to_type": "project",
+                    "to_id": request.project_id,
+                    "edge_type": "belongs_to_project",
+                    "confidence": 1.0,
+                    "explanation": "Assigned from live /vnext source review.",
+                    "created_by": "user",
+                    "metadata_json": {"review_action": action},
+                },
+                actor_type="user",
+            )
+        append_event(
+            store,
+            event_type={
+                "review": "source.reviewed",
+                "update": "source.updated_from_workspace",
+                "assign_project": "source.assigned_project",
+            }[action],
+            actor_type="user",
+            target_type="source",
+            target_id=str(source_id),
+            payload={"action": action, "project_id": request.project_id, "review_note": request.review_note},
+        )
+        trace = _vnext_source_trace(
+            store=store,
+            source=updated,
+            memories=store.list_memories(status=None),
+            artifacts=store.list_artifacts(limit=100),
+            open_loops=store.list_open_loops(status=None, limit=100),
+            events=store.list_events(limit=100),
+        )
+
+    return JSONResponse(status_code=200, content=jsonable_encoder({"source": updated, "archived": False, "trace": trace}))
+
+
+@app.get("/v0/vnext/traces/sources/{source_id}")
+def get_vnext_source_trace(source_id: UUID, user_id: UUID) -> JSONResponse:
+    settings = get_settings()
+    with user_connection(settings.database_url, user_id) as conn:
+        store = PostgresVNextStore(conn)
+        source = store.get_source(str(source_id))
+        if source is None:
+            return _vnext_public_error_response(status_code=404, detail="vNext source was not found")
+        payload = _vnext_source_trace(
+            store=store,
+            source=source,
+            memories=store.list_memories(status=None),
+            artifacts=store.list_artifacts(limit=100),
+            open_loops=store.list_open_loops(status=None, limit=100),
+            events=store.list_events(limit=100),
+        )
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.get("/v0/vnext/traces/artifacts/{artifact_id}")
+def get_vnext_artifact_trace(artifact_id: UUID, user_id: UUID) -> JSONResponse:
+    settings = get_settings()
+    with user_connection(settings.database_url, user_id) as conn:
+        store = PostgresVNextStore(conn)
+        artifact = store.get_artifact(str(artifact_id))
+        if artifact is None:
+            return _vnext_public_error_response(status_code=404, detail="vNext artifact was not found")
+        payload = _vnext_artifact_trace(
+            artifact=artifact,
+            sources=store.list_sources(limit=100),
+            quality_evals=store.list_artifact_quality_ratings(artifact_id=str(artifact_id), limit=100),
+            events=store.list_events(limit=100),
+        )
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
 
 @app.delete("/v0/vnext/sources/{source_id}")

--- a/apps/web/app/vnext/page.test.tsx
+++ b/apps/web/app/vnext/page.test.tsx
@@ -27,8 +27,10 @@ const EXPECTED_SURFACES = [
   "Agent Activity",
   "Schedules",
   "Timeline",
+  "Trace",
   "Graph",
   "Connectors",
+  "Doctor",
   "Settings",
 ];
 
@@ -92,14 +94,16 @@ describe("VNextPage", () => {
 
     expect(screen.getByText("Recent activity")).toBeInTheDocument();
     expect(screen.getByText("Source capture")).toBeInTheDocument();
-    expect(screen.getByText("Candidate memories")).toBeInTheDocument();
+    expect(screen.getAllByText("Candidate memories").length).toBeGreaterThan(0);
     expect(screen.getByText("Evidence-first answer")).toBeInTheDocument();
     expect(screen.getByText("Artifacts with review actions")).toBeInTheDocument();
     expect(screen.getByText("Belief review")).toBeInTheDocument();
     expect(screen.getByText("Agents and policy posture")).toBeInTheDocument();
     expect(screen.getByText("Governed scheduler")).toBeInTheDocument();
+    expect(screen.getByText("Capture-to-brief trace")).toBeInTheDocument();
     expect(screen.getByText("Connection graph")).toBeInTheDocument();
     expect(screen.getByText("Connector settings")).toBeInTheDocument();
+    expect(screen.getByText("Readiness checks")).toBeInTheDocument();
     expect(screen.getByText("Brain Charter")).toBeInTheDocument();
     expect(screen.getAllByText("Telegram capture").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Browser clipper").length).toBeGreaterThan(0);
@@ -135,6 +139,16 @@ describe("VNextPage", () => {
 
   it("updates review state, labels, project assignment, and open loops from Inbox actions", async () => {
     await renderVNextPage();
+
+    fireEvent.change(screen.getByLabelText("Selected source title"), {
+      target: { value: "Reviewed launch source" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save source update" }));
+    expect(screen.getAllByText("Demo source action applied: update.").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Reviewed launch source").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark reviewed" }));
+    expect(screen.getAllByText("Demo source action applied: review.").length).toBeGreaterThan(0);
 
     fireEvent.change(screen.getByLabelText("Edited memory title"), {
       target: { value: "Confirmed launch owner needs explicit review." },
@@ -172,7 +186,7 @@ describe("VNextPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Create open loop from selected memory" }));
     expect(screen.getAllByText("Demo open loop created.").length).toBeGreaterThan(0);
     expect(screen.getByText("Follow up with Sam about launch owner")).toBeInTheDocument();
-  });
+  }, 10000);
 
   it("refreshes Ask Alice output and generates reviewable artifacts", async () => {
     await renderVNextPage();
@@ -227,5 +241,14 @@ describe("VNextPage", () => {
     expect(screen.getAllByText("Demo Brain Charter settings saved.").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Browser clipper").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Default sensitivity: Private").length).toBeGreaterThan(0);
+  });
+
+  it("runs fixture doctor checks from the readiness panel", async () => {
+    await renderVNextPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Run doctor" }));
+
+    expect(screen.getAllByText("Demo doctor check completed.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Doctor: pass")).toBeInTheDocument();
   });
 });

--- a/apps/web/components/vnext-brain-workspace.tsx
+++ b/apps/web/components/vnext-brain-workspace.tsx
@@ -12,6 +12,7 @@ import type {
   VNextConnectorHealthRecord,
   VNextContextPack,
   VNextDogfoodingDashboard,
+  VNextDoctorPayload,
   VNextEventRecord,
   VNextMemoryRecord,
   VNextOpenLoopRecord,
@@ -21,6 +22,7 @@ import type {
   VNextProjectRecord,
   VNextSchedulerStatus,
   VNextSourceRecord,
+  VNextSourceTracePayload,
   VNextTaskRecord,
   VNextWorkspacePayload,
 } from "../lib/api";
@@ -39,6 +41,8 @@ import {
   reviewVNextArtifact,
   reviewVNextMemory,
   reviewVNextOpenLoop,
+  reviewVNextSource,
+  runVNextDoctor,
   runVNextSchedulerDue,
   runVNextSchedulerWorkflowNow,
   syncVNextLocalFolderConnector,
@@ -132,6 +136,8 @@ type WorkspaceView = {
   qualityEvals: VNextArtifactQualityEvalRecord[];
   connectorHealth: { items: VNextConnectorHealthRecord[]; count: number; order: string[] };
   dogfooding: VNextDogfoodingDashboard;
+  doctor: VNextDoctorPayload;
+  traceability: { items: VNextSourceTracePayload[]; count: number; order: string[] };
   agentActivity: NonNullable<VNextWorkspacePayload["agent_activity"]>;
   policyTelemetry: VNextPolicyTelemetrySummary;
   scheduler: VNextSchedulerStatus;
@@ -161,8 +167,10 @@ const SURFACES = [
   "Agent Activity",
   "Schedules",
   "Timeline",
+  "Trace",
   "Graph",
   "Connectors",
+  "Doctor",
   "Settings",
 ];
 
@@ -344,6 +352,24 @@ const EMPTY_DOGFOODING: VNextDogfoodingDashboard = {
   last_successful_scheduler_run: null,
   connector_health: EMPTY_CONNECTOR_HEALTH,
   insight_feedback: { count: 0, useful_yes: 0, useful_no: 0, useful_not_sure: 0, missed_something_yes: 0 },
+};
+
+const EMPTY_DOCTOR: VNextDoctorPayload = {
+  status: "unknown",
+  fix_safe_applied: false,
+  ci_mode: true,
+  blocking_failure_count: 0,
+  warning_count: 0,
+  checks: [],
+  recommended_fixes: [],
+  migration_status: {},
+  connector_health: EMPTY_CONNECTOR_HEALTH,
+};
+
+const EMPTY_TRACEABILITY: { items: VNextSourceTracePayload[]; count: number; order: string[] } = {
+  items: [],
+  count: 0,
+  order: [],
 };
 
 const FIXTURE_SOURCES: VNextSourceRecord[] = [
@@ -908,6 +934,90 @@ const FIXTURE_DOGFOODING: VNextDogfoodingDashboard = {
   insight_feedback: { count: 3, useful_yes: 2, useful_no: 0, useful_not_sure: 1, missed_something_yes: 1 },
 };
 
+const FIXTURE_DOCTOR: VNextDoctorPayload = {
+  status: "pass",
+  fix_safe_applied: false,
+  ci_mode: true,
+  blocking_failure_count: 0,
+  warning_count: 0,
+  checks: [
+    {
+      name: "migrations",
+      status: "pass",
+      severity: "info",
+      message: "Required vNext dogfood hardening tables are present.",
+      details: { status: "ok" },
+    },
+    {
+      name: "connector_settings",
+      status: "pass",
+      severity: "info",
+      message: "Core connector settings rows exist.",
+      details: { missing: [] },
+    },
+    {
+      name: "scheduler_daemon",
+      status: "pass",
+      severity: "info",
+      message: "Scheduler daemon status is available.",
+      details: { running: false, configured: true },
+    },
+  ],
+  recommended_fixes: [],
+  migration_status: { status: "ok", missing_tables: [] },
+  connector_health: FIXTURE_CONNECTOR_HEALTH,
+};
+
+const FIXTURE_TRACEABILITY = {
+  items: FIXTURE_SOURCES.map((source) => {
+    const sourceId = source.id;
+    const candidateMemories = FIXTURE_REVIEW_ITEMS.filter(
+      (memory) => textValue(asRecord(memory.metadata_json).source_id) === sourceId,
+    );
+    const artifacts = FIXTURE_ARTIFACTS.filter((artifact) => {
+      const metadata = asRecord(artifact.metadata_json);
+      const refs = Array.isArray(metadata.source_refs) ? metadata.source_refs : metadata.source_ids;
+      return Array.isArray(refs) && refs.map(String).some((ref) => ref === sourceId || ref === `source:${sourceId}`);
+    });
+    const openLoops = FIXTURE_OPEN_LOOPS.filter((loop) => loop.source_id === sourceId);
+    const events = FIXTURE_EVENTS.filter(
+      (event) =>
+        event.target_id === sourceId ||
+        candidateMemories.some((memory) => memory.id === event.target_id) ||
+        artifacts.some((artifact) => artifact.id === event.target_id) ||
+        openLoops.some((loop) => loop.id === event.target_id),
+    );
+    return {
+      trace_id: `source:${sourceId}`,
+      trace_kind: "capture_to_brief",
+      source,
+      chunks: [
+        {
+          id: `chunk-${sourceId}`,
+          source_id: sourceId,
+          chunk_index: 0,
+          text: sourceText(source),
+          token_count: sourceText(source).split(/\s+/).filter(Boolean).length,
+        },
+      ],
+      candidate_memories: candidateMemories,
+      artifacts,
+      open_loops: openLoops,
+      events,
+      summary: {
+        source_id: sourceId,
+        chunk_count: 1,
+        candidate_memory_count: candidateMemories.length,
+        artifact_count: artifacts.length,
+        open_loop_count: openLoops.length,
+        event_count: events.length,
+      },
+    };
+  }),
+  count: FIXTURE_SOURCES.length,
+  order: FIXTURE_SOURCES.map((source) => `source:${source.id}`),
+};
+
 function fixtureWorkspace(): WorkspaceView {
   const projectDashboards: VNextProjectDashboard[] = FIXTURE_PROJECTS.map((project) => {
     const openLoops = FIXTURE_OPEN_LOOPS.filter((loop) => loop.project_id === project.id);
@@ -942,6 +1052,8 @@ function fixtureWorkspace(): WorkspaceView {
     qualityEvals: FIXTURE_QUALITY_EVALS,
     connectorHealth: FIXTURE_CONNECTOR_HEALTH,
     dogfooding: FIXTURE_DOGFOODING,
+    doctor: FIXTURE_DOCTOR,
+    traceability: FIXTURE_TRACEABILITY,
     agentActivity: FIXTURE_AGENT_ACTIVITY,
     policyTelemetry: FIXTURE_POLICY_TELEMETRY,
     scheduler: FIXTURE_SCHEDULER,
@@ -969,6 +1081,8 @@ function emptyWorkspace(): WorkspaceView {
     qualityEvals: [],
     connectorHealth: EMPTY_CONNECTOR_HEALTH,
     dogfooding: EMPTY_DOGFOODING,
+    doctor: EMPTY_DOCTOR,
+    traceability: EMPTY_TRACEABILITY,
     agentActivity: EMPTY_AGENT_ACTIVITY,
     policyTelemetry: EMPTY_POLICY_TELEMETRY,
     scheduler: EMPTY_SCHEDULER,
@@ -993,6 +1107,8 @@ function workspaceFromPayload(payload: VNextWorkspacePayload): WorkspaceView {
     qualityEvals: payload.quality_evals ?? [],
     connectorHealth: payload.connector_health ?? EMPTY_CONNECTOR_HEALTH,
     dogfooding: payload.dogfooding ?? EMPTY_DOGFOODING,
+    doctor: payload.doctor ?? EMPTY_DOCTOR,
+    traceability: payload.traceability ?? EMPTY_TRACEABILITY,
     agentActivity: payload.agent_activity ?? EMPTY_AGENT_ACTIVITY,
     policyTelemetry: payload.policy_telemetry ?? EMPTY_POLICY_TELEMETRY,
     scheduler: payload.scheduler ?? EMPTY_SCHEDULER,
@@ -1160,6 +1276,23 @@ export function VNextBrainWorkspace({
   );
   const [defaultDomain, setDefaultDomain] = useState<Domain>("project");
   const [defaultSensitivity, setDefaultSensitivity] = useState<Sensitivity>("private");
+  const [selectedSourceId, setSelectedSourceId] = useState("");
+  const selectedSource = useMemo(
+    () => workspace.sources.find((source) => source.id === selectedSourceId) ?? workspace.sources[0] ?? null,
+    [selectedSourceId, workspace.sources],
+  );
+  const selectedSourceTrace = useMemo(
+    () =>
+      selectedSource
+        ? workspace.traceability.items.find((trace) => trace.summary.source_id === selectedSource.id) ?? null
+        : null,
+    [selectedSource, workspace.traceability.items],
+  );
+  const [sourceTitleDraft, setSourceTitleDraft] = useState("");
+  const [sourceDomainDraft, setSourceDomainDraft] = useState<Domain>("project");
+  const [sourceSensitivityDraft, setSourceSensitivityDraft] = useState<Sensitivity>("private");
+  const [sourceProjectDraft, setSourceProjectDraft] = useState("");
+  const [sourceReviewNote, setSourceReviewNote] = useState("Reviewed from /vnext operator console.");
 
   const [selectedReviewId, setSelectedReviewId] = useState("");
   const selectedReview = useMemo(
@@ -1259,6 +1392,21 @@ export function VNextBrainWorkspace({
       void refreshWorkspace("Live vNext workspace loaded.");
     }
   }, [liveModeReady, refreshWorkspace]);
+
+  useEffect(() => {
+    if (selectedSource) {
+      const metadata = asRecord(selectedSource.metadata_json);
+      setSelectedSourceId(selectedSource.id);
+      setSourceTitleDraft(textValue(selectedSource.title) || selectedSource.source_type);
+      setSourceDomainDraft(asDomain(selectedSource.domain));
+      setSourceSensitivityDraft(asSensitivity(selectedSource.sensitivity));
+      setSourceProjectDraft(textValue(metadata.project_id) || workspace.projects[0]?.id || "");
+    } else {
+      setSelectedSourceId("");
+      setSourceTitleDraft("");
+      setSourceProjectDraft(workspace.projects[0]?.id ?? "");
+    }
+  }, [selectedSource, workspace.projects]);
 
   useEffect(() => {
     if (selectedReview) {
@@ -1377,6 +1525,7 @@ export function VNextBrainWorkspace({
         "Demo source captured and candidate memory generated.",
       );
       setSelectedReviewId(nextMemory.id);
+      setSelectedSourceId(nextSource.id);
       return;
     }
 
@@ -1550,6 +1699,150 @@ export function VNextBrainWorkspace({
         });
       },
       "Open loop created from live workspace.",
+    );
+  }
+
+  async function handleSourceAction(action: "review" | "update" | "assign_project" | "archive") {
+    if (!selectedSource) {
+      return;
+    }
+    if (action === "assign_project" && !sourceProjectDraft) {
+      setStatusTone("danger");
+      setStatusText("Choose a project before assigning the source.");
+      return;
+    }
+
+    if (!liveModeReady || !apiBaseUrl || !userId) {
+      updateFixtureWorkspace(
+        (previous) => {
+          const now = new Date().toISOString();
+          if (action === "archive") {
+            const view = {
+              ...previous,
+              sources: previous.sources.filter((source) => source.id !== selectedSource.id),
+              traceability: {
+                ...previous.traceability,
+                items: previous.traceability.items.filter((trace) => trace.summary.source_id !== selectedSource.id),
+                count: previous.traceability.items.filter((trace) => trace.summary.source_id !== selectedSource.id).length,
+                order: previous.traceability.order.filter((traceId) => traceId !== `source:${selectedSource.id}`),
+              },
+            };
+            return { ...view, summary: createSummary(view) };
+          }
+          const nextSources = previous.sources.map((source) =>
+            source.id === selectedSource.id
+              ? {
+                  ...source,
+                  title: sourceTitleDraft,
+                  domain: sourceDomainDraft,
+                  sensitivity: sourceSensitivityDraft,
+                  metadata_json: {
+                    ...asRecord(source.metadata_json),
+                    review_status: action === "review" ? "reviewed" : "updated",
+                    reviewed_at: now,
+                    review_note: sourceReviewNote,
+                    project_id: action === "assign_project" ? sourceProjectDraft : asRecord(source.metadata_json).project_id,
+                    updated_from: "vnext_workspace",
+                  },
+                }
+              : source,
+          );
+          const traceability = {
+            ...previous.traceability,
+            items: previous.traceability.items.map((trace) =>
+              trace.summary.source_id === selectedSource.id
+                ? {
+                    ...trace,
+                    source: nextSources.find((source) => source.id === selectedSource.id) ?? trace.source,
+                  }
+                : trace,
+            ),
+          };
+          const view = { ...previous, sources: nextSources, traceability };
+          return { ...view, summary: createSummary(view) };
+        },
+        `Demo source action applied: ${action}.`,
+      );
+      return;
+    }
+
+    await runLiveAction(
+      `Applying source action: ${action}...`,
+      async () => {
+        await reviewVNextSource(apiBaseUrl, selectedSource.id, {
+          user_id: userId,
+          action,
+          title: action === "archive" ? undefined : sourceTitleDraft,
+          domain: action === "archive" ? undefined : sourceDomainDraft,
+          sensitivity: action === "archive" ? undefined : sourceSensitivityDraft,
+          project_id: action === "assign_project" ? sourceProjectDraft : undefined,
+          review_note: sourceReviewNote.trim() || undefined,
+        });
+      },
+      `Source action applied: ${action}.`,
+    );
+  }
+
+  async function handleCreateOpenLoopFromSource() {
+    if (!selectedSource) {
+      return;
+    }
+    const title = openLoopTitle.trim() || `Review ${sourceTitleDraft || selectedSource.title || selectedSource.source_type}`;
+    if (!liveModeReady || !apiBaseUrl || !userId) {
+      const nextLoop: VNextOpenLoopRecord = {
+        id: `loop-source-demo-${workspace.openLoops.length + 1}`,
+        title,
+        description: sourceReviewNote,
+        due_at: openLoopDueAt || null,
+        priority: openLoopPriority,
+        status: "open",
+        source_id: selectedSource.id,
+        project_id: sourceProjectDraft || null,
+        domain: sourceDomainDraft,
+        sensitivity: sourceSensitivityDraft,
+      };
+      updateFixtureWorkspace(
+        (previous) => {
+          const traceability = {
+            ...previous.traceability,
+            items: previous.traceability.items.map((trace) =>
+              trace.summary.source_id === selectedSource.id
+                ? {
+                    ...trace,
+                    open_loops: [nextLoop, ...trace.open_loops],
+                    summary: {
+                      ...trace.summary,
+                      open_loop_count: trace.summary.open_loop_count + 1,
+                    },
+                  }
+                : trace,
+            ),
+          };
+          const view = { ...previous, openLoops: [nextLoop, ...previous.openLoops], traceability };
+          return { ...view, summary: createSummary(view) };
+        },
+        "Demo source-backed open loop created.",
+      );
+      setSelectedOpenLoopId(nextLoop.id);
+      return;
+    }
+
+    await runLiveAction(
+      "Creating source-backed open loop...",
+      async () => {
+        await createVNextOpenLoop(apiBaseUrl, {
+          user_id: userId,
+          title,
+          description: sourceReviewNote.trim() || undefined,
+          due_at: openLoopDueAt.trim() || undefined,
+          priority: openLoopPriority,
+          project_id: sourceProjectDraft || undefined,
+          source_id: selectedSource.id,
+          domain: sourceDomainDraft,
+          sensitivity: sourceSensitivityDraft,
+        });
+      },
+      "Source-backed open loop created.",
     );
   }
 
@@ -2208,6 +2501,35 @@ export function VNextBrainWorkspace({
     );
   }
 
+  async function handleRunDoctor(fixSafe: boolean) {
+    if (fixSafe && typeof window !== "undefined" && !window.confirm("Run vNext doctor --fix-safe?")) {
+      return;
+    }
+    if (!liveModeReady || !apiBaseUrl || !userId) {
+      updateFixtureWorkspace(
+        (previous) => ({
+          ...previous,
+          doctor: {
+            ...previous.doctor,
+            status: "pass",
+            fix_safe_applied: fixSafe,
+            checks: previous.doctor.checks.length ? previous.doctor.checks : FIXTURE_DOCTOR.checks,
+            recommended_fixes: [],
+          },
+        }),
+        fixSafe ? "Demo doctor safe fix completed." : "Demo doctor check completed.",
+      );
+      return;
+    }
+    await runLiveAction(
+      fixSafe ? "Running doctor safe fix..." : "Running doctor checks...",
+      async () => {
+        await runVNextDoctor(apiBaseUrl, { user_id: userId, fix_safe: fixSafe, ci: true });
+      },
+      fixSafe ? "Doctor safe fix completed." : "Doctor checks completed.",
+    );
+  }
+
   const selectedLoop = workspace.openLoops.find((loop) => loop.id === selectedOpenLoopId) ?? workspace.openLoops[0] ?? null;
   const selectedConnector =
     INITIAL_CONNECTORS.find((connector) => connector.id === selectedConnectorId) ?? INITIAL_CONNECTORS[0];
@@ -2435,23 +2757,129 @@ export function VNextBrainWorkspace({
           <div className="list-rows">
             {workspace.sources.length ? (
               workspace.sources.slice(0, 5).map((source) => (
-                <article key={source.id} className="list-row">
-                  <div className="list-row__topline">
-                    <div>
+                <button
+                  key={source.id}
+                  type="button"
+                  className={`list-row vnext-review-button${selectedSource?.id === source.id ? " is-selected" : ""}`}
+                  onClick={() => setSelectedSourceId(source.id)}
+                >
+                  <span className="list-row__topline">
+                    <span className="detail-stack">
                       <span className="list-row__eyebrow mono">{source.source_type}</span>
-                      <h3 className="list-row__title">{source.title || source.id}</h3>
-                    </div>
+                      <span className="list-row__title">{source.title || source.id}</span>
+                    </span>
                     <StatusBadge status={source.sensitivity ?? "unknown"} />
-                  </div>
-                  <p>{sourceText(source).slice(0, 220)}</p>
-                  <div className="list-row__meta">
+                  </span>
+                  <span>{sourceText(source).slice(0, 220)}</span>
+                  <span className="list-row__meta">
                     <span className="meta-pill">Domain: {domainLabel(asDomain(source.domain))}</span>
+                    <span className="meta-pill">Review: {textValue(asRecord(source.metadata_json).review_status) || "unreviewed"}</span>
                     <span className="meta-pill">Captured: {source.captured_at}</span>
-                  </div>
-                </article>
+                  </span>
+                </button>
               ))
             ) : (
               <EmptyState title="Inbox is empty" description="Capture a note to create a live source and candidate memory." />
+            )}
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          eyebrow="Inbox"
+          title="Source detail and review"
+          description="Selected source evidence can be reviewed, relabeled, assigned to a project, archived, or turned into an open loop without promoting memory."
+        >
+          <div className="detail-stack">
+            {selectedSource ? (
+              <>
+                <div className="cluster">
+                  <StatusBadge status={textValue(asRecord(selectedSource.metadata_json).review_status) || "unreviewed"} />
+                  <span className="meta-pill mono">Source {selectedSource.id}</span>
+                  <span className="meta-pill">Connector: {textValue(selectedSource.connector_name) || "manual"}</span>
+                </div>
+                <div className="form-field">
+                  <label htmlFor="vnext-source-title-edit">Selected source title</label>
+                  <input
+                    id="vnext-source-title-edit"
+                    value={sourceTitleDraft}
+                    onChange={(event) => setSourceTitleDraft(event.target.value)}
+                  />
+                </div>
+                <div className="form-field-group form-field-group--two-up">
+                  <div className="form-field">
+                    <label htmlFor="vnext-source-domain-edit">Source domain</label>
+                    <select
+                      id="vnext-source-domain-edit"
+                      value={sourceDomainDraft}
+                      onChange={(event) => setSourceDomainDraft(event.target.value as Domain)}
+                    >
+                      {VNEXT_DOMAIN_OPTIONS.map((domain) => (
+                        <option key={domain.value} value={domain.value}>{domain.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="form-field">
+                    <label htmlFor="vnext-source-sensitivity-edit">Source sensitivity</label>
+                    <select
+                      id="vnext-source-sensitivity-edit"
+                      value={sourceSensitivityDraft}
+                      onChange={(event) => setSourceSensitivityDraft(event.target.value as Sensitivity)}
+                    >
+                      {VNEXT_SENSITIVITY_OPTIONS.map((sensitivity) => (
+                        <option key={sensitivity.value} value={sensitivity.value}>{sensitivity.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+                <div className="form-field">
+                  <label htmlFor="vnext-source-project-edit">Source project</label>
+                  <select
+                    id="vnext-source-project-edit"
+                    value={sourceProjectDraft}
+                    onChange={(event) => setSourceProjectDraft(event.target.value)}
+                  >
+                    <option value="">No project</option>
+                    {workspace.projects.map((project) => (
+                      <option key={project.id} value={project.id}>{project.name}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="form-field">
+                  <label htmlFor="vnext-source-review-note">Review note</label>
+                  <textarea
+                    id="vnext-source-review-note"
+                    value={sourceReviewNote}
+                    onChange={(event) => setSourceReviewNote(event.target.value)}
+                  />
+                </div>
+                <div className="vnext-review-actions">
+                  <button type="button" className="button" onClick={() => void handleSourceAction("review")} disabled={Boolean(pendingAction)}>Mark reviewed</button>
+                  <button type="button" className="button-secondary" onClick={() => void handleSourceAction("update")} disabled={Boolean(pendingAction)}>Save source update</button>
+                  <button type="button" className="button-secondary" onClick={() => void handleSourceAction("assign_project")} disabled={Boolean(pendingAction || !sourceProjectDraft)}>Assign source project</button>
+                  <button type="button" className="button-secondary" onClick={() => void handleCreateOpenLoopFromSource()} disabled={Boolean(pendingAction)}>Create source open loop</button>
+                  <button type="button" className="button-secondary button-secondary--danger" onClick={() => void handleSourceAction("archive")} disabled={Boolean(pendingAction)}>Archive source</button>
+                </div>
+                <div className="key-value-grid">
+                  <div>
+                    <dt>Raw evidence</dt>
+                    <dd>{sourceText(selectedSource).slice(0, 600)}</dd>
+                  </div>
+                  <div>
+                    <dt>Chunks</dt>
+                    <dd>{selectedSourceTrace?.summary.chunk_count ?? 0}</dd>
+                  </div>
+                  <div>
+                    <dt>Candidate memories</dt>
+                    <dd>{selectedSourceTrace?.summary.candidate_memory_count ?? 0}</dd>
+                  </div>
+                  <div>
+                    <dt>Artifacts</dt>
+                    <dd>{selectedSourceTrace?.summary.artifact_count ?? 0}</dd>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <EmptyState title="No selected source" description="Capture or select source evidence before reviewing it." />
             )}
           </div>
         </SectionCard>
@@ -2560,6 +2988,12 @@ export function VNextBrainWorkspace({
                     <span className="meta-pill">Sensitivity: {sensitivityLabel(asSensitivity(artifact.sensitivity))}</span>
                     <span className="meta-pill">Generated by: {artifact.generated_by}</span>
                     <span className="meta-pill">Mode: {artifactGenerationMode(artifact)}</span>
+                    {textValue(asRecord(artifact.metadata_json).scheduler_run_id) ? (
+                      <span className="meta-pill mono">Run {textValue(asRecord(artifact.metadata_json).scheduler_run_id)}</span>
+                    ) : null}
+                    {textValue(asRecord(artifact.metadata_json).trace_id) ? (
+                      <span className="meta-pill mono">Trace {textValue(asRecord(artifact.metadata_json).trace_id)}</span>
+                    ) : null}
                     {artifactGenerationMode(artifact) === "model_backed" ? (
                       <span className="meta-pill">Model: {artifactModelLabel(artifact)}</span>
                     ) : null}
@@ -3371,6 +3805,69 @@ export function VNextBrainWorkspace({
         </SectionCard>
 
         <SectionCard
+          eyebrow="Trace"
+          title="Capture-to-brief trace"
+          description="Follow selected source evidence through chunks, candidate memories, generated artifacts, open loops, ratings, and event-log records."
+        >
+          <div id="vnext-trace" className="detail-stack">
+            {selectedSourceTrace ? (
+              <>
+                <div className="cluster">
+                  <span className="meta-pill mono">{selectedSourceTrace.trace_id}</span>
+                  <span className="meta-pill">Chunks: {selectedSourceTrace.summary.chunk_count}</span>
+                  <span className="meta-pill">Memories: {selectedSourceTrace.summary.candidate_memory_count}</span>
+                  <span className="meta-pill">Artifacts: {selectedSourceTrace.summary.artifact_count}</span>
+                  <span className="meta-pill">Events: {selectedSourceTrace.summary.event_count}</span>
+                </div>
+                <div className="key-value-grid">
+                  <div>
+                    <dt>Source</dt>
+                    <dd>{selectedSourceTrace.source.title || selectedSourceTrace.source.id}</dd>
+                  </div>
+                  <div>
+                    <dt>Candidate memories</dt>
+                    <dd>
+                      {selectedSourceTrace.candidate_memories.length
+                        ? selectedSourceTrace.candidate_memories.map(memoryText).join(" ")
+                        : "No candidate memory linked yet."}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Generated artifacts</dt>
+                    <dd>
+                      {selectedSourceTrace.artifacts.length
+                        ? selectedSourceTrace.artifacts.map((artifact) => artifact.title || artifact.id).join(", ")
+                        : "No generated artifact references this source yet."}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Open loops</dt>
+                    <dd>
+                      {selectedSourceTrace.open_loops.length
+                        ? selectedSourceTrace.open_loops.map((loop) => loop.title).join(", ")
+                        : "No open loop linked yet."}
+                    </dd>
+                  </div>
+                </div>
+                <div className="timeline-list">
+                  {selectedSourceTrace.events.slice(0, 6).map((event) => (
+                    <article key={`trace-event-${event.id}`} className="timeline-item">
+                      <div className="timeline-item__topline">
+                        <span className="list-row__eyebrow mono">{event.occurred_at}</span>
+                        <h3 className="list-row__title">{event.event_type}</h3>
+                      </div>
+                      <p>{event.target_type ? `${event.target_type}:${event.target_id}` : "workspace event"}</p>
+                    </article>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <EmptyState title="No source trace" description="Select a source with linked candidates or artifacts to inspect its capture-to-brief path." />
+            )}
+          </div>
+        </SectionCard>
+
+        <SectionCard
           eyebrow="Graph"
           title="Connection graph"
           description="Graph visualization remains lightweight and read-only; live graph polish is deferred."
@@ -3594,6 +4091,82 @@ export function VNextBrainWorkspace({
               </div>
             </div>
           ) : null}
+        </SectionCard>
+      </div>
+
+      <div id="vnext-doctor" className="content-grid content-grid--wide">
+        <SectionCard
+          eyebrow="Doctor"
+          title="Readiness checks"
+          description="Doctor checks expose migration, connector settings/state, secret reference, scheduler daemon, and capture pipeline posture."
+        >
+          <div className="cluster">
+            <StatusBadge
+              status={workspace.doctor.status === "pass" ? "accepted" : workspace.doctor.status === "fail" ? "failed" : "requires_review"}
+              label={`Doctor: ${workspace.doctor.status}`}
+            />
+            <span className="meta-pill">Blocking: {workspace.doctor.blocking_failure_count}</span>
+            <span className="meta-pill">Warnings: {workspace.doctor.warning_count}</span>
+            <span className="meta-pill">CI mode: {workspace.doctor.ci_mode ? "on" : "off"}</span>
+            <span className="meta-pill">Safe fix: {workspace.doctor.fix_safe_applied ? "applied" : "not applied"}</span>
+          </div>
+          <div className="vnext-review-actions">
+            <button type="button" className="button" onClick={() => void handleRunDoctor(false)} disabled={Boolean(pendingAction)}>
+              Run doctor
+            </button>
+            <button type="button" className="button-secondary" onClick={() => void handleRunDoctor(true)} disabled={Boolean(pendingAction)}>
+              Run doctor --fix-safe
+            </button>
+          </div>
+          <div className="list-rows">
+            {workspace.doctor.checks.length ? (
+              workspace.doctor.checks.map((check) => (
+                <article key={check.name} className="list-row">
+                  <div className="list-row__topline">
+                    <div>
+                      <span className="list-row__eyebrow mono">{check.severity}</span>
+                      <h3 className="list-row__title">{check.name}</h3>
+                    </div>
+                    <StatusBadge status={check.status} />
+                  </div>
+                  <p>{check.message}</p>
+                  {check.recommended_fix ? <p className="responsive-note">Fix: {check.recommended_fix}</p> : null}
+                </article>
+              ))
+            ) : (
+              <EmptyState title="No doctor checks loaded" description="Run doctor or load live workspace readiness to populate checks." />
+            )}
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          eyebrow="Doctor"
+          title="Readiness details"
+          description="Dogfood readiness and connector health are shown together so setup issues are visible before daily use."
+        >
+          <div className="key-value-grid key-value-grid--compact">
+            <div>
+              <dt>Dogfood readiness</dt>
+              <dd>{workspace.dogfooding.dogfood_readiness?.status ?? "unknown"}</dd>
+            </div>
+            <div>
+              <dt>Migration status</dt>
+              <dd>{textValue(workspace.doctor.migration_status["status"]) || "unknown"}</dd>
+            </div>
+            <div>
+              <dt>Connector health rows</dt>
+              <dd>{workspace.doctor.connector_health.count}</dd>
+            </div>
+            <div>
+              <dt>Recommended fixes</dt>
+              <dd>{workspace.doctor.recommended_fixes.filter(Boolean).length}</dd>
+            </div>
+          </div>
+          <div className="cluster">
+            {workspace.doctor.recommended_fixes.filter(Boolean).map((fix) => (
+              <span key={String(fix)} className="meta-pill">{fix}</span>
+            ))}
+          </div>
         </SectionCard>
       </div>
 

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -38,9 +38,11 @@ import {
   getVNextBrainCharter,
   getVNextConnectorsHealth,
   getVNextDogfoodingDashboard,
+  getVNextArtifactTrace,
   getVNextPolicyTelemetry,
   getVNextQualityEvals,
   getVNextSchedulerFailures,
+  getVNextSourceTrace,
   getVNextWorkspace,
   getThreadDetail,
   getThreadEvents,
@@ -87,6 +89,8 @@ import {
   reviewVNextArtifact,
   reviewVNextMemory,
   reviewVNextOpenLoop,
+  reviewVNextSource,
+  runVNextDoctor,
   runVNextSchedulerDue,
   runVNextSchedulerWorkflowNow,
   shouldExpectThreadExecutionReview,
@@ -3793,6 +3797,54 @@ describe("api helpers", () => {
       useful_insight: "yes",
       surfaced_missed: "no",
       comments: "Grounded in captured evidence.",
+    });
+  });
+
+  it("uses vNext source review, trace, and doctor endpoints", async () => {
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    await reviewVNextSource("https://api.example.com", "source-1", {
+      user_id: "user-1",
+      action: "assign_project",
+      title: "Reviewed source",
+      domain: "project",
+      sensitivity: "private",
+      project_id: "project-1",
+      review_note: "Reviewed in operator console.",
+    });
+    await getVNextSourceTrace("https://api.example.com", "source-1", "user-1");
+    await getVNextArtifactTrace("https://api.example.com", "artifact-1", "user-1");
+    await runVNextDoctor("https://api.example.com", {
+      user_id: "user-1",
+      fix_safe: true,
+      ci: true,
+    });
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "https://api.example.com/v0/vnext/sources/source-1/review",
+      "https://api.example.com/v0/vnext/traces/sources/source-1?user_id=user-1",
+      "https://api.example.com/v0/vnext/traces/artifacts/artifact-1?user_id=user-1",
+      "https://api.example.com/v0/vnext/doctor/run",
+    ]);
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      user_id: "user-1",
+      action: "assign_project",
+      title: "Reviewed source",
+      domain: "project",
+      sensitivity: "private",
+      project_id: "project-1",
+      review_note: "Reviewed in operator console.",
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[3]?.[1]?.body))).toEqual({
+      user_id: "user-1",
+      fix_safe: true,
+      ci: true,
     });
   });
 });

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -205,6 +205,8 @@ export type VNextRow = JsonObject & {
 export type VNextSourceRecord = VNextRow & {
   source_type: string;
   captured_at: string;
+  connector_name?: string | null;
+  external_id?: string | null;
   metadata_json?: JsonObject;
 };
 
@@ -501,6 +503,56 @@ export type VNextDogfoodingDashboard = {
   };
 };
 
+export type VNextDoctorCheckRecord = {
+  name: string;
+  status: string;
+  severity: string;
+  message: string;
+  recommended_fix?: string | null;
+  details?: JsonObject;
+};
+
+export type VNextDoctorPayload = {
+  status: "pass" | "warn" | "fail" | string;
+  fix_safe_applied: boolean;
+  ci_mode: boolean;
+  blocking_failure_count: number;
+  warning_count: number;
+  checks: VNextDoctorCheckRecord[];
+  recommended_fixes: Array<string | null>;
+  migration_status: JsonObject;
+  connector_health: { items: VNextConnectorHealthRecord[]; count: number; order: string[] };
+};
+
+export type VNextSourceTracePayload = {
+  trace_id: string;
+  trace_kind: string;
+  source: VNextSourceRecord;
+  chunks: JsonObject[];
+  candidate_memories: VNextMemoryRecord[];
+  artifacts: VNextArtifactRecord[];
+  open_loops: VNextOpenLoopRecord[];
+  events: VNextEventRecord[];
+  summary: {
+    source_id: string;
+    chunk_count: number;
+    candidate_memory_count: number;
+    artifact_count: number;
+    open_loop_count: number;
+    event_count: number;
+  };
+};
+
+export type VNextArtifactTracePayload = {
+  trace_id: string;
+  trace_kind: string;
+  artifact: VNextArtifactRecord;
+  sources: VNextSourceRecord[];
+  quality_evals: VNextArtifactQualityEvalRecord[];
+  events: VNextEventRecord[];
+  summary: JsonObject;
+};
+
 export type VNextTelemetryCounter = {
   count: number;
   [key: string]: unknown;
@@ -549,6 +601,8 @@ export type VNextWorkspacePayload = {
   agent_activity?: VNextAgentActivity;
   connector_health?: { items: VNextConnectorHealthRecord[]; count: number; order: string[] };
   dogfooding?: VNextDogfoodingDashboard;
+  doctor?: VNextDoctorPayload;
+  traceability?: { items: VNextSourceTracePayload[]; count: number; order: string[] };
   policy_telemetry?: VNextPolicyTelemetrySummary;
   scheduler?: VNextSchedulerStatus;
   brain_charter: VNextBrainCharterRecord | null;
@@ -560,6 +614,16 @@ export type VNextSourceCreatePayload = {
   title?: string | null;
   domain: string;
   sensitivity: string;
+};
+
+export type VNextSourceReviewPayload = {
+  user_id: string;
+  action: "review" | "update" | "assign_project" | "archive";
+  title?: string;
+  domain?: string;
+  sensitivity?: string;
+  project_id?: string;
+  review_note?: string;
 };
 
 export type VNextMemoryReviewPayload = {
@@ -4076,6 +4140,39 @@ export function createVNextSource(apiBaseUrl: string, payload: VNextSourceCreate
   });
 }
 
+export function reviewVNextSource(
+  apiBaseUrl: string,
+  sourceId: string,
+  payload: VNextSourceReviewPayload,
+) {
+  return requestJson<{ source: VNextSourceRecord; archived: boolean; trace: VNextSourceTracePayload }>(
+    apiBaseUrl,
+    `/v0/vnext/sources/${sourceId}/review`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export function getVNextSourceTrace(apiBaseUrl: string, sourceId: string, userId: string) {
+  return requestJson<VNextSourceTracePayload>(
+    apiBaseUrl,
+    `/v0/vnext/traces/sources/${sourceId}`,
+    undefined,
+    { user_id: userId },
+  );
+}
+
+export function getVNextArtifactTrace(apiBaseUrl: string, artifactId: string, userId: string) {
+  return requestJson<VNextArtifactTracePayload>(
+    apiBaseUrl,
+    `/v0/vnext/traces/artifacts/${artifactId}`,
+    undefined,
+    { user_id: userId },
+  );
+}
+
 export function createVNextContextPack(
   apiBaseUrl: string,
   payload: {
@@ -4272,6 +4369,16 @@ export function getVNextDogfoodingDashboard(apiBaseUrl: string, userId: string) 
     undefined,
     { user_id: userId },
   );
+}
+
+export function runVNextDoctor(
+  apiBaseUrl: string,
+  payload: { user_id: string; fix_safe?: boolean; ci?: boolean },
+) {
+  return requestJson<VNextDoctorPayload>(apiBaseUrl, "/v0/vnext/doctor/run", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
 }
 
 export function recordVNextArtifactInsightFeedback(

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -75,6 +75,7 @@ alicebot vnext smoke capture-to-brief
 alicebot vnext smoke connector-hardening
 alicebot vnext smoke secret-redaction
 alicebot vnext smoke dogfood-doctor
+alicebot vnext smoke operator-console
 ```
 
 The vNext agent arguments are `--agent-id`, `--agent-type`, `--agent-run-id`, `--agent-task-id`, `--project-scope`, and `--permission-profile`. Agent-originated scheduler and memory-proposal commands are policy checked, logged, and kept review-only where they create memory or generated artifacts.
@@ -82,6 +83,8 @@ The vNext agent arguments are `--agent-id`, `--agent-type`, `--agent-run-id`, `-
 Model-backed generation arguments are available on daily brief, weekly synthesis, connection report, contradiction report, project update candidate, and scheduler run-now commands: `--generation-mode`, `--model-route-mode`, `--model-provider`, `--model`, `--model-temperature`, and `--allow-cloud-private`. Private and highly sensitive scopes remain local-only or disabled unless explicitly configured.
 
 Live capture connector commands preserve the same trust model as manual capture: raw source text is archived, domain/sensitivity defaults are explicit, source material is treated as untrusted, agent output produces review-only artifacts/proposals, and capture-to-brief promotion still requires human review. Connector settings and state now persist outside the event log, while settings/state changes still write audit events. Secret values are never printed; the CLI stores or resolves only `secret_ref` values.
+
+The `operator-console` smoke is the broadest local go/no-go check for daily `/vnext` operation. It verifies source review, memory review, artifact review/rating, source-backed open-loop creation, scheduler run-now artifact creation, connector health visibility, doctor readiness, event logging, and source-to-brief traceability.
 
 ## Temporal History Commands
 

--- a/docs/livebackedoperatorconsole.md
+++ b/docs/livebackedoperatorconsole.md
@@ -1,0 +1,711 @@
+
+Alice vNext Sprint Prompt: Live-Backed Operator Console Completion
+Sprint Objective
+Alice vNext now has a hardened local dogfood loop with live capture connectors, dedicated connector settings/state tables, secret references, doctor checks, scheduler runtime, model-backed Brain workflows, quality ratings, and dogfooding telemetry.
+This sprint should make /vnext the primary daily operator console for Alice.
+The goal is not to add major new connectors or redesign the UI. The goal is to connect the existing backend capabilities to real /vnext workflows so a user can operate Alice day to day from the web workspace instead of relying on CLI/API calls.
+By the end of this sprint, /vnext should let the user:
+review captured sources
+accept/edit/reject candidate memories
+review/promote/archive generated artifacts
+rate artifact usefulness
+manage open loops
+review project updates
+configure connector settings
+inspect connector health
+run/schedule Brain workflows
+inspect scheduler history
+inspect agent activity
+inspect policy blocks
+run/read doctor checks
+trace capture-to-brief provenance
+CLI should remain available for power-user/admin operations, but the normal dogfooding workflow should be possible from /vnext.
+
+⸻
+
+Product Principle
+Alice is still:
+agentic-first
+local-first
+review-first
+provenance-first
+no-auto-promotion
+The /vnext UI is not the “main memory engine.” It is the operator cockpit for the memory engine.
+Agents such as Hermes and OpenClaw may continue using MCP/API/CLI as primary access paths. /vnext should show what agents did, what Alice generated, what policies blocked or filtered, and what needs human review.
+No UI action should bypass the existing policy/review model.
+
+⸻
+
+Current State Assumption
+Alice already has:
+live-backed /vnext foundation
+agentic control plane
+governed scheduler daemon
+model-backed Brain workflows
+quality ratings
+live Telegram capture
+local folder / Obsidian capture
+browser clipper MVP
+agent output ingestion
+dedicated connector settings table
+dedicated connector state/cursor table
+secret-provider abstraction
+doctor checks
+dogfooding dashboard
+capture-to-brief smoke
+privacy and prompt-injection evals
+The previous phase specifically hardened connector settings/state, secret references, doctor checks, live connector configuration, and dogfooding telemetry.
+This sprint should build on that and make /vnext the daily control surface.
+
+⸻
+
+Core Build Requirements
+1. Live Workspace Data Contract
+Create or harden a clear live workspace data contract for /vnext.
+The workspace payload should include enough real data to render the operator console without fixture dependence:
+current user/system status
+recent sources
+candidate memories
+generated artifacts
+artifact ratings
+open loops
+projects
+project update candidates
+recent events/timeline
+agent activity
+policy blocks/filters
+scheduler status
+scheduler run history
+connector settings
+connector health
+dogfooding metrics
+doctor/readiness status
+Requirements:
+live mode should be default when API config exists
+demo fixture mode should remain available
+fixture/demo data must be clearly separated from live data
+UI should not silently mix live and fixture data in ways that confuse operators
+workspace payload should be versioned or typed
+loading, empty, error, and permission states must be handled
+Acceptance criteria:
+/vnext loads a live workspace payload by default.
+Demo mode still works via explicit mode selection or query parameter.
+The UI clearly indicates live vs demo mode.
+The workspace payload is typed and tested.
+No required daily operator panel depends only on fixtures.
+
+⸻
+
+2. Inbox and Captured Source Review
+Make the Inbox a real operator workflow.
+The user should be able to:
+view recently captured sources
+filter by connector
+filter by domain/sensitivity
+filter by review status
+open source detail
+view raw evidence preview
+view chunks/provenance where available
+see candidate memories generated from source
+assign source to project
+update source domain/sensitivity if allowed
+create open loop from source
+mark source reviewed
+soft-delete or archive source where policy allows
+Required source metadata display:
+source type
+connector name
+captured_at
+source_created_at
+title
+domain
+sensitivity
+content hash/dedupe status
+provenance links
+candidate memory count
+artifact usage count
+Acceptance criteria:
+Captured Telegram/local folder/browser/agent-output sources appear in live Inbox.
+Source detail shows provenance and connector metadata.
+Source domain/sensitivity can be updated through policy-checked API.
+Source can be assigned to project.
+Source can create an open loop.
+Source review actions create event-log entries.
+No source action auto-promotes trusted memory.
+
+⸻
+
+3. Memory Review Console
+Make Memory Review fully live-backed and usable.
+The user should be able to:
+see pending candidate memories
+filter by source, project, connector, domain, sensitivity, agent, confidence
+open candidate detail
+see source evidence/provenance
+accept candidate
+edit candidate then accept
+reject candidate
+mark candidate private
+assign candidate to project
+merge or supersede where existing backend supports it
+see review history
+Required candidate detail sections:
+candidate memory text
+why Alice thinks it matters
+source evidence
+provenance links
+confidence
+domain/sensitivity
+agent or workflow origin
+policy decision
+review status
+event history
+Acceptance criteria:
+Candidate memories from live captures appear in Memory Review.
+Accept/edit/reject/private/project assignment write to real backend.
+Every review action creates event-log entry.
+Accepted memory appears in later context packs.
+Rejected memory does not keep reappearing unless new evidence changes the proposal.
+No generated artifact or candidate memory auto-promotes.
+
+⸻
+
+4. Generated Artifacts Console
+Make Generated Artifacts a complete daily review surface.
+The user should be able to:
+view artifacts by type
+filter by generated_by: scheduler, agent, user, system
+filter by workflow type
+filter by review status
+filter by model mode: deterministic/model-backed
+open artifact detail
+see source references
+see provider/model metadata
+see scheduler_run_id / agent_run_id / trace_id
+review artifact
+archive artifact
+promote artifact to memory proposal
+create open loop from artifact
+create project update from artifact
+rate artifact quality
+mark useful insight: yes/no/not sure
+compare deterministic vs model-backed where available
+Required artifact detail sections:
+content
+facts
+inferences
+recommendations
+uncertainties
+source references
+contradictions considered
+open questions
+provider/model metadata
+policy/routing decision
+review history
+quality ratings
+useful insight feedback
+Acceptance criteria:
+Daily Brief, Weekly Synthesis, Connection Report, Contradiction Report, Open Loop Review, and Project Update Scan artifacts render from live data.
+Artifact review/archive/promote/rate actions persist.
+Quality ratings update dogfooding dashboard.
+Useful insight feedback persists.
+Artifact promotion creates review-only memory proposal, not trusted memory.
+Model metadata is visible where available.
+
+⸻
+
+5. Open Loops Console
+Make Open Loops fully live-backed.
+The user should be able to:
+create open loop
+edit open loop
+close open loop
+reopen open loop
+snooze open loop
+assign project
+assign person if supported
+set priority
+set due date
+link to source/artifact/memory
+filter by project/status/priority/due date
+Acceptance criteria:
+Open loops created from source/artifact/manual UI persist.
+Close/reopen/snooze/edit actions persist.
+Open loops appear in Daily Brief and relevant project dashboards.
+Event log records all state changes.
+Invalid status transitions are blocked with clear UI errors.
+
+⸻
+
+6. Project Operator View
+Make Projects useful for daily work.
+Each project page should show live:
+current state
+recent project sources
+project memories
+project update candidates
+open loops
+generated artifacts
+recent decisions
+recent changes
+related agents/activity
+policy blocks relevant to project
+timeline events
+The user should be able to:
+create project
+edit project basics
+review project update candidate
+accept/edit/reject project update
+create project open loop
+generate project-specific context pack
+run project update scan
+view project-related artifacts
+Acceptance criteria:
+Project dashboard uses real backend data.
+Project update candidates can be accepted/edited/rejected.
+Accepted project update creates memory/revision/event log.
+Project-specific context pack can be generated from UI.
+Project open loops and artifacts are visible.
+
+⸻
+
+7. Scheduler and Brain Workflow Operations
+The Schedules view should become an operator-grade control panel.
+The user should be able to:
+view daemon status
+view global pause/resume state
+view all workflows
+enable/disable workflows
+edit schedule where supported
+run now
+pause/resume scheduler
+view next run
+view last run
+view last success
+view last failure
+view run history
+open generated artifact from run
+open trace/event history for run
+Workflow types:
+daily_brief
+weekly_synthesis
+connection_report
+contradiction_report
+open_loop_review
+project_update_scan
+Acceptance criteria:
+Schedule settings are live-backed.
+Run-now works from UI.
+Pause/resume works from UI where policy allows.
+Run history is visible.
+Failures are visible and understandable.
+Generated artifacts link back to scheduler runs.
+Scheduler actions create event-log entries.
+No scheduled workflow auto-promotes trusted memory.
+
+⸻
+
+8. Connector Configuration and Health Console
+Make connector configuration fully usable from /vnext for the dogfood connectors.
+Supported connectors:
+Telegram
+Local Folder / Obsidian
+Browser Clipper
+Agent Output
+Telegram
+UI should support:
+enabled/disabled
+secret_ref status
+allowed chat IDs
+default domain
+default sensitivity
+polling/sync settings
+test connection
+run sync now
+view last sync
+view next offset/cursor posture
+view rejected chats
+view failures
+view recent captures
+Local Folder
+UI should support:
+add watched path
+remove watched path
+enable/disable path
+recursive yes/no
+extension allowlist
+ignore patterns
+default domain
+default sensitivity
+run sync now
+watch status
+last captured file
+duplicates skipped
+ignored files
+errors
+Browser Clipper
+UI should support:
+endpoint status
+bookmarklet generator
+optional token status
+default domain
+default sensitivity
+test clip form
+recent clips
+copy setup instructions
+Agent Output
+UI should show:
+recent agent-ingested outputs
+agent_id
+agent_type
+project scope
+source/artifact links
+proposal status
+policy decision
+Acceptance criteria:
+Connector settings are editable from /vnext.
+Connector state/health is visible from /vnext.
+Manual sync/test actions work from /vnext.
+Secret values are never displayed.
+Connector failures link to relevant events/logs.
+Live connector changes create event-log entries.
+
+⸻
+
+9. Agent Activity and Policy Console
+Make agent observability useful.
+The Agent Activity view should show:
+agent identities
+permission profile
+recent context packs requested
+artifacts generated
+outputs ingested
+memory proposals submitted
+open loops created
+project updates proposed
+scheduler actions requested
+policy blocks
+policy filters
+requires-review decisions
+restricted-domain requests
+The user should be able to:
+filter by agent
+filter by project
+filter by policy decision
+open related artifact/source/memory proposal
+open event detail
+view trace ID/run ID/task ID
+Acceptance criteria:
+Hermes/OpenClaw-style agent activity is visible.
+Policy blocks/filters are visible and explainable.
+Agent memory proposals link to Memory Review.
+Agent artifacts link to Generated.
+Agent output ingestion links to sources/artifacts.
+
+⸻
+
+10. Doctor and Readiness UI
+Expose doctor/readiness checks in /vnext.
+The user should be able to see:
+database/migration status
+scheduler daemon status
+connector settings status
+connector state status
+secret provider status
+model provider/routing status
+capture pipeline status
+recent blocking failures
+recommended fixes
+Optional if safe:
+run doctor from UI
+run doctor --fix-safe from UI with confirmation
+Acceptance criteria:
+/vnext shows dogfood readiness status.
+Readiness reasons are understandable.
+Blocking failures are clear.
+Safe fixes require confirmation.
+Doctor output does not expose secrets.
+
+⸻
+
+11. Capture-to-Brief Traceability
+Add a trace view or detail panel that lets the user follow an item through the loop:
+source captured
+source chunked
+candidate memory created
+context pack retrieved it
+artifact cited it
+artifact rated useful/not useful
+memory accepted/rejected
+This can be implemented as a timeline panel on source/artifact detail or as a dedicated trace view.
+Acceptance criteria:
+User can open a captured source and see whether it influenced context packs or artifacts.
+User can open an artifact and see which sources influenced it.
+Capture-to-brief smoke proves traceability.
+Trace view includes source/artifact/memory/event IDs.
+
+⸻
+
+API Requirements
+Add or harden API endpoints as needed for the UI.
+The API should support:
+workspace live payload
+source list/detail/review/update
+candidate memory list/detail/review
+artifact list/detail/review/rate/promote/archive
+open loop CRUD
+project dashboard/update candidate review
+scheduler status/config/run history/run-now/pause/resume
+connector settings/state/health/test/sync
+agent activity/policy events
+doctor/readiness status
+capture-to-brief trace
+All write endpoints must:
+run policy checks
+create event-log entries
+return clear errors
+not expose secrets
+not auto-promote memory
+
+⸻
+
+UI Requirements
+The UI should prioritize usability over visual redesign.
+Required pages or tabs:
+Home
+Inbox
+Memory Review
+Generated
+Daily Brief
+Weekly Synthesis
+Projects
+Open Loops
+Schedules
+Connectors
+Agent Activity
+Dogfooding Dashboard
+Timeline
+Settings / Brain Charter
+Doctor / Readiness
+Existing pages can be reused and improved.
+Requirements:
+consistent loading states
+consistent empty states
+consistent error states
+clear live/demo mode indicator
+clear domain/sensitivity labels
+clear review status labels
+clear generated_by labels
+clear policy decision labels
+clear source/provenance links
+
+⸻
+
+Security and Privacy Requirements
+Preserve all existing guardrails.
+Required:
+No UI action auto-promotes trusted memory.
+No connector content bypasses review.
+No generated artifact bypasses review.
+No agent proposal bypasses review.
+No source content becomes tool/system instruction.
+Secret values are never displayed in UI/API/logs.
+Domain/sensitivity policies are enforced.
+Restricted actions show clear permission errors.
+Prompt-injection tests still pass.
+Privacy leakage evals still pass.
+
+⸻
+
+Explicit Deferrals
+Do not build these in this sprint:
+Gmail OAuth
+Calendar OAuth
+live email polling
+live calendar polling
+Telegram webhook automation
+Telegram voice transcription
+OCR execution
+PDF OCR
+voice transcription execution
+mobile app
+hosted cloud deployment
+automatic memory promotion
+major UI redesign
+full production browser extension polish
+team accounts
+billing
+cloud sync
+This sprint is about completing the local operator console, not expanding the integration surface.
+
+⸻
+
+Required End-to-End Flows
+Flow 1: Daily review from
+/vnext
+User opens /vnext.
+User sees dogfood readiness.
+User reviews new captured sources in Inbox.
+User accepts/edits/rejects candidate memories.
+User reviews generated Daily Brief.
+User rates artifact usefulness.
+Dogfooding dashboard updates.
+Timeline shows actions.
+Flow 2: Connector operation from
+/vnext
+User opens Connectors.
+User configures Telegram/local folder/browser clipper defaults.
+User runs sync now.
+Connector captures source.
+Connector health updates.
+Source appears in Inbox.
+No secrets are exposed.
+Flow 3: Scheduler operation from
+/vnext
+User opens Schedules.
+User runs Connection Report now.
+Scheduler run starts and completes.
+Generated artifact appears.
+Run history links to artifact.
+Timeline logs run lifecycle.
+No artifact auto-promotes.
+Flow 4: Agent activity review
+OpenClaw submits agent output or memory proposal.
+Agent Activity shows the action.
+Memory Review shows pending proposal.
+User accepts/rejects proposal.
+Event log records full flow.
+Flow 5: Capture-to-brief trace
+Browser clip is captured.
+Daily Brief cites browser clip.
+User opens source trace.
+Trace shows source → context pack/artifact → rating/review path.
+
+⸻
+
+Acceptance Criteria
+The sprint is complete only when all of the following are true:
+/vnext live mode is the default when API config exists.
+
+Demo mode remains available and clearly labeled.
+
+Inbox is live-backed and supports source review/update/project/open-loop actions.
+
+Memory Review is live-backed and supports accept/edit/reject/private/project assignment actions.
+
+Generated Artifacts is live-backed and supports review/archive/promote/rate/useful insight actions.
+
+Open Loops are live-backed and support create/edit/close/reopen/snooze.
+
+Projects are live-backed and show project state, open loops, artifacts, update candidates, and recent activity.
+
+Project update candidates can be accepted/edited/rejected from UI.
+
+Schedules are live-backed and support status, run-now, pause/resume, run history, and failure visibility.
+
+Connectors are live-backed and support Telegram/local-folder/browser configuration, health, test/sync where supported.
+
+Agent Activity is live-backed and shows agent events, proposals, artifacts, and policy blocks/filters.
+
+Dogfooding Dashboard is live-backed and reflects captures, ratings, reviews, scheduler freshness, policy events, and connector failures.
+
+Doctor/Readiness status is visible in /vnext.
+
+Capture-to-brief traceability exists for sources and artifacts.
+
+All write actions create event-log entries.
+
+All write actions are policy-checked.
+
+No UI/API path exposes secrets.
+
+No UI/API path auto-promotes trusted memory.
+
+Prompt-injection evals still pass.
+
+Privacy leakage evals still pass.
+
+Existing connector hardening smokes still pass.
+
+Existing capture-to-brief smoke still passes.
+
+Existing agentic scheduler smoke still passes.
+
+Python unit tests pass.
+
+Python integration tests pass.
+
+Web tests pass.
+
+Web lint passes.
+
+Web build passes.
+
+Eval suite passes.
+
+git diff --check passes.
+
+⸻
+
+Validation Commands
+Run the standard validation suite:
+pytest tests/unit -q
+pytest tests/integration -q
+pnpm --dir apps/web test
+pnpm --dir apps/web lint
+pnpm --dir apps/web build
+alicebot eval run --suite all
+git diff --check
+Re-run existing vNext smokes:
+alicebot vnext smoke connector-hardening
+alicebot vnext smoke secret-redaction
+alicebot vnext smoke dogfood-doctor
+alicebot vnext smoke live-capture-connectors
+alicebot vnext smoke capture-to-brief
+alicebot vnext smoke agentic-scheduler
+Add a new smoke test:
+alicebot vnext smoke operator-console
+The new smoke should verify:
+live workspace loads
+source review action persists
+memory review action persists
+artifact rating/review persists
+open-loop update persists
+scheduler run-now creates artifact
+connector health is visible
+agent activity is visible
+doctor/readiness status is available
+capture-to-brief trace exists
+event logs are created
+
+⸻
+
+Final Deliverable
+At the end of the sprint, provide a CTO summary with:
+what was built
+which /vnext pages are now fully live-backed
+API additions/changes
+UI additions/changes
+operator workflows supported
+connector configuration behavior
+scheduler operation behavior
+agent activity behavior
+doctor/readiness behavior
+capture-to-brief traceability
+security/privacy guardrails preserved
+tests and validation results
+known limitations
+recommended next phase
+PR number
+merge commit
+
+⸻
+
+Recommended Next Phase After This
+After this sprint, choose based on dogfooding.
+Likely candidates:
+1. Public Alpha Packaging
+2. Voice Capture + Local Transcription
+3. Gmail/Calendar Read-Only Connectors
+4. Intelligence Improvement Based on Ratings
+Default recommendation after this sprint will likely be Public Alpha Packaging, assuming the operator console is usable enough for daily local dogfooding.

--- a/docs/release/v0.5.1-vnext-preview-release-notes.md
+++ b/docs/release/v0.5.1-vnext-preview-release-notes.md
@@ -19,9 +19,9 @@ Alice vNext is now ready as a public preview of the true second-brain direction 
 - Live local connector capture for allowlisted Telegram sync, local folder/Obsidian scan and watch, browser clipper capture, and Hermes/OpenClaw-style agent output ingestion.
 - Dedicated connector settings and state tables for enabled/configured flags, defaults, sync modes, poll intervals, validation errors, cursors, counters, failures, and timestamps.
 - Local secret-provider abstraction for environment references and encrypted local fallback storage, with redaction before connector payloads reach source metadata or event logs.
-- Local dogfood readiness checks through `alicebot vnext migrations status`, `alicebot vnext doctor`, and connector-hardening/secret-redaction/doctor smokes.
+- Local dogfood readiness checks through `alicebot vnext migrations status`, `alicebot vnext doctor`, and connector-hardening/secret-redaction/doctor/operator-console smokes.
 - Deterministic connector payload ingestion for Telegram, browser clipper, PDF, DOCX, CSV, screenshot OCR, and voice transcript payloads.
-- Live/fixture-backed `/vnext` workspace covering Home, Inbox, Ask Alice, briefs, queue, generated artifacts, memory review, projects, people, beliefs, open loops, timeline, graph, connector health, dogfooding capture health, and settings/privacy.
+- Live/fixture-backed `/vnext` workspace covering Home, Inbox source review/archive, capture-to-brief traces, Ask Alice, briefs, queue, generated artifacts, memory review, projects, people, beliefs, open loops, timeline, graph, connector health, doctor/readiness, dogfooding capture health, and settings/privacy.
 - Synthetic eval corpus and baseline suites for recall, temporal reasoning, contradictions, provenance, privacy, open loops, and prompt-injection write safety.
 - Public-preview docs: quickstart, architecture, security/privacy, contributor guide, synthetic demo dataset, demo video script, release checklist, and tag plan.
 
@@ -32,6 +32,7 @@ Release-readiness evidence recorded on 2026-05-11:
 - Real Postgres vNext smoke passed for source capture, connector ingest, scoped and unscoped context packs, daily brief generation, project update review, open-loop close, API context packs, API project dashboard, MCP context pack, and MCP project dashboard.
 - Real Postgres live-capture connector smoke passed.
 - Real Postgres capture-to-brief smoke passed.
+- Real Postgres operator-console smoke passed.
 - Real Postgres connector-hardening smoke passed.
 - Real Postgres secret-redaction smoke passed.
 - Real Postgres dogfood-doctor smoke passed.

--- a/docs/release/vnext-public-release-checklist.md
+++ b/docs/release/vnext-public-release-checklist.md
@@ -22,6 +22,7 @@ Use this checklist before cutting a vNext preview tag or public announcement. Do
 - [x] Connector secrets use references and local encrypted/env-backed providers without exposing raw values.
 - [x] Connector health and dogfooding capture metrics are visible in the UI.
 - [x] Local doctor checks report missing migrations, missing connector rows, secret reference problems, scheduler posture, and capture failures.
+- [x] `/vnext` exposes live source review/update/archive, source-backed open-loop creation, doctor/readiness checks, and capture-to-brief traces.
 - [x] Live local capture works for allowlisted Telegram, local folder/Obsidian notes, browser clips, and agent outputs.
 - [x] Connector payload ingestion preserves raw evidence, default domain/sensitivity, and cursor posture.
 - [x] Generated artifacts remain reviewable and are not auto-promoted to trusted memory.
@@ -42,6 +43,7 @@ Use this checklist before cutting a vNext preview tag or public announcement. Do
 - [x] Real Postgres connector-hardening smoke check.
 - [x] Real Postgres secret-redaction smoke check.
 - [x] Real Postgres dogfood-doctor smoke check.
+- [x] Real Postgres operator-console smoke check.
 
 ## Security and Privacy
 
@@ -72,6 +74,7 @@ Current evidence recorded on 2026-05-11:
 - Real Postgres connector-hardening smoke passed for settings rows, cursor persistence, rejected-chat logging, generated-folder ignores, restart dedupe, and health counters.
 - Real Postgres secret-redaction smoke passed for Telegram token absence, browser token absence, and redacted capture-token evidence.
 - Real Postgres dogfood-doctor smoke passed with zero blocking failures and zero warnings.
+- Real Postgres operator-console smoke passed for source review, memory review, artifact review/rating, source-backed open loops, scheduler run-now, connector health, doctor readiness, event logging, and capture-to-brief traceability.
 - `./.venv/bin/python -m pytest tests/unit -q`: `1125 passed`.
 - `./.venv/bin/python -m pytest tests/integration -q`: `370 passed`.
 - `pnpm --dir apps/web test`: `207 passed`.

--- a/docs/vnext-live-backed-operator-console-cto-summary.md
+++ b/docs/vnext-live-backed-operator-console-cto-summary.md
@@ -1,0 +1,143 @@
+# Alice vNext Live-Backed Operator Console: CTO Summary
+
+Date: 2026-05-12
+Audience: CTO / technical leadership
+Sprint artifact: `codex/live-backed-operator-console`
+Baseline preserved: `v0.5.1` stable public release, `v0.5.1-vnext-preview` public-preview boundary
+
+## Executive Summary
+
+This phase turns `/vnext` from a broad preview dashboard into a daily local operator console for Alice vNext. The backend already had the major primitives: source capture, candidate memories, generated artifacts, project updates, open loops, connector settings/state, scheduler runs, dogfood telemetry, and doctor checks. This sprint connected the remaining operational gaps so a user can run the review loop from the web workspace instead of dropping to CLI/API for core actions.
+
+The working loop is now:
+
+```text
+capture -> source review -> candidate memory review -> context pack -> generated/scheduled artifact -> artifact review/rating -> open-loop/project follow-up -> doctor/readiness + trace audit
+```
+
+The product rule remains unchanged: source evidence and generated artifacts stay review-only until a human explicitly accepts, promotes, or archives them.
+
+## What We Built
+
+### 1. Live Source Review And Archive
+
+`/vnext` now supports source-level operator actions backed by the API:
+
+- mark source reviewed
+- update source title/domain/sensitivity
+- assign source to a project
+- create source-backed open loops
+- archive source through the existing soft-delete path
+- preserve review metadata in source `metadata_json`
+- append event-log records for source review/archive actions
+
+This closes the biggest daily-use gap: users can now operate the Inbox at the raw-evidence level before any memory promotion happens.
+
+### 2. Capture-To-Brief Traceability
+
+The workspace payload now includes traceability records that connect a source to:
+
+- source chunks
+- candidate memories
+- generated artifacts
+- source-backed open loops
+- related event-log entries
+
+The UI renders a Trace panel for the selected source, and the API exposes source/artifact trace endpoints. This gives operators a practical audit path from captured evidence through brief generation and review.
+
+### 3. Doctor And Readiness In The Console
+
+Doctor checks are now available through API and UI, not only CLI:
+
+- `GET /v0/vnext/doctor`
+- `POST /v0/vnext/doctor/run`
+- `/vnext` Doctor panel
+- run doctor
+- run doctor `--fix-safe` with confirmation
+
+The console shows migration status, connector settings/state posture, scheduler daemon posture, connector health, blocking failures, warnings, and recommended fixes.
+
+### 4. Stronger Workspace Data Contract
+
+The live workspace payload now includes:
+
+- doctor/readiness status
+- source traceability records
+- source review metadata
+- connector health
+- scheduler state
+- dogfooding telemetry
+- agent activity and policy telemetry
+- quality ratings and artifact state
+
+The web API client has typed helpers for source review, source trace, artifact trace, and doctor runs.
+
+### 5. Operator Smoke Test
+
+Added `alicebot vnext smoke operator-console` as the broad daily-operation smoke. It verifies:
+
+- source review action persists
+- memory review action persists
+- artifact review and rating persist
+- source-backed open-loop creation persists
+- scheduler run-now creates a reviewable artifact
+- connector health is visible
+- doctor/readiness is available
+- capture-to-brief traceability exists
+- event-log entries record operator actions
+
+## API And UI Changes
+
+New API surface:
+
+- `POST /v0/vnext/sources/{source_id}/review`
+- `GET /v0/vnext/traces/sources/{source_id}`
+- `GET /v0/vnext/traces/artifacts/{artifact_id}`
+- `GET /v0/vnext/doctor`
+- `POST /v0/vnext/doctor/run`
+
+Updated `/vnext` surfaces:
+
+- Inbox source detail/review controls
+- Capture-to-brief Trace panel
+- Doctor/Readiness panel
+- Generated artifact run/trace metadata display
+- Fixture contract updated so demo mode exercises the same enum-backed values and supported connector set
+
+## Guardrails Preserved
+
+- No connector content bypasses review.
+- Generated artifacts remain reviewable outputs.
+- Source review does not auto-promote memory.
+- Secrets remain referenced/redacted, not exposed in UI/API payloads.
+- Scheduler outputs remain policy-checked and reviewable.
+- Doctor `--fix-safe` is explicit and confirmed from the UI.
+
+## Validation Evidence
+
+Current validation from this phase:
+
+- `./.venv/bin/pytest tests/unit -q`: `1126 passed`
+- `./.venv/bin/pytest tests/integration -q`: `370 passed`
+- `pnpm --dir apps/web test`: `209 passed`
+- `pnpm --dir apps/web lint`: passed
+- `pnpm --dir apps/web build`: passed and built `/vnext`
+- `./.venv/bin/python scripts/check_control_doc_truth.py`: passed
+- `./.venv/bin/alicebot vnext migrations status`: passed
+- `./.venv/bin/alicebot vnext smoke operator-console`: passed
+- `./.venv/bin/alicebot vnext smoke connector-hardening`: passed
+- `./.venv/bin/alicebot vnext smoke secret-redaction`: passed
+- `./.venv/bin/alicebot vnext smoke dogfood-doctor`: passed
+- `./.venv/bin/alicebot vnext smoke live-capture-connectors`: passed
+- `./.venv/bin/alicebot vnext smoke capture-to-brief`: passed
+- `./.venv/bin/alicebot vnext smoke agentic-scheduler`: passed
+- `./.venv/bin/alicebot eval run --suite all`: `170/170` cases, zero critical privacy leaks, zero prompt-injection tool writes
+- `git diff --check`: clean
+
+## Intentional Boundaries
+
+This sprint did not add managed Gmail/Calendar OAuth, Telegram webhook hosting, cloud sync, hosted scheduler SLA, packaged browser extension actions, OCR/transcription execution, team/billing surfaces, or automatic memory promotion.
+
+## Recommended Next Phase
+
+The best next phase is Public Alpha Packaging if dogfooding confirms the console is usable day to day. If dogfooding shows missing input coverage is the blocker, prioritize Gmail/Calendar or voice capture next; otherwise package the local alpha around install, first-run, doctor, operator-console smoke, and the `/vnext` daily review loop.

--- a/docs/vnext/README.md
+++ b/docs/vnext/README.md
@@ -22,7 +22,7 @@ Alice vNext has three layers:
 - Agentic control plane: scoped agent identities, permission profiles, policy decisions, memory proposals, and Agent Activity audit surface.
 - Governed scheduler: disabled-by-default workflow controls, a local daemon runner, due scans, run history, trace IDs, failures, duplicate-run locks, and reviewable artifacts.
 - Connectors: allowlisted Telegram sync, local folder/Obsidian scan and watch, browser clipper capture endpoint, Hermes/OpenClaw-style agent output ingestion, dedicated settings/state rows, local encrypted secret references, retry/cursor hardening, plus deterministic PDF, DOCX, CSV, screenshot OCR, and voice transcript payload ingestion.
-- UI: live/fixture-backed `/vnext` workspace for review, Ask Alice, briefs, queue, projects, Agent Activity, Schedules, beliefs, graph, live connector configuration, connector health/defaults/bookmarklet guidance, dogfooding readiness telemetry, privacy settings, model comparison, and quality ratings.
+- UI: live/fixture-backed `/vnext` workspace for source review, source archive, capture-to-brief traces, Ask Alice, briefs, queue, projects, Agent Activity, Schedules, beliefs, graph, live connector configuration, connector health/defaults/bookmarklet guidance, dogfooding readiness telemetry, doctor/readiness checks, privacy settings, model comparison, and quality ratings.
 - Evals: synthetic corpus and baseline metrics for recall, temporal reasoning, contradictions, provenance, privacy, open loops, and prompt injection.
 
 ## Start Here
@@ -36,7 +36,7 @@ Alice vNext has three layers:
 7. Use [release checklist](../release/vnext-public-release-checklist.md) before publishing or tagging.
 8. Review [preview release notes](../release/v0.5.1-vnext-preview-release-notes.md) and [tag plan](../release/v0.5.1-vnext-preview-tag-plan.md).
 9. Review the [dogfood daily checklist](../runbooks/vnext-dogfood-daily-checklist.md) before daily local-alpha use.
-10. Review the [agentic control plane CTO summary](../vnext-agentic-control-plane-cto-summary.md), [local runtime CTO summary](../vnext-local-runtime-cto-summary.md), [model-backed intelligence CTO summary](../vnext-model-backed-intelligence-cto-summary.md), [live capture connectors CTO summary](../vnext-live-capture-connectors-cto-summary.md), and [dogfood hardening CTO summary](../vnext-dogfood-hardening-cto-summary.md) for sprint closeouts.
+10. Review the [agentic control plane CTO summary](../vnext-agentic-control-plane-cto-summary.md), [local runtime CTO summary](../vnext-local-runtime-cto-summary.md), [model-backed intelligence CTO summary](../vnext-model-backed-intelligence-cto-summary.md), [live capture connectors CTO summary](../vnext-live-capture-connectors-cto-summary.md), [dogfood hardening CTO summary](../vnext-dogfood-hardening-cto-summary.md), and [live-backed operator console CTO summary](../vnext-live-backed-operator-console-cto-summary.md) for sprint closeouts.
 
 ## Launch Boundary
 

--- a/docs/vnext/local-runtime.md
+++ b/docs/vnext/local-runtime.md
@@ -61,7 +61,7 @@ Useful options:
 
 The `/vnext` Schedules surface shows daemon posture, last due scan, next due workflow, currently running workflow, recent failures, last successful run per workflow, and run history. The Timeline surface remains backed by the append-only event log. Agent Activity includes policy blocks, filters, review-gated decisions, workflow triggers, memory proposals, and artifact generation telemetry.
 
-The `/vnext` Home and Connectors surfaces also show dogfooding and capture health: captures by connector, captures today/week, candidate memory creation, artifact ratings, useful-insight feedback, connector enabled/configured state, persisted settings, secret presence, cursors, dedupe, failures, and last sync posture.
+The `/vnext` Home, Inbox, Trace, Doctor, and Connectors surfaces also show dogfooding and capture health: captures by connector, captures today/week, candidate memory creation, source review/archive posture, capture-to-brief traceability, doctor readiness, artifact ratings, useful-insight feedback, connector enabled/configured state, persisted settings, secret presence, cursors, dedupe, failures, and last sync posture.
 
 The API exposes the same local runtime posture through:
 
@@ -76,6 +76,11 @@ The API exposes the same local runtime posture through:
 - `POST /v0/vnext/connectors/telegram/sync`
 - `POST /v0/vnext/connectors/local-folder/sync`
 - `GET /v0/vnext/dogfooding`
+- `GET /v0/vnext/doctor`
+- `POST /v0/vnext/doctor/run`
+- `POST /v0/vnext/sources/{source_id}/review`
+- `GET /v0/vnext/traces/sources/{source_id}`
+- `GET /v0/vnext/traces/artifacts/{artifact_id}`
 
 Scheduler workflow configuration can also carry `model_options` so due scans run model-backed workflows only when policy and routing allow them.
 
@@ -112,6 +117,7 @@ alicebot vnext smoke capture-to-brief
 alicebot vnext smoke connector-hardening
 alicebot vnext smoke secret-redaction
 alicebot vnext smoke dogfood-doctor
+alicebot vnext smoke operator-console
 ```
 
 It seeds a small local-runtime fixture, marks all six scheduler workflows due, runs the foreground daemon once, and checks that each workflow produces a reviewable artifact with scheduler metadata.
@@ -120,4 +126,4 @@ The model-backed smoke seeds a scheduled model-backed workflow and verifies that
 
 The live-capture connector smoke verifies allowlisted Telegram import, rejected Telegram chat isolation, local folder import with generated-folder ignore rules, browser clipper capture, review-only agent output ingestion, and connector health telemetry. The capture-to-brief smoke verifies that a fresh browser clip can enter retrieval, produce a reviewable Daily Brief, record a quality rating, and show up in dogfooding telemetry.
 
-The connector-hardening smoke verifies dedicated connector settings/state rows, Telegram cursor persistence, rejected-chat logging, local-folder generated-output ignores, restart dedupe, and health counters. The secret-redaction smoke verifies that Telegram and browser clipper secrets never appear in persisted source/event output. The dogfood-doctor smoke verifies migration readiness, default connector rows, scheduler posture, configured secret references, and blocking failure counts.
+The connector-hardening smoke verifies dedicated connector settings/state rows, Telegram cursor persistence, rejected-chat logging, local-folder generated-output ignores, restart dedupe, and health counters. The secret-redaction smoke verifies that Telegram and browser clipper secrets never appear in persisted source/event output. The dogfood-doctor smoke verifies migration readiness, default connector rows, scheduler posture, configured secret references, and blocking failure counts. The operator-console smoke verifies the live daily operation path across source review, memory review, artifact review/rating, source-backed open loops, scheduler run-now, connector health, doctor readiness, event logging, and capture-to-brief traceability.

--- a/docs/vnext/quickstart.md
+++ b/docs/vnext/quickstart.md
@@ -143,7 +143,10 @@ alicebot vnext smoke capture-to-brief
 alicebot vnext smoke connector-hardening
 alicebot vnext smoke secret-redaction
 alicebot vnext smoke dogfood-doctor
+alicebot vnext smoke operator-console
 ```
+
+The operator-console smoke verifies the live `/vnext` loop end to end: source review persists, memory/artifact/open-loop actions persist, scheduler run-now creates an artifact, connector health and doctor readiness are visible, and capture-to-brief traceability exists.
 
 ## Connector Payload Demo
 

--- a/tests/unit/test_vnext_main.py
+++ b/tests/unit/test_vnext_main.py
@@ -50,6 +50,11 @@ class FakeVNextStore:
     def list_sources(self, **kwargs) -> list[dict[str, object]]:
         return list(self.sources.values())[: kwargs.get("limit", 20)]
 
+    def update_source(self, *, source_id: str, patch: dict[str, object], **_kwargs) -> dict[str, object]:
+        source = self.sources[source_id]
+        source.update(patch)
+        return source
+
     def delete_source(self, *, source_id: str, **_kwargs) -> dict[str, object]:
         source = self.sources[source_id]
         source["deleted_at"] = "now"
@@ -59,6 +64,9 @@ class FakeVNextStore:
         row = {**chunk, "id": f"chunk-{len(self.chunks) + 1}"}
         self.chunks.append(row)
         return row
+
+    def list_source_chunks(self, source_id: str) -> list[dict[str, object]]:
+        return [chunk for chunk in self.chunks if chunk.get("source_id") == source_id]
 
     def create_memory(self, memory: dict[str, object], **_kwargs) -> dict[str, object]:
         row = {**memory, "id": f"memory-{len(self.memories) + 1}"}
@@ -352,6 +360,48 @@ class FakeVNextStore:
     def list_scheduler_runs(self, **_kwargs) -> list[dict[str, object]]:
         return []
 
+    def connector_storage_status(self) -> dict[str, object]:
+        return {
+            "connector_settings_exists": True,
+            "connector_state_exists": True,
+            "artifact_quality_ratings_exists": True,
+            "scheduler_workflows_exists": True,
+            "scheduler_runs_exists": True,
+            "migration_revision": "test",
+        }
+
+    def list_connector_settings(self) -> list[dict[str, object]]:
+        return [
+            {
+                "connector_name": name,
+                "enabled": False,
+                "configured": True,
+                "default_domain": "project",
+                "default_sensitivity": "private",
+                "sync_mode": "manual",
+                "poll_interval_seconds": None,
+                "secret_ref": None,
+                "validation_errors_json": [],
+                "metadata_json": {"config_json": {}},
+            }
+            for name in ("telegram", "local_folder", "browser_clipper", "agent_output")
+        ]
+
+    def list_connector_states(self) -> list[dict[str, object]]:
+        return [
+            {
+                "connector_name": name,
+                "cursor_type": "sync_cursor",
+                "cursor_value": None,
+                "state_json": {},
+                "items_seen": 0,
+                "items_captured": 0,
+                "items_deduped": 0,
+                "items_failed": 0,
+            }
+            for name in ("telegram", "local_folder", "browser_clipper", "agent_output")
+        ]
+
 
 def _install_fake_vnext_store(monkeypatch, store: FakeVNextStore) -> None:
     @contextmanager
@@ -451,6 +501,84 @@ def test_delete_vnext_source_endpoint_soft_deletes_source(monkeypatch) -> None:
     assert response.status_code == 200
     assert payload["id"] == source_id
     assert payload["deleted_at"] == "now"
+
+
+def test_vnext_source_review_trace_and_doctor_endpoints(monkeypatch) -> None:
+    store = FakeVNextStore(None)
+    source_id = str(uuid4())
+    artifact_id = str(uuid4())
+    store.sources[source_id] = {
+        "id": source_id,
+        "source_type": "manual_text",
+        "title": "Operator console source",
+        "content_hash": "sha256:source",
+        "captured_at": "2026-05-12T00:00:00Z",
+        "domain": "project",
+        "sensitivity": "private",
+        "metadata_json": {"raw_text": "Fact: source review persists."},
+    }
+    store.chunks.append({"id": "chunk-1", "source_id": source_id, "chunk_index": 0, "text": "Fact: source review persists."})
+    store.memories.append(
+        {
+            "id": "memory-1",
+            "memory_key": "memory.operator.source",
+            "memory_type": "semantic",
+            "canonical_text": "Source review persists.",
+            "status": "candidate",
+            "domain": "project",
+            "sensitivity": "private",
+            "metadata_json": {"source_id": source_id},
+        }
+    )
+    store.artifacts[artifact_id] = {
+        "id": artifact_id,
+        "artifact_type": "daily_brief",
+        "title": "Daily",
+        "content_markdown": "# Daily",
+        "status": "needs_review",
+        "domain": "project",
+        "sensitivity": "private",
+        "metadata_json": {"source_refs": [f"source:{source_id}"]},
+    }
+    store.open_loops.append({"id": "loop-1", "title": "Review source", "source_id": source_id, "status": "open"})
+    _install_fake_vnext_store(monkeypatch, store)
+    user_id = uuid4()
+
+    review_response = main_module.review_vnext_source(
+        main_module.UUID(source_id),
+        main_module.VNextSourceReviewRequest(
+            user_id=user_id,
+            action="assign_project",
+            title="Reviewed source",
+            domain="project",
+            sensitivity="private",
+            project_id="project-1",
+            review_note="Reviewed from test.",
+        ),
+    )
+    trace_response = main_module.get_vnext_source_trace(main_module.UUID(source_id), user_id=user_id)
+    artifact_trace_response = main_module.get_vnext_artifact_trace(main_module.UUID(artifact_id), user_id=user_id)
+    doctor_response = main_module.run_vnext_doctor(
+        main_module.VNextDoctorRunRequest(user_id=user_id, fix_safe=False, ci=True)
+    )
+
+    review_payload = json.loads(review_response.body)
+    trace_payload = json.loads(trace_response.body)
+    artifact_trace_payload = json.loads(artifact_trace_response.body)
+    doctor_payload = json.loads(doctor_response.body)
+
+    assert review_response.status_code == 200
+    assert review_payload["source"]["title"] == "Reviewed source"
+    assert review_payload["source"]["metadata_json"]["project_id"] == "project-1"
+    assert review_payload["trace"]["summary"]["candidate_memory_count"] == 1
+    assert trace_response.status_code == 200
+    assert trace_payload["summary"]["chunk_count"] == 1
+    assert trace_payload["summary"]["artifact_count"] == 1
+    assert artifact_trace_response.status_code == 200
+    assert artifact_trace_payload["summary"]["source_count"] == 1
+    assert doctor_response.status_code == 200
+    assert doctor_payload["blocking_failure_count"] == 0
+    assert any(check["name"] == "migrations" for check in doctor_payload["checks"])
 
 
 def test_create_vnext_context_pack_endpoint_returns_structured_pack(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Turns `/vnext` into a live-backed daily operator console for Alice vNext. This adds source review/update/archive APIs, source/artifact trace endpoints, Doctor/readiness APIs, UI panels for source detail/review, capture-to-brief traceability, and Doctor/readiness, plus a broad `alicebot vnext smoke operator-console` validation path.

Also updates the README, vNext docs, release docs, CLI docs, and adds a CTO-facing phase summary in `docs/vnext-live-backed-operator-console-cto-summary.md`.

## Validation

- `./.venv/bin/pytest tests/unit -q`: `1126 passed`
- `./.venv/bin/pytest tests/integration -q`: `370 passed`
- `pnpm --dir apps/web test`: `209 passed`
- `pnpm --dir apps/web lint`: passed
- `pnpm --dir apps/web build`: passed and built `/vnext`
- `./.venv/bin/python scripts/check_control_doc_truth.py`: passed
- `./.venv/bin/alicebot vnext migrations status`: passed
- `./.venv/bin/alicebot vnext smoke operator-console`: passed
- `./.venv/bin/alicebot vnext smoke connector-hardening`: passed
- `./.venv/bin/alicebot vnext smoke secret-redaction`: passed
- `./.venv/bin/alicebot vnext smoke dogfood-doctor`: passed
- `./.venv/bin/alicebot vnext smoke live-capture-connectors`: passed
- `./.venv/bin/alicebot vnext smoke capture-to-brief`: passed
- `./.venv/bin/alicebot vnext smoke agentic-scheduler`: passed
- `./.venv/bin/alicebot eval run --suite all`: `170/170` cases, zero critical privacy leaks, zero prompt-injection tool writes
- `git diff --check`: clean

## Upgrade Overview

Complete this section when the PR touches a protected path listed in `PROTECTED_PATHS.md`.
CI enforces this section for protected-path changes.

### Protected Areas

- [ ] memory schema
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact

Additive-only API, CLI, and web-client changes. Existing vNext source, memory, artifact, scheduler, connector, and doctor contracts remain compatible; this PR adds new operator actions and trace/readiness endpoints without removing or changing existing fields.

### Migration / Rollout

No database migration or backfill is required. Roll out as a normal API/web update on top of the existing vNext migrations and connector-state tables.

### Operator Action

No manual action is required. Operators can optionally run `alicebot vnext smoke operator-console` after deployment to verify the daily review loop.

### Validation

Used the full validation list above, including unit/integration tests, web lint/build/test, all vNext smoke checks, full eval suite, migration status, and protected control-doc check.

### Rollback

Rollback is a straight revert of this PR. The changes are additive and store only review metadata/event-log/open-loop records through existing persistence paths, so reverting removes the new console/API affordances without requiring schema rollback.