### PR TITLE
Document clean web dev cache reset

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@10.23.0",
   "scripts": {
     "dev": "next dev",
+    "dev:clean": "rm -rf .next && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",

--- a/docs/alpha/troubleshooting.md
+++ b/docs/alpha/troubleshooting.md
@@ -76,6 +76,24 @@ alicebot vnext smoke local-cors
 alicebot vnext doctor --fix-safe --ci
 ```
 
+## `/vnext` Fails With `Cannot find module './316.js'`
+
+If the web server returns a 500 for `/vnext?mode=live` with an error like `Cannot find module './316.js'` from `.next/server/webpack-runtime.js`, the local Next.js dev cache is stale or mixed across builds.
+
+Check that the API is still healthy:
+
+```bash
+curl -i "http://127.0.0.1:8000/healthz"
+```
+
+Then restart the web server with a clean generated cache:
+
+```bash
+pnpm --dir apps/web dev:clean
+```
+
+If a dev server is already running, stop it first with `Ctrl-C`, then run the command again. This removes only `apps/web/.next`, which is generated build output; it does not remove source files, env files, or local data.
+
 ## Agent Policy Blocked
 
 Common reasons:

--- a/tests/unit/test_vnext_release_polish.py
+++ b/tests/unit/test_vnext_release_polish.py
@@ -209,6 +209,7 @@ def test_installation_issue_regressions_are_guarded() -> None:
     compose_lite = _read("docker-compose.lite.yml")
     postgres_init = _read("infra/postgres/init/001_roles.sh")
     install_doc = _read("docs/alpha/headless-ubuntu-install.md")
+    troubleshooting = _read("docs/alpha/troubleshooting.md")
     web_env = _read("apps/web/.env.local.example")
 
     assert "test -f .env || cp .env.example .env" in makefile
@@ -220,6 +221,7 @@ def test_installation_issue_regressions_are_guarded() -> None:
     assert "apps/web/.env.local" in gitignore
 
     assert web_package["packageManager"].startswith("pnpm@10.")
+    assert web_package["scripts"]["dev:clean"] == "rm -rf .next && next dev"
     assert set(web_package["pnpm"]["onlyBuiltDependencies"]) >= {"esbuild", "sharp", "unrs-resolver"}
     assert "NEXT_PUBLIC_ALICEBOT_API_BASE_URL=http://127.0.0.1:8000" in web_env
 
@@ -242,6 +244,8 @@ def test_installation_issue_regressions_are_guarded() -> None:
     assert 'ALICE_MCP_COMMAND="' in install_doc
     assert "CORS_ALLOWED_ORIGINS=http://127.0.0.1:3000,http://localhost:3000" in install_doc
     assert "docker compose down -v" in install_doc
+    assert "Cannot find module './316.js'" in troubleshooting
+    assert "pnpm --dir apps/web dev:clean" in troubleshooting
 
 
 def test_env_validator_rejects_unquoted_values_with_spaces(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This PR makes the local fix for the Next.js stale-cache failure discoverable and repeatable.

When `/vnext?mode=live` fails with an error like `Cannot find module './316.js'` from `.next/server/webpack-runtime.js`, the practical fix is to restart the web dev server with a clean generated `.next` cache. This adds a first-class script for that reset and documents the exact troubleshooting flow.

## What changed

- Added `pnpm --dir apps/web dev:clean`, which removes the generated `.next` cache and starts `next dev`.
- Added an alpha troubleshooting section for the exact `Cannot find module './316.js'` failure.
- Added a release-polish regression check so the clean-reset script and troubleshooting note remain present.

## Validation

- `pytest tests/unit/test_vnext_release_polish.py -q` passed.
- `pnpm --dir apps/web lint` passed.
- `git diff --check` passed.

## Operator note

No database migration, env change, tag update, or production behavior change is needed. This is local developer/operator tooling and documentation only.