### PR TITLE
Add low-CPU local runtime targets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ APP_ACCESS_LOG=false
 DATABASE_URL=postgresql://alicebot_app:alicebot_app@localhost:5432/alicebot
 DATABASE_ADMIN_URL=postgresql://alicebot_admin:alicebot_admin@localhost:5432/alicebot
 REDIS_URL=redis://localhost:6379/0
+# Optional Docker Compose host port overrides when another local stack owns
+# 5432/6379. If you set these, update DATABASE_URL, DATABASE_ADMIN_URL,
+# and REDIS_URL ports above.
+# ALICEBOT_POSTGRES_HOST_PORT=15432
+# ALICEBOT_REDIS_HOST_PORT=16379
 S3_ENDPOINT_URL=http://localhost:9000
 S3_ACCESS_KEY=alicebot
 S3_SECRET_KEY=alicebot-secret

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@ PYTHON ?= ./.venv/bin/python
 ALICEBOT ?= ./.venv/bin/alicebot
 PNPM ?= pnpm
 WEB_DIR ?= apps/web
+ALICE_WEB_HOST ?= 127.0.0.1
+ALICE_WEB_PORT ?= 3000
 
-.PHONY: setup migrate dev doctor vnext scheduler alpha-check test-web test-python
+.PHONY: setup migrate api dev runtime web-build doctor vnext scheduler alpha-check test-web test-python
 
 setup:
 	@test -f .env || cp .env.example .env
@@ -18,6 +20,9 @@ setup:
 migrate:
 	./scripts/dev_up.sh
 
+api:
+	APP_RELOAD=false ./scripts/api_dev.sh
+
 doctor:
 	$(ALICEBOT) vnext doctor --fix-safe --ci
 
@@ -30,9 +35,23 @@ dev:
 	trap 'kill $$api_pid $$web_pid 2>/dev/null || true' INT TERM EXIT; \
 	wait $$api_pid $$web_pid
 
+runtime:
+	./scripts/dev_up.sh
+	$(PNPM) --dir $(WEB_DIR) build
+	APP_RELOAD=false ./scripts/api_dev.sh & \
+	api_pid=$$!; \
+	$(PNPM) --dir $(WEB_DIR) start --hostname $(ALICE_WEB_HOST) --port $(ALICE_WEB_PORT) & \
+	web_pid=$$!; \
+	trap 'kill $$api_pid $$web_pid 2>/dev/null || true' INT TERM EXIT; \
+	wait $$api_pid $$web_pid
+
+web-build:
+	$(PNPM) --dir $(WEB_DIR) build
+
 vnext:
-	@echo "Start the local runtime with: make dev"
-	@echo "Then open: http://localhost:3000/vnext"
+	@echo "Start the low-CPU local runtime with: make runtime"
+	@echo "Use make dev only when editing the web UI."
+	@echo "Then open: http://localhost:$(ALICE_WEB_PORT)/vnext"
 
 scheduler:
 	$(ALICEBOT) vnext scheduler daemon start --foreground

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -9,7 +9,7 @@ services:
       ALICEBOT_APP_USER: ${ALICEBOT_COMPOSE_APP_USER:-alicebot_app}
       ALICEBOT_APP_PASSWORD: ${ALICEBOT_COMPOSE_APP_PASSWORD:-alicebot_app}
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:${ALICEBOT_POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./infra/postgres/init:/docker-entrypoint-initdb.d:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       ALICEBOT_APP_USER: ${ALICEBOT_COMPOSE_APP_USER:-alicebot_app}
       ALICEBOT_APP_PASSWORD: ${ALICEBOT_COMPOSE_APP_PASSWORD:-alicebot_app}
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:${ALICEBOT_POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./infra/postgres/init:/docker-entrypoint-initdb.d:ro
@@ -18,7 +18,7 @@ services:
     image: redis:7-alpine
     container_name: alicebot-redis
     ports:
-      - "127.0.0.1:6379:6379"
+      - "127.0.0.1:${ALICEBOT_REDIS_HOST_PORT:-6379}:6379"
 
   minio:
     image: minio/minio:RELEASE.2025-02-28T09-55-16Z


### PR DESCRIPTION
Adds Makefile targets that match the preview docs: make api for API-only sessions, make runtime for low-CPU API plus next start, and make web-build for explicit web builds. Also allows local Docker Compose host port overrides for Postgres and Redis so Alice can coexist with another local stack. Verification: make -n api; make -n runtime; make -n web-build; env ALICEBOT_POSTGRES_HOST_PORT= ALICEBOT_REDIS_HOST_PORT= docker compose config; env ALICEBOT_POSTGRES_HOST_PORT=15432 ALICEBOT_REDIS_HOST_PORT=16379 docker compose config; env ALICEBOT_POSTGRES_HOST_PORT= ALICEBOT_REDIS_HOST_PORT= docker compose -f docker-compose.lite.yml config; env ALICEBOT_POSTGRES_HOST_PORT=15432 docker compose -f docker-compose.lite.yml config; ./scripts/validate_env.sh .env.example .env.lite.example apps/web/.env.local.example; git diff --check.