### PR TITLE
Align vNext preview documentation truth

### DIFF
--- a/.ai/handoff/CURRENT_STATE.md
+++ b/.ai/handoff/CURRENT_STATE.md
@@ -52,18 +52,7 @@
 - `M-001` is implemented in this working tree and should be validated in GitHub Actions after PR push/merge.
 - Alice vNext Sprint 1 through Sprint 12, the live capture connectors sprint, and dogfood hardening are implemented and in the public-preview release gate.
 
-## Immediate Control Tower Decisions Needed
-- Use the separate `PostgresVNextStore` facade as the Sprint 2 persistence boundary unless a concrete integration blocker appears.
-- Decide whether old `memories` rows should be backfilled into full v2 canonical text/domain/sensitivity values before Sprint 2.
-- Decide whether the vNext capture API should expose local folder import directly or keep folder import CLI-only for local deployments.
-- Decide whether vNext context packs should be automatically persisted as generated artifacts or remain ephemeral until a user enqueues a queue task.
-- Decide which queue write policies may advance beyond deterministic local artifacts into external tool execution.
-- Decide how production daily/weekly scheduling should be configured and whether model-backed synthesis should replace or augment the deterministic Sprint 5 templates.
-- Decide how accepted vNext graph edges should influence retrieval ranking beyond trace/neighborhood visibility.
-- Decide how vNext belief status history should be unified with the existing temporal-state APIs and whether contradiction classification should use model-backed evidence review.
-- Decide how project-update rejection suppression should be persisted beyond event logs and how UI project pages should expose candidate review state.
-- Decide which remaining vNext UI write surfaces should become live-backed after the current live/fixture hybrid workspace.
-- Decide when the deterministic eval harness should graduate to model-backed, live-store-backed, or human-rated scoring.
-- Decide whether the next connector security layer should use OS keychain, hosted secret infrastructure, or both behind the existing secret-provider interface.
-- After dogfood hardening, decide the next build slice: broader live-backed `/vnext` workflows, managed connector OAuth, production scheduling, or model-backed evaluation.
+## Post-Preview Decisions
+- After the preview gate closes, choose the next product slice: broader live-backed `/vnext` workflows, managed connector OAuth, production scheduling, or model-backed evaluation.
+- Decide whether the older implementation-planning notes for early vNext sprints should be compacted or archived now that the release gate is the active execution posture.
 - Avoid reopening completed Phase 14 or `HF-001` scope unless a concrete defect or release-readiness issue is identified.

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -55,18 +55,7 @@ Canonical handoff state lives at [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURR
 - `M-001` is implemented in this working tree and should be validated in GitHub Actions after PR push/merge.
 - Alice vNext Sprint 1 through Sprint 12, the live capture connectors sprint, and dogfood hardening are implemented and in the public-preview release gate.
 
-## Immediate Control Tower Decisions Needed
-- Use the separate `PostgresVNextStore` facade as the Sprint 2 persistence boundary unless a concrete integration blocker appears.
-- Decide whether old `memories` rows should be backfilled into full v2 canonical text/domain/sensitivity values before Sprint 2.
-- Decide whether the vNext capture API should expose local folder import directly or keep folder import CLI-only for local deployments.
-- Decide whether vNext context packs should be automatically persisted as generated artifacts or remain ephemeral until a user enqueues a queue task.
-- Decide which queue write policies may advance beyond deterministic local artifacts into external tool execution.
-- Decide how production daily/weekly scheduling should be configured and whether model-backed synthesis should replace or augment the deterministic Sprint 5 templates.
-- Decide how accepted vNext graph edges should influence retrieval ranking beyond trace/neighborhood visibility.
-- Decide how vNext belief status history should be unified with the existing temporal-state APIs and whether contradiction classification should use model-backed evidence review.
-- Decide how project-update rejection suppression should be persisted beyond event logs and how UI project pages should expose candidate review state.
-- Decide which remaining vNext UI write surfaces should become live-backed after the current live/fixture hybrid workspace.
-- Decide when the deterministic eval harness should graduate to model-backed, live-store-backed, or human-rated scoring.
-- Decide whether the next connector security layer should use OS keychain, hosted secret infrastructure, or both behind the existing secret-provider interface.
-- After dogfood hardening, decide the next build slice: broader live-backed `/vnext` workflows, managed connector OAuth, production scheduling, or model-backed evaluation.
+## Post-Preview Decisions
+- After the preview gate closes, choose the next product slice: broader live-backed `/vnext` workflows, managed connector OAuth, production scheduling, or model-backed evaluation.
+- Decide whether the older implementation-planning notes for early vNext sprints should be compacted or archived now that the release gate is the active execution posture.
 - Avoid reopening completed Phase 14 or `HF-001` scope unless a concrete defect or release-readiness issue is identified.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Alice vNext is the next release candidate for the true second-brain product. It 
 
 The vNext preview currently includes deterministic source capture, retrieval/context packs, queue/artifact workflows, daily and weekly brain artifacts, connection/contradiction/project/open-loop workflows, model-backed source-grounded synthesis, human artifact quality ratings, deterministic-vs-model comparison controls, synthetic evals, live local capture connectors for Telegram, local folders/Obsidian notes, browser clips, and Hermes/OpenClaw-style agent outputs, dedicated connector settings/state storage, encrypted local secret references, deterministic document connector payload ingestion, trusted agent memory commit with inline confirmation/review/reject policy, agent identity/policy auditing, a governed local scheduler with due scans, a local scheduler daemon, policy telemetry, dogfooding readiness telemetry, doctor/readiness checks, capture-to-brief traceability, and a live/fixture-backed `/vnext` operator workspace with source review, memory review, trusted commit audit, artifact review, project, open-loop, scheduler, connector, and doctor controls.
 
-## Public Alpha Quickstart
+## Public Preview Quickstart
 
 Alice is a local-first memory and continuity layer for humans and agents. It lets agents like Hermes, OpenClaw, or your own custom agents request scoped context, submit outputs, explicitly commit user-directed memories through Alice policy, propose reviewable memories, create open loops, and generate reviewable artifacts without giving them direct database access to trusted memory. The `/vnext` workspace is the operator console for review, audit, configuration, undo/correction/forget, and troubleshooting.
 
-Alice is not a notes app, an Obsidian clone, a chatbot with memory, hosted SaaS, or automatic memory autopilot. The public alpha is a technical local alpha for design partners and agent builders.
+Alice is not a notes app, an Obsidian clone, a chatbot with memory, hosted SaaS, or automatic memory autopilot. The current release candidate is a technical local public preview for design partners and agent builders.
 
 Fast path:
 
@@ -66,7 +66,7 @@ Then open:
 http://localhost:3000/vnext
 ```
 
-Load safe synthetic demo data and run the public alpha readiness gate:
+Load safe synthetic demo data and run the preview-readiness gate:
 
 ```bash
 alicebot vnext demo load --reset
@@ -78,7 +78,7 @@ alicebot vnext alpha check
 
 Agent integration starts with [docs/alpha/agent-integration.md](docs/alpha/agent-integration.md), [docs/alpha/mcp-tools.md](docs/alpha/mcp-tools.md), [docs/alpha/hermes-skill.md](docs/alpha/hermes-skill.md), and [docs/alpha/openclaw-skill.md](docs/alpha/openclaw-skill.md). Security, privacy, and limitations are documented in [docs/alpha/security-and-privacy.md](docs/alpha/security-and-privacy.md) and [docs/alpha/known-limitations.md](docs/alpha/known-limitations.md).
 
-Headless Ubuntu/Hermes dogfood starts with [docs/alpha/headless-ubuntu-install.md](docs/alpha/headless-ubuntu-install.md) and [docs/alpha/hermes-dogfood-ubuntu.md](docs/alpha/hermes-dogfood-ubuntu.md). The secure default is localhost binding plus SSH tunneling:
+Headless Ubuntu/Hermes preview dogfood starts with [docs/alpha/headless-ubuntu-install.md](docs/alpha/headless-ubuntu-install.md) and [docs/alpha/hermes-dogfood-ubuntu.md](docs/alpha/hermes-dogfood-ubuntu.md). The secure default is localhost binding plus SSH tunneling:
 
 ```bash
 ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@server
@@ -86,8 +86,8 @@ ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 user@server
 
 Start with:
 
-- [Public alpha docs](docs/alpha/README.md)
-- [Public alpha quickstart](docs/alpha/quickstart.md)
+- [Public preview docs](docs/alpha/README.md)
+- [Public preview quickstart](docs/alpha/quickstart.md)
 - [First-run checklist](docs/alpha/first-run.md)
 - [Headless Ubuntu install](docs/alpha/headless-ubuntu-install.md)
 - [Hermes dogfood on Ubuntu](docs/alpha/hermes-dogfood-ubuntu.md)
@@ -108,7 +108,7 @@ Start with:
 - [Live capture connectors CTO summary](docs/vnext-live-capture-connectors-cto-summary.md)
 - [Dogfood hardening CTO summary](docs/vnext-dogfood-hardening-cto-summary.md)
 - [Live-backed operator console CTO summary](docs/vnext-live-backed-operator-console-cto-summary.md)
-- [Public alpha packaging CTO summary](docs/vnext-public-alpha-packaging-cto-summary.md)
+- [Legacy public-alpha packaging CTO summary](docs/vnext-public-alpha-packaging-cto-summary.md)
 - [Headless Ubuntu packaging CTO summary](docs/vnext-headless-ubuntu-cto-summary.md)
 - [Agentic memory commit CTO summary](docs/vnext-agentic-memory-commit-cto-summary.md)
 - [Dogfood daily checklist](docs/runbooks/vnext-dogfood-daily-checklist.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,6 @@
 - Phase 10: shipped
 - Phase 11: shipped
 - Bridge `B1`-`B4`: shipped
-- Bridge Phase (`B1`-`B4`): shipped
 - Phase 12: shipped
 - Phase 13: shipped
 - Phase 14: shipped

--- a/RULES.md
+++ b/RULES.md
@@ -8,8 +8,11 @@
 - Keep [CURRENT_STATE.md](CURRENT_STATE.md) factual/current and [ROADMAP.md](ROADMAP.md) future-facing.
 - Keep [.ai/handoff/CURRENT_STATE.md](.ai/handoff/CURRENT_STATE.md) as the canonical handoff copy when duplicate current-state files exist.
 
-## Phase 14 Rule
-- Phase 14 is a platform-and-adoption phase. Prioritize provider adapters, model packs, reference integrations, and design partner onboarding. Do not allow scope drift into new substrate research, new channels, or enterprise governance work unless required by a declared Phase 14 deliverable.
+## Phase 14 Baseline Rule
+- Phase 14 was a platform-and-adoption phase. Preserve that shipped boundary as baseline truth: provider adapters, model packs, reference integrations, and design partner onboarding are complete baseline surfaces, not open scope.
+
+## Active vNext Preview Rule
+- While `v0.5.1-vnext-preview` is the active release gate, prioritize release accuracy, install clarity, preview-safe docs, and verification evidence. Do not add net-new feature scope unless it is required to fix preview readiness, release evidence, or operator safety.
 
 ## Provider Rules
 - Continuity semantics must not fork by provider.

--- a/docs/alpha/README.md
+++ b/docs/alpha/README.md
@@ -1,6 +1,8 @@
-# Alice vNext Public Alpha
+# Alice vNext Public Preview
 
-Alice vNext public alpha is a technical, local-first package for design partners who want agent memory and continuity without hosted storage or direct database writes by agents.
+This folder keeps the legacy `docs/alpha` path name, but the current release posture is Alice vNext public preview.
+
+Alice vNext public preview is a technical, local-first package for design partners who want agent memory and continuity without hosted storage or direct database writes by agents.
 
 Alice is agent-first, not dashboard-first:
 

--- a/docs/alpha/agent-integration.md
+++ b/docs/alpha/agent-integration.md
@@ -38,7 +38,7 @@ Permission profiles:
 ## CLI Example
 
 ```bash
-alicebot context-pack "Alice public alpha sprint context" --domain project --project Alice
+alicebot context-pack "Alice public preview sprint context" --domain project --project Alice
 
 alicebot vnext agents ingest-output \
   --agent-id openclaw \
@@ -51,7 +51,7 @@ alicebot vnext agents ingest-output \
   --domain project \
   --sensitivity private \
   --propose-memory \
-  "Decision: Alice public alpha agents use scoped context packs and review-only memory proposals."
+  "Decision: Alice public preview agents use scoped context packs and review-only memory proposals."
 
 alicebot vnext memories commit \
   --agent-id openclaw \
@@ -60,7 +60,7 @@ alicebot vnext memories commit \
   --project-scope Alice \
   --permission-profile project_scoped_agent \
   --title "Release gate decision" \
-  --text "Alice public alpha release gates require doctor, smokes, evals, and git diff checks before merge." \
+  --text "Alice public preview release gates require doctor, smokes, evals, and git diff checks before merge." \
   --domain project \
   --sensitivity private \
   --confidence 0.94

--- a/docs/alpha/demo-mode.md
+++ b/docs/alpha/demo-mode.md
@@ -1,6 +1,6 @@
 # Demo Dataset And Demo Mode
 
-The public alpha ships a small synthetic vNext dataset in:
+The public preview ships a small synthetic vNext dataset in:
 
 ```text
 fixtures/vnext/demo_dataset.json

--- a/docs/alpha/dogfooding-guide.md
+++ b/docs/alpha/dogfooding-guide.md
@@ -1,6 +1,6 @@
 # Dogfooding Guide
 
-Daily public alpha dogfood loop:
+Daily public preview dogfood loop:
 
 ```bash
 alicebot vnext doctor --fix-safe --ci
@@ -21,7 +21,7 @@ Then use `/vnext`:
 Include these with bug reports:
 
 - output from `alicebot vnext doctor --fix-safe --ci`
-- output from `alicebot vnext alpha check --skip-smokes`
+- output from the preview-readiness command `alicebot vnext alpha check --skip-smokes`
 - failing smoke command and error
 - `/vnext` page and action that failed
 - redacted connector config, never secret values

--- a/docs/alpha/first-run.md
+++ b/docs/alpha/first-run.md
@@ -10,7 +10,7 @@ Use this checklist after a fresh clone.
 | 4. Start API | `APP_RELOAD=false ./scripts/api_dev.sh` | API serves locally |
 | 5. Start scheduler | `alicebot vnext scheduler daemon start --foreground` | daemon reports status and due scans |
 | 6. Check live browser env | `cat apps/web/.env.local` | `NEXT_PUBLIC_ALICEBOT_API_BASE_URL=http://127.0.0.1:8000` and a local user id are present |
-| 7. Start `/vnext` | `pnpm --dir apps/web dev` | web app serves locally |
+| 7. Start `/vnext` | `pnpm --dir apps/web build` then `pnpm --dir apps/web start --hostname 127.0.0.1 --port 3000` | web app serves locally |
 | 8. Open `/vnext` | `http://localhost:3000/vnext` | live mode loads or shows a clear empty state |
 | 9. Configure Brain Charter | [../vnext/ALICE.example.md](../vnext/ALICE.example.md) | Brain Charter is visible in Settings |
 | 10. Configure one capture path | local folder, browser clipper, or Telegram | connector health becomes configured |
@@ -25,3 +25,5 @@ Use this checklist after a fresh clone.
 When doctor fails, go to [doctor.md](doctor.md) first. It lists the exact command that usually fixes the blocking issue.
 
 For local live mode, `.env` must include `CORS_ALLOWED_ORIGINS=http://127.0.0.1:3000,http://localhost:3000`, and `apps/web/.env.local` must include `NEXT_PUBLIC_ALICEBOT_API_BASE_URL=http://127.0.0.1:8000`.
+
+Use `pnpm --dir apps/web dev` only while editing the web UI. For long-running agent or Hermes sessions, prefer `make runtime` as the combined API plus web command, or use the `next start` command above when API is already running.

--- a/docs/alpha/local-runtime.md
+++ b/docs/alpha/local-runtime.md
@@ -8,13 +8,17 @@ The alpha runtime is local and technical. It runs Postgres, Redis, API, web, and
 make setup
 make migrate
 make doctor
-make dev
+make runtime
 make alpha-check
 alicebot vnext alpha check --headless
 alicebot vnext smoke headless-ubuntu
 ```
 
-Equivalent explicit commands:
+`make runtime` is the recommended low-CPU local mode. It builds the web app and serves `/vnext` with `next start`. Use `make dev` only for web UI development.
+
+For API-only agent or Hermes sessions, use `make api` and skip the web process entirely.
+
+Equivalent explicit development commands:
 
 ```bash
 ./scripts/dev_up.sh

--- a/docs/alpha/mcp-tools.md
+++ b/docs/alpha/mcp-tools.md
@@ -43,7 +43,7 @@ Request scoped context with `alice_vnext_context_pack`:
   "task_id": "public-alpha-docs",
   "project_scope": ["Alice"],
   "permission_profile": "project_scoped_agent",
-  "query": "Alice public alpha packaging",
+  "query": "Alice public preview packaging",
   "scope": {
     "domains": ["project"],
     "projects": ["Alice"]

--- a/docs/alpha/memory-proposal-recipes.md
+++ b/docs/alpha/memory-proposal-recipes.md
@@ -34,7 +34,7 @@ Do not propose memory for:
   "project_scope": ["Alice"],
   "permission_profile": "project_scoped_agent",
   "title": "Decision: Review-only agent memory",
-  "canonical_text": "Alice public alpha agents must create review-only memory proposals, not trusted memory.",
+  "canonical_text": "Alice public preview agents must create review-only memory proposals, not trusted memory.",
   "domain": "project",
   "sensitivity": "private",
   "confidence": 0.86,
@@ -58,7 +58,7 @@ Do not propose memory for:
 ## Project Update Proposal
 
 ```json
-{"proposal_type":"project_update","canonical_text":"The public alpha packaging sprint is ready for design-partner onboarding after alpha-check passes.","domain":"project","sensitivity":"private","confidence":0.8}
+{"proposal_type":"project_update","canonical_text":"The public preview packaging sprint is ready for design-partner onboarding after alpha-check passes.","domain":"project","sensitivity":"private","confidence":0.8}
 ```
 
 ## Belief Update Proposal
@@ -70,13 +70,13 @@ Do not propose memory for:
 ## Open-loop Proposal
 
 ```json
-{"proposal_type":"open_loop","canonical_text":"Confirm which design partner will run the first public alpha install.","domain":"project","sensitivity":"private","confidence":0.76}
+{"proposal_type":"open_loop","canonical_text":"Confirm which design partner will run the first public preview install.","domain":"project","sensitivity":"private","confidence":0.76}
 ```
 
 ## Contradiction Proposal
 
 ```json
-{"proposal_type":"contradiction","canonical_text":"Resolve whether public alpha should prioritize Gmail/Calendar connectors or agent skill hardening next.","domain":"project","sensitivity":"private","confidence":0.7}
+{"proposal_type":"contradiction","canonical_text":"Resolve whether public preview should prioritize Gmail/Calendar connectors or agent skill hardening next.","domain":"project","sensitivity":"private","confidence":0.7}
 ```
 
 Review behavior:

--- a/docs/alpha/openclaw-skill.md
+++ b/docs/alpha/openclaw-skill.md
@@ -76,7 +76,7 @@ Explicit project memory commit:
   "project_scope": ["Alice"],
   "intent": "explicit_remember",
   "title": "Release gate decision",
-  "canonical_text": "Alice public alpha release gates require doctor, smokes, evals, and git diff checks before merge.",
+  "canonical_text": "Alice public preview release gates require doctor, smokes, evals, and git diff checks before merge.",
   "domain": "project",
   "sensitivity": "private",
   "confidence": 0.94,

--- a/docs/alpha/quickstart.md
+++ b/docs/alpha/quickstart.md
@@ -31,19 +31,24 @@ Expected success:
 
 ## Start Alice
 
-Run API and web together:
+Run API and web together for day-to-day local use:
 
 ```bash
-make dev
+make runtime
 ```
+
+`make runtime` builds the web app and serves it with `next start`, which avoids the idle CPU cost of the Next.js development watcher.
 
 Or use separate terminals:
 
 ```bash
 APP_RELOAD=false ./scripts/api_dev.sh
-pnpm --dir apps/web dev
+pnpm --dir apps/web build
+pnpm --dir apps/web start --hostname 127.0.0.1 --port 3000
 alicebot vnext scheduler daemon start --foreground
 ```
+
+Use `make dev` or `pnpm --dir apps/web dev` only when editing the web UI and you need hot reload.
 
 Open:
 

--- a/docs/alpha/release-notes.md
+++ b/docs/alpha/release-notes.md
@@ -1,8 +1,10 @@
-# Alice vNext Public Alpha Release Notes
+# Alice vNext Public Preview Install Notes
 
 Audience: technical design partners and agent builders.
 
-This is a local technical alpha, not hosted SaaS, not a production SLA, and not automatic memory autopilot.
+This file stays under the legacy `docs/alpha` path, but it now describes the current public-preview install posture.
+
+This is a local technical preview, not hosted SaaS, not a production SLA, and not automatic memory autopilot.
 
 ## Included
 
@@ -21,7 +23,7 @@ This is a local technical alpha, not hosted SaaS, not a production SLA, and not 
 - Hermes skill guidance
 - OpenClaw skill guidance
 - custom agent guide
-- alpha readiness command
+- preview-readiness command
 
 ## Who It Is For
 
@@ -55,7 +57,7 @@ Start with [quickstart.md](quickstart.md), then run:
 alicebot vnext alpha check
 ```
 
-Headless Ubuntu dogfood readiness is prepared for `v0.6.0-alpha-rc.2` through [headless-ubuntu-install.md](headless-ubuntu-install.md), [hermes-dogfood-ubuntu.md](hermes-dogfood-ubuntu.md), `scripts/install-ubuntu.sh`, systemd templates under `packaging/systemd/`, and:
+Headless Ubuntu dogfood readiness uses the current preview install guide at [headless-ubuntu-install.md](headless-ubuntu-install.md), [hermes-dogfood-ubuntu.md](hermes-dogfood-ubuntu.md), `scripts/install-ubuntu.sh`, systemd templates under `packaging/systemd/`, and:
 
 ```bash
 alicebot vnext alpha check --headless

--- a/docs/alpha/security-and-privacy.md
+++ b/docs/alpha/security-and-privacy.md
@@ -1,6 +1,6 @@
 # Public Alpha Security And Privacy
 
-Alice public alpha is local-first.
+Alice public preview is local-first.
 
 Security posture:
 

--- a/docs/alpha/troubleshooting.md
+++ b/docs/alpha/troubleshooting.md
@@ -76,6 +76,24 @@ alicebot vnext smoke local-cors
 alicebot vnext doctor --fix-safe --ci
 ```
 
+## Next.js Dev Server Uses CPU While Idle
+
+If Activity Monitor shows `next-server` using noticeable CPU while Alice is idle, check whether it was started through `make dev` or `pnpm --dir apps/web dev`. That mode runs the Next.js development watcher and compiler, which can keep native `next-swc` worker activity alive even when no agent work is happening.
+
+If the agent only needs Alice's API/MCP surface and not the web UI, stop the web process and run only:
+
+```bash
+make api
+```
+
+If you want `/vnext` open for a long-running local agent or Hermes session, stop the dev server and run:
+
+```bash
+make runtime
+```
+
+This builds the web app and serves `/vnext` with `next start`, which is the low-CPU runtime path. Keep `make dev` for active web UI development where hot reload matters.
+
 ## `/vnext` Fails With `Cannot find module './316.js'`
 
 If the web server returns a 500 for `/vnext?mode=live` with an error like `Cannot find module './316.js'` from `.next/server/webpack-runtime.js`, the local Next.js dev cache is stale or mixed across builds.

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -87,9 +87,9 @@ Model-backed generation arguments are available on daily brief, weekly synthesis
 
 Live capture connector commands preserve the same trust model as manual capture: raw source text is archived, domain/sensitivity defaults are explicit, source material is treated as untrusted, agent output produces review-only artifacts/proposals, and capture-to-brief promotion still requires human review. Connector settings and state now persist outside the event log, while settings/state changes still write audit events. Secret values are never printed; the CLI stores or resolves only `secret_ref` values.
 
-`alicebot vnext alpha check` is the public alpha readiness gate. It summarizes migrations, doctor, scheduler posture, connector settings/state storage, core vNext smokes, agent integration pack smoke, and the eval command expected for release evidence.
+`alicebot vnext alpha check` is the public-preview readiness gate. It summarizes migrations, doctor, scheduler posture, connector settings/state storage, core vNext smokes, agent integration pack smoke, and the eval command expected for release evidence.
 
-`alicebot vnext demo load --reset` loads the safe synthetic public alpha dataset from `fixtures/vnext/demo_dataset.json`; `alicebot vnext demo reset` archives rows from that dataset.
+`alicebot vnext demo load --reset` loads the safe synthetic public-preview dataset from `fixtures/vnext/demo_dataset.json`; `alicebot vnext demo reset` archives rows from that dataset.
 
 The `operator-console` smoke is the broadest local go/no-go check for daily `/vnext` operation. It verifies source review, memory review, artifact review/rating, source-backed open-loop creation, scheduler run-now artifact creation, connector health visibility, doctor readiness, event logging, and source-to-brief traceability.
 

--- a/docs/release/v0.6.0-alpha-rc.1-release-notes.md
+++ b/docs/release/v0.6.0-alpha-rc.1-release-notes.md
@@ -1,5 +1,7 @@
 # v0.6.0-alpha-rc.1 Release Notes
 
+Historical note: this document is retained as an earlier internal Ubuntu dogfood packaging milestone. The current public preview line is `v0.5.1-vnext-preview`; stable latest remains `v0.5.1`.
+
 Status: internal pre-release candidate for Hermes dogfood testing.
 
 Latest stable remains: `v0.5.1`.
@@ -22,7 +24,7 @@ This headless Ubuntu RC is intended for operator-controlled dogfood only.
 - Hermes dogfood guide at `docs/alpha/hermes-dogfood-ubuntu.md`
 - headless package smoke: `alicebot vnext smoke headless-ubuntu`
 - headless alpha readiness mode: `alicebot vnext alpha check --headless`
-- public alpha agent integration pack from the prior packaging phase
+- public-preview agent integration pack from the prior packaging phase
 
 ## Security Defaults
 

--- a/docs/release/v0.6.0-alpha-rc.2-release-notes.md
+++ b/docs/release/v0.6.0-alpha-rc.2-release-notes.md
@@ -1,5 +1,7 @@
 # v0.6.0-alpha-rc.2 Release Notes
 
+Historical note: this document is retained as an internal Ubuntu dogfood packaging milestone. The current public preview line is `v0.5.1-vnext-preview`; stable latest remains `v0.5.1`.
+
 Status: internal pre-release candidate for Hermes dogfood testing.
 
 Latest stable remains: `v0.5.1`.
@@ -22,7 +24,7 @@ The target dogfood setup is Alice and Hermes running on the same Ubuntu server o
 - Hermes dogfood guide at `docs/alpha/hermes-dogfood-ubuntu.md`
 - headless package smoke: `alicebot vnext smoke headless-ubuntu`
 - headless alpha readiness mode: `alicebot vnext alpha check --headless`
-- public alpha agent integration pack from the prior packaging phase
+- public-preview agent integration pack from the prior packaging phase
 
 ## Installer Hardening Since rc.1
 

--- a/docs/vnext/README.md
+++ b/docs/vnext/README.md
@@ -27,19 +27,19 @@ Alice vNext has three layers:
 
 ## Start Here
 
-1. Follow [public alpha quickstart](../alpha/quickstart.md) for the design-partner install path.
+1. Follow the [public preview quickstart](../alpha/quickstart.md) for the design-partner install path.
 2. Use [first-run checklist](../alpha/first-run.md) and [doctor](../alpha/doctor.md) for onboarding.
 3. Review [headless Ubuntu install](../alpha/headless-ubuntu-install.md), [Hermes dogfood on Ubuntu](../alpha/hermes-dogfood-ubuntu.md), [agent integration pack](../alpha/agent-integration.md), [MCP tools](../alpha/mcp-tools.md), [Hermes skill](../alpha/hermes-skill.md), and [OpenClaw skill](../alpha/openclaw-skill.md).
 4. Follow [vNext quickstart](quickstart.md) for the broader preview path.
 5. Review [architecture](architecture.md).
-6. Review [security and privacy](security-privacy.md) and [public alpha security posture](../alpha/security-and-privacy.md).
+6. Review [security and privacy](security-privacy.md) and the [public-preview security posture](../alpha/security-and-privacy.md).
 7. Review [local runtime](local-runtime.md) before running scheduler workflows in the background.
 8. Use [example ALICE.md](ALICE.example.md) as the first Brain Charter.
 9. Use [demo script](demo-video-script.md) and [demo mode](../alpha/demo-mode.md) for a short walkthrough.
 10. Use [release checklist](../release/vnext-public-release-checklist.md) before publishing or tagging.
-11. Review [preview release notes](../release/v0.5.1-vnext-preview-release-notes.md), [public alpha release notes](../alpha/release-notes.md), and [tag plan](../release/v0.5.1-vnext-preview-tag-plan.md).
-12. Review the [dogfood daily checklist](../runbooks/vnext-dogfood-daily-checklist.md) before daily local-alpha use.
-13. Review the [agentic control plane CTO summary](../vnext-agentic-control-plane-cto-summary.md), [agentic memory commit CTO summary](../vnext-agentic-memory-commit-cto-summary.md), [local runtime CTO summary](../vnext-local-runtime-cto-summary.md), [model-backed intelligence CTO summary](../vnext-model-backed-intelligence-cto-summary.md), [live capture connectors CTO summary](../vnext-live-capture-connectors-cto-summary.md), [dogfood hardening CTO summary](../vnext-dogfood-hardening-cto-summary.md), [live-backed operator console CTO summary](../vnext-live-backed-operator-console-cto-summary.md), [public alpha packaging CTO summary](../vnext-public-alpha-packaging-cto-summary.md), and [headless Ubuntu packaging CTO summary](../vnext-headless-ubuntu-cto-summary.md) for sprint closeouts.
+11. Review [preview release notes](../release/v0.5.1-vnext-preview-release-notes.md), [preview install notes](../alpha/release-notes.md), and [tag plan](../release/v0.5.1-vnext-preview-tag-plan.md).
+12. Review the [dogfood daily checklist](../runbooks/vnext-dogfood-daily-checklist.md) before daily local preview use.
+13. Review the [agentic control plane CTO summary](../vnext-agentic-control-plane-cto-summary.md), [agentic memory commit CTO summary](../vnext-agentic-memory-commit-cto-summary.md), [local runtime CTO summary](../vnext-local-runtime-cto-summary.md), [model-backed intelligence CTO summary](../vnext-model-backed-intelligence-cto-summary.md), [live capture connectors CTO summary](../vnext-live-capture-connectors-cto-summary.md), [dogfood hardening CTO summary](../vnext-dogfood-hardening-cto-summary.md), [live-backed operator console CTO summary](../vnext-live-backed-operator-console-cto-summary.md), [legacy public-alpha packaging CTO summary](../vnext-public-alpha-packaging-cto-summary.md), and [historical headless Ubuntu packaging CTO summary](../vnext-headless-ubuntu-cto-summary.md) for sprint closeouts.
 
 ## Launch Boundary
 

--- a/docs/vnext/local-runtime.md
+++ b/docs/vnext/local-runtime.md
@@ -1,6 +1,6 @@
 # Alice vNext Local Runtime
 
-Alice vNext now includes a local scheduler runtime for running governed Alice Brain workflows in the background. This is a local alpha runtime, not a hosted scheduler service.
+Alice vNext now includes a local scheduler runtime for running governed Alice Brain workflows in the background. This is a local preview runtime, not a hosted scheduler service.
 
 ## What It Runs
 
@@ -132,4 +132,4 @@ The live-capture connector smoke verifies allowlisted Telegram import, rejected 
 
 The connector-hardening smoke verifies dedicated connector settings/state rows, Telegram cursor persistence, rejected-chat logging, local-folder generated-output ignores, restart dedupe, and health counters. The local-cors smoke verifies the explicit localhost CORS allowlist and public browser API env needed by `/vnext?mode=live`. The secret-redaction smoke verifies that Telegram and browser clipper secrets never appear in persisted source/event output. The dogfood-doctor smoke verifies migration readiness, default connector rows, scheduler posture, configured secret references, and blocking failure counts. The operator-console smoke verifies the live daily operation path across source review, memory review, artifact review/rating, source-backed open loops, scheduler run-now, connector health, doctor readiness, event logging, and capture-to-brief traceability.
 
-The agent-integration-pack smoke verifies the public alpha agent path: OpenClaw identity, scoped project context, review-only output ingestion, review-only memory proposal creation, no auto-promotion, event logging, restricted-domain policy blocking, and Agent Activity visibility. The alpha check wraps readiness posture and the core smokes into one command for technical design partners.
+The agent-integration-pack smoke verifies the public-preview agent path: OpenClaw identity, scoped project context, review-only output ingestion, review-only memory proposal creation, no auto-promotion, event logging, restricted-domain policy blocking, and Agent Activity visibility. The `alicebot vnext alpha check` command remains the preview-readiness wrapper for technical design partners.

--- a/docs/vnext/quickstart.md
+++ b/docs/vnext/quickstart.md
@@ -18,7 +18,7 @@ cd AliceBot
 make setup
 ```
 
-Then start the project-native public alpha setup:
+Then start the project-native public preview setup:
 
 ```bash
 make migrate
@@ -47,7 +47,13 @@ alicebot vnext migrations status
 alicebot vnext doctor --fix-safe
 ```
 
-Run the API and web app in separate terminals:
+Run the low-CPU day-to-day runtime:
+
+```bash
+make runtime
+```
+
+Use separate terminals only when you are actively editing the web UI and need hot reload:
 
 ```bash
 APP_RELOAD=false ./scripts/api_dev.sh
@@ -156,7 +162,7 @@ The operator-console smoke verifies the live `/vnext` loop end to end: source re
 
 The agent-integration-pack smoke verifies OpenClaw identity, project-scoped context, review-only output ingestion and memory proposal creation, no auto-promotion, event logging, restricted-domain policy blocking, and Agent Activity visibility.
 
-Load or reset the synthetic public alpha demo dataset:
+Load or reset the synthetic public preview demo dataset:
 
 ```bash
 alicebot vnext demo load --reset

--- a/scripts/check_control_doc_truth.py
+++ b/scripts/check_control_doc_truth.py
@@ -45,7 +45,7 @@ CONTROL_DOC_TRUTH_RULES: tuple[ControlDocTruthRule, ...] = (
     ControlDocTruthRule(
         relative_path="RULES.md",
         required_markers=(
-            "Phase 14 is a platform-and-adoption phase.",
+            "While `v0.5.1-vnext-preview` is the active release gate",
             "Continuity semantics must not fork by provider.",
         ),
     ),


### PR DESCRIPTION
Aligns the canonical docs and public preview/install docs around stable v0.5.1 plus the v0.5.1-vnext-preview release gate. Keeps the v0.6.0-alpha-rc.* docs as historical dogfood packaging notes and leaves runtime/config changes out of this PR. Verification: python3 scripts/check_control_doc_truth.py; ./.venv/bin/python -m pytest tests/unit/test_control_doc_truth.py -q; git diff --cached --check.