### PR TITLE
Keep MCP tool errors on the connection

### DIFF
--- a/apps/api/src/alicebot_api/mcp_server.py
+++ b/apps/api/src/alicebot_api/mcp_server.py
@@ -209,6 +209,23 @@ class MCPServer:
                         "isError": True,
                     },
                 )
+            except Exception as exc:
+                print(f"error: MCP tool call failed unexpectedly: {type(exc).__name__}", file=sys.stderr)
+                return _response_success(
+                    request_id,
+                    result={
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "Tool execution failed unexpectedly. "
+                                    f"Check Alice MCP server logs for {type(exc).__name__}."
+                                ),
+                            }
+                        ],
+                        "isError": True,
+                    },
+                )
 
             return _response_success(
                 request_id,

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -859,3 +859,19 @@ def test_mcp_server_tools_call_success_and_error_paths(monkeypatch) -> None:
     assert error_response is not None
     assert error_response["result"]["isError"] is True
     assert error_response["result"]["content"][0]["text"] == "invalid input"
+
+    def raise_unexpected_error(*_args, **_kwargs):
+        raise RuntimeError("database connection dropped")
+
+    monkeypatch.setattr(mcp_server, "call_mcp_tool", raise_unexpected_error)
+    unexpected_response = server._handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {"name": "alice_vnext_commit_memory", "arguments": {}},
+        }
+    )
+    assert unexpected_response is not None
+    assert unexpected_response["result"]["isError"] is True
+    assert "Tool execution failed unexpectedly" in unexpected_response["result"]["content"][0]["text"]


### PR DESCRIPTION
## Upgrade Overview

### Protected Areas

- [x] continuity APIs
- [ ] memory schema
- [ ] evidence pipeline
- [ ] trust rules
- [ ] promotion logic

### Compatibility Impact

This preserves the existing MCP tool response shape for known validation and policy errors while adding a defensive boundary for unexpected runtime failures. MCP clients should now receive a normal tool `isError` response instead of losing the stdio connection when a backend dependency fails during `tools/call`.

### Migration / Rollout

No migration is required. Restart any running Alice MCP server or connected agent process after deploying so it picks up the patched `mcp_server.py`.

### Operator Action

After merge, restart the local Alice MCP server/agent and retry the memory commit. If the underlying issue is environmental, such as a database connection problem, the agent will now see a structured tool error instead of `MCP connection closed during the call`.

### Validation

Validated locally with the targeted MCP unit suite, Python compile check, whitespace check, MCP stdio failure reproduction, and an MCP trusted commit plus undo smoke against local Postgres.

### Rollback

Rollback is a normal revert of this PR. The change only affects MCP JSON-RPC error containment and does not alter memory data, schemas, or commit policy.

## What Changed

- Catches unexpected exceptions at the MCP `tools/call` JSON-RPC boundary.
- Returns a structured `isError` tool result instead of letting the MCP server process terminate.
- Logs the exception type to stderr without exposing full internals to the client payload.
- Adds unit coverage for unexpected tool failures so future MCP tools cannot regress back to connection-closing behavior.

## Validation Evidence

Passed locally:

- `./.venv/bin/pytest tests/unit/test_mcp.py -q` (`15 passed`)
- `./.venv/bin/python -m py_compile apps/api/src/alicebot_api/mcp_server.py`
- `git diff --check`
- MCP stdio repro returns structured `isError` instead of crashing on an injected database connection failure.
- MCP trusted commit plus undo smoke completed against local Postgres.
