### PR TITLE
Fix Ubuntu installer regressions

### DIFF
--- a/docs/alpha/headless-ubuntu-install.md
+++ b/docs/alpha/headless-ubuntu-install.md
@@ -7,10 +7,12 @@ Supported assumptions for this alpha:
 - Ubuntu 22.04 LTS or 24.04 LTS
 - Python 3.12-compatible system Python or newer venv support
 - Node 20 through NodeSource or an existing Node 20 install
-- local Postgres on the same host, or an existing Postgres reached through `DATABASE_URL`
+- local Postgres with `pgvector` on the same host, or an existing Postgres reached through `DATABASE_URL`
 - services bound to `127.0.0.1` by default
 
-This is an RC/dogfood install path for `v0.6.0-alpha-rc.2`, not a public beta or hosted SaaS release. `rc.2` supersedes `rc.1` for Ubuntu installs after the first install attempt exposed setup and environment drift issues.
+This is the current headless install path for the Alice vNext public-preview line. The active preview release target is `v0.5.1-vnext-preview` on top of stable `v0.5.1`.
+
+Historical note: `v0.6.0-alpha-rc.2` remains an older internal Ubuntu dogfood packaging milestone. Keep it for audit trail and rollback evidence, but do not treat it as the current public preview boundary.
 
 ## Recommended Secure Access
 
@@ -31,26 +33,20 @@ Do not expose `/vnext`, the API, MCP, or browser clipper endpoint publicly by de
 ## Inspect-Before-Run Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/samrusani/AliceBot/v0.6.0-alpha-rc.2/scripts/install-ubuntu.sh -o install-alice.sh
-less install-alice.sh
-bash install-alice.sh --tag v0.6.0-alpha-rc.2
-```
-
-Install from `main` instead:
-
-```bash
 curl -fsSL https://raw.githubusercontent.com/samrusani/AliceBot/main/scripts/install-ubuntu.sh -o install-alice.sh
 less install-alice.sh
 bash install-alice.sh --branch main --install-dir ~/alicebot
 ```
+
+For an immutable preview install after the preview tag is published, replace `--branch main` with `--tag v0.5.1-vnext-preview`.
 
 Use `--non-interactive` only after you have chosen a safe install directory and know whether the host should install local Postgres.
 
 ## Installer Options
 
 ```bash
-bash install-alice.sh --tag v0.6.0-alpha-rc.2
 bash install-alice.sh --branch main
+bash install-alice.sh --tag v0.5.1-vnext-preview
 bash install-alice.sh --install-dir ~/alicebot
 bash install-alice.sh --skip-postgres-install
 bash install-alice.sh --install-systemd
@@ -74,9 +70,11 @@ Default paths:
 - config: `~/.config/alicebot/.env`
 - data: `~/.local/share/alicebot/`
 - logs/state: `~/.local/state/alicebot/logs/`
+- runtime pid/status files: `~/.alicebot/`
 - local secret references: `~/.config/alicebot/secrets/`
 
 The installer renders [packaging/ubuntu/alicebot.env.example](../../packaging/ubuntu/alicebot.env.example) into `~/.config/alicebot/.env` if the file does not already exist. Existing config is preserved.
+For local Postgres installs, it detects the server major version, installs the matching `postgresql-<major>-pgvector` package, and creates the `vector` extension before migrations.
 
 Important config keys:
 
@@ -102,10 +100,10 @@ Secrets are referenced, not printed. Store real connector secrets through the co
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y ca-certificates curl git build-essential python3 python3-venv python3-pip libpq-dev postgresql postgresql-contrib
+sudo apt-get install -y ca-certificates curl git build-essential python3 python3-venv python3-pip libpq-dev postgresql postgresql-contrib postgresql-16-pgvector
 git clone https://github.com/samrusani/AliceBot.git ~/alicebot
 cd ~/alicebot
-git checkout tags/v0.6.0-alpha-rc.2
+git checkout main
 python3 -m venv .venv
 ./.venv/bin/python -m pip install -e '.[dev]'
 corepack enable
@@ -118,12 +116,14 @@ cp packaging/ubuntu/alicebot.env.example ~/.config/alicebot/.env
 less ~/.config/alicebot/.env
 ln -sfn ~/.config/alicebot/.env .env
 scripts/validate_env.sh ~/.config/alicebot/.env .env.lite apps/web/.env.local
+# Create the alicebot database/roles to match ~/.config/alicebot/.env before this step.
+sudo -u postgres psql -d alicebot -c 'CREATE EXTENSION IF NOT EXISTS vector;'
 ./.venv/bin/python -m alembic -c apps/api/alembic.ini upgrade head
 ./.venv/bin/alicebot vnext doctor --fix-safe --ci
 ./.venv/bin/alicebot vnext alpha check --headless --skip-smokes
 ```
 
-If you use existing Postgres, set `DATABASE_URL` and `DATABASE_ADMIN_URL` before migrations.
+If you use existing Postgres, set `DATABASE_URL` and `DATABASE_ADMIN_URL` before migrations and confirm the database has `CREATE EXTENSION IF NOT EXISTS vector;` installed by a superuser. On Ubuntu 22.04, replace `postgresql-16-pgvector` with the package matching the installed server major version.
 
 ## Systemd Services
 
@@ -136,7 +136,7 @@ Templates live under [packaging/systemd](../../packaging/systemd):
 Install them through:
 
 ```bash
-bash install-alice.sh --tag v0.6.0-alpha-rc.2 --install-systemd
+bash install-alice.sh --branch main --install-systemd
 ```
 
 Then start:
@@ -161,6 +161,7 @@ Service behavior:
 - API binds to `127.0.0.1:8000`
 - web binds to `127.0.0.1:3000`
 - scheduler uses the governed `alicebot vnext scheduler daemon start --foreground` path
+- scheduler pid/status files live under the explicit installing-user path `~/.alicebot`, not systemd `%h`
 - logs are visible through `journalctl`
 
 ## Headless Alpha Check
@@ -203,7 +204,7 @@ CLI-only fallback if you cannot open `/vnext`:
 
 ```bash
 ~/alicebot/.venv/bin/alicebot vnext demo load --reset
-~/alicebot/.venv/bin/alicebot context-pack --query "public alpha launch checklist" --domain project --sensitivity-allowed private
+~/alicebot/.venv/bin/alicebot context-pack --query "public preview launch checklist" --domain project --sensitivity-allowed private
 ~/alicebot/.venv/bin/alicebot daily-brief --domain project --sensitivity-allowed private
 ~/alicebot/.venv/bin/alicebot vnext artifacts list
 ~/alicebot/.venv/bin/alicebot vnext demo reset
@@ -255,6 +256,16 @@ Postgres unreachable:
 systemctl status postgresql
 sudo -u postgres psql -c 'SELECT 1'
 ```
+
+Migration fails with `extension "vector" is not available`:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y postgresql-16-pgvector
+sudo -u postgres psql -d alicebot -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+```
+
+Use the pgvector package that matches your Postgres server major version.
 
 Environment file rejected before startup:
 

--- a/packaging/systemd/alice-api.service
+++ b/packaging/systemd/alice-api.service
@@ -19,7 +19,7 @@ RestartSec=5
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
-ReadWritePaths=__ALICE_INSTALL_DIR__ __ALICE_STATE_DIR__ %h/.alicebot
+ReadWritePaths=__ALICE_INSTALL_DIR__ __ALICE_STATE_DIR__ __ALICE_RUNTIME_DIR__
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/alice-scheduler.service
+++ b/packaging/systemd/alice-scheduler.service
@@ -11,13 +11,13 @@ WorkingDirectory=__ALICE_INSTALL_DIR__
 EnvironmentFile=__ALICE_ENV_FILE__
 Environment=ALICE_API_HOST=127.0.0.1
 Environment=ALICE_API_PORT=8000
-ExecStart=__ALICE_INSTALL_DIR__/.venv/bin/alicebot vnext scheduler daemon start --foreground --interval-seconds 60 --limit 10 --pid-file %h/.alicebot/vnext-scheduler/scheduler.pid --status-file %h/.alicebot/vnext-scheduler/scheduler-status.json --log-file __ALICE_STATE_DIR__/logs/scheduler.log
+ExecStart=__ALICE_INSTALL_DIR__/.venv/bin/alicebot vnext scheduler daemon start --foreground --interval-seconds 60 --limit 10 --pid-file __ALICE_RUNTIME_DIR__/vnext-scheduler/scheduler.pid --status-file __ALICE_RUNTIME_DIR__/vnext-scheduler/scheduler-status.json --log-file __ALICE_STATE_DIR__/logs/scheduler.log
 Restart=on-failure
 RestartSec=10
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
-ReadWritePaths=__ALICE_INSTALL_DIR__ __ALICE_STATE_DIR__ %h/.alicebot
+ReadWritePaths=__ALICE_INSTALL_DIR__ __ALICE_STATE_DIR__ __ALICE_RUNTIME_DIR__
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/install-ubuntu.sh
+++ b/scripts/install-ubuntu.sh
@@ -9,6 +9,7 @@ CONFIG_DIR="${HOME}/.config/alicebot"
 DATA_DIR="${HOME}/.local/share/alicebot"
 STATE_DIR="${HOME}/.local/state/alicebot"
 SECRETS_DIR="${HOME}/.config/alicebot/secrets"
+ALICE_RUNTIME_DIR="${HOME}/.alicebot"
 ENV_FILE=""
 SKIP_POSTGRES_INSTALL=0
 NON_INTERACTIVE=0
@@ -102,12 +103,20 @@ CONFIG_DIR="$(realpath -m "${CONFIG_DIR/#\~/${HOME}}")"
 DATA_DIR="$(realpath -m "${DATA_DIR/#\~/${HOME}}")"
 STATE_DIR="$(realpath -m "${STATE_DIR/#\~/${HOME}}")"
 SECRETS_DIR="$(realpath -m "${SECRETS_DIR/#\~/${HOME}}")"
+ALICE_RUNTIME_DIR="$(realpath -m "${ALICE_RUNTIME_DIR/#\~/${HOME}}")"
 ENV_FILE="${CONFIG_DIR}/.env"
 
 run() {
   log "+ $*"
   if [ "${DRY_RUN}" -eq 0 ]; then
     "$@"
+  fi
+}
+
+run_in_install_dir() {
+  log "+ (cd ${INSTALL_DIR} && $*)"
+  if [ "${DRY_RUN}" -eq 0 ]; then
+    (cd "${INSTALL_DIR}" && "$@")
   fi
 }
 
@@ -145,8 +154,23 @@ install_system_packages() {
     openssl pkg-config libpq-dev redis-tools
 }
 
+install_pnpm_from_npm() {
+  local npm_bin npm_prefix
+  npm_bin="$(command -v npm || true)"
+  if [ -z "${npm_bin}" ]; then
+    fail "npm is required to install pnpm when corepack is unavailable."
+  fi
+
+  npm_prefix="$("${npm_bin}" config get prefix 2>/dev/null || true)"
+  if [[ "${npm_bin}" == "${HOME}/"* || "${npm_prefix}" == "${HOME}/"* ]]; then
+    run "${npm_bin}" install -g "pnpm@${PNPM_VERSION}"
+  else
+    run sudo "${npm_bin}" install -g "pnpm@${PNPM_VERSION}"
+  fi
+}
+
 install_node_and_pnpm() {
-  local node_major
+  local corepack_bin node_major
   node_major="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || true)"
   if [ -z "${node_major}" ] || [ "${node_major}" -lt 20 ]; then
     log "Installing Node.js 20 through NodeSource."
@@ -163,12 +187,36 @@ install_node_and_pnpm() {
     run sudo apt-get update
     run sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
   fi
-  if command -v corepack >/dev/null 2>&1; then
-    run sudo corepack enable
-    run sudo corepack prepare "pnpm@${PNPM_VERSION}" --activate
+  corepack_bin="$(command -v corepack || true)"
+  if [ -n "${corepack_bin}" ]; then
+    if [[ "${corepack_bin}" == "${HOME}/"* ]]; then
+      run "${corepack_bin}" enable
+      run "${corepack_bin}" prepare "pnpm@${PNPM_VERSION}" --activate
+    else
+      run sudo "${corepack_bin}" enable
+      run sudo "${corepack_bin}" prepare "pnpm@${PNPM_VERSION}" --activate
+    fi
   elif ! command -v pnpm >/dev/null 2>&1; then
-    run sudo npm install -g "pnpm@${PNPM_VERSION}"
+    install_pnpm_from_npm
   fi
+}
+
+install_pgvector_package() {
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    log "+ install postgresql-\$(server major)-pgvector for local Postgres"
+    return
+  fi
+
+  local package pg_major pg_version_num
+  pg_version_num="$(sudo -u postgres psql -Atqc "SHOW server_version_num")"
+  pg_major="${pg_version_num:0:2}"
+  package="postgresql-${pg_major}-pgvector"
+
+  if ! apt-cache show "${package}" >/dev/null 2>&1; then
+    fail "Required pgvector package ${package} is not available. Install pgvector for PostgreSQL ${pg_major}, or rerun with --skip-postgres-install and provide DATABASE_URL/DATABASE_ADMIN_URL for a Postgres instance with pgvector."
+  fi
+
+  run sudo DEBIAN_FRONTEND=noninteractive apt-get install -y "${package}"
 }
 
 prepare_postgres() {
@@ -178,6 +226,7 @@ prepare_postgres() {
   fi
   run sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql postgresql-contrib
   run sudo systemctl enable --now postgresql
+  install_pgvector_package
   if [ "${DRY_RUN}" -eq 1 ]; then
     log "+ prepare local alicebot Postgres roles/database without printing generated passwords"
     return
@@ -209,7 +258,7 @@ random_secret() {
 }
 
 write_env_if_missing() {
-  run mkdir -p "${CONFIG_DIR}" "${DATA_DIR}" "${STATE_DIR}/logs" "${SECRETS_DIR}"
+  run mkdir -p "${CONFIG_DIR}" "${DATA_DIR}" "${STATE_DIR}/logs" "${SECRETS_DIR}" "${ALICE_RUNTIME_DIR}/vnext-scheduler"
   if [ -f "${ENV_FILE}" ]; then
     log "Preserving existing ${ENV_FILE}."
   else
@@ -314,6 +363,7 @@ SELECT 'CREATE DATABASE alicebot OWNER alicebot_admin'
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'alicebot')\\gexec
 GRANT CONNECT ON DATABASE alicebot TO alicebot_app;
 SQL
+  sudo -u postgres psql -d alicebot -c "CREATE EXTENSION IF NOT EXISTS vector;" >/dev/null
 }
 
 install_project_dependencies() {
@@ -331,7 +381,7 @@ run_migrations_and_checks() {
     . "${ENV_FILE}"
     set +a
   fi
-  run "${INSTALL_DIR}/.venv/bin/python" -m alembic -c "${INSTALL_DIR}/apps/api/alembic.ini" upgrade head
+  run_in_install_dir "${INSTALL_DIR}/.venv/bin/python" -m alembic -c apps/api/alembic.ini upgrade head
   run "${INSTALL_DIR}/.venv/bin/alicebot" vnext doctor --fix-safe --ci
   if [ "${RUN_ALPHA_CHECK}" -eq 1 ]; then
     run "${INSTALL_DIR}/.venv/bin/alicebot" vnext alpha check --headless --skip-smokes
@@ -355,6 +405,7 @@ install_systemd_units() {
         -e "s#__ALICE_INSTALL_DIR__#${INSTALL_DIR}#g" \
         -e "s#__ALICE_ENV_FILE__#${ENV_FILE}#g" \
         -e "s#__ALICE_STATE_DIR__#${STATE_DIR}#g" \
+        -e "s#__ALICE_RUNTIME_DIR__#${ALICE_RUNTIME_DIR}#g" \
         "${INSTALL_DIR}/packaging/systemd/${service}.service" \
         | sudo tee "/etc/systemd/system/${service}.service" >/dev/null
     fi

--- a/tests/unit/test_vnext_release_polish.py
+++ b/tests/unit/test_vnext_release_polish.py
@@ -188,10 +188,13 @@ def test_headless_ubuntu_packaging_is_discoverable_and_safe_by_default() -> None
         assert "Restart=on-failure" in service
         assert "EnvironmentFile=__ALICE_ENV_FILE__" in service
         assert "0.0.0.0" not in service
+        assert "%h/.alicebot" not in service
 
     assert "127.0.0.1" in api_service
     assert "127.0.0.1" in web_service
     assert "127.0.0.1" in scheduler_service
+    assert "__ALICE_RUNTIME_DIR__" in api_service
+    assert "__ALICE_RUNTIME_DIR__/vnext-scheduler" in scheduler_service
     assert "headless-ubuntu" in cli
     assert "--headless" in cli
 
@@ -227,6 +230,15 @@ def test_installation_issue_regressions_are_guarded() -> None:
 
     assert "PNPM_VERSION" in installer
     assert "pnpm@latest" not in installer
+    assert "install_pnpm_from_npm" in installer
+    assert "command -v npm" in installer
+    assert '"${npm_bin}" install -g "pnpm@${PNPM_VERSION}"' in installer
+    assert 'sudo "${npm_bin}" install -g "pnpm@${PNPM_VERSION}"' in installer
+    assert "postgresql-${pg_major}-pgvector" in installer
+    assert "CREATE EXTENSION IF NOT EXISTS vector" in installer
+    assert '"${ALICE_RUNTIME_DIR}/vnext-scheduler"' in installer
+    assert "run_in_install_dir" in installer
+    assert "-c apps/api/alembic.ini" in installer
     assert "write_lite_env_if_missing" in installer
     assert "write_web_env_if_missing" in installer
     assert "validate_env_files" in installer
@@ -242,6 +254,9 @@ def test_installation_issue_regressions_are_guarded() -> None:
     assert "ALICEBOT_APP_PASSWORD" in postgres_init
     assert "ALTER ROLE" in postgres_init
     assert 'ALICE_MCP_COMMAND="' in install_doc
+    assert "postgresql-16-pgvector" in install_doc
+    assert "CREATE EXTENSION IF NOT EXISTS vector" in install_doc
+    assert "`~/.alicebot`" in install_doc
     assert "CORS_ALLOWED_ORIGINS=http://127.0.0.1:3000,http://localhost:3000" in install_doc
     assert "docker compose down -v" in install_doc
     assert "Cannot find module './316.js'" in troubleshooting


### PR DESCRIPTION
## Summary
- fix pnpm fallback when npm is installed in a user-local path instead of sudo PATH
- install and initialize pgvector for local Ubuntu Postgres before Alembic migrations
- render explicit Alice runtime paths into systemd units instead of relying on %h
- create the scheduler runtime directory during install and run migrations from the repo root
- document the pgvector/runtime-path troubleshooting path and add regression guards

## Validation
- bash -n scripts/install-ubuntu.sh scripts/uninstall-ubuntu.sh scripts/pnpm_web_install.sh
- ./.venv/bin/pytest tests/unit/test_vnext_release_polish.py -q
- git diff --cached --check