### PR TITLE
[codex] Add headless Ubuntu installer packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,19 @@ alicebot vnext alpha check
 
 Agent integration starts with [docs/alpha/agent-integration.md](docs/alpha/agent-integration.md), [docs/alpha/mcp-tools.md](docs/alpha/mcp-tools.md), [docs/alpha/hermes-skill.md](docs/alpha/hermes-skill.md), and [docs/alpha/openclaw-skill.md](docs/alpha/openclaw-skill.md). Security, privacy, and limitations are documented in [docs/alpha/security-and-privacy.md](docs/alpha/security-and-privacy.md) and [docs/alpha/known-limitations.md](docs/alpha/known-limitations.md).
 
+Headless Ubuntu/Hermes dogfood starts with [docs/alpha/headless-ubuntu-install.md](docs/alpha/headless-ubuntu-install.md) and [docs/alpha/hermes-dogfood-ubuntu.md](docs/alpha/hermes-dogfood-ubuntu.md). The secure default is localhost binding plus SSH tunneling:
+
+```bash
+ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@server
+```
+
 Start with:
 
 - [Public alpha docs](docs/alpha/README.md)
 - [Public alpha quickstart](docs/alpha/quickstart.md)
 - [First-run checklist](docs/alpha/first-run.md)
+- [Headless Ubuntu install](docs/alpha/headless-ubuntu-install.md)
+- [Hermes dogfood on Ubuntu](docs/alpha/hermes-dogfood-ubuntu.md)
 - [Agent integration pack](docs/alpha/agent-integration.md)
 - [vNext overview](docs/vnext/README.md)
 - [vNext quickstart](docs/vnext/quickstart.md)
@@ -99,6 +107,7 @@ Start with:
 - [Dogfood hardening CTO summary](docs/vnext-dogfood-hardening-cto-summary.md)
 - [Live-backed operator console CTO summary](docs/vnext-live-backed-operator-console-cto-summary.md)
 - [Public alpha packaging CTO summary](docs/vnext-public-alpha-packaging-cto-summary.md)
+- [Headless Ubuntu packaging CTO summary](docs/vnext-headless-ubuntu-cto-summary.md)
 - [Dogfood daily checklist](docs/runbooks/vnext-dogfood-daily-checklist.md)
 
 ## Release Boundary (`v0.5.1`)
@@ -440,6 +449,8 @@ Deferred beyond `v0.5.1`:
 - [Public Alpha](docs/alpha/README.md)
 - [Public Alpha Quickstart](docs/alpha/quickstart.md)
 - [Public Alpha Agent Integration](docs/alpha/agent-integration.md)
+- [Headless Ubuntu Install](docs/alpha/headless-ubuntu-install.md)
+- [Hermes Dogfood On Ubuntu](docs/alpha/hermes-dogfood-ubuntu.md)
 - [Public Alpha Known Limitations](docs/alpha/known-limitations.md)
 - [vNext Quickstart](docs/vnext/quickstart.md)
 - [vNext Architecture](docs/vnext/architecture.md)

--- a/apps/api/src/alicebot_api/cli.py
+++ b/apps/api/src/alicebot_api/cli.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import sys
 import tempfile
 import time
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 from uuid import UUID, uuid4
 
 import psycopg
@@ -2633,6 +2635,116 @@ def _run_alpha_smoke(ctx: CLIContext, *, name: str, runner) -> JsonObject:
         return {"name": name, "status": "failed", "error_type": type(exc).__name__, "error": str(exc)}
 
 
+def _headless_file_contains(path: Path, markers: tuple[str, ...]) -> bool:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return False
+    return all(marker in content for marker in markers)
+
+
+def _run_vnext_smoke_headless_ubuntu(_ctx: CLIContext, _args: argparse.Namespace) -> str:
+    repo_root = Path(__file__).resolve().parents[4]
+    install_script = repo_root / "scripts" / "install-ubuntu.sh"
+    uninstall_script = repo_root / "scripts" / "uninstall-ubuntu.sh"
+    service_paths = {
+        "api": repo_root / "packaging" / "systemd" / "alice-api.service",
+        "web": repo_root / "packaging" / "systemd" / "alice-web.service",
+        "scheduler": repo_root / "packaging" / "systemd" / "alice-scheduler.service",
+    }
+    doc_paths = {
+        "install": repo_root / "docs" / "alpha" / "headless-ubuntu-install.md",
+        "hermes": repo_root / "docs" / "alpha" / "hermes-dogfood-ubuntu.md",
+        "release_notes": repo_root / "docs" / "release" / "v0.6.0-alpha-rc.1-release-notes.md",
+        "cto": repo_root / "docs" / "vnext-headless-ubuntu-cto-summary.md",
+        "env": repo_root / "packaging" / "ubuntu" / "alicebot.env.example",
+    }
+    service_contents = {
+        name: path.read_text(encoding="utf-8") if path.exists() else "" for name, path in service_paths.items()
+    }
+    gates = {
+        "installer_exists_and_is_executable": install_script.exists() and os.access(install_script, os.X_OK),
+        "installer_supports_required_flags": _headless_file_contains(
+            install_script,
+            ("--tag", "--branch", "--install-dir", "--skip-postgres-install", "--non-interactive"),
+        ),
+        "uninstaller_exists_and_confirms_destructive_actions": _headless_file_contains(
+            uninstall_script,
+            ("--remove-repo", "--remove-config", "--drop-database", "confirm"),
+        ),
+        "systemd_templates_exist": all(path.exists() for path in service_paths.values()),
+        "systemd_runs_as_non_root": all("User=__ALICE_USER__" in content for content in service_contents.values()),
+        "systemd_binds_localhost_by_default": all("127.0.0.1" in content for content in service_contents.values())
+        and not any("0.0.0.0" in content for content in service_contents.values()),
+        "env_template_documents_config_layout": _headless_file_contains(
+            doc_paths["env"],
+            ("DATABASE_URL=", "ALICE_API_HOST=127.0.0.1", "ALICE_WEB_HOST=127.0.0.1", "ALICE_SECRET_PROVIDER="),
+        ),
+        "headless_install_doc_covers_ssh_tunnel": _headless_file_contains(
+            doc_paths["install"],
+            ("ssh -L 3000:127.0.0.1:3000", "Do not expose", "alicebot vnext alpha check --headless"),
+        ),
+        "hermes_guide_covers_identity_and_policy": _headless_file_contains(
+            doc_paths["hermes"],
+            ("agent_id: hermes", "trusted_local_agent", "policy-boundary test", "alicebot vnext smoke agent-integration-pack"),
+        ),
+        "rc_release_notes_exist": _headless_file_contains(
+            doc_paths["release_notes"],
+            ("v0.6.0-alpha-rc.1", "pre-release", "not latest", "headless Ubuntu"),
+        ),
+        "cto_summary_exists": _headless_file_contains(
+            doc_paths["cto"],
+            ("Headless Ubuntu", "Hermes dogfood", "SSH tunnel", "v0.6.0-alpha-rc.1"),
+        ),
+    }
+    payload = {
+        "status": "passed" if all(gates.values()) else "failed",
+        "smoke": "headless-ubuntu",
+        "gates": gates,
+        "checked_paths": {
+            "install_script": str(install_script.relative_to(repo_root)),
+            "uninstall_script": str(uninstall_script.relative_to(repo_root)),
+            "systemd": {name: str(path.relative_to(repo_root)) for name, path in service_paths.items()},
+            "docs": {name: str(path.relative_to(repo_root)) for name, path in doc_paths.items()},
+        },
+    }
+    if payload["status"] != "passed":
+        raise RuntimeError(_json_dumps(payload))
+    return _json_dumps(payload)
+
+
+def _check_headless_http_url(url: str | None) -> JsonObject:
+    if not url:
+        return {
+            "status": "skipped",
+            "url": None,
+            "message": "No URL supplied. Pass --api-url or --web-url after services are running.",
+        }
+    request = Request(url, method="GET", headers={"User-Agent": "alicebot-headless-alpha-check"})
+    try:
+        with urlopen(request, timeout=2.0) as response:
+            status_code = int(response.getcode())
+    except (OSError, URLError) as exc:
+        return {"status": "failed", "url": url, "error_type": type(exc).__name__, "error": str(exc)}
+    return {"status": "passed" if status_code < 500 else "failed", "url": url, "status_code": status_code}
+
+
+def _check_headless_mcp_import() -> JsonObject:
+    try:
+        import importlib.util
+
+        spec = importlib.util.find_spec("alicebot_api.mcp_server")
+    except Exception as exc:
+        return {"status": "failed", "error_type": type(exc).__name__, "error": str(exc)}
+    if spec is None:
+        return {"status": "failed", "error": "alicebot_api.mcp_server module was not found"}
+    return {
+        "status": "passed",
+        "command": "./.venv/bin/python -m alicebot_api.mcp_server",
+        "message": "MCP server module is importable from the installed Alice package.",
+    }
+
+
 def _run_vnext_alpha_check(ctx: CLIContext, args: argparse.Namespace) -> str:
     alpha_secret_provider = InMemorySecretProvider(
         {
@@ -2648,6 +2760,25 @@ def _run_vnext_alpha_check(ctx: CLIContext, args: argparse.Namespace) -> str:
         connector_settings = store.list_connector_settings()
         connector_states = store.list_connector_states()
 
+    headless: JsonObject | None = None
+    if args.headless:
+        headless_smoke = _run_alpha_smoke(ctx, name="headless-ubuntu", runner=_run_vnext_smoke_headless_ubuntu)
+        headless = {
+            "mode": "headless_ubuntu",
+            "package": headless_smoke,
+            "api_reachability": _check_headless_http_url(args.api_url),
+            "web_reachability": _check_headless_http_url(args.web_url),
+            "mcp": _check_headless_mcp_import(),
+            "demo_cycle": {"status": "skipped", "message": "Pass --demo-cycle to run demo load/reset."},
+        }
+        if args.demo_cycle:
+            try:
+                demo_load = json.loads(_run_vnext_demo_load(ctx, argparse.Namespace(fixture=str(DEFAULT_VNEXT_DEMO_DATASET_PATH), reset=True)))
+                demo_reset = json.loads(_run_vnext_demo_reset(ctx, argparse.Namespace(dataset_id=None, fixture=str(DEFAULT_VNEXT_DEMO_DATASET_PATH))))
+                headless["demo_cycle"] = {"status": "passed", "load": demo_load, "reset": demo_reset}
+            except Exception as exc:
+                headless["demo_cycle"] = {"status": "failed", "error_type": type(exc).__name__, "error": str(exc)}
+
     smokes: list[JsonObject] = []
     if not args.skip_smokes:
         smoke_runners = (
@@ -2659,6 +2790,7 @@ def _run_vnext_alpha_check(ctx: CLIContext, args: argparse.Namespace) -> str:
             ("agentic-scheduler", _run_vnext_smoke_agentic_scheduler),
             ("operator-console", _run_vnext_smoke_operator_console),
             ("agent-integration-pack", _run_vnext_smoke_agent_integration_pack),
+            *((("headless-ubuntu", _run_vnext_smoke_headless_ubuntu),) if args.headless else ()),
         )
         smokes = [_run_alpha_smoke(ctx, name=name, runner=runner) for name, runner in smoke_runners]
 
@@ -2669,10 +2801,19 @@ def _run_vnext_alpha_check(ctx: CLIContext, args: argparse.Namespace) -> str:
         blocking.append("connector_storage")
     failed_smokes = [str(smoke.get("name")) for smoke in smokes if smoke.get("status") != "passed"]
     blocking.extend(f"smoke:{name}" for name in failed_smokes)
+    if isinstance(headless, dict):
+        package_status = ((headless.get("package") or {}) if isinstance(headless.get("package"), dict) else {}).get("status")
+        if package_status != "passed":
+            blocking.append("headless:package")
+        for key in ("api_reachability", "web_reachability", "mcp", "demo_cycle"):
+            item = headless.get(key)
+            if isinstance(item, dict) and item.get("status") == "failed":
+                blocking.append(f"headless:{key}")
 
     payload = {
         "status": "failed" if blocking else "passed" if doctor.get("status") == "pass" else "warning",
         "alpha_check": "vnext_public_alpha",
+        "headless": headless,
         "blocking_failures": blocking,
         "doctor": doctor,
         "scheduler": {
@@ -4106,6 +4247,10 @@ def build_parser() -> argparse.ArgumentParser:
     vnext_alpha_subparsers = vnext_alpha_parser.add_subparsers(dest="vnext_alpha_command", required=True)
     vnext_alpha_check_parser = vnext_alpha_subparsers.add_parser("check", help="Check public alpha local readiness.")
     vnext_alpha_check_parser.add_argument("--skip-smokes", action="store_true", help="Only summarize storage, doctor, and scheduler posture.")
+    vnext_alpha_check_parser.add_argument("--headless", action="store_true", help="Include headless Ubuntu packaging and optional service reachability checks.")
+    vnext_alpha_check_parser.add_argument("--api-url", default=None, help="Optional local API URL to check, for example http://127.0.0.1:8000/healthz.")
+    vnext_alpha_check_parser.add_argument("--web-url", default=None, help="Optional local web URL to check, for example http://127.0.0.1:3000/vnext.")
+    vnext_alpha_check_parser.add_argument("--demo-cycle", action="store_true", help="Run demo load/reset as part of the headless check.")
     vnext_alpha_check_parser.set_defaults(handler=_run_vnext_alpha_check)
 
     vnext_demo_parser = vnext_subparsers.add_parser("demo", help="Load or reset the safe vNext public alpha demo dataset.")
@@ -4562,6 +4707,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run the public alpha agent integration pack smoke.",
     )
     vnext_smoke_agent_integration_pack_parser.set_defaults(handler=_run_vnext_smoke_agent_integration_pack)
+    vnext_smoke_headless_ubuntu_parser = vnext_smoke_subparsers.add_parser(
+        "headless-ubuntu",
+        help="Run the headless Ubuntu installer/docs/systemd packaging smoke.",
+    )
+    vnext_smoke_headless_ubuntu_parser.set_defaults(handler=_run_vnext_smoke_headless_ubuntu)
 
     mutations_parser = subparsers.add_parser("mutations", help="Generate, inspect, and apply memory operations.")
     mutations_subparsers = mutations_parser.add_subparsers(dest="mutations_command", required=True)

--- a/docs/alpha/README.md
+++ b/docs/alpha/README.md
@@ -16,8 +16,10 @@ Start here:
 - [Local runtime](local-runtime.md)
 - [Doctor](doctor.md)
 - [Demo mode](demo-mode.md)
+- [Headless Ubuntu install](headless-ubuntu-install.md)
 - [Agent integration](agent-integration.md)
 - [MCP tools](mcp-tools.md)
+- [Hermes dogfood on Ubuntu](hermes-dogfood-ubuntu.md)
 - [Hermes skill](hermes-skill.md)
 - [OpenClaw skill](openclaw-skill.md)
 - [Custom agent guide](custom-agent-guide.md)
@@ -34,6 +36,7 @@ Start here:
 Current alpha posture:
 
 - local runtime, not hosted SaaS
+- headless Ubuntu install path for SSH-only dogfood hosts
 - technical setup, not consumer install
 - review-only source, artifact, and agent memory proposal flows
 - no automatic promotion into trusted memory

--- a/docs/alpha/headless-ubuntu-install.md
+++ b/docs/alpha/headless-ubuntu-install.md
@@ -1,0 +1,272 @@
+# Headless Ubuntu Install
+
+This guide installs Alice vNext from GitHub on a headless Ubuntu server, VPS, home lab box, or same-host agent machine. It assumes SSH access and no local GUI on the server.
+
+Supported assumptions for this alpha:
+
+- Ubuntu 22.04 LTS or 24.04 LTS
+- Python 3.12-compatible system Python or newer venv support
+- Node 20 through NodeSource or an existing Node 20 install
+- local Postgres on the same host, or an existing Postgres reached through `DATABASE_URL`
+- services bound to `127.0.0.1` by default
+
+This is an RC/dogfood install path for `v0.6.0-alpha-rc.1`, not a public beta or hosted SaaS release.
+
+## Recommended Secure Access
+
+Use an SSH tunnel from your laptop:
+
+```bash
+ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@ubuntu-box
+```
+
+Then open this from your local browser:
+
+```text
+http://127.0.0.1:3000/vnext
+```
+
+Do not expose `/vnext`, the API, MCP, or browser clipper endpoint publicly by default. Keep services bound to localhost and add an authenticated reverse proxy only after the alpha path is working over SSH.
+
+## Inspect-Before-Run Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/samrusani/AliceBot/v0.6.0-alpha-rc.1/scripts/install-ubuntu.sh -o install-alice.sh
+less install-alice.sh
+bash install-alice.sh --tag v0.6.0-alpha-rc.1
+```
+
+Install from `main` instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/samrusani/AliceBot/main/scripts/install-ubuntu.sh -o install-alice.sh
+less install-alice.sh
+bash install-alice.sh --branch main --install-dir ~/alicebot
+```
+
+Use `--non-interactive` only after you have chosen a safe install directory and know whether the host should install local Postgres.
+
+## Installer Options
+
+```bash
+bash install-alice.sh --tag v0.6.0-alpha-rc.1
+bash install-alice.sh --branch main
+bash install-alice.sh --install-dir ~/alicebot
+bash install-alice.sh --skip-postgres-install
+bash install-alice.sh --install-systemd
+bash install-alice.sh --non-interactive
+bash install-alice.sh --dry-run
+```
+
+The installer is idempotent enough to rerun safely:
+
+- existing git checkout is fetched and checked out to the requested tag or branch
+- existing config is preserved
+- repo `.env` is linked to the preserved config file when safe
+- generated local database passwords are not printed
+- blocking failures exit non-zero
+
+## Local Configuration Layout
+
+Default paths:
+
+- repo: `~/alicebot`
+- config: `~/.config/alicebot/.env`
+- data: `~/.local/share/alicebot/`
+- logs/state: `~/.local/state/alicebot/logs/`
+- local secret references: `~/.config/alicebot/secrets/`
+
+The installer renders [packaging/ubuntu/alicebot.env.example](../../packaging/ubuntu/alicebot.env.example) into `~/.config/alicebot/.env` if the file does not already exist. Existing config is preserved.
+
+Important config keys:
+
+```dotenv
+DATABASE_URL=postgresql://alicebot_app:<redacted>@127.0.0.1:5432/alicebot
+DATABASE_ADMIN_URL=postgresql://alicebot_admin:<redacted>@127.0.0.1:5432/alicebot
+ALICE_API_HOST=127.0.0.1
+ALICE_API_PORT=8000
+ALICE_WEB_HOST=127.0.0.1
+ALICE_WEB_PORT=3000
+ALICE_SECRET_PROVIDER=encrypted_local
+MODEL_PROVIDER=deterministic_local
+ALICE_MCP_COMMAND=~/alicebot/.venv/bin/python -m alicebot_api.mcp_server
+```
+
+Secrets are referenced, not printed. Store real connector secrets through the configured secret-provider path, then configure connectors with `secret_ref` values such as `telegram.bot_token.default`.
+
+## Manual Install Fallback
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl git build-essential python3 python3-venv python3-pip libpq-dev postgresql postgresql-contrib
+git clone https://github.com/samrusani/AliceBot.git ~/alicebot
+cd ~/alicebot
+git checkout tags/v0.6.0-alpha-rc.1
+python3 -m venv .venv
+./.venv/bin/python -m pip install -e '.[dev]'
+corepack enable
+corepack prepare pnpm@latest --activate
+pnpm --dir apps/web install
+pnpm --dir apps/web build
+cp packaging/ubuntu/alicebot.env.example ~/.config/alicebot/.env
+less ~/.config/alicebot/.env
+ln -sfn ~/.config/alicebot/.env .env
+./.venv/bin/python -m alembic -c apps/api/alembic.ini upgrade head
+./.venv/bin/alicebot vnext doctor --fix-safe --ci
+./.venv/bin/alicebot vnext alpha check --headless --skip-smokes
+```
+
+If you use existing Postgres, set `DATABASE_URL` and `DATABASE_ADMIN_URL` before migrations.
+
+## Systemd Services
+
+Templates live under [packaging/systemd](../../packaging/systemd):
+
+- `alice-api.service`
+- `alice-web.service`
+- `alice-scheduler.service`
+
+Install them through:
+
+```bash
+bash install-alice.sh --tag v0.6.0-alpha-rc.1 --install-systemd
+```
+
+Then start:
+
+```bash
+sudo systemctl enable --now alice-api
+sudo systemctl enable --now alice-web
+sudo systemctl enable --now alice-scheduler
+systemctl status alice-api
+systemctl status alice-web
+systemctl status alice-scheduler
+journalctl -u alice-api -f
+journalctl -u alice-web -f
+journalctl -u alice-scheduler -f
+```
+
+Service behavior:
+
+- runs as the installing non-root user
+- loads `~/.config/alicebot/.env`
+- restarts on failure
+- API binds to `127.0.0.1:8000`
+- web binds to `127.0.0.1:3000`
+- scheduler uses the governed `alicebot vnext scheduler daemon start --foreground` path
+- logs are visible through `journalctl`
+
+## Headless Alpha Check
+
+Before services:
+
+```bash
+~/alicebot/.venv/bin/alicebot vnext alpha check --headless --skip-smokes
+~/alicebot/.venv/bin/alicebot vnext smoke headless-ubuntu
+```
+
+After services:
+
+```bash
+~/alicebot/.venv/bin/alicebot vnext alpha check --headless \
+  --api-url http://127.0.0.1:8000/healthz \
+  --web-url http://127.0.0.1:3000/vnext
+```
+
+Optional demo cycle:
+
+```bash
+~/alicebot/.venv/bin/alicebot vnext alpha check --headless --demo-cycle
+```
+
+No check requires a local browser on the Ubuntu host.
+
+## Verify Runtime Posture
+
+```bash
+curl -fsS http://127.0.0.1:8000/healthz
+curl -I http://127.0.0.1:3000/vnext
+~/alicebot/.venv/bin/alicebot vnext doctor --fix-safe --ci
+~/alicebot/.venv/bin/alicebot vnext smoke agent-integration-pack
+~/alicebot/.venv/bin/alicebot vnext scheduler daemon status
+~/alicebot/.venv/bin/alicebot vnext scheduler runs
+```
+
+CLI-only fallback if you cannot open `/vnext`:
+
+```bash
+~/alicebot/.venv/bin/alicebot vnext demo load --reset
+~/alicebot/.venv/bin/alicebot context-pack --query "public alpha launch checklist" --domain project --sensitivity-allowed private
+~/alicebot/.venv/bin/alicebot daily-brief --domain project --sensitivity-allowed private
+~/alicebot/.venv/bin/alicebot vnext artifacts list
+~/alicebot/.venv/bin/alicebot vnext demo reset
+```
+
+## Connect Hermes
+
+Use [hermes-dogfood-ubuntu.md](hermes-dogfood-ubuntu.md) for same-host Hermes setup. The short shape is:
+
+- API URL: `http://127.0.0.1:8000`
+- MCP command: `~/alicebot/.venv/bin/python -m alicebot_api.mcp_server`
+- agent id: `hermes`
+- agent type: `personal_assistant`
+- permission profile: `trusted_local_agent`
+
+## Firewall Note
+
+Do not open ports `3000` or `8000` to the public internet. On a VPS, keep the host firewall closed for those ports and access through SSH tunnel first.
+
+## Reset And Uninstall
+
+Safe demo reset:
+
+```bash
+~/alicebot/.venv/bin/alicebot vnext demo reset
+~/alicebot/.venv/bin/alicebot vnext doctor --fix-safe --ci
+```
+
+Stop services:
+
+```bash
+sudo systemctl disable --now alice-api alice-web alice-scheduler
+```
+
+Inspect the uninstall script before destructive cleanup:
+
+```bash
+less ~/alicebot/scripts/uninstall-ubuntu.sh
+bash ~/alicebot/scripts/uninstall-ubuntu.sh
+```
+
+By default, uninstall only stops/removes services and preserves repo, config, secrets, local data, and database. Destructive cleanup requires explicit flags such as `--remove-repo`, `--remove-config`, `--remove-data`, or `--drop-database` and confirmation.
+
+## Troubleshooting
+
+Postgres unreachable:
+
+```bash
+systemctl status postgresql
+sudo -u postgres psql -c 'SELECT 1'
+```
+
+API not reachable:
+
+```bash
+journalctl -u alice-api -n 100 --no-pager
+~/alicebot/.venv/bin/alicebot vnext doctor --fix-safe --ci
+```
+
+Web not reachable:
+
+```bash
+journalctl -u alice-web -n 100 --no-pager
+pnpm --dir ~/alicebot/apps/web build
+```
+
+Scheduler not running:
+
+```bash
+journalctl -u alice-scheduler -n 100 --no-pager
+~/alicebot/.venv/bin/alicebot vnext scheduler daemon status
+~/alicebot/.venv/bin/alicebot vnext scheduler failures
+```

--- a/docs/alpha/hermes-dogfood-ubuntu.md
+++ b/docs/alpha/hermes-dogfood-ubuntu.md
@@ -1,0 +1,180 @@
+# Hermes Dogfood On Ubuntu
+
+This guide connects Hermes to Alice on the same headless Ubuntu host. Alice remains local-first and review-first: Hermes can request scoped context, submit outputs, propose memory, and create open loops, but it cannot directly promote trusted memory.
+
+## Same-Host Endpoints
+
+```yaml
+alice:
+  api_url: http://127.0.0.1:8000
+  mcp_command: ~/alicebot/.venv/bin/python -m alicebot_api.mcp_server
+  mcp_server_name: alice_core
+```
+
+Recommended Hermes identity:
+
+```yaml
+agent_id: hermes
+agent_type: personal_assistant
+permission_profile: trusted_local_agent
+project_scope:
+  - Alice
+```
+
+Use `trusted_local_agent` only for a local operator-owned Hermes runtime on the same host. For narrower project work, use `project_scoped_agent`.
+
+## MCP Config Example
+
+```yaml
+mcp_servers:
+  alice_core:
+    command: /home/alice/alicebot/.venv/bin/python
+    args: ["-m", "alicebot_api.mcp_server"]
+    cwd: /home/alice/alicebot
+    env:
+      DATABASE_URL: postgresql://alicebot_app:<redacted>@127.0.0.1:5432/alicebot
+      ALICEBOT_AUTH_USER_ID: "00000000-0000-0000-0000-000000000001"
+```
+
+Do not paste real database passwords into shared logs. Keep this config readable only by the Hermes/Alice operator.
+
+## API Request Shape
+
+Hermes should include identity metadata when it asks Alice for context or submits output:
+
+```json
+{
+  "agent_id": "hermes",
+  "agent_type": "personal_assistant",
+  "agent_run_id": "hermes-dogfood-001",
+  "task_id": "first-alice-context-test",
+  "permission_profile": "trusted_local_agent",
+  "project_scope": ["Alice"]
+}
+```
+
+## First Hermes Test Task
+
+Ask Hermes:
+
+```text
+Use Alice to retrieve project context for the headless Ubuntu alpha install. Summarize the next three operator actions, then submit your output back to Alice as a reviewable project update and propose one memory only if it is durable and source-grounded.
+```
+
+Expected Alice behavior:
+
+- Hermes requests a project-scoped context pack.
+- Hermes submits a source/artifact back to Alice.
+- Hermes proposes memory as a candidate only.
+- `/vnext` Agent Activity shows the Hermes run.
+- `/vnext` Inbox or Memory Review shows the proposal.
+- No trusted memory is auto-promoted.
+
+## Context Pack Recipe
+
+Use MCP where available:
+
+```json
+{
+  "tool": "alice_vnext_context_pack",
+  "arguments": {
+    "query": "headless Ubuntu Alice install Hermes dogfood",
+    "domains": ["project"],
+    "projects": ["Alice"],
+    "sensitivity_allowed": ["public", "internal", "private", "unknown"],
+    "max_items": 8,
+    "agent_identity": {
+      "agent_id": "hermes",
+      "agent_type": "personal_assistant",
+      "agent_run_id": "hermes-dogfood-001",
+      "task_id": "first-alice-context-test",
+      "permission_profile": "trusted_local_agent",
+      "project_scope": ["Alice"]
+    }
+  }
+}
+```
+
+## Submit Output And Propose Memory
+
+```json
+{
+  "tool": "alice_vnext_ingest_agent_output",
+  "arguments": {
+    "agent_id": "hermes",
+    "agent_type": "personal_assistant",
+    "agent_run_id": "hermes-dogfood-001",
+    "task_id": "first-alice-context-test",
+    "project_scope": ["Alice"],
+    "permission_profile": "trusted_local_agent",
+    "title": "Hermes headless Ubuntu dogfood summary",
+    "content": "Decision: Alice should be accessed over SSH tunnel first on headless Ubuntu. Next actions: verify services, run alpha check, inspect /vnext review queues.",
+    "output_type": "project_update",
+    "domain": "project",
+    "sensitivity": "private",
+    "propose_memory": true
+  }
+}
+```
+
+If the output includes uncertainty or one-off observations, set `propose_memory` to `false` and create an open loop instead.
+
+## Policy-Boundary Test
+
+Use this policy-boundary test to prove Hermes cannot expand a project-scoped request into restricted personal domains.
+
+Ask Hermes to request private family, health, or spiritual context while using the Alice project scope:
+
+```text
+Request Alice context for family and health memories while scoped only to the Alice project.
+```
+
+Expected result:
+
+- Alice blocks or filters the restricted-domain request.
+- A policy event is recorded.
+- `/vnext` Agent Activity shows the block/filter.
+- Hermes should continue with project-scoped context only.
+
+Run the shipped smoke:
+
+```bash
+~/alicebot/.venv/bin/alicebot vnext smoke agent-integration-pack
+```
+
+Run the headless package smoke:
+
+```bash
+~/alicebot/.venv/bin/alicebot vnext smoke headless-ubuntu
+```
+
+## Verify In `/vnext`
+
+Tunnel from your laptop:
+
+```bash
+ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@ubuntu-box
+```
+
+Open:
+
+```text
+http://127.0.0.1:3000/vnext
+```
+
+Review:
+
+- Agent Activity for `hermes`
+- Memory Review for candidate proposals
+- Generated artifacts for submitted outputs
+- Open Loops for unresolved follow-ups
+- Trace view for source-to-artifact provenance
+
+## CLI Fallback
+
+```bash
+~/alicebot/.venv/bin/alicebot vnext agents policy-telemetry
+~/alicebot/.venv/bin/alicebot context-pack --query "Hermes dogfood" --domain project --sensitivity-allowed private
+~/alicebot/.venv/bin/alicebot vnext artifacts list
+~/alicebot/.venv/bin/alicebot vnext doctor --fix-safe --ci
+```

--- a/docs/alpha/local-runtime.md
+++ b/docs/alpha/local-runtime.md
@@ -10,6 +10,8 @@ make migrate
 make doctor
 make dev
 make alpha-check
+alicebot vnext alpha check --headless
+alicebot vnext smoke headless-ubuntu
 ```
 
 Equivalent explicit commands:
@@ -29,10 +31,13 @@ alicebot vnext scheduler daemon start --foreground
 - vNext operator console: `http://localhost:3000/vnext`
 - MCP server: stdio process via `alicebot-mcp`
 
+For Ubuntu systemd service setup, use [headless-ubuntu-install.md](headless-ubuntu-install.md). The default headless posture binds API and web services to `127.0.0.1` and expects `/vnext` access through an SSH tunnel.
+
 ## Alpha Readiness
 
 ```bash
 alicebot vnext alpha check
+alicebot vnext alpha check --headless
 ```
 
 The readiness check summarizes migrations, doctor, scheduler posture, connector settings/state storage, core vNext smokes, agent integration smoke, and the eval command expected for release evidence.

--- a/docs/alpha/release-notes.md
+++ b/docs/alpha/release-notes.md
@@ -55,6 +55,13 @@ Start with [quickstart.md](quickstart.md), then run:
 alicebot vnext alpha check
 ```
 
+Headless Ubuntu dogfood readiness is prepared for `v0.6.0-alpha-rc.1` through [headless-ubuntu-install.md](headless-ubuntu-install.md), [hermes-dogfood-ubuntu.md](hermes-dogfood-ubuntu.md), `scripts/install-ubuntu.sh`, systemd templates under `packaging/systemd/`, and:
+
+```bash
+alicebot vnext alpha check --headless
+alicebot vnext smoke headless-ubuntu
+```
+
 ## Support And Feedback
 
 Use [design-partner-onboarding.md](design-partner-onboarding.md) for what to include in reports.

--- a/docs/headless_ubuntu.md
+++ b/docs/headless_ubuntu.md
@@ -1,0 +1,563 @@
+
+Alice vNext Sprint Prompt: Headless Ubuntu GitHub Installer + Hermes Dogfood Readiness
+
+Sprint Objective
+
+Prepare Alice vNext so it can be installed from GitHub on a headless Ubuntu server or VPS using command-line instructions.
+
+The immediate use case is installing Alice on the same Ubuntu box where Hermes runs, then testing the real agent-first flow:
+
+Hermes -> Alice MCP/API -> context packs / memory proposals / artifacts / open loops -> /vnext review cockpit
+
+Alice already has public alpha packaging, make setup, make dev, make doctor, make vnext, make scheduler, make alpha-check, demo load/reset commands, MCP quickstart, Hermes/OpenClaw skill packs, custom-agent docs, and an agent-integration-pack smoke.
+
+This sprint should make that package practically installable on Ubuntu from GitHub.
+
+---
+
+Target User
+
+Technical alpha user running Alice on:
+
+Ubuntu server
+headless box
+home lab machine
+VPS
+agent host running Hermes/OpenClaw/custom agents
+
+The user may not have local desktop access to the machine.
+
+The install path must work over SSH.
+
+---
+
+Product Principle
+
+Alice remains:
+
+agent-first
+local-first
+review-first
+no-auto-promotion
+secure-by-default
+
+The default install must not expose /vnext, the API, MCP, or browser clipper endpoint publicly.
+
+Recommended access should be through SSH tunnel first:
+
+ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@server
+
+Do not default-bind services to 0.0.0.0.
+
+---
+
+Core Build Requirements
+
+1. GitHub-Installable Ubuntu Bootstrap Script
+
+Add a script such as:
+
+scripts/install-ubuntu.sh
+
+It should support a clean Ubuntu install path.
+
+The intended command should be something like:
+
+curl -fsSL https://raw.githubusercontent.com/samrusani/AliceBot/v0.6.0-alpha-rc.1/scripts/install-ubuntu.sh -o install-alice.sh
+bash install-alice.sh
+
+For safety, docs should recommend downloading and inspecting before running:
+
+curl -fsSL https://raw.githubusercontent.com/samrusani/AliceBot/v0.6.0-alpha-rc.1/scripts/install-ubuntu.sh -o install-alice.sh
+less install-alice.sh
+bash install-alice.sh
+
+The script should:
+
+detect Ubuntu version
+check required packages
+install system dependencies
+install Python dependencies
+install Node/pnpm dependencies
+prepare Postgres or verify existing Postgres
+clone or update AliceBot repo
+checkout requested tag/branch
+create local config/env template
+run migrations
+run doctor
+run alpha check
+print next-step commands
+
+Support flags:
+
+bash install-alice.sh --tag v0.6.0-alpha-rc.1
+bash install-alice.sh --branch main
+bash install-alice.sh --install-dir ~/alicebot
+bash install-alice.sh --skip-postgres-install
+bash install-alice.sh --non-interactive
+
+Acceptance criteria:
+
+Fresh Ubuntu machine can install from GitHub using documented CLI flow.
+Installer can target a tag or branch.
+Installer is idempotent enough to rerun safely.
+Installer does not overwrite existing config without confirmation.
+Installer prints clear next steps.
+Installer exits non-zero on blocking failures.
+Installer never prints secrets.
+
+---
+
+2. Headless Ubuntu Documentation
+
+Add:
+
+docs/alpha/headless-ubuntu-install.md
+
+It should include:
+
+prerequisites
+one-command install
+safe inspect-before-run install
+manual install fallback
+environment configuration
+Postgres setup
+starting services
+systemd service setup
+SSH tunnel setup
+opening /vnext remotely
+connecting Hermes
+running alpha check
+troubleshooting
+uninstall/reset notes
+
+Required sections:
+
+Recommended secure access: SSH tunnel
+Do not expose /vnext publicly by default
+How to bind to localhost
+How to verify API/web/scheduler are running
+How to run doctor
+How to run agent integration smoke
+How to connect Hermes through MCP/API
+
+Acceptance criteria:
+
+A technical user can follow the doc over SSH.
+Docs do not assume local GUI access.
+Docs distinguish RC/dogfood install from public alpha release.
+Docs clearly state security defaults.
+
+---
+
+3. Systemd Services for Ubuntu
+
+Create or harden systemd units for:
+
+alice-api
+alice-web
+alice-scheduler
+
+Possible paths:
+
+packaging/systemd/alice-api.service
+packaging/systemd/alice-web.service
+packaging/systemd/alice-scheduler.service
+
+The installer should optionally install them.
+
+Commands should be documented:
+
+sudo systemctl enable --now alice-api
+sudo systemctl enable --now alice-web
+sudo systemctl enable --now alice-scheduler
+systemctl status alice-api
+systemctl status alice-web
+systemctl status alice-scheduler
+journalctl -u alice-api -f
+journalctl -u alice-web -f
+journalctl -u alice-scheduler -f
+
+Requirements:
+
+services run as non-root user
+services load env from a local env file
+services restart on failure
+scheduler uses existing governed scheduler daemon/run-due path
+logs are inspectable through journalctl
+
+Acceptance criteria:
+
+Services can be installed on Ubuntu.
+Services start after reboot.
+Scheduler daemon runs due workflows.
+Doctor can detect service posture.
+Logs do not expose secrets.
+
+---
+
+4. Local Configuration Layout
+
+Standardize alpha local paths.
+
+Recommended:
+
+Repo:
+~/alicebot
+Config:
+~/.config/alicebot/.env
+Data:
+~/.local/share/alicebot/
+Logs:
+~/.local/state/alicebot/logs/
+Secrets:
+~/.config/alicebot/secrets/
+
+Docs and installer should agree on these paths.
+
+The env template should include:
+
+DATABASE_URL
+ALICE_API_HOST=127.0.0.1
+ALICE_API_PORT=8000
+ALICE_WEB_HOST=127.0.0.1
+ALICE_WEB_PORT=3000
+ALICE_SECRET_PROVIDER
+TELEGRAM_BOT_TOKEN ref example
+MODEL_PROVIDER mode
+MCP settings if applicable
+
+Acceptance criteria:
+
+Config path is documented.
+Installer creates .env from template if missing.
+Existing .env is preserved.
+Secrets are referenced, not printed.
+
+---
+
+5. GitHub Release / RC Packaging
+
+Prepare an internal RC tag release path.
+
+Recommended immediate tag:
+
+v0.6.0-alpha-rc.1
+
+Do not mark as latest.
+
+Prepare release notes explaining:
+
+RC for Hermes dogfood testing
+not public beta
+headless Ubuntu install supported
+agent integration pack included
+known limitations
+security defaults
+
+Optional but useful GitHub release assets:
+
+alicebot-v0.6.0-alpha-rc.1-source.tar.gz
+SHA256SUMS
+install-ubuntu.sh
+
+Acceptance criteria:
+
+GitHub tag can be checked out cleanly.
+Installer can target the tag.
+Release notes are accurate.
+Stable v0.5.1 remains latest.
+Alpha RC is marked pre-release if published.
+
+---
+
+6. Hermes Dogfood Setup Guide
+
+Add:
+
+docs/alpha/hermes-dogfood-ubuntu.md
+
+This should explain how to connect Hermes running on the same Ubuntu box.
+
+Include:
+
+Alice API URL
+Alice MCP server command/config
+agent identity fields for Hermes
+recommended permission profile
+how Hermes should request context packs
+how Hermes should submit outputs
+how Hermes should propose memory
+how to verify activity in /vnext
+how to run the agent integration smoke
+
+Hermes defaults:
+
+agent_id: hermes
+agent_type: personal_assistant
+permission_profile: trusted_local_agent
+project_scope: configurable
+
+Acceptance criteria:
+
+Guide includes copy-paste Hermes config/example.
+Guide includes first Hermes test task.
+Guide includes expected /vnext evidence.
+Guide includes policy-boundary test.
+
+---
+
+7. Headless Alpha Check
+
+Extend or document:
+
+alicebot vnext alpha check
+
+For headless installs, it should verify:
+
+database reachable
+migrations current
+doctor passing
+API reachable
+web reachable
+scheduler status
+MCP available or configured
+connector settings/state initialized
+demo load/reset works if requested
+agent integration smoke available
+secret redaction smoke passing
+operator console smoke passing
+
+Add a headless-specific smoke if needed:
+
+alicebot vnext smoke headless-ubuntu
+
+Acceptance criteria:
+
+Headless alpha check passes on Ubuntu.
+Failures include remediation.
+No check requires local browser access.
+
+---
+
+8. Remote /vnext Access Instructions
+
+Document secure access through SSH tunnel.
+
+Example:
+
+ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@ubuntu-box
+
+Then from local browser:
+
+http://127.0.0.1:3000/vnext
+
+Also document CLI-only fallback if the user cannot open the dashboard.
+
+Do not instruct users to expose /vnext publicly without auth.
+
+Acceptance criteria:
+
+Docs show SSH tunnel method.
+Docs warn against public bind.
+Docs include firewall/security note.
+Docs include CLI fallback.
+
+---
+
+9. Clean Uninstall / Reset
+
+Add safe reset instructions.
+
+Document:
+
+make stop
+alicebot vnext demo reset
+alicebot vnext doctor
+
+If appropriate, add:
+
+scripts/uninstall-ubuntu.sh
+
+or document manual cleanup:
+
+disable systemd services
+remove repo directory
+preserve or delete config
+preserve or delete database
+preserve or delete local secrets
+
+Acceptance criteria:
+
+User can reset demo data.
+User can stop services.
+User can understand what data will be deleted before deleting it.
+No destructive reset runs without confirmation.
+
+---
+
+Required End-to-End Flow
+
+Flow 1: Fresh Ubuntu install from GitHub
+
+SSH into Ubuntu box.
+Download installer from GitHub tag.
+Run installer.
+Installer installs dependencies and repo.
+Installer creates config template.
+Installer runs migrations.
+Installer runs doctor.
+Installer runs alpha check.
+User starts services.
+
+Flow 2: Remote /vnext access
+
+User creates SSH tunnel.
+User opens /vnext from local browser.
+Doctor/readiness is visible.
+Demo data or live data loads.
+
+Flow 3: Hermes connection
+
+Hermes connects through Alice MCP/API.
+Hermes identifies as hermes.
+Hermes requests scoped context pack.
+Hermes submits output.
+Hermes proposes memory.
+Memory proposal appears in /vnext.
+No trusted memory is auto-promoted.
+
+Flow 4: Scheduler works headlessly
+
+alice-scheduler service runs.
+Due workflow executes.
+Generated artifact appears.
+Scheduler run history records lifecycle.
+
+Flow 5: Security defaults
+
+API/web bind to localhost by default.
+Secrets are not printed.
+Doctor/alpha check do not expose secrets.
+Public network exposure is not enabled by default.
+
+---
+
+Explicit Deferrals
+
+Do not build:
+
+hosted cloud deployment
+public SaaS auth
+team accounts
+billing
+Gmail OAuth
+Calendar OAuth
+voice transcription
+OCR
+mobile app
+automatic memory promotion
+major UI redesign
+
+This sprint is installation, packaging, and Hermes dogfood readiness.
+
+---
+
+Acceptance Criteria
+
+The sprint is complete when:
+
+Ubuntu installer exists.
+Installer supports tag/branch/install-dir flags.
+Installer works on a clean Ubuntu server or documented test environment.
+Systemd service templates exist for API, web, and scheduler.
+Headless Ubuntu install docs exist.
+Remote /vnext SSH tunnel docs exist.
+Hermes dogfood guide exists.
+Alpha check works in headless mode.
+Optional headless-ubuntu smoke exists and passes, or equivalent documented validation exists.
+GitHub RC tag/release instructions exist.
+Release notes for v0.6.0-alpha-rc.1 exist.
+Stable v0.5.1 remains latest.
+Secrets are never printed in install logs.
+Services bind to localhost by default.
+Hermes integration flow is documented and tested.
+Agent integration smoke still passes.
+Operator console smoke still passes.
+Connector hardening smoke still passes.
+Secret redaction smoke still passes.
+Dogfood doctor smoke still passes.
+Capture-to-brief smoke still passes.
+Agentic scheduler smoke still passes.
+Eval suite passes with 0 critical privacy leaks and 0 prompt-injection tool writes.
+Python unit tests pass.
+Python integration tests pass.
+Web tests pass.
+Web lint/build pass.
+git diff --check passes.
+
+---
+
+Validation Commands
+
+Run:
+
+pytest tests/unit -q
+pytest tests/integration -q
+pnpm --dir apps/web test
+pnpm --dir apps/web lint
+pnpm --dir apps/web build
+alicebot eval run --suite all
+git diff --check
+
+Run:
+
+alicebot vnext alpha check
+alicebot vnext smoke agent-integration-pack
+alicebot vnext smoke operator-console
+alicebot vnext smoke connector-hardening
+alicebot vnext smoke secret-redaction
+alicebot vnext smoke dogfood-doctor
+alicebot vnext smoke live-capture-connectors
+alicebot vnext smoke capture-to-brief
+alicebot vnext smoke agentic-scheduler
+
+Add if practical:
+
+alicebot vnext smoke headless-ubuntu
+
+---
+
+Final Deliverable
+
+Provide a CTO summary with:
+
+what was built
+installer command
+supported Ubuntu assumptions
+systemd service behavior
+config/secrets layout
+remote access instructions
+Hermes dogfood guide
+GitHub RC tag/release status
+validation results
+known limitations
+recommended next phase
+PR number
+merge commit
+
+---
+
+My recommendation on tagging
+
+Prep the repo for:
+
+v0.6.0-alpha-rc.1
+
+Then install that exact tag on your Ubuntu/Hermes box.
+
+After your Hermes dogfood test passes, publish:
+
+v0.6.0-alpha.1
+
+as a GitHub pre-release, not latest.

--- a/docs/release/v0.6.0-alpha-rc.1-release-notes.md
+++ b/docs/release/v0.6.0-alpha-rc.1-release-notes.md
@@ -1,0 +1,80 @@
+# v0.6.0-alpha-rc.1 Release Notes
+
+Status: internal pre-release candidate for Hermes dogfood testing.
+
+Latest stable remains: `v0.5.1`.
+
+Do not mark this release as latest. If published on GitHub, publish it as a pre-release and not latest.
+
+## Purpose
+
+`v0.6.0-alpha-rc.1` packages Alice vNext for a headless Ubuntu install path from GitHub. The target dogfood setup is Alice and Hermes running on the same Ubuntu server or VPS, with Alice accessed through SSH tunneling and Hermes connected through MCP/API.
+
+This headless Ubuntu RC is intended for operator-controlled dogfood only.
+
+## Included
+
+- headless Ubuntu installer: `scripts/install-ubuntu.sh`
+- safe uninstall/reset helper: `scripts/uninstall-ubuntu.sh`
+- systemd templates for `alice-api`, `alice-web`, and `alice-scheduler`
+- local config template at `packaging/ubuntu/alicebot.env.example`
+- headless install guide at `docs/alpha/headless-ubuntu-install.md`
+- Hermes dogfood guide at `docs/alpha/hermes-dogfood-ubuntu.md`
+- headless package smoke: `alicebot vnext smoke headless-ubuntu`
+- headless alpha readiness mode: `alicebot vnext alpha check --headless`
+- public alpha agent integration pack from the prior packaging phase
+
+## Security Defaults
+
+- API and web bind to `127.0.0.1` by default.
+- `/vnext` is intended to be accessed through SSH tunnel first.
+- The installer preserves existing config and does not overwrite secrets.
+- Generated local database passwords are not printed.
+- Agent outputs and memory proposals remain review-only.
+- Trusted memory is not auto-promoted.
+
+## Known Limitations
+
+- This is not hosted cloud deployment.
+- This is not public SaaS auth.
+- This is not a public beta.
+- Gmail OAuth, Calendar OAuth, OCR execution, voice transcription, mobile app, billing, and team accounts remain out of scope.
+- The installer is documented for Ubuntu 22.04 and 24.04.
+- Systemd templates are local-alpha templates and should be reviewed before production hardening.
+
+## Recommended GitHub Release Command
+
+```bash
+git tag -a v0.6.0-alpha-rc.1 -m "v0.6.0-alpha-rc.1"
+git push origin v0.6.0-alpha-rc.1
+gh release create v0.6.0-alpha-rc.1 \
+  --title "Alice v0.6.0-alpha-rc.1" \
+  --notes-file docs/release/v0.6.0-alpha-rc.1-release-notes.md \
+  --prerelease \
+  --latest=false
+```
+
+Optional assets:
+
+```bash
+git archive --format=tar.gz --prefix=AliceBot-v0.6.0-alpha-rc.1/ \
+  -o alicebot-v0.6.0-alpha-rc.1-source.tar.gz v0.6.0-alpha-rc.1
+sha256sum alicebot-v0.6.0-alpha-rc.1-source.tar.gz scripts/install-ubuntu.sh > SHA256SUMS
+gh release upload v0.6.0-alpha-rc.1 alicebot-v0.6.0-alpha-rc.1-source.tar.gz SHA256SUMS scripts/install-ubuntu.sh
+```
+
+## Install Command
+
+Inspect before running:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/samrusani/AliceBot/v0.6.0-alpha-rc.1/scripts/install-ubuntu.sh -o install-alice.sh
+less install-alice.sh
+bash install-alice.sh --tag v0.6.0-alpha-rc.1
+```
+
+Then access `/vnext` through:
+
+```bash
+ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@ubuntu-box
+```

--- a/docs/vnext-headless-ubuntu-cto-summary.md
+++ b/docs/vnext-headless-ubuntu-cto-summary.md
@@ -1,0 +1,71 @@
+# Alice vNext Headless Ubuntu Packaging: CTO Summary
+
+Date: 2026-05-12
+Audience: CTO / technical leadership
+Sprint artifact: `codex/headless-ubuntu-installer`
+
+## Executive Summary
+
+This phase makes Alice vNext practically installable from GitHub on a headless Ubuntu box for Hermes dogfood testing. It keeps the product local-first, agent-first, review-first, and secure-by-default: Alice binds to localhost, `/vnext` is reached through SSH tunneling, and Hermes connects through MCP/API without direct trusted-memory writes.
+
+## What Was Built
+
+- `scripts/install-ubuntu.sh` for tag/branch/install-dir based GitHub installs
+- `scripts/uninstall-ubuntu.sh` for safe service stop/reset and opt-in destructive cleanup
+- systemd templates for `alice-api`, `alice-web`, and `alice-scheduler`
+- `packaging/ubuntu/alicebot.env.example` for agreed headless config paths
+- `docs/alpha/headless-ubuntu-install.md`
+- `docs/alpha/hermes-dogfood-ubuntu.md`
+- `docs/release/v0.6.0-alpha-rc.1-release-notes.md`
+- `alicebot vnext smoke headless-ubuntu`
+- `alicebot vnext alpha check --headless`
+
+## Installer Command
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/samrusani/AliceBot/v0.6.0-alpha-rc.1/scripts/install-ubuntu.sh -o install-alice.sh
+less install-alice.sh
+bash install-alice.sh --tag v0.6.0-alpha-rc.1
+```
+
+Supported assumptions: Ubuntu 22.04 or 24.04, SSH access, local or existing Postgres, Node 20, Python venv, and local-only service binding.
+
+## Systemd Behavior
+
+The templates run as the installing non-root user, load `~/.config/alicebot/.env`, restart on failure, and log through `journalctl`. API binds to `127.0.0.1:8000`, web binds to `127.0.0.1:3000`, and scheduler uses the governed `alicebot vnext scheduler daemon start --foreground` path.
+
+## Config And Secrets Layout
+
+- repo: `~/alicebot`
+- config: `~/.config/alicebot/.env`
+- data: `~/.local/share/alicebot/`
+- logs/state: `~/.local/state/alicebot/logs/`
+- local secret references: `~/.config/alicebot/secrets/`
+
+Existing config is preserved. The installer does not print generated local database passwords or connector secrets.
+
+## Remote Access
+
+Recommended access is an SSH tunnel:
+
+```bash
+ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@ubuntu-box
+```
+
+Then open `http://127.0.0.1:3000/vnext` locally.
+
+## Hermes Dogfood
+
+Hermes should identify as `agent_id=hermes`, `agent_type=personal_assistant`, `permission_profile=trusted_local_agent`, and request project-scoped context through Alice MCP/API. Outputs become reviewable source/artifact evidence. Durable facts become candidate memory proposals only.
+
+## RC Tag / Release Status
+
+The repo is prepared for `v0.6.0-alpha-rc.1`. Stable `v0.5.1` remains latest. If published, the RC should be a GitHub pre-release with `--latest=false`.
+
+## Known Limitations
+
+This does not add hosted cloud deployment, public SaaS auth, team accounts, billing, Gmail OAuth, Calendar OAuth, OCR execution, voice transcription, mobile app, or automatic memory promotion.
+
+## Recommended Next Phase
+
+Run the exact `v0.6.0-alpha-rc.1` installer on the Ubuntu/Hermes dogfood host, record the real install transcript, then publish `v0.6.0-alpha.1` as a pre-release only after Hermes completes the first context-pack/output/proposal loop.

--- a/docs/vnext/README.md
+++ b/docs/vnext/README.md
@@ -29,7 +29,7 @@ Alice vNext has three layers:
 
 1. Follow [public alpha quickstart](../alpha/quickstart.md) for the design-partner install path.
 2. Use [first-run checklist](../alpha/first-run.md) and [doctor](../alpha/doctor.md) for onboarding.
-3. Review [agent integration pack](../alpha/agent-integration.md), [MCP tools](../alpha/mcp-tools.md), [Hermes skill](../alpha/hermes-skill.md), and [OpenClaw skill](../alpha/openclaw-skill.md).
+3. Review [headless Ubuntu install](../alpha/headless-ubuntu-install.md), [Hermes dogfood on Ubuntu](../alpha/hermes-dogfood-ubuntu.md), [agent integration pack](../alpha/agent-integration.md), [MCP tools](../alpha/mcp-tools.md), [Hermes skill](../alpha/hermes-skill.md), and [OpenClaw skill](../alpha/openclaw-skill.md).
 4. Follow [vNext quickstart](quickstart.md) for the broader preview path.
 5. Review [architecture](architecture.md).
 6. Review [security and privacy](security-privacy.md) and [public alpha security posture](../alpha/security-and-privacy.md).
@@ -39,7 +39,7 @@ Alice vNext has three layers:
 10. Use [release checklist](../release/vnext-public-release-checklist.md) before publishing or tagging.
 11. Review [preview release notes](../release/v0.5.1-vnext-preview-release-notes.md), [public alpha release notes](../alpha/release-notes.md), and [tag plan](../release/v0.5.1-vnext-preview-tag-plan.md).
 12. Review the [dogfood daily checklist](../runbooks/vnext-dogfood-daily-checklist.md) before daily local-alpha use.
-13. Review the [agentic control plane CTO summary](../vnext-agentic-control-plane-cto-summary.md), [local runtime CTO summary](../vnext-local-runtime-cto-summary.md), [model-backed intelligence CTO summary](../vnext-model-backed-intelligence-cto-summary.md), [live capture connectors CTO summary](../vnext-live-capture-connectors-cto-summary.md), [dogfood hardening CTO summary](../vnext-dogfood-hardening-cto-summary.md), [live-backed operator console CTO summary](../vnext-live-backed-operator-console-cto-summary.md), and [public alpha packaging CTO summary](../vnext-public-alpha-packaging-cto-summary.md) for sprint closeouts.
+13. Review the [agentic control plane CTO summary](../vnext-agentic-control-plane-cto-summary.md), [local runtime CTO summary](../vnext-local-runtime-cto-summary.md), [model-backed intelligence CTO summary](../vnext-model-backed-intelligence-cto-summary.md), [live capture connectors CTO summary](../vnext-live-capture-connectors-cto-summary.md), [dogfood hardening CTO summary](../vnext-dogfood-hardening-cto-summary.md), [live-backed operator console CTO summary](../vnext-live-backed-operator-console-cto-summary.md), [public alpha packaging CTO summary](../vnext-public-alpha-packaging-cto-summary.md), and [headless Ubuntu packaging CTO summary](../vnext-headless-ubuntu-cto-summary.md) for sprint closeouts.
 
 ## Launch Boundary
 

--- a/packaging/systemd/alice-api.service
+++ b/packaging/systemd/alice-api.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Alice API service
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=__ALICE_USER__
+Group=__ALICE_GROUP__
+WorkingDirectory=__ALICE_INSTALL_DIR__
+EnvironmentFile=__ALICE_ENV_FILE__
+Environment=APP_HOST=127.0.0.1
+Environment=APP_PORT=8000
+Environment=APP_LOG_MODE=stdout
+Environment=APP_ACCESS_LOG=false
+ExecStart=__ALICE_INSTALL_DIR__/.venv/bin/python -m alicebot_api.local_server
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ReadWritePaths=__ALICE_INSTALL_DIR__ __ALICE_STATE_DIR__ %h/.alicebot
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/alice-scheduler.service
+++ b/packaging/systemd/alice-scheduler.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Alice governed scheduler daemon
+After=network-online.target postgresql.service alice-api.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=__ALICE_USER__
+Group=__ALICE_GROUP__
+WorkingDirectory=__ALICE_INSTALL_DIR__
+EnvironmentFile=__ALICE_ENV_FILE__
+Environment=ALICE_API_HOST=127.0.0.1
+Environment=ALICE_API_PORT=8000
+ExecStart=__ALICE_INSTALL_DIR__/.venv/bin/alicebot vnext scheduler daemon start --foreground --interval-seconds 60 --limit 10 --pid-file %h/.alicebot/vnext-scheduler/scheduler.pid --status-file %h/.alicebot/vnext-scheduler/scheduler-status.json --log-file __ALICE_STATE_DIR__/logs/scheduler.log
+Restart=on-failure
+RestartSec=10
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ReadWritePaths=__ALICE_INSTALL_DIR__ __ALICE_STATE_DIR__ %h/.alicebot
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/alice-web.service
+++ b/packaging/systemd/alice-web.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Alice web service
+After=network-online.target alice-api.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=__ALICE_USER__
+Group=__ALICE_GROUP__
+WorkingDirectory=__ALICE_INSTALL_DIR__
+EnvironmentFile=__ALICE_ENV_FILE__
+Environment=ALICE_WEB_HOST=127.0.0.1
+Environment=ALICE_WEB_PORT=3000
+ExecStart=/usr/bin/bash -lc 'pnpm --dir apps/web start --hostname "${ALICE_WEB_HOST:-127.0.0.1}" --port "${ALICE_WEB_PORT:-3000}"'
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ReadWritePaths=__ALICE_INSTALL_DIR__ __ALICE_STATE_DIR__
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/ubuntu/alicebot.env.example
+++ b/packaging/ubuntu/alicebot.env.example
@@ -1,0 +1,51 @@
+# Alice headless Ubuntu local alpha environment.
+# Installer renders this file to ~/.config/alicebot/.env with 0600 permissions.
+
+APP_ENV=production
+APP_HOST=127.0.0.1
+APP_PORT=8000
+APP_RELOAD=false
+APP_LOG_MODE=stdout
+APP_ACCESS_LOG=false
+APP_LOG_PATH=__ALICE_STATE_DIR__/logs/api.log
+APP_LOG_MAX_BYTES=10485760
+APP_LOG_BACKUP_COUNT=5
+
+ALICE_API_HOST=127.0.0.1
+ALICE_API_PORT=8000
+ALICE_WEB_HOST=127.0.0.1
+ALICE_WEB_PORT=3000
+
+DATABASE_URL=postgresql://alicebot_app:__ALICEBOT_APP_PASSWORD__@127.0.0.1:5432/alicebot
+DATABASE_ADMIN_URL=postgresql://alicebot_admin:__ALICEBOT_ADMIN_PASSWORD__@127.0.0.1:5432/alicebot
+REDIS_URL=redis://127.0.0.1:6379/0
+
+ALICEBOT_AUTH_USER_ID=00000000-0000-0000-0000-000000000001
+TASK_WORKSPACE_ROOT=__ALICE_DATA_DIR__/task-workspaces
+PUBLIC_SAMPLE_DATA_PATH=fixtures/public_sample_data/continuity_v1.json
+
+# Local alpha secret posture.
+# Store real secret material outside the repo and configure connectors with secret_ref values.
+ALICE_SECRET_PROVIDER=encrypted_local
+ALICE_SECRETS_DIR=__ALICE_SECRETS_DIR__
+TELEGRAM_BOT_TOKEN=
+# Example connector secret_ref to use after storing the token:
+# telegram.bot_token.default
+
+# Model/runtime posture.
+MODEL_PROVIDER=deterministic_local
+OPENAI_API_KEY=
+OPENAI_BASE_URL=
+
+# Browser/API security posture.
+CORS_ALLOWED_ORIGINS=http://127.0.0.1:3000,http://localhost:3000
+CORS_ALLOWED_METHODS=GET,POST,PUT,PATCH,DELETE,OPTIONS
+CORS_ALLOWED_HEADERS=Authorization,Content-Type,X-AliceBot-User-Id,X-Telegram-Bot-Api-Secret-Token
+CORS_ALLOW_CREDENTIALS=false
+SECURITY_HEADERS_ENABLED=true
+TRUST_PROXY_HEADERS=false
+TRUSTED_PROXY_IPS=
+
+# MCP settings for same-host Hermes/OpenClaw/custom agents.
+ALICE_MCP_COMMAND=__ALICE_INSTALL_DIR__/.venv/bin/python -m alicebot_api.mcp_server
+ALICE_MCP_SERVER_NAME=alice_core

--- a/scripts/install-ubuntu.sh
+++ b/scripts/install-ubuntu.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${ALICEBOT_REPO_URL:-https://github.com/samrusani/AliceBot.git}"
+TAG=""
+BRANCH="main"
+INSTALL_DIR="${HOME}/alicebot"
+CONFIG_DIR="${HOME}/.config/alicebot"
+DATA_DIR="${HOME}/.local/share/alicebot"
+STATE_DIR="${HOME}/.local/state/alicebot"
+SECRETS_DIR="${HOME}/.config/alicebot/secrets"
+ENV_FILE=""
+SKIP_POSTGRES_INSTALL=0
+NON_INTERACTIVE=0
+INSTALL_SYSTEMD=0
+DRY_RUN=0
+RUN_ALPHA_CHECK=1
+
+log() {
+  printf '[alice-install] %s\n' "$*"
+}
+
+fail() {
+  printf '[alice-install] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Install AliceBot on a headless Ubuntu host.
+
+Usage:
+  bash install-alice.sh [options]
+
+Options:
+  --tag VERSION              Check out a specific tag, for example v0.6.0-alpha-rc.1.
+  --branch NAME              Check out a branch. Defaults to main when --tag is omitted.
+  --install-dir PATH         Repository install directory. Defaults to ~/alicebot.
+  --config-dir PATH          Config directory. Defaults to ~/.config/alicebot.
+  --skip-postgres-install    Do not install/configure local Postgres; verify only.
+  --install-systemd          Install alice-api, alice-web, and alice-scheduler systemd units.
+  --non-interactive          Fail instead of prompting.
+  --skip-alpha-check         Skip final alicebot vnext alpha check --headless --skip-smokes.
+  --dry-run                  Print planned commands without changing the host.
+  -h, --help                 Show this help.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tag)
+      TAG="${2:-}"
+      BRANCH=""
+      shift 2
+      ;;
+    --branch)
+      BRANCH="${2:-}"
+      TAG=""
+      shift 2
+      ;;
+    --install-dir)
+      INSTALL_DIR="${2:-}"
+      shift 2
+      ;;
+    --config-dir)
+      CONFIG_DIR="${2:-}"
+      shift 2
+      ;;
+    --skip-postgres-install)
+      SKIP_POSTGRES_INSTALL=1
+      shift
+      ;;
+    --install-systemd)
+      INSTALL_SYSTEMD=1
+      shift
+      ;;
+    --non-interactive)
+      NON_INTERACTIVE=1
+      shift
+      ;;
+    --skip-alpha-check)
+      RUN_ALPHA_CHECK=0
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown option: $1"
+      ;;
+  esac
+done
+
+INSTALL_DIR="$(realpath -m "${INSTALL_DIR/#\~/${HOME}}")"
+CONFIG_DIR="$(realpath -m "${CONFIG_DIR/#\~/${HOME}}")"
+DATA_DIR="$(realpath -m "${DATA_DIR/#\~/${HOME}}")"
+STATE_DIR="$(realpath -m "${STATE_DIR/#\~/${HOME}}")"
+SECRETS_DIR="$(realpath -m "${SECRETS_DIR/#\~/${HOME}}")"
+ENV_FILE="${CONFIG_DIR}/.env"
+
+run() {
+  log "+ $*"
+  if [ "${DRY_RUN}" -eq 0 ]; then
+    "$@"
+  fi
+}
+
+confirm() {
+  local prompt="$1"
+  if [ "${NON_INTERACTIVE}" -eq 1 ]; then
+    fail "${prompt} Re-run without --non-interactive or choose a non-destructive path."
+  fi
+  read -r -p "${prompt} [y/N] " answer
+  case "${answer}" in
+    y|Y|yes|YES) return 0 ;;
+    *) fail "Operator cancelled." ;;
+  esac
+}
+
+require_ubuntu() {
+  if [ ! -r /etc/os-release ]; then
+    fail "This installer expects Ubuntu and could not read /etc/os-release."
+  fi
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  if [ "${ID:-}" != "ubuntu" ]; then
+    fail "This installer currently supports Ubuntu only; detected ID=${ID:-unknown}."
+  fi
+  case "${VERSION_ID:-}" in
+    22.04|24.04) log "Detected Ubuntu ${VERSION_ID}." ;;
+    *) log "Detected Ubuntu ${VERSION_ID:-unknown}; continuing, but 22.04 and 24.04 are the documented assumptions." ;;
+  esac
+}
+
+install_system_packages() {
+  run sudo apt-get update
+  run sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates curl git build-essential python3 python3-venv python3-pip \
+    openssl pkg-config libpq-dev redis-tools
+}
+
+install_node_and_pnpm() {
+  local node_major
+  node_major="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || true)"
+  if [ -z "${node_major}" ] || [ "${node_major}" -lt 20 ]; then
+    log "Installing Node.js 20 through NodeSource."
+    run sudo install -d -m 0755 /etc/apt/keyrings
+    if [ "${DRY_RUN}" -eq 0 ]; then
+      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+        | sudo tee /etc/apt/sources.list.d/nodesource.list >/dev/null
+    else
+      log "+ curl NodeSource key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg"
+      log "+ write /etc/apt/sources.list.d/nodesource.list"
+    fi
+    run sudo apt-get update
+    run sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+  fi
+  if command -v corepack >/dev/null 2>&1; then
+    run sudo corepack enable
+    run sudo corepack prepare pnpm@latest --activate
+  elif ! command -v pnpm >/dev/null 2>&1; then
+    run sudo npm install -g pnpm
+  fi
+}
+
+prepare_postgres() {
+  if [ "${SKIP_POSTGRES_INSTALL}" -eq 1 ]; then
+    log "Skipping local Postgres install. Existing DATABASE_URL settings will be verified by migrations."
+    return
+  fi
+  run sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql postgresql-contrib
+  run sudo systemctl enable --now postgresql
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    log "+ prepare local alicebot Postgres roles/database without printing generated passwords"
+    return
+  fi
+  command -v psql >/dev/null 2>&1 || fail "psql is not available after local Postgres install."
+  sudo -u postgres psql -tc "SELECT 1" >/dev/null || fail "Postgres is not reachable as the postgres OS user."
+}
+
+sync_repo() {
+  if [ -e "${INSTALL_DIR}" ] && [ ! -d "${INSTALL_DIR}/.git" ]; then
+    fail "${INSTALL_DIR} exists but is not a git checkout. Choose --install-dir or move it first."
+  fi
+  if [ -d "${INSTALL_DIR}/.git" ]; then
+    run git -C "${INSTALL_DIR}" fetch --tags origin
+  else
+    run mkdir -p "$(dirname "${INSTALL_DIR}")"
+    run git clone "${REPO_URL}" "${INSTALL_DIR}"
+  fi
+  if [ -n "${TAG}" ]; then
+    run git -C "${INSTALL_DIR}" checkout "tags/${TAG}"
+  else
+    run git -C "${INSTALL_DIR}" checkout "${BRANCH}"
+    run git -C "${INSTALL_DIR}" pull --ff-only origin "${BRANCH}"
+  fi
+}
+
+random_secret() {
+  openssl rand -hex 24
+}
+
+write_env_if_missing() {
+  run mkdir -p "${CONFIG_DIR}" "${DATA_DIR}" "${STATE_DIR}/logs" "${SECRETS_DIR}"
+  if [ -f "${ENV_FILE}" ]; then
+    log "Preserving existing ${ENV_FILE}."
+  else
+    if [ "${DRY_RUN}" -eq 1 ]; then
+      log "+ create ${ENV_FILE} from packaging/ubuntu/alicebot.env.example with generated local passwords"
+    else
+      local admin_password app_password
+      admin_password="$(random_secret)"
+      app_password="$(random_secret)"
+      sed \
+        -e "s#__ALICE_INSTALL_DIR__#${INSTALL_DIR}#g" \
+        -e "s#__ALICE_CONFIG_DIR__#${CONFIG_DIR}#g" \
+        -e "s#__ALICE_DATA_DIR__#${DATA_DIR}#g" \
+        -e "s#__ALICE_STATE_DIR__#${STATE_DIR}#g" \
+        -e "s#__ALICE_SECRETS_DIR__#${SECRETS_DIR}#g" \
+        -e "s#__ALICEBOT_ADMIN_PASSWORD__#${admin_password}#g" \
+        -e "s#__ALICEBOT_APP_PASSWORD__#${app_password}#g" \
+        "${INSTALL_DIR}/packaging/ubuntu/alicebot.env.example" > "${ENV_FILE}"
+      chmod 0600 "${ENV_FILE}"
+    fi
+  fi
+  if [ -e "${INSTALL_DIR}/.env" ] && [ ! -L "${INSTALL_DIR}/.env" ]; then
+    log "Preserving existing ${INSTALL_DIR}/.env."
+  else
+    run ln -sfn "${ENV_FILE}" "${INSTALL_DIR}/.env"
+  fi
+}
+
+prepare_database_from_env() {
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    log "+ create alicebot database and roles from generated local env file"
+    return
+  fi
+  # shellcheck disable=SC1090
+  . "${ENV_FILE}"
+  local admin_pass app_pass
+  admin_pass="${DATABASE_ADMIN_URL#*alicebot_admin:}"
+  admin_pass="${admin_pass%@*}"
+  app_pass="${DATABASE_URL#*alicebot_app:}"
+  app_pass="${app_pass%@*}"
+  sudo -u postgres psql <<SQL >/dev/null
+DO \$\$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'alicebot_admin') THEN
+    CREATE ROLE alicebot_admin LOGIN PASSWORD '${admin_pass}';
+  ELSE
+    ALTER ROLE alicebot_admin WITH LOGIN PASSWORD '${admin_pass}';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'alicebot_app') THEN
+    CREATE ROLE alicebot_app LOGIN PASSWORD '${app_pass}';
+  ELSE
+    ALTER ROLE alicebot_app WITH LOGIN PASSWORD '${app_pass}';
+  END IF;
+END
+\$\$;
+SELECT 'CREATE DATABASE alicebot OWNER alicebot_admin'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'alicebot')\\gexec
+GRANT CONNECT ON DATABASE alicebot TO alicebot_app;
+SQL
+}
+
+install_project_dependencies() {
+  run python3 -m venv "${INSTALL_DIR}/.venv"
+  run "${INSTALL_DIR}/.venv/bin/python" -m pip install --upgrade pip
+  run "${INSTALL_DIR}/.venv/bin/python" -m pip install -e "${INSTALL_DIR}[dev]"
+  run pnpm --dir "${INSTALL_DIR}/apps/web" install
+  run pnpm --dir "${INSTALL_DIR}/apps/web" build
+}
+
+run_migrations_and_checks() {
+  if [ "${DRY_RUN}" -eq 0 ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "${ENV_FILE}"
+    set +a
+  fi
+  run "${INSTALL_DIR}/.venv/bin/python" -m alembic -c "${INSTALL_DIR}/apps/api/alembic.ini" upgrade head
+  run "${INSTALL_DIR}/.venv/bin/alicebot" vnext doctor --fix-safe --ci
+  if [ "${RUN_ALPHA_CHECK}" -eq 1 ]; then
+    run "${INSTALL_DIR}/.venv/bin/alicebot" vnext alpha check --headless --skip-smokes
+  fi
+}
+
+install_systemd_units() {
+  if [ "${INSTALL_SYSTEMD}" -eq 0 ]; then
+    return
+  fi
+  local user group service
+  user="$(id -un)"
+  group="$(id -gn)"
+  for service in alice-api alice-web alice-scheduler; do
+    if [ "${DRY_RUN}" -eq 1 ]; then
+      log "+ install /etc/systemd/system/${service}.service from packaging/systemd/${service}.service"
+    else
+      sed \
+        -e "s#__ALICE_USER__#${user}#g" \
+        -e "s#__ALICE_GROUP__#${group}#g" \
+        -e "s#__ALICE_INSTALL_DIR__#${INSTALL_DIR}#g" \
+        -e "s#__ALICE_ENV_FILE__#${ENV_FILE}#g" \
+        -e "s#__ALICE_STATE_DIR__#${STATE_DIR}#g" \
+        "${INSTALL_DIR}/packaging/systemd/${service}.service" \
+        | sudo tee "/etc/systemd/system/${service}.service" >/dev/null
+    fi
+  done
+  run sudo systemctl daemon-reload
+  log "Systemd units installed. Start them with: sudo systemctl enable --now alice-api alice-web alice-scheduler"
+}
+
+print_next_steps() {
+  cat <<EOF
+
+Alice headless Ubuntu install prepared.
+
+Next steps:
+  1. Review config: ${ENV_FILE}
+  2. Start services:
+       sudo systemctl enable --now alice-api alice-web alice-scheduler
+  3. Check services:
+       systemctl status alice-api alice-web alice-scheduler
+       journalctl -u alice-api -f
+  4. Tunnel from your laptop:
+       ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@server
+  5. Open:
+       http://127.0.0.1:3000/vnext
+  6. Run:
+       ${INSTALL_DIR}/.venv/bin/alicebot vnext alpha check --headless --api-url http://127.0.0.1:8000/healthz --web-url http://127.0.0.1:3000/vnext
+       ${INSTALL_DIR}/.venv/bin/alicebot vnext smoke agent-integration-pack
+
+Security default: Alice services bind to 127.0.0.1. Use SSH tunneling first; do not expose /vnext publicly without adding your own authenticated reverse proxy.
+EOF
+}
+
+require_ubuntu
+install_system_packages
+install_node_and_pnpm
+prepare_postgres
+sync_repo
+write_env_if_missing
+if [ "${SKIP_POSTGRES_INSTALL}" -eq 0 ]; then
+  prepare_database_from_env
+fi
+install_project_dependencies
+run_migrations_and_checks
+install_systemd_units
+print_next_steps

--- a/scripts/uninstall-ubuntu.sh
+++ b/scripts/uninstall-ubuntu.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="${HOME}/alicebot"
+CONFIG_DIR="${HOME}/.config/alicebot"
+DATA_DIR="${HOME}/.local/share/alicebot"
+STATE_DIR="${HOME}/.local/state/alicebot"
+REMOVE_REPO=0
+REMOVE_CONFIG=0
+REMOVE_DATA=0
+DROP_DATABASE=0
+NON_INTERACTIVE=0
+DRY_RUN=0
+
+log() {
+  printf '[alice-uninstall] %s\n' "$*"
+}
+
+fail() {
+  printf '[alice-uninstall] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Safely stop or uninstall headless Alice Ubuntu services.
+
+By default this script only disables/stops services and preserves repo, config,
+data, database, and local secret references.
+
+Options:
+  --install-dir PATH      Alice repo directory. Defaults to ~/alicebot.
+  --config-dir PATH       Config directory. Defaults to ~/.config/alicebot.
+  --remove-repo           Delete the Alice repo directory after confirmation.
+  --remove-config         Delete config and local secret references after confirmation.
+  --remove-data           Delete local Alice data/state directories after confirmation.
+  --drop-database         Drop local alicebot database and roles after confirmation.
+  --non-interactive       Fail instead of prompting for destructive actions.
+  --dry-run               Print planned commands without changing the host.
+  -h, --help              Show this help.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --install-dir)
+      INSTALL_DIR="${2:-}"
+      shift 2
+      ;;
+    --config-dir)
+      CONFIG_DIR="${2:-}"
+      shift 2
+      ;;
+    --remove-repo)
+      REMOVE_REPO=1
+      shift
+      ;;
+    --remove-config)
+      REMOVE_CONFIG=1
+      shift
+      ;;
+    --remove-data)
+      REMOVE_DATA=1
+      shift
+      ;;
+    --drop-database)
+      DROP_DATABASE=1
+      shift
+      ;;
+    --non-interactive)
+      NON_INTERACTIVE=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown option: $1"
+      ;;
+  esac
+done
+
+INSTALL_DIR="$(realpath -m "${INSTALL_DIR/#\~/${HOME}}")"
+CONFIG_DIR="$(realpath -m "${CONFIG_DIR/#\~/${HOME}}")"
+DATA_DIR="$(realpath -m "${DATA_DIR/#\~/${HOME}}")"
+STATE_DIR="$(realpath -m "${STATE_DIR/#\~/${HOME}}")"
+
+run() {
+  log "+ $*"
+  if [ "${DRY_RUN}" -eq 0 ]; then
+    "$@"
+  fi
+}
+
+confirm() {
+  local prompt="$1"
+  if [ "${NON_INTERACTIVE}" -eq 1 ]; then
+    fail "${prompt} Re-run without --non-interactive or omit the destructive flag."
+  fi
+  read -r -p "${prompt} Type DELETE to continue: " answer
+  if [ "${answer}" != "DELETE" ]; then
+    fail "Operator cancelled."
+  fi
+}
+
+stop_services() {
+  if command -v systemctl >/dev/null 2>&1; then
+    run sudo systemctl disable --now alice-api alice-web alice-scheduler || true
+    run sudo rm -f /etc/systemd/system/alice-api.service /etc/systemd/system/alice-web.service /etc/systemd/system/alice-scheduler.service
+    run sudo systemctl daemon-reload
+  else
+    log "systemctl is not available; skip service removal."
+  fi
+}
+
+reset_demo_data() {
+  if [ -x "${INSTALL_DIR}/.venv/bin/alicebot" ]; then
+    run "${INSTALL_DIR}/.venv/bin/alicebot" vnext demo reset || true
+    run "${INSTALL_DIR}/.venv/bin/alicebot" vnext doctor --fix-safe --ci || true
+  else
+    log "Alice virtualenv not found; skip demo reset and doctor."
+  fi
+}
+
+drop_database() {
+  if [ "${DROP_DATABASE}" -eq 0 ]; then
+    return
+  fi
+  confirm "Drop local alicebot database and alicebot roles?"
+  run sudo -u postgres psql -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'alicebot';"
+  run sudo -u postgres dropdb --if-exists alicebot
+  run sudo -u postgres dropuser --if-exists alicebot_app
+  run sudo -u postgres dropuser --if-exists alicebot_admin
+}
+
+remove_paths() {
+  if [ "${REMOVE_REPO}" -eq 1 ]; then
+    confirm "Delete Alice repo directory ${INSTALL_DIR}?"
+    run rm -rf "${INSTALL_DIR}"
+  fi
+  if [ "${REMOVE_CONFIG}" -eq 1 ]; then
+    confirm "Delete Alice config and local secret references under ${CONFIG_DIR}?"
+    run rm -rf "${CONFIG_DIR}"
+  fi
+  if [ "${REMOVE_DATA}" -eq 1 ]; then
+    confirm "Delete Alice local data/state under ${DATA_DIR} and ${STATE_DIR}?"
+    run rm -rf "${DATA_DIR}" "${STATE_DIR}"
+  fi
+}
+
+stop_services
+reset_demo_data
+drop_database
+remove_paths
+
+cat <<EOF
+
+Alice services are stopped and disabled.
+Preserved by default:
+  repo: ${INSTALL_DIR}
+  config/secrets: ${CONFIG_DIR}
+  data: ${DATA_DIR}
+  state/logs: ${STATE_DIR}
+  database: alicebot
+
+Use explicit --remove-* or --drop-database flags for destructive cleanup.
+EOF

--- a/tests/unit/test_vnext_release_polish.py
+++ b/tests/unit/test_vnext_release_polish.py
@@ -121,3 +121,66 @@ def test_public_alpha_packaging_docs_and_commands_are_discoverable() -> None:
     assert "trusted_local_agent" in hermes_copy
     assert "project_scoped_agent" in openclaw_copy
     assert "alpha-check" in makefile
+
+
+def test_headless_ubuntu_packaging_is_discoverable_and_safe_by_default() -> None:
+    readme = _read("README.md")
+    alpha_readme = _read("docs/alpha/README.md")
+    install_doc = _read("docs/alpha/headless-ubuntu-install.md")
+    hermes_doc = _read("docs/alpha/hermes-dogfood-ubuntu.md")
+    release_notes = _read("docs/release/v0.6.0-alpha-rc.1-release-notes.md")
+    cto_summary = _read("docs/vnext-headless-ubuntu-cto-summary.md")
+    installer = _read("scripts/install-ubuntu.sh")
+    uninstaller = _read("scripts/uninstall-ubuntu.sh")
+    env_template = _read("packaging/ubuntu/alicebot.env.example")
+    api_service = _read("packaging/systemd/alice-api.service")
+    web_service = _read("packaging/systemd/alice-web.service")
+    scheduler_service = _read("packaging/systemd/alice-scheduler.service")
+    cli = _read("apps/api/src/alicebot_api/cli.py")
+
+    assert "docs/alpha/headless-ubuntu-install.md" in readme
+    assert "headless-ubuntu-install.md" in alpha_readme
+    assert "ssh -L 3000:127.0.0.1:3000" in install_doc
+    assert "Do not expose `/vnext`" in install_doc
+    assert "alicebot vnext alpha check --headless" in install_doc
+    assert "agent_id: hermes" in hermes_doc
+    assert "trusted_local_agent" in hermes_doc
+    assert "policy-boundary test" in hermes_doc
+    assert "v0.6.0-alpha-rc.1" in release_notes
+    assert "not latest" in release_notes
+    assert "Headless Ubuntu" in cto_summary
+
+    for marker in (
+        "--tag",
+        "--branch",
+        "--install-dir",
+        "--skip-postgres-install",
+        "--non-interactive",
+        "--install-systemd",
+    ):
+        assert marker in installer
+
+    assert "--remove-repo" in uninstaller
+    assert "--drop-database" in uninstaller
+    assert "Type DELETE to continue" in uninstaller
+
+    for marker in (
+        "DATABASE_URL=",
+        "ALICE_API_HOST=127.0.0.1",
+        "ALICE_WEB_HOST=127.0.0.1",
+        "ALICE_SECRET_PROVIDER=",
+        "ALICE_MCP_COMMAND=",
+    ):
+        assert marker in env_template
+
+    for service in (api_service, web_service, scheduler_service):
+        assert "User=__ALICE_USER__" in service
+        assert "Restart=on-failure" in service
+        assert "EnvironmentFile=__ALICE_ENV_FILE__" in service
+        assert "0.0.0.0" not in service
+
+    assert "127.0.0.1" in api_service
+    assert "127.0.0.1" in web_service
+    assert "127.0.0.1" in scheduler_service
+    assert "headless-ubuntu" in cli
+    assert "--headless" in cli


### PR DESCRIPTION
## Summary

- Add a headless Ubuntu installer and safe uninstall helper for Alice vNext dogfood hosts.
- Add systemd service templates and a local config/env layout for API, web, scheduler, Postgres, secrets, MCP, and same-host Hermes integration.
- Add the headless Ubuntu install guide, Hermes dogfood guide, RC release notes, and CTO summary under `docs/`.
- Extend `alicebot vnext alpha check` with `--headless` readiness checks and add `alicebot vnext smoke headless-ubuntu`.
- Add release-polish coverage so the packaging, docs, service defaults, and safe localhost posture stay discoverable.

## Validation

- `bash -n scripts/install-ubuntu.sh`
- `bash -n scripts/uninstall-ubuntu.sh`
- `./scripts/install-ubuntu.sh --help`
- `./scripts/uninstall-ubuntu.sh --help`
- `docker run --rm -v /Users/samirusani/Desktop/Codex/AliceBot:/repo:ro ubuntu:24.04 bash /repo/scripts/install-ubuntu.sh --dry-run --skip-postgres-install --skip-alpha-check --install-dir /tmp/alicebot --config-dir /tmp/alice-config`
- `./.venv/bin/python -m py_compile apps/api/src/alicebot_api/cli.py`
- `./.venv/bin/pytest tests/unit/test_vnext_release_polish.py -q`
- `./.venv/bin/pytest tests/unit -q` (`1128 passed`)
- `./.venv/bin/pytest tests/integration -q` (`370 passed`)
- `pnpm --dir apps/web test` (`63` files, `209` tests passed)
- `pnpm --dir apps/web lint`
- `pnpm --dir apps/web build`
- `./.venv/bin/alicebot eval run --suite all` (`170/170`, `0` critical privacy leaks, `0` prompt-injection tool writes)
- `./.venv/bin/alicebot vnext smoke headless-ubuntu`
- `./.venv/bin/alicebot vnext alpha check --headless --skip-smokes`
- `./.venv/bin/alicebot vnext alpha check --headless`
- `./.venv/bin/python scripts/check_control_doc_truth.py`
- `git diff --cached --check`
- ASCII scan over the changed/added surface

## Upgrade Overview

Complete this section when the PR touches a protected path listed in `PROTECTED_PATHS.md`.
CI enforces this section for protected-path changes.

### Protected Areas

- [ ] memory schema
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic
- [x] continuity APIs

### Compatibility Impact

Additive-only. The protected change is in `apps/api/src/alicebot_api/cli.py` and adds new optional CLI surfaces: `alicebot vnext smoke headless-ubuntu` and `alicebot vnext alpha check --headless`. Existing alpha checks and smokes keep their existing defaults unless the new flag/command is explicitly used.

### Migration / Rollout

No database migration or backfill is required. Operators can roll this out by installing from the selected branch/tag on Ubuntu 22.04 or 24.04, reviewing `~/.config/alicebot/.env`, running migrations through the installer, and starting the optional systemd units after inspection.

### Operator Action

For headless dogfood hosts, download and inspect `scripts/install-ubuntu.sh`, then run it on Ubuntu. Access `/vnext` through an SSH tunnel first: `ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@server`. Do not bind the alpha API or web UI publicly without adding an authenticated reverse proxy.

### Validation

Validated with shell syntax checks, an Ubuntu 24.04 container dry run, Python unit/integration suites, web test/lint/build, the full vNext eval suite, the new headless smoke, and the full `alicebot vnext alpha check --headless` gate. Exact commands are listed in the Validation section above.

### Rollback

Revert this PR to remove the new installer, uninstall helper, systemd/env templates, headless docs, release notes, and additive CLI commands. Installed hosts can stop the alpha services and run `scripts/uninstall-ubuntu.sh`; destructive repo/config/data/database removal still requires explicit flags and confirmation.
